### PR TITLE
Cycle.Rail support

### DIFF
--- a/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -128,12 +128,17 @@ namespace OpenBve {
 			internal double Roll;
 			internal string Text;
 		}
-		private class Block {
+        private struct RailCycle {
+            internal int RailCycleIndex;
+            internal int CurrentCycle;
+        }
+        private class Block {
 			internal int Background;
 			internal Brightness[] Brightness;
 			internal Game.Fog Fog;
 			internal bool FogDefined;
 			internal int[] Cycle;
+			internal RailCycle[] RailCycle;
 			internal double Height;
 			internal Rail[] Rail;
 			internal int[] RailType;
@@ -180,7 +185,8 @@ namespace OpenBve {
 			internal ObjectManager.UnifiedObject[] FreeObj;
 			internal ObjectManager.UnifiedObject[] Beacon;
 			internal int[][] Cycle;
-			internal int[] Run;
+			internal int[][] RailCycle;
+            internal int[] Run;
 			internal int[] Flange;
 		}
 		private abstract class SignalData { }
@@ -240,13 +246,15 @@ namespace OpenBve {
 			Data.Blocks[0].Accuracy = 2.0;
 			Data.Blocks[0].AdhesionMultiplier = 1.0;
 			Data.Blocks[0].CurrentTrackState = new TrackManager.TrackElement(0.0);
-			if (!PreviewOnly) {
-				Data.Blocks[0].Background = 0;
-				Data.Blocks[0].Brightness = new Brightness[] { };
-				Data.Blocks[0].Fog.Start = Game.NoFogStart;
-				Data.Blocks[0].Fog.End = Game.NoFogEnd;
-				Data.Blocks[0].Fog.Color = new World.ColorRGB(128, 128, 128);
-				Data.Blocks[0].Cycle = new int[] { -1 };
+            if (!PreviewOnly) {
+                Data.Blocks[0].Background = 0;
+                Data.Blocks[0].Brightness = new Brightness[] { };
+                Data.Blocks[0].Fog.Start = Game.NoFogStart;
+                Data.Blocks[0].Fog.End = Game.NoFogEnd;
+                Data.Blocks[0].Fog.Color = new World.ColorRGB(128, 128, 128);
+                Data.Blocks[0].Cycle = new int[] { -1 };
+                Data.Blocks[0].RailCycle = new RailCycle[1];
+                Data.Blocks[0].RailCycle[0].RailCycleIndex = -1;
 				Data.Blocks[0].Height = IsRW ? 0.3 : 0.0;
 				Data.Blocks[0].RailFreeObj = new FreeObj[][] { };
 				Data.Blocks[0].GroundFreeObj = new FreeObj[] { };
@@ -292,7 +300,8 @@ namespace OpenBve {
 				Data.Structure.FreeObj = new ObjectManager.UnifiedObject[] { };
 				Data.Structure.Beacon = new ObjectManager.UnifiedObject[] { };
 				Data.Structure.Cycle = new int[][] { };
-				Data.Structure.Run = new int[] { };
+				Data.Structure.RailCycle = new int[][] { };
+                Data.Structure.Run = new int[] { };
 				Data.Structure.Flange = new int[] { };
 				Data.Backgrounds = new World.Background[] { };
 				Data.TimetableDaytime = new int[] { -1, -1, -1, -1 };
@@ -2592,6 +2601,31 @@ namespace OpenBve {
 											Data.Structure.Cycle[CommandIndex1][k] = ix;
 										}
 									} break;
+									// rail cycle
+								case "cycle.rail":
+									if (!PreviewOnly)
+									{
+										if (CommandIndex1 >= Data.Structure.RailCycle.Length)
+										{
+											Array.Resize<int[]>(ref Data.Structure.RailCycle, CommandIndex1 + 1);
+                                        }
+										Data.Structure.RailCycle[CommandIndex1] = new int[Arguments.Length];
+                                        for (int k = 0; k < Arguments.Length; k++)
+										{
+											int ix = 0;
+											if (Arguments[k].Length > 0 && !Interface.TryParseIntVb6(Arguments[k], out ix))
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex" + (k + 1).ToString(Culture) + " is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												ix = 0;
+											}
+											if (ix < 0 | ix >= Data.Structure.Rail.Length)
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex" + (k + 1).ToString(Culture) + " is out of range in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												ix = 0;
+											}
+											Data.Structure.RailCycle[CommandIndex1][k] = ix;
+										}
+									} break;
 							}
 						}
 					}
