### PR TITLE
Crop the in-game route map image to actually used area

### DIFF
--- a/openBVE/OpenBve/Game/RouteInfoOverlay.cs
+++ b/openBVE/OpenBve/Game/RouteInfoOverlay.cs
@@ -36,7 +36,9 @@ namespace OpenBve
 		//
 		private state				currentState	= state.none;
 		private Textures.Texture	gradientImage	= null;
+		private Size				gradientSize;
 		private Textures.Texture	mapImage		= null;
+		private Size				mapSize;
 
 		//
 		// C'TOR
@@ -76,15 +78,13 @@ namespace OpenBve
 			// NO: compressing the image below its original size makes texs hard to read
 //			int		width		= Math.Min(Math.Min(Screen.Height, Screen.Width) / 2,
 //						Game.RouteInformation.DefaultRouteInfoSize);
-			int		width		= Game.RouteInformation.DefaultRouteInfoSize;
 			Point	origin		= new Point(0, 0);
-			Size	size		= new Size(width, width);
 			GL.Color4(1.0f, 1.0f, 1.0f, 1.0f);
 			// draw the relevant image
 			switch (currentState)
 			{
 			case state.map:
-				Renderer.DrawRectangle(mapImage, origin, size, null);
+				Renderer.DrawRectangle(mapImage, origin, mapSize, null);
 				// get current train position
 				int n = TrainManager.Trains.Length;
 				for (i = 0; i < n; i++)
@@ -92,9 +92,9 @@ namespace OpenBve
 					trainX = (int)TrainManager.Trains[i].Cars[0].FrontAxle.Follower.WorldPosition.X;
 					trainZ = (int)TrainManager.Trains[i].Cars[0].FrontAxle.Follower.WorldPosition.Z;
 					// convert to route map coordinates
-					xPos = width * (trainX - Game.RouteInformation.RouteMinX) /
+					xPos = mapSize.Width * (trainX - Game.RouteInformation.RouteMinX) /
 							(Game.RouteInformation.RouteMaxX - Game.RouteInformation.RouteMinX) - trainDotRadius;
-					zPos = width - width * (trainZ - Game.RouteInformation.RouteMinZ) /
+					zPos = mapSize.Height - mapSize.Height * (trainZ - Game.RouteInformation.RouteMinZ) /
 							(Game.RouteInformation.RouteMaxZ - Game.RouteInformation.RouteMinZ) - trainDotRadius;
 					// draw a dot at current train position
 					Renderer.DrawRectangle(null, new Point(xPos, zPos),
@@ -103,17 +103,17 @@ namespace OpenBve
 				}
 				break;
 			case state.gradient:
-				Renderer.DrawRectangle(gradientImage, origin, size, null);
+				Renderer.DrawRectangle(gradientImage, origin, gradientSize, null);
 				// get current train position in track
 				int trackPos	= (int)(TrainManager.PlayerTrain.Cars[0].FrontAxle.Follower.TrackPosition
 						- TrainManager.PlayerTrain.Cars[0].FrontAxlePosition
 					+ 0.5 * TrainManager.PlayerTrain.Cars[0].Length);
 				// convert to gradient profile offset
-				xPos = width * (trackPos - Game.RouteInformation.GradientMinTrack) /
+				xPos = gradientSize.Width * (trackPos - Game.RouteInformation.GradientMinTrack) /
 						(Game.RouteInformation.GradientMaxTrack - Game.RouteInformation.GradientMinTrack);
 				// draw a vertical bar at the current train position
-				Renderer.DrawRectangle(null, new Point(xPos, width / 2),
-					new Size(gradientPosWidth, width / 2), gradientPosBar);
+				Renderer.DrawRectangle(null, new Point(xPos, gradientSize.Height / 2),
+					new Size(gradientPosWidth, gradientSize.Height / 2), gradientPosBar);
 				break;
 			}
 		}
@@ -140,11 +140,17 @@ namespace OpenBve
 			{
 			case state.map:
 				if (mapImage == null)
-					mapImage = new Textures.Texture(Game.RouteInformation.RouteMap);
+				{
+					mapImage	= new Textures.Texture(Game.RouteInformation.RouteMap);
+					mapSize		= Game.RouteInformation.RouteMap.Size;
+				}
 				break;
 			case state.gradient:
 				if (gradientImage == null)
-					gradientImage = new Textures.Texture(Game.RouteInformation.GradientProfile);
+				{
+					gradientImage	= new Textures.Texture(Game.RouteInformation.GradientProfile);
+					gradientSize	= Game.RouteInformation.GradientProfile.Size;
+				}
 				break;
 			}
 			currentState	= newState;

