### PR TITLE
Fix translation issue in TrainManager

### DIFF
--- a/openBVE/OpenBve/OldCode/TrainManager.cs
+++ b/openBVE/OpenBve/OldCode/TrainManager.cs
@@ -3762,6 +3762,7 @@ namespace OpenBve {
 						string s = Interface.GetInterfaceString("message_signal_proceed");
 						double a = 3.6 * Train.CurrentSectionLimit;
 						s = s.Replace("[speed]", a.ToString("0", System.Globalization.CultureInfo.InvariantCulture));
+						s = s.Replace("[unit]", Game.UnitOfSpeed);
 						Game.AddMessage(s, Game.MessageDependency.None, Interface.GameMode.Normal, Game.MessageColor.Red, Game.SecondsSinceMidnight + 5.0);
 					}
 				}


### PR DESCRIPTION
Hi,
this issue came to my eyes when I was breaking the speed limit and I crossed the red signal light. Instead of suggesting me to proceed at 25 km/h, it suggested me that I should proceed at 25 [unit].
Before:
![screenshot - 31 12 2015 - 15 53 01](https://cloud.githubusercontent.com/assets/6003171/12065407/079594c4-afd7-11e5-965f-06512b6a250e.png)
After:
![screenshot - 31 12 2015 - 15 48 01](https://cloud.githubusercontent.com/assets/6003171/12065408/0795dbdc-afd7-11e5-89c9-8a40afce3e99.png)