@@ -2819,6 +2853,7 @@ namespace OpenBve {
 								case "texture.background.x":
 								case "texture.background.aspect":
 								case "cycle.ground":
+								case "cycle.rail":
 								case "route.loadingscreen":
 								case "route.displayspeed":
 									break;
@@ -2842,57 +2877,86 @@ namespace OpenBve {
 												}
 												if (Data.Blocks[BlockIndex].Rail.Length <= idx) {
 													Array.Resize<Rail>(ref Data.Blocks[BlockIndex].Rail, idx + 1);
-												}
+                                                    Array.Resize<RailCycle>(ref Data.Blocks[BlockIndex].RailCycle, idx + 1);
+                                                    for (int rc = 0; rc < Data.Blocks[BlockIndex].RailCycle.Length; rc++)
+                                                    {
+                                                        Data.Blocks[BlockIndex].RailCycle[rc].RailCycleIndex = -1;
+                                                    }
+                                                }
 												if (Data.Blocks[BlockIndex].Rail[idx].RailStartRefreshed) {
 													Data.Blocks[BlockIndex].Rail[idx].RailEnd = true;
 												}
-												{
-													Data.Blocks[BlockIndex].Rail[idx].RailStart = true;
-													Data.Blocks[BlockIndex].Rail[idx].RailStartRefreshed = true;
-													if (Arguments.Length >= 2) {
-														if (Arguments[1].Length > 0) {
-															double x;
-															if (!Interface.TryParseDoubleVb6(Arguments[1], UnitOfLength, out x)) {
-																Interface.AddMessage(Interface.MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																x = 0.0;
-															}
-															Data.Blocks[BlockIndex].Rail[idx].RailStartX = x;
-														}
-														if (!Data.Blocks[BlockIndex].Rail[idx].RailEnd) {
-															Data.Blocks[BlockIndex].Rail[idx].RailEndX = Data.Blocks[BlockIndex].Rail[idx].RailStartX;
-														}
-													}
-													if (Arguments.Length >= 3) {
-														if (Arguments[2].Length > 0) {
-															double y;
-															if (!Interface.TryParseDoubleVb6(Arguments[2], UnitOfLength, out y)) {
-																Interface.AddMessage(Interface.MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																y = 0.0;
-															}
-															Data.Blocks[BlockIndex].Rail[idx].RailStartY = y;
-														}
-														if (!Data.Blocks[BlockIndex].Rail[idx].RailEnd) {
-															Data.Blocks[BlockIndex].Rail[idx].RailEndY = Data.Blocks[BlockIndex].Rail[idx].RailStartY;
-														}
-													}
-													if (Data.Blocks[BlockIndex].RailType.Length <= idx) {
-														Array.Resize<int>(ref Data.Blocks[BlockIndex].RailType, idx + 1);
-													}
-													if (Arguments.Length >= 4 && Arguments[3].Length != 0) {
-														int sttype;
-														if (!Interface.TryParseIntVb6(Arguments[3], out sttype)) {
-															Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-															sttype = 0;
-														}
-														if (sttype < 0) {
-															Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-														} else if (sttype >= Data.Structure.Rail.Length || Data.Structure.Rail[sttype] == null) {
-															Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex" + sttype + " references an object not loaded in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-														} else {
-															Data.Blocks[BlockIndex].RailType[idx] = sttype;
-														}
-													}
-												}
+                                                {
+                                                    Data.Blocks[BlockIndex].Rail[idx].RailStart = true;
+                                                    Data.Blocks[BlockIndex].Rail[idx].RailStartRefreshed = true;
+                                                    if (Arguments.Length >= 2)
+                                                    {
+                                                        if (Arguments[1].Length > 0)
+                                                        {
+                                                            double x;
+                                                            if (!Interface.TryParseDoubleVb6(Arguments[1], UnitOfLength, out x))
+                                                            {
+                                                                Interface.AddMessage(Interface.MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+                                                                x = 0.0;
+                                                            }
+                                                            Data.Blocks[BlockIndex].Rail[idx].RailStartX = x;
+                                                        }
+                                                        if (!Data.Blocks[BlockIndex].Rail[idx].RailEnd)
+                                                        {
+                                                            Data.Blocks[BlockIndex].Rail[idx].RailEndX = Data.Blocks[BlockIndex].Rail[idx].RailStartX;
+                                                        }
+                                                    }
+                                                    if (Arguments.Length >= 3)
+                                                    {
+                                                        if (Arguments[2].Length > 0)
+                                                        {
+                                                            double y;
+                                                            if (!Interface.TryParseDoubleVb6(Arguments[2], UnitOfLength, out y))
+                                                            {
+                                                                Interface.AddMessage(Interface.MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+                                                                y = 0.0;
+                                                            }
+                                                            Data.Blocks[BlockIndex].Rail[idx].RailStartY = y;
+                                                        }
+                                                        if (!Data.Blocks[BlockIndex].Rail[idx].RailEnd)
+                                                        {
+                                                            Data.Blocks[BlockIndex].Rail[idx].RailEndY = Data.Blocks[BlockIndex].Rail[idx].RailStartY;
+                                                        }
+                                                    }
+                                                    if (Data.Blocks[BlockIndex].RailType.Length <= idx)
+                                                    {
+                                                        Array.Resize<int>(ref Data.Blocks[BlockIndex].RailType, idx + 1);
+                                                    }
+                                                    if (Arguments.Length >= 4 && Arguments[3].Length != 0)
+                                                    {
+                                                        int sttype;
+                                                        if (!Interface.TryParseIntVb6(Arguments[3], out sttype))
+                                                        {
+                                                            Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+                                                            sttype = 0;
+                                                        }
+                                                        if (sttype < 0)
+                                                        {
+                                                            Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+                                                        }
+                                                        else if (sttype >= Data.Structure.Rail.Length || Data.Structure.Rail[sttype] == null)
+                                                        {
+                                                            Interface.AddMessage(Interface.MessageType.Error, false, "RailStructureIndex" + sttype + " references an object not loaded in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+                                                        }
+                                                        else {
+                                                            if (sttype < Data.Structure.RailCycle.Length && Data.Structure.RailCycle[sttype] != null)
+                                                            {
+                                                                Data.Blocks[BlockIndex].RailType[idx] = Data.Structure.RailCycle[sttype][0];
+                                                                Data.Blocks[BlockIndex].RailCycle[idx].RailCycleIndex = sttype;
+                                                                Data.Blocks[BlockIndex].RailCycle[idx].CurrentCycle = 0;
+                                                            }
+                                                            else {
+                                                                Data.Blocks[BlockIndex].RailType[idx] = sttype;
+                                                                Data.Blocks[BlockIndex].RailCycle[idx].RailCycleIndex = -1;
+                                                            }
+                                                        }
+                                                    }
+                                                }
 											}
 										}
 									} break;
@@ -2958,9 +3022,18 @@ namespace OpenBve {
 												} else {
 													if (Data.Blocks[BlockIndex].RailType.Length <= idx) {
 														Array.Resize<int>(ref Data.Blocks[BlockIndex].RailType, idx + 1);
-													}
-													Data.Blocks[BlockIndex].RailType[idx] = sttype;
-												}
+                                                    }
+                                                    if (sttype < Data.Structure.RailCycle.Length && Data.Structure.RailCycle[sttype] != null)
+                                                    {
+                                                        Data.Blocks[BlockIndex].RailType[idx] = Data.Structure.RailCycle[sttype][0];
+                                                        Data.Blocks[BlockIndex].RailCycle[idx].RailCycleIndex = sttype;
+                                                        Data.Blocks[BlockIndex].RailCycle[idx].CurrentCycle = 0;
+                                                    }
+                                                    else {
+                                                        Data.Blocks[BlockIndex].RailType[idx] = sttype;
+                                                        Data.Blocks[BlockIndex].RailCycle[idx].RailCycleIndex = -1;
+                                                    }
+                                                }
 											}
 										}
 									} break;
