### PR TITLE
Fix load error deadlock

### DIFF
--- a/openBVE/OpenBve/OldCode/NewCode/GameWindow.cs
+++ b/openBVE/OpenBve/OldCode/NewCode/GameWindow.cs
@@ -627,6 +627,8 @@ namespace OpenBve
                 GL.PopMatrix();
                 GL.MatrixMode(MatrixMode.Projection);
                 SetupSimulation();
+            } else {
+                this.Close();
             }
         }
 


### PR DESCRIPTION
How to reproduce bug: throw exception inside LoadEverythingThreaded
What happens during the bug: Loading.Cancel becomes true, LoadingScreenLoop ends, but the window **and it's loop** are still there. Loop is generating ~85% CPU on my dualcore Intel P8600.
What is causing the deadlock: Well, technically, it might not be a deadlock but it looks it is. Draw() is returning immediately because firstFrame is the wrong value because Loading.Complete is false. The CPU load is just Update().
What this fix does: When Loading.Cancel becomes true, LoadingScreenLoops calls Close() on the window. This fixes the deadlock.
PS: do you know where to find trainscript train plugin? OdakyUfan's web is down and google didn't find anything useful at the first glance. Alstom Metropolis requires it and I don't have it, so it throws an exception.