### PR TITLE
Remove localization from UserData path

### DIFF
--- a/openBVE/OpenBve/System/Functions/FileSystem.cs
+++ b/openBVE/OpenBve/System/Functions/FileSystem.cs
@@ -38,7 +38,7 @@ namespace OpenBve {
 		internal FileSystem() {
 			string assemblyFile = Assembly.GetExecutingAssembly().Location;
 			string assemblyFolder = Path.GetDirectoryName(assemblyFile);
-            string userDataFolder = OpenBveApi.Path.CombineDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Interface.GetInterfaceString("program_title"));
+			string userDataFolder = OpenBveApi.Path.CombineDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenBve");
 			this.DataFolder = OpenBveApi.Path.CombineDirectory(assemblyFolder, "Data");
 			this.ManagedContentFolders = new string[] { OpenBveApi.Path.CombineDirectory(userDataFolder, "ManagedContent") };
 			this.SettingsFolder = OpenBveApi.Path.CombineDirectory(userDataFolder, "Settings");


### PR DESCRIPTION
This appeared in my ~/.config directory:
```sh
$ find program_title/ OpenBve/
program_title/
program_title/Settings
program_title/Settings/OpenBVE Crash- 2016.3.04[08.14].log
program_title/Settings/logs.bin
program_title/Settings/controls.cfg
program_title/Settings/log.txt
program_title/Settings/OpenBVE Crash- 2016.3.08[13.48].log
program_title/Settings/options.cfg
program_title/ManagedContent
program_title/LegacyContent
program_title/LegacyContent/Railway
program_title/LegacyContent/Railway/Route
program_title/LegacyContent/Train
OpenBve/
OpenBve/Settings
OpenBve/Settings/logs.bin
OpenBve/Settings/controls.cfg
OpenBve/Settings/log.txt
OpenBve/Settings/options.cfg
OpenBve/ManagedContent
OpenBve/LegacyContent
OpenBve/LegacyContent/Railway
OpenBve/LegacyContent/Railway/Route
OpenBve/LegacyContent/Train
```