### PR TITLE
Main form tweaked

### DIFF
--- a/openBVE/OpenBve/UserInterface/formMain.Start.cs
+++ b/openBVE/OpenBve/UserInterface/formMain.Start.cs
@@ -435,6 +435,7 @@ namespace OpenBve {
 				if (System.IO.File.Exists(Result.RouteFile) & System.IO.Directory.Exists(Result.TrainFolder)) {
 					Result.Start = true;
 					this.Close();
+					this.Dispose();
 				}
 			} else {
 				System.Media.SystemSounds.Exclamation.Play();


### PR DESCRIPTION
The main form could become stuck in the background and would not close correctly when starting a route under Mono/Linux.