@@ -4573,11 +4646,29 @@ namespace OpenBve {
 						Data.Blocks[i].Fog = Data.Blocks[i - 1].Fog;
 						Data.Blocks[i].FogDefined = false;
 						Data.Blocks[i].Cycle = Data.Blocks[i - 1].Cycle;
-						Data.Blocks[i].Height = double.NaN;
+                        Data.Blocks[i].RailCycle = Data.Blocks[i - 1].RailCycle;
+                        Data.Blocks[i].Height = double.NaN;
 					}
 					Data.Blocks[i].RailType = new int[Data.Blocks[i - 1].RailType.Length];
-					for (int j = 0; j < Data.Blocks[i].RailType.Length; j++) {
-						Data.Blocks[i].RailType[j] = Data.Blocks[i - 1].RailType[j];
+					if (!PreviewOnly) {
+						for (int j = 0; j < Data.Blocks[i].RailType.Length; j++) {
+							int rc = Data.Blocks[i].RailCycle[j].RailCycleIndex;
+							if (rc != -1 && Data.Structure.RailCycle[rc].Length > 1) {
+								int cc = Data.Blocks[i].RailCycle[j].CurrentCycle;
+								if (cc == Data.Structure.RailCycle[rc].Length - 1) {
+									Data.Blocks[i].RailType[j] = Data.Structure.RailCycle[rc][0];
+									Data.Blocks[i].RailCycle[j].CurrentCycle = 0;
+								}
+								else {
+									cc++;
+									Data.Blocks[i].RailType[j] = Data.Structure.RailCycle[rc][cc];
+									Data.Blocks[i].RailCycle[j].CurrentCycle++;
+								}
+							}
+							else {
+								Data.Blocks[i].RailType[j] = Data.Blocks[i - 1].RailType[j];
+							}
+						}
 					}
 					Data.Blocks[i].Rail = new Rail[Data.Blocks[i - 1].Rail.Length];
 					for (int j = 0; j < Data.Blocks[i].Rail.Length; j++) {

--- a/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -2877,8 +2877,9 @@ namespace OpenBve {
 												}
 												if (Data.Blocks[BlockIndex].Rail.Length <= idx) {
 													Array.Resize<Rail>(ref Data.Blocks[BlockIndex].Rail, idx + 1);
+													int ol = Data.Blocks[BlockIndex].RailCycle.Length;
                                                     Array.Resize<RailCycle>(ref Data.Blocks[BlockIndex].RailCycle, idx + 1);
-                                                    for (int rc = 0; rc < Data.Blocks[BlockIndex].RailCycle.Length; rc++)
+                                                    for (int rc = ol; rc < Data.Blocks[BlockIndex].RailCycle.Length; rc++)
                                                     {
                                                         Data.Blocks[BlockIndex].RailCycle[rc].RailCycleIndex = -1;
                                                     }

--- a/openBVE/OpenBve/OldParsers/BveRouteParser/CsvRwRouteParser.Structures.cs
+++ b/openBVE/OpenBve/OldParsers/BveRouteParser/CsvRwRouteParser.Structures.cs
@@ -155,6 +155,10 @@
 			internal double Roll;
 			internal string Text;
 		}
+		private struct RailCycle {
+            internal int RailCycleIndex;
+            internal int CurrentCycle;
+        }
 		private class Block
 		{
 			internal int Background;
@@ -162,6 +166,7 @@
 			internal Game.Fog Fog;
 			internal bool FogDefined;
 			internal int[] Cycle;
+			internal RailCycle[] RailCycle;
 			internal double Height;
 			internal Rail[] Rail;
 			internal int[] RailType;
@@ -209,6 +214,7 @@
 			internal ObjectManager.UnifiedObject[] FreeObj;
 			internal ObjectManager.UnifiedObject[] Beacon;
 			internal int[][] Cycle;
+			internal int[][] RailCycle;
 			internal int[] Run;
 			internal int[] Flange;
 		}

--- a/openBVE/OpenBve/OldParsers/BveRouteParser/CsvRwRouteParser.cs
+++ b/openBVE/OpenBve/OldParsers/BveRouteParser/CsvRwRouteParser.cs
@@ -2871,11 +2871,12 @@ namespace OpenBve {
 												}
 												if (Data.Blocks[BlockIndex].Rail.Length <= idx) {
 													Array.Resize<Rail>(ref Data.Blocks[BlockIndex].Rail, idx + 1);
+													int ol = Data.Blocks[BlockIndex].RailCycle.Length;
 													Array.Resize<RailCycle>(ref Data.Blocks[BlockIndex].RailCycle, idx + 1);
-                                                    for (int rc = 0; rc < Data.Blocks[BlockIndex].RailCycle.Length; rc++)
-                                                    {
-                                                        Data.Blocks[BlockIndex].RailCycle[rc].RailCycleIndex = -1;
-                                                    }
+													for (int rc = ol; rc < Data.Blocks[BlockIndex].RailCycle.Length; rc++)
+													{
+														Data.Blocks[BlockIndex].RailCycle[rc].RailCycleIndex = -1;
+													}
 												}
 												if (Data.Blocks[BlockIndex].Rail[idx].RailStartRefreshed) {
 													Data.Blocks[BlockIndex].Rail[idx].RailEnd = true;


### PR DESCRIPTION
Added support in both OpenBVE and RouteViewer for the Cycle.Rail command in CSV routes. It has the same functionality as Cycle.Ground but applied to rail objects. If the Railtype structure index is the same as a Cycle.Rail index, the cycle will be used. If not, it will look for a standard rail object.

More information at #81 