--- a/openBVE/OpenBve/System/Functions/Illustrations.cs
+++ b/openBVE/OpenBve/System/Functions/Illustrations.cs
@@ -8,6 +8,8 @@ namespace OpenBve {
 		private const double	TopPad			= 8.0;
 		private const double	RightPad		= 8.0;
 		private const double	BottomPad		= 8.0;
+		private const int		TrackOffDist	= 48;		// the distance in pixels between track offset labels
+		private const double	TrackOffY		= 6.0;		// distance from bottom of track offset labels
 		private const double	TrackOffsPad	= 16.0;		// how much space to leave for track offsets
 															// at the bottom of the gradient profile
 		private const float		StationRadius	= 4.0f;
@@ -55,9 +57,6 @@ namespace OpenBve {
 							actNameFill=Brushes.Black,		inactNameFill=Brushes.Gray,
 							actNameBrdr=Pens.White,			inactNameBrdr=Pens.LightGray,
 							actNameText=Brushes.White,		inactNameText=Brushes.LightGray,
-// a previous attempt at colours:
-//							belowSeaFill= new SolidBrush(Color.FromArgb(0x7fdaa520)),	belowSeaBrdr=Pens.Gray,
-//							elevFill= new SolidBrush(Color.FromArgb(0x7f8b0000)),		elevBrdr=Pens.Gray}
 							belowSeaFill= new SolidBrush(Color.FromArgb(0x7feee8aa)),	belowSeaBrdr=Pens.Gray,
 							elevFill= new SolidBrush(Color.FromArgb(0x7fd2b48c)),		elevBrdr=Pens.Gray}
 		};
