### PR TITLE
Install a copy of OpenTK.dll.config under Linux

### DIFF
--- a/openBVE/OpenBve/OpenBve.csproj
+++ b/openBVE/OpenBve/OpenBve.csproj
@@ -318,6 +318,7 @@ if %25textTemplatingPath%25=="\Microsoft Shared\TextTemplating\$(VisualStudioVer
   <PropertyGroup>
     <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">xcopy "$(ProjectDir)Data\*.*" "$(TargetDir)Data" /Y /I /E /C</PostBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -rf "$(ProjectDir)/Data" "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -f "$(ProjectDir)../../Dependencies/OpenTK.dll.config" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
The OpenTk.dll.config file, which is needed for OpenTK to work properly under Linux was not copied to the target directory.