@@ -83,26 +82,8 @@ namespace OpenBve {
 		/// <param name="inGame"><c>true</c> = bitmap for in-game overlay | <c>false<c> = for standard window.</param>
 		internal static Bitmap CreateRouteMap(int Width, int Height, bool inGame)
 		{
-			// find first and last used element based on stations
-			int n = TrackManager.CurrentTrack.Elements.Length;
-			int n0 = n - 1;
-			int n1 = 0;
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++)
-			{
-				for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
-				{
-					if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
-					{
-						if (i < n0) n0 = i;
-						if (i > n1) n1 = i;
-					}
-				}
-			}
-			n0 -= 4;
-			n1 += 8;
-			if (n0 < 0) n0 = 0;
-			if (n1 >= TrackManager.CurrentTrack.Elements.Length) n1 = TrackManager.CurrentTrack.Elements.Length - 1;
-			if (n1 <= n0) n1 = n0 + 1;
+			int n, n0, n1;
+			RouteRange(out n, out n0, out n1);
 			// find dimensions
 			double x0 = double.PositiveInfinity, z0 = double.PositiveInfinity;
 			double x1 = double.NegativeInfinity, z1 = double.NegativeInfinity;
@@ -115,32 +96,41 @@ namespace OpenBve {
 				if (z < z0) z0 = z;
 				if (z > z1) z1 = z;
 			}
+			// avoid 0 or negative height or width
 			if (x0 >= x1 - 1.0) x0 = x1 - 1.0;
 			if (z0 >= z1 - 1.0) z0 = z1 - 1.0;
+			// remember area occupied so far
+			double xMin, xMax, zMin, zMax;			// used to track the bitmap area actually occupied by drawings
+			xMin = x0;
+			xMax = x1;
+			zMin = z1;								// bitmap z goes down, while world z goes up
+			zMax = z0;
+			// fit route w/h ratio in image w/h ratio
 			double wrh = (double)Width / (double)Height;
-			if ((x1 - x0) / (z1 - z0) <= wrh)
+			if ((x1 - x0) / (z1 - z0) <= wrh)		// if route ratio is taller than bitmap ratio
 			{
-				double dx = 0.5 * (z1 - z0) * wrh;
-				double px = 0.5 * (x0 + x1);
-				x0 = px - dx;
+				double dx = 0.5 * (z1 - z0) * wrh;	//	scale (half of) x range as much as (half of) z range
+				double px = 0.5 * (x0 + x1);		//	x range mid point
+				x0 = px - dx;						//	centre scaled x range around mid point
 				x1 = px + dx;
-			} else
-			{
+			} else									// if route ratio is wider than bitmap ratio
+			{										//	do the opposite (scale z range on x)
 				double dz = 0.5 * (x1 - x0) / wrh;
 				double pz = 0.5 * (z0 + z1);
 				z0 = pz - dz;
 				z1 = pz + dz;
 			}
-			double xd = 1.0 / (x1 - x0);
-			double zd = 1.0 / (z1 - z0);
 			double ox = LeftPad, oy = TopPad;
 			double w = (double)(Width - (LeftPad+RightPad));
 			double h = (double)(Height- (TopPad+BottomPad));
-			//set total bitmap X and Z ranges
-			lastRouteMinX = (int)(x0 - ox * (x1 - x0) / w);
-			lastRouteMaxX = (int)(x1 + (Width - w - ox) * (x1 - x0) / w);
-			lastRouteMinZ = (int)(z0 - oy * (z1 - z0) / h);
-			lastRouteMaxZ = (int)(z1 + (Height- h - oy) * (z1 - z0) / h);
+			// horizontal and vertical scales
+			double xd = w / (x1 - x0);
+			double zd = h / (z1 - z0);
+			// convert bitmap occupied area from world to bitmap coordinates
+			xMin = ox + (xMin - x0) * xd;
+			xMax = ox + (xMax - x0) * xd;
+			zMin = oy + (z0 - zMin) * zd + h;
+			zMax = oy + (z0 - zMax) * zd + h;
 			// create bitmap
 			int		mode = inGame ? 1 : 0;
 			Bitmap b = new Bitmap(Width, Height, inGame ? System.Drawing.Imaging.PixelFormat.Format32bppArgb
@@ -149,29 +139,38 @@ namespace OpenBve {
 			g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
 			g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
 			g.Clear(mapColors[mode].background);
-			// draw route path
+
+			// ROUTE PATH
 			{
 				int start = 0;
 				bool atc = false;
+				n = n1 - n0 + 1;
 				PointF[] p = new PointF[n];
-				for (int i = 0; i < n; i++) {
-					double x = TrackManager.CurrentTrack.Elements[i].WorldPosition.X;
-					double z = TrackManager.CurrentTrack.Elements[i].WorldPosition.Z;
-					x = ox + w * (x - x0) * xd;
-					z = oy + h * (z0 - z) * zd + h;
+				for (int i = 0; i < n; i++)
+				{
+					double x = TrackManager.CurrentTrack.Elements[i+n0].WorldPosition.X;
+					double z = TrackManager.CurrentTrack.Elements[i+n0].WorldPosition.Z;
+					x = ox + (x - x0) * xd;
+					z = oy + (z0 - z) * zd + h;
 					p[i] = new PointF((float)x, (float)z);
-					// ats/atc
-					for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
+					// ATS / ATC
+					// for each track element, look for a StationStartEvent
+					for (int j = 0; j < TrackManager.CurrentTrack.Elements[i+n0].Events.Length; j++)
 					{
-						if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
+						if (TrackManager.CurrentTrack.Elements[i+n0].Events[j] is TrackManager.StationStartEvent)
 						{
-							TrackManager.StationStartEvent e = (TrackManager.StationStartEvent)TrackManager.CurrentTrack.Elements[i].Events[j];
+							TrackManager.StationStartEvent e =
+								(TrackManager.StationStartEvent)TrackManager.CurrentTrack.Elements[i+n0].Events[j];
+							// if StationStartEvent found, look for a change in ATS/ATC control;
+							// if there is a change, draw all previous track elements
+							// with colour for the previous control state
 							if (Game.Stations[e.StationIndex].SafetySystem == Game.SafetySystem.Atc)
 							{
 								if (!atc)
 								{
 									atc = true;
-									if (i - start - 1 > 0) g.DrawCurve(mapColors[mode].normalMap, p, start, i - start - 1);
+									if (i - start - 1 > 0)
+										g.DrawCurve(mapColors[mode].normalMap, p, start, i - start - 1);
 									start = i;
 								}
 							} else
@@ -179,17 +178,21 @@ namespace OpenBve {
 								if (atc)
 								{
 									atc = false;
-									if (i - start - 1 > 0) g.DrawCurve(mapColors[mode].atcMap, p, start, i - start - 1);
+									if (i - start - 1 > 0)
+										g.DrawCurve(mapColors[mode].atcMap, p, start, i - start - 1);
 									start = i;
 								}
 							}
+							break;
 						}
 					}
 				}
+				// draw all remaining track element not drawn yet
 				DrawSegmentedCurve(g, atc ? mapColors[mode].atcMap : mapColors[mode].normalMap, p, start, n - start - 1);
 			}
-			// draw station circles
-			for (int i = 0; i < n; i++)
+
+			// STATION ICONS
+			for (int i = n0; i <= n1; i++)
 			{
 				for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
 				{
@@ -200,23 +203,33 @@ namespace OpenBve {
 						{
 							double x = TrackManager.CurrentTrack.Elements[i].WorldPosition.X;
 							double y = TrackManager.CurrentTrack.Elements[i].WorldPosition.Z;
-							x = ox + w * (x - x0) * xd;
-							y = oy + h + h * zd * (z0 - y);
+							x = ox + (x - x0) * xd;
+							y = oy + (z0 - y) * zd + h;
 							// station circle
 							RectangleF r = new RectangleF((float)x - StationRadius, (float)y - StationRadius,
 								StationDiameter, StationDiameter);
 							bool q = Game.PlayerStopsAtStation(e.StationIndex);
 							g.FillEllipse(q ? mapColors[mode].actStatnFill : mapColors[mode].inactStatnFill, r);
 							g.DrawEllipse(q ? mapColors[mode].actStatnBrdr : mapColors[mode].inactStatnBrdr, r);
+							// adjust bitmap occupied area
+							if (r.Left < xMin)
+								xMin = r.Left;
+							if (r.Top  < zMin)
+								zMin = r.Top;
+							if (r.Right > xMax)
+								xMax = r.Right;
+							if (r.Bottom > zMax)
+								zMax = r.Bottom;
 						}
 					}
 				}
 			}
-			// draw station names
+
+			// STATION NAMES
 			{
 				double wh = w * h;
 				Font f = new Font(FontFamily.GenericSansSerif, wh < 65536.0 ? 9.0f : 10.0f, GraphicsUnit.Pixel);
-				for (int i = 0; i < n; i++)
+				for (int i = n0; i <= n1; i++)
 				{
 					for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
 					{
@@ -227,8 +240,8 @@ namespace OpenBve {
 							{
 								double x = TrackManager.CurrentTrack.Elements[i].WorldPosition.X;
 								double y = TrackManager.CurrentTrack.Elements[i].WorldPosition.Z;
-								x = ox + w * (x - x0) * xd;
-								y = oy + h + h * zd * (z0 - y);
+								x = ox + (x - x0) * xd;
+								y = oy + (z0 - y) * zd + h;
 								RectangleF r = new RectangleF((float)x - StationRadius, (float)y - StationRadius,
 									StationDiameter, StationDiameter);
 								bool stop = Game.PlayerStopsAtStation(e.StationIndex);
@@ -268,35 +281,66 @@ namespace OpenBve {
 										yt = y + StationTextPad;
 									}
 								}
+								// constrain text within bitmap edges (taking into account also paddings)
 								if (xt < ox)
-								{
 									xt = ox;
-								}
 								else if (xt + m.Width > w)
-								{
 									xt = w - m.Width;
-								}
 								if (yt < oy)
-								{
 									yt = oy;
-								}
 								else if (yt + m.Height > h)
-								{
 									yt = h - m.Height;
-								}
-								r = new RectangleF((float)xt, (float)yt, m.Width, m.Height);
+								r = new RectangleF((float)xt - 1.0f, (float)yt - 1.0f, m.Width + 2.0f, m.Height + 2.0f);
 								g.FillRectangle(stop ? mapColors[mode].actNameFill : mapColors[mode].inactNameFill,
-									r.Left - 1.0f, r.Top - 1.0f, r.Width + 2.0f, r.Height + 2.0f);
+									r.Left, r.Top, r.Width, r.Height);
 								g.DrawRectangle(stop ? mapColors[mode].actNameBrdr : mapColors[mode].inactNameBrdr,
-									r.Left - 1.0f, r.Top - 1.0f, r.Width + 2.0f, r.Height + 2.0f);
+									r.Left, r.Top, r.Width, r.Height);
 								g.DrawString(t, f, stop ? mapColors[mode].actNameText : mapColors[mode].inactNameText,
 									(float)xt, (float)yt);
+								// adjust bitmap occupied area
+								if (r.Left < xMin)
+									xMin = r.Left;
+								if (r.Top  < zMin)
+									zMin = r.Top;
+								if (r.Right > xMax)
+									xMax = r.Right;
+								if (r.Bottom > zMax)
+									zMax = r.Bottom;
 							}
 						}
 					}
 				}
 			}
-			// finalize
+			// if in-game, trim unused parts of the bitmap
+			if (inGame)
+			{
+				xMin -= LeftPad;
+				xMax += RightPad;
+				zMin -= TopPad;
+				zMax += BottomPad;
+				if (xMin < 0)
+					xMin = 0;
+				if (xMax >= Width)
+					xMax = Width - 1;
+				if (zMin < 0)
+					zMin = 0;
+				if (zMax >= Height)
+					zMax = Height - 1;
+				Bitmap nb = new Bitmap((int)(xMax - xMin + 1.0), (int)(zMax - zMin + 1.0));	// round up
+				g = Graphics.FromImage(nb);
+				g.DrawImage(b, (int)-xMin, (int)-zMin);										// round down
+				// set total bitmap world X and Z ranges from bitmap ranges
+				lastRouteMinX = (int)((xMin - ox) / xd + x0);
+				lastRouteMaxX = (int)((xMax - ox) / xd + x0);
+				lastRouteMinZ = (int)(z0 - (zMax - oy - h) / zd);
+				lastRouteMaxZ = (int)(z0 - (zMin - oy - h) / zd);
+				return nb;
+			}
+			//set total bitmap X and Z ranges
+			lastRouteMinX = (int)(x0 - ox * (x1 - x0) / w);
+			lastRouteMaxX = (int)(x1 + (Width - w - ox) * (x1 - x0) / w);
+			lastRouteMinZ = (int)(z0 - oy * (z1 - z0) / h);
+			lastRouteMaxZ = (int)(z1 + (Height- h - oy) * (z1 - z0) / h);
 			return b;
 		}
 
@@ -312,32 +356,11 @@ namespace OpenBve {
 		{
 			// Track elements are assumed to be all of the same length, and this length
 			// is used as measure unit, rather than computing the incremental track length
-			// in any 'real world' unut (like m).
+			// in any 'real world' unit (like m).
 
 			// HORIZONTAL RANGE: find first and last used element based on stations
-			int n = TrackManager.CurrentTrack.Elements.Length;
-			int n0 = n - 1;
-			int n1 = 0;
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++)
-			{
-				for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
-				{
-					if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
-					{
-						if (i < n0) n0 = i;
-						if (i > n1) n1 = i;
-					}
-				}
-			}
-			// Allow for 4 track units before first station and 8 track units after the last one
-			n0 -= 4;
-			n1 += 8;
-			// But not outside of actual track element array!
-			if (n0 < 0) n0 = 0;
-			if (n1 >= TrackManager.CurrentTrack.Elements.Length)
-				n1 = TrackManager.CurrentTrack.Elements.Length - 1;
-			if (n1 <= n0)		// neither a 0-length or 'negative' track!
-				n1 = n0 + 1;
+			int n, n0, n1;
+			RouteRange(out n, out n0, out n1);
 			// VERTICAL RANGE
 			double y0 = double.PositiveInfinity, y1 = double.NegativeInfinity;
 			for (int i = n0; i <= n1; i++)
@@ -349,12 +372,13 @@ namespace OpenBve {
 			if (y0 >= y1 - 1.0)
 				y0 = y1 - 1.0;
 
-			double nd = 1.0 / (double)(n1 - n0);	// horizontal scale
-			double yd = 1.0 / (double)(y1 - y0);	// vertical scale
 			// allow for some padding around actual data
 			double ox = LeftPad, oy = TopPad;
 			double w = (double)(Width - (LeftPad+RightPad));
 			double h = (double)(Height - (TopPad+BottomPad+TrackOffsPad));
+			// horizontal and vertical scale
+			double nd = w / (double)(n1 - n0);
+			double yd = h / (double)(y1 - y0);
 			// set total bitmap track position range; used by in-game profile to place
 			// the current position of the trains; as the train positions are known as track positions,
 			// actual track positions are needed here, rather than indices into the track element array.
@@ -373,35 +397,38 @@ namespace OpenBve {
 			g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
 			int mode = inGame ? 1 : 0;
 			g.Clear(mapColors[mode].background);
-			// draw below sea level
+
+			// BELOW SEA LEVEL
 			{
-				double y = oy + h * (1.0 - 0.5 * (double)(-Game.RouteInitialElevation - y0) * yd);
-				double x0 = ox - w * (double)(n0) * nd;
-				double x1 = ox + w * (double)(n - n0) * nd;
+				double y = oy + (h - 0.5 * (double)(-Game.RouteInitialElevation - y0) * yd);
+				double x0 = ox - (double)(0) * nd;
+				double x1 = ox + (double)(n1 - n0) * nd;
 				g.FillRectangle(mapColors[mode].belowSeaFill, (float)x0, (float)y, (float)x1, (float)(oy + h) - (float)y);
 				g.DrawLine(mapColors[mode].belowSeaBrdr, (float)x0, (float)y, (float)x1, (float)y);
 			}
-			// draw route gradient profile
+			// GRADIENT PROFILE
 			{
+				n = n1 - n0 + 1;
 				PointF[] p = new PointF[n + 2];
-				p[0] = new PointF((float)(ox - w * (double)n0 * nd), (float)(oy + h));
-				for (int i = 0; i < n; i++)
+				p[0] = new PointF((float)ox, (float)(oy + h));
+				for (int i = n0; i <= n1; i++)
 				{
-					double x = ox + w * (double)(i - n0) * nd;
-					double y = oy + h * (1.0 - 0.5 * (double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
-					p[i + 1] = new PointF((float)x, (float)y);
+					double x = ox + (double)(i - n0) * nd;
+					double y = oy + (h - 0.5 *
+						(double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
+					p[i -n0 + 1] = new PointF((float)x, (float)y);
 				}
-				p[n + 1] = new PointF((float)(ox + w * (double)(n - n0 - 1) * nd), (float)(oy + h));
+				p[n + 1] = new PointF((float)(ox + (double)(n - 1) * nd), (float)(oy + h));
 				g.FillPolygon(mapColors[mode].elevFill, p);
 				for (int i = 1; i < n; i++)
 					g.DrawLine(mapColors[mode].elevBrdr, p[i], p[i + 1]);
 				g.DrawLine(mapColors[mode].elevBrdr, 0.0f, (float)(oy + h), (float)Width, (float)(oy + h));
 			}
-			// draw station names
+			// STATION NAMES
 			{
 				Font f = new Font(FontFamily.GenericSansSerif, 12.0f, GraphicsUnit.Pixel);
 				StringFormat m = new StringFormat();
-				for (int i = 0; i < n; i++)
+				for (int i = n0; i <= n1; i++)
 				{
 					for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
 					{
@@ -415,8 +442,9 @@ namespace OpenBve {
 								{
 									m.Alignment = StringAlignment.Near;
 									m.LineAlignment = StringAlignment.Near;
-									double x = ox + w * (double)(i - n0) * nd;
-									double y = oy + h * (1.0 - 0.5 * (double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
+									double x = ox + (double)(i - n0) * nd;
+									double y = oy + (h - 0.5 *
+										(double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
 									string t = Game.Stations[e.StationIndex].Name;
 									float tx = 0.0f, ty = (float)oy;
 									for (int k = 0; k < t.Length; k++)
@@ -438,8 +466,9 @@ namespace OpenBve {
 								{
 									m.Alignment = StringAlignment.Far;
 									m.LineAlignment = StringAlignment.Near;
-									double x = ox + w * (double)(i - n0) * nd;
-									double y = oy + h * (1.0 - 0.5 * (double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
+									double x = ox + (double)(i - n0) * nd;
+									double y = oy + (h - 0.5 *
+										(double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd);
 									g.RotateTransform(-90.0f);
 									g.TranslateTransform((float)x, (float)oy, System.Drawing.Drawing2D.MatrixOrder.Append);
 									g.DrawString(Game.Stations[e.StationIndex].Name, f,
@@ -455,7 +484,7 @@ namespace OpenBve {
 					}
 				}
 			}
-			// draw route markers
+			// ROUTE MARKERS
 			{
 				Font f = new Font(FontFamily.GenericSansSerif, 10.0f, GraphicsUnit.Pixel);
 				Font fs = new Font(FontFamily.GenericSansSerif, 9.0f, GraphicsUnit.Pixel);
@@ -465,18 +494,20 @@ namespace OpenBve {
 					LineAlignment = StringAlignment.Center
 				};
 				System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
-				int k = 48 * n / Width;
-				for (int i = 0; i < n; i += k)
+				int k = TrackOffDist * n / Width;
+				for (int i = n0; i <= n1; i += k)
 				{
-					double x = ox + w * (double)(i - n0) * nd;
+					double x = ox + (double)(i - n0) * nd;
 					double y = (double)(TrackManager.CurrentTrack.Elements[i].WorldPosition.Y - y0) * yd;
+					// track offset label
 					if (x < w)
 					{
 						string t = ((int)Math.Round(TrackManager.CurrentTrack.Elements[i].StartingTrackPosition)).ToString(Culture);
-						g.DrawString(t + "m", f, mapColors[mode].actNameText, (float)x, (float)(oy + h + 6.0));
+						g.DrawString(t + "m", f, mapColors[mode].actNameText, (float)x, (float)(oy + h + TrackOffY));
 					}
+					// route height at track offset (with measure and vertical line)
 					{
-						y = oy + h * (1.0 - 0.5 * y) + 2.0f;
+						y = oy + (h - 0.5 * y) + 2.0f;
 						string t = ((int)Math.Round(Game.RouteInitialElevation + TrackManager.CurrentTrack.Elements[i].WorldPosition.Y)).ToString(Culture);
 						SizeF s = g.MeasureString(t, fs);
 						if (y < oy + h - (double)s.Width - 10.0)
@@ -505,6 +536,42 @@ namespace OpenBve {
 				if (m > Count) m = Count;
 				Graphics.DrawCurve(Pen, Points, k, m);
 			}
+		}
+
+		//
+		// FIND USED ROUTE RANGE
+		//
+		/// <summary>Finds the route range actually used by stations (with some margin before and after.</summary>
+		/// <param name="n">Route total number of elements</param>
+		/// <param name="n0">First element in used range</param>
+		/// <param name="n1">Last element in used range</param>
+		private static void RouteRange(out int n, out int n0, out int n1)
+		{
+			// find first and last track element actually used by stations
+			n	= TrackManager.CurrentTrack.Elements.Length;
+			n0	= n - 1;
+			n1	= 0;
+			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++)
+			{
+				for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
+				{
+					if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
+					{
+						if (i < n0) n0 = i;
+						if (i > n1) n1 = i;
+						break;
+					}
+				}
+			}
+			// Allow for 4 track units before first station and 8 track units after the last one
+			n0 -= 4;
+			n1 += 8;
+			// But not outside of actual track element array!
+			if (n0 < 0) n0 = 0;
+			if (n1 >= TrackManager.CurrentTrack.Elements.Length)
+				n1 = TrackManager.CurrentTrack.Elements.Length - 1;
+			if (n1 <= n0)		// neither a 0-length or 'negative' track!
+				n1 = n0 + 1;
 		}
 
 	}


### PR DESCRIPTION
- The in-game image of the route map is now cropped removing unused areas at the edges. This reduces, if possible, the portion of screen covered by the map.
- The map image for the main menu is not cropped, though.

In addition:
- For both route map and gradient profile, only the part of route initially considered relevant (from the first to the last station) is scanned and plotted; this ensures padding are (more) respected.
- Factored out a routine used by both images.
- Streamlined a few calculations,
- Added more comments.

Sample screen-shot showing a horizontally cropped map:
![cropped_map_00](https://cloud.githubusercontent.com/assets/1420743/13812440/749cd20e-eb7c-11e5-9432-90bc9421fd86.png)
