### PR TITLE
Fix or Silence all Warnings

### DIFF
--- a/makefile
+++ b/makefile
@@ -138,7 +138,7 @@ openbve-release: print_csc_type
 openbve-release: ARGS := $(RELEASE_ARGS)
 openbve-release: OUTPUT_DIR := $(RELEASE_DIR)
 openbve-release: $(RELEASE_DIR)/$(OPEN_BVE_FILE)
-openbve-release: copy_depends
+openbve-release: copy_release_depends
 
 all: all-debug
 
@@ -158,7 +158,7 @@ all-release: $(RELEASE_DIR)/$(OBJECT_BENDER_FILE)
 all-release: $(RELEASE_DIR)/$(OBJECT_VIEWER_FILE)
 all-release: $(RELEASE_DIR)/$(ROUTE_VIEWER_FILE)
 all-release: $(RELEASE_DIR)/$(TRAIN_EDITOR_FILE)
-all-release: copy_depends
+all-release: copy_release_depends
 
 CP_UPDATE_FLAG = -u
 CP_RECURSE = -r

--- a/makefile
+++ b/makefile
@@ -270,7 +270,7 @@ create_resource_tmp = $(eval $(call resource_rule_impl, $(firstword $(subst ^, ,
 
 OPEN_BVE_FOLDERS  := . Audio Game Graphics Graphics/Renderer Interface OldCode OldCode/NewCode Parsers Properties OldParsers OldParsers/BveRouteParser Simulation/TrainManager Simulation/TrainManager/Train Simulation/World System System/Functions System/Input System/Logging System/Program System/Translations UserInterface
 OPEN_BVE_FOLDERS  := $(addprefix $(OPEN_BVE_ROOT)/, $(OPEN_BVE_FOLDERS))
-OPEN_BVE_SRC      := $(filter-out $(OPEN_BVE_ROOT)/Properties/AssemblyInfo.cs,$(patsubst %, "%", $(foreach sdir, $(OPEN_BVE_FOLDERS), $(wildcard $(sdir)/*.cs))))
+OPEN_BVE_SRC      := $(filter-out "$(OPEN_BVE_ROOT)/Properties/AssemblyInfo.cs",$(patsubst %, "%", $(foreach sdir, $(OPEN_BVE_FOLDERS), $(wildcard $(sdir)/*.cs))))
 OPEN_BVE_DOC      := $(addprefix /doc:, $(foreach sdir, $(OPEN_BVE_FOLDERS), $(wildcard $(sdir)/*.xml)))
 OPEN_BVE_RESX     := $(foreach sdir, $(OPEN_BVE_FOLDERS), $(wildcard $(sdir)/*.resx))
 OPEN_BVE_RESOURCE := $(addprefix $(OPEN_BVE_ROOT)/, $(subst /,., $(subst /./,/, $(patsubst $(dir $(OPEN_BVE_ROOT))%.resx, %.resources, $(OPEN_BVE_RESX)))))

--- a/source/ObjectBender/Bender.cs
+++ b/source/ObjectBender/Bender.cs
@@ -297,7 +297,7 @@ namespace ObjectBender {
 							{
 								double dx = cells[i].Length >= 2 ? double.Parse(cells[i][1], culture) : 0.0;
 								double dy = cells[i].Length >= 3 ? double.Parse(cells[i][2], culture) : 0.0;
-								double dz = cells[i].Length >= 4 ? double.Parse(cells[i][3], culture) : 0.0;
+								// double dz = cells[i].Length >= 4 ? double.Parse(cells[i][3], culture) : 0.0;
 								double sx = cells[i].Length >= 5 ? double.Parse(cells[i][4], culture) : 0.0;
 								double sy = cells[i].Length >= 6 ? double.Parse(cells[i][5], culture) : 0.0;
 								double sz = cells[i].Length >= 7 ? double.Parse(cells[i][6], culture) : 0.0;

--- a/source/ObjectViewer/InterfaceS.cs
+++ b/source/ObjectViewer/InterfaceS.cs
@@ -27,7 +27,9 @@ namespace OpenBve {
 			internal static int[] Panel = new int[] { };
 		}
 	}
-	
+
+#pragma warning disable 0649
+
 	// --- Game.cs ---
 	internal static class Game {
 		internal static double SecondsSinceMidnight = 0.0;
@@ -130,6 +132,8 @@ namespace OpenBve {
 		internal static Options CurrentOptions;
 
 		// ================================
+
+#pragma warning restore 0649
 
 		// try parse vb6
 		internal static bool TryParseDoubleVb6(string Expression, out double Value) {

--- a/source/ObjectViewer/ObjectManager.cs
+++ b/source/ObjectViewer/ObjectManager.cs
@@ -412,7 +412,7 @@ namespace OpenBve
             {
                 if (UpdateFunctions)
                 {
-                    double lastangle = Object.LEDFunction.LastResult;
+                    // double lastangle = Object.LEDFunction.LastResult;
                     ledangle = Object.LEDFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, Object.CurrentState);
                 }
                 else
@@ -1844,7 +1844,7 @@ namespace OpenBve
             Object = new StaticObject();
             Object.StartingDistance = float.MaxValue;
             Object.EndingDistance = float.MinValue;
-            bool brightnesschange = Brightness != 1.0;
+            // bool brightnesschange = Brightness != 1.0;
             // vertices
             Object.Mesh.Vertices = new World.Vertex[Prototype.Mesh.Vertices.Length];
             for (int j = 0; j < Prototype.Mesh.Vertices.Length; j++)

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -26,7 +26,7 @@ namespace OpenBve {
 		internal const ProgramType CurrentProgramType = ProgramType.ObjectViewer;
 
 		// members
-		private static bool Quit = false;
+		private const bool Quit = false;
 	    internal static string[] Files = new string[] { };
 	    internal static bool[] SkipArgs;
 

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -47,7 +47,7 @@ namespace OpenBve
         {
             internal int ObjectListIndex;
             internal int ObjectIndex;
-            internal int MeshIndex;
+            internal const int MeshIndex = 0;
             internal int FaceIndex;
         }
         // opaque
@@ -499,19 +499,19 @@ namespace OpenBve
             switch (FaceType)
             {
                 case World.MeshFace.FaceTypeTriangles:
-                    GL.Begin(BeginMode.Triangles);
+                    GL.Begin(PrimitiveType.Triangles);
                     break;
                 case World.MeshFace.FaceTypeTriangleStrip:
-                    GL.Begin(BeginMode.TriangleStrip);
+                    GL.Begin(PrimitiveType.TriangleStrip);
                     break;
                 case World.MeshFace.FaceTypeQuads:
-                    GL.Begin(BeginMode.Quads);
+                    GL.Begin(PrimitiveType.Quads);
                     break;
                 case World.MeshFace.FaceTypeQuadStrip:
-                    GL.Begin(BeginMode.QuadStrip);
+                    GL.Begin(PrimitiveType.QuadStrip);
                     break;
                 default:
-                    GL.Begin(BeginMode.Polygon);
+                    GL.Begin(PrimitiveType.Polygon);
                     break;
             }
             if (Material.GlowAttenuationData != 0)
@@ -590,19 +590,19 @@ namespace OpenBve
                 switch (FaceType)
                 {
                     case World.MeshFace.FaceTypeTriangles:
-                        GL.Begin(BeginMode.Triangles);
+                        GL.Begin(PrimitiveType.Triangles);
                         break;
                     case World.MeshFace.FaceTypeTriangleStrip:
-                        GL.Begin(BeginMode.TriangleStrip);
+                        GL.Begin(PrimitiveType.TriangleStrip);
                         break;
                     case World.MeshFace.FaceTypeQuads:
-                        GL.Begin(BeginMode.Quads);
+                        GL.Begin(PrimitiveType.Quads);
                         break;
                     case World.MeshFace.FaceTypeQuadStrip:
-                        GL.Begin(BeginMode.QuadStrip);
+                        GL.Begin(PrimitiveType.QuadStrip);
                         break;
                     default:
-                        GL.Begin(BeginMode.Polygon);
+                        GL.Begin(PrimitiveType.Polygon);
                         break;
                 }
                 float alphafactor;
@@ -659,7 +659,7 @@ namespace OpenBve
                 }
                 for (int j = 0; j < Face.Vertices.Length; j++)
                 {
-                    GL.Begin(BeginMode.Lines);
+                    GL.Begin(PrimitiveType.Lines);
                     GL.Color4(inv255 * (float)Material.Color.R, inv255 * (float)Material.Color.G, inv255 * (float)Material.Color.B, 1.0f);
                     GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
                     GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X + Face.Vertices[j].Normal.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y + Face.Vertices[j].Normal.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z + Face.Vertices[j].Normal.Z - CameraZ));

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -26,7 +26,7 @@ namespace OpenBve
 
 		}
 
-        internal string[] commandLineArgs;
+        internal const string[] commandLineArgs = null;
         
         private static double ReducedModeEnteringTime = 0;
         
@@ -311,29 +311,29 @@ namespace OpenBve
             Fonts.Initialize();
             Program.UpdateViewport();
             // command line arguments
-            if (commandLineArgs != null)
-            {
-                for (int i = 0; i < commandLineArgs.Length; i++)
-                {
-                    if (!Program.SkipArgs[i] && System.IO.File.Exists(commandLineArgs[i]))
-                    {
-                        try
-                        {
-                            ObjectManager.UnifiedObject o = ObjectManager.LoadObject(commandLineArgs[i],
-                                System.Text.Encoding.UTF8, ObjectManager.ObjectLoadMode.Normal, false, false, false,0,0,0);
-                            ObjectManager.CreateObject(o, new World.Vector3D(0.0, 0.0, 0.0),
-                                new World.Transformation(0.0, 0.0, 0.0), new World.Transformation(0.0, 0.0, 0.0), true,
-                                0.0, 0.0, 25.0, 0.0);
-                        }
-                        catch (Exception ex)
-                        {
-                            Interface.AddMessage(Interface.MessageType.Critical, false, "Unhandled error (" + ex.Message + ") encountered while processing the file " + commandLineArgs[i] + ".");
-                        }
-                        Array.Resize<string>(ref Program.Files, Program.Files.Length + 1);
-                        Program.Files[Program.Files.Length - 1] = commandLineArgs[i];
-                    }
-                }
-            }
+            // if (commandLineArgs != null)
+            // {
+            //     for (int i = 0; i < commandLineArgs.Length; i++)
+            //     {
+            //         if (!Program.SkipArgs[i] && System.IO.File.Exists(commandLineArgs[i]))
+            //         {
+            //             try
+            //             {
+            //                 ObjectManager.UnifiedObject o = ObjectManager.LoadObject(commandLineArgs[i],
+            //                     System.Text.Encoding.UTF8, ObjectManager.ObjectLoadMode.Normal, false, false, false,0,0,0);
+            //                 ObjectManager.CreateObject(o, new World.Vector3D(0.0, 0.0, 0.0),
+            //                     new World.Transformation(0.0, 0.0, 0.0), new World.Transformation(0.0, 0.0, 0.0), true,
+            //                     0.0, 0.0, 25.0, 0.0);
+            //             }
+            //             catch (Exception ex)
+            //             {
+            //                 Interface.AddMessage(Interface.MessageType.Critical, false, "Unhandled error (" + ex.Message + ") encountered while processing the file " + commandLineArgs[i] + ".");
+            //             }
+            //             Array.Resize<string>(ref Program.Files, Program.Files.Length + 1);
+            //             Program.Files[Program.Files.Length - 1] = commandLineArgs[i];
+            //         }
+            //     }
+            // }
             ObjectManager.InitializeVisibility();
             ObjectManager.FinishCreatingObjects();
             ObjectManager.UpdateVisibility(0.0, true);

--- a/source/ObjectViewer/TrainManagerS.cs
+++ b/source/ObjectViewer/TrainManagerS.cs
@@ -10,6 +10,9 @@ using System;
 namespace OpenBve {
 	internal static class TrainManager {
 
+// Silence the absurd amount of unused variable warnings
+#pragma warning disable 0649
+
 		// structures
 		internal struct Axle {
 			internal TrackManager.TrackFollower Follower;
@@ -401,6 +404,8 @@ namespace OpenBve {
 			internal TrainSpecs Specs;
 			internal int CurrentSectionIndex;
 		}
+
+#pragma warning restore 0649
 
 		// trains
 		internal static Train[] Trains = new Train[] { };

--- a/source/ObjectViewer/WorldS.cs
+++ b/source/ObjectViewer/WorldS.cs
@@ -358,7 +358,7 @@ namespace OpenBve {
 		internal static Background CurrentBackground = new Background(-1, 6, false);
 		internal static Background TargetBackground = new Background(-1, 6, false);
 		internal const double TargetBackgroundDefaultCountdown = 0.8;
-		internal static double TargetBackgroundCountdown;
+		internal const double TargetBackgroundCountdown = 0.0; // static
 
 		// relative camera
 		internal struct CameraAlignment {
@@ -377,6 +377,7 @@ namespace OpenBve {
 				this.Zoom = Zoom;
 			}
 		}
+#pragma warning disable 0649
 		internal static TrackManager.TrackFollower CameraTrackFollower;
 		internal static CameraAlignment CameraCurrentAlignment;
 		internal static CameraAlignment CameraAlignmentDirection;
@@ -389,6 +390,7 @@ namespace OpenBve {
 		internal const double CameraZoomTopSpeed = 2.0;
 		internal enum CameraViewMode { Interior, Exterior, Track, FlyBy, FlyByZooming }
 		internal static CameraViewMode CameraMode;
+#pragma warning restore 0649
 
 		// camera restriction
 		internal enum CameraRestrictionMode {

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -318,9 +318,11 @@ namespace OpenBve
 		}
 		//Using a much cut-down version of the car struct for bogies
 		internal struct Bogie {
+#pragma warning disable 0649
 			internal double Width;
 			internal double Height;
 			internal double Length;
+#pragma warning restore 0649
 			internal Axle FrontAxle;
 			internal Axle RearAxle;
 			internal double FrontAxlePosition;

--- a/source/OpenBVE/OldParsers/BveRouteParser/CsvRwRouteParser.cs
+++ b/source/OpenBVE/OldParsers/BveRouteParser/CsvRwRouteParser.cs
@@ -5266,31 +5266,32 @@ namespace OpenBve {
 									World.Rotate(ref Direction2, cosag, sinag);
 								}
 								double a2 = 0.0;
-								double c2 = Data.BlockInterval;
-								double h2 = 0.0;
+								// double c2 = Data.BlockInterval;
+								// double h2 = 0.0;
 								if (Data.Blocks[i + 1].CurrentTrackState.CurveRadius != 0.0 & Data.Blocks[i + 1].Pitch != 0.0) {
 									double d2 = Data.BlockInterval;
 									double p2 = Data.Blocks[i + 1].Pitch;
 									double r2 = Data.Blocks[i + 1].CurrentTrackState.CurveRadius;
 									double s2 = d2 / Math.Sqrt(1.0 + p2 * p2);
-									h2 = s2 * p2;
+									// h2 = s2 * p2;
 									double b2 = s2 / Math.Abs(r2);
-									c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
+									// c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
 									a2 = 0.5 * (double)Math.Sign(r2) * b2;
 									World.Rotate(ref Direction2, Math.Cos(-a2), Math.Sin(-a2));
 								} else if (Data.Blocks[i + 1].CurrentTrackState.CurveRadius != 0.0) {
 									double d2 = Data.BlockInterval;
 									double r2 = Data.Blocks[i + 1].CurrentTrackState.CurveRadius;
 									double b2 = d2 / Math.Abs(r2);
-									c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
+									// c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
 									a2 = 0.5 * (double)Math.Sign(r2) * b2;
 									World.Rotate(ref Direction2, Math.Cos(-a2), Math.Sin(-a2));
-								} else if (Data.Blocks[i + 1].Pitch != 0.0) {
-									double p2 = Data.Blocks[i + 1].Pitch;
-									double d2 = Data.BlockInterval;
-									c2 = d2 / Math.Sqrt(1.0 + p2 * p2);
-									h2 = c2 * p2;
 								}
+								// else if (Data.Blocks[i + 1].Pitch != 0.0) {
+									// double p2 = Data.Blocks[i + 1].Pitch;
+									// double d2 = Data.BlockInterval;
+									// c2 = d2 / Math.Sqrt(1.0 + p2 * p2);
+									// h2 = c2 * p2;
+								// }
 								
 								//These generate a compiler warning, as secondary tracks do not generate yaw, as they have no
 								//concept of a curve, but rather are a straight line between two points

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -179,8 +179,8 @@ namespace OpenBve {
 		/// <returns>Whether loading the sound was successful.</returns>
 		public override bool RegisterSound(string path, out OpenBveApi.Sounds.SoundHandle handle) {
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
-				Sounds.SoundBuffer data;
-				data = Sounds.RegisterBuffer(path, 0.0); // TODO
+				// Sounds.SoundBuffer data;
+				// data = Sounds.RegisterBuffer(path, 0.0); // TODO
 			} else {
 				ReportProblem(OpenBveApi.Hosts.ProblemType.PathNotFound, path.ToString());
 			}

--- a/source/OpenBVE/UserInterface/formMain.Packages.cs
+++ b/source/OpenBVE/UserInterface/formMain.Packages.cs
@@ -765,7 +765,7 @@ namespace OpenBve
 				if (!Program.CurrentlyRunningOnMono)
 				{
 					//Mono doesn't support System.Security.AccessControl, so this doesn't work....
-					System.Security.AccessControl.DirectorySecurity ds = Directory.GetAccessControl(directory);
+					// System.Security.AccessControl.DirectorySecurity ds = Directory.GetAccessControl(directory);
 				}
 				using (FileStream fs = File.OpenWrite(currentPackage.FileName))
 				{

--- a/source/OpenBVE/UserInterface/formMain.Packages.cs
+++ b/source/OpenBVE/UserInterface/formMain.Packages.cs
@@ -765,7 +765,7 @@ namespace OpenBve
 				if (!Program.CurrentlyRunningOnMono)
 				{
 					//Mono doesn't support System.Security.AccessControl, so this doesn't work....
-					// System.Security.AccessControl.DirectorySecurity ds = Directory.GetAccessControl(directory);
+					Directory.GetAccessControl(directory);
 				}
 				using (FileStream fs = File.OpenWrite(currentPackage.FileName))
 				{

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -158,6 +158,7 @@ namespace OpenBve {
 			Image Logo = LoadImage(MenuFolder, "logo.png");
 			if (Logo != null) pictureboxLogo.Image = Logo;
 			string flagsFolder = Program.FileSystem.GetDataFolder("Flags");
+	#pragma warning disable 0219
 			string[] flags = new string[] { };
 			try
 			{
@@ -166,6 +167,7 @@ namespace OpenBve {
 			catch (Exception)
 			{
 			}
+	#pragma warning restore 0219
 			// route selection
 			listviewRouteFiles.SmallImageList = new ImageList { TransparentColor = Color.White };
 			if (ParentIcon != null) listviewRouteFiles.SmallImageList.Images.Add("parent", ParentIcon);

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -158,6 +158,9 @@ namespace OpenBve {
 			Image Logo = LoadImage(MenuFolder, "logo.png");
 			if (Logo != null) pictureboxLogo.Image = Logo;
 			string flagsFolder = Program.FileSystem.GetDataFolder("Flags");
+			/* 
+			 * TODO: Integrate into packages
+			 */
 	#pragma warning disable 0219
 			string[] flags = new string[] { };
 			try

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -324,7 +324,7 @@ namespace OpenBve {
 			int d = Sections[SectionIndex].StationIndex;
 			if (d >= 0) {
 				// look for train in previous blocks
-				int l = Sections[SectionIndex].PreviousSection;
+				//int l = Sections[SectionIndex].PreviousSection;
 				if (Stations[d].StationType != StationType.Normal) {
 					settored = true;
 				}

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -260,7 +260,7 @@ namespace OpenBve {
 			internal int PreviousSection;
 			internal int NextSection;
 			internal TrainManager.Train[] Trains;
-			internal bool TrainReachedStopPoint;
+			internal const bool TrainReachedStopPoint = false;
 			internal int StationIndex;
 			internal bool Invisible;
 			internal int[] SignalIndices;

--- a/source/RouteViewer/InterfaceR.cs
+++ b/source/RouteViewer/InterfaceR.cs
@@ -40,6 +40,7 @@ namespace OpenBve {
 			Medium = 1,
 			High = 2
 		}
+#pragma warning disable 0649
 		internal struct Options {
 			internal TextureManager.InterpolationMode Interpolation;
 			internal int AnisotropicFilteringLevel;
@@ -58,6 +59,7 @@ namespace OpenBve {
 			internal bool LoadingBackground;
 		}
 		internal static Options CurrentOptions;
+#pragma warning restore 0649
 
 		// messages
 		internal enum MessageType {

--- a/source/RouteViewer/LoadingR.cs
+++ b/source/RouteViewer/LoadingR.cs
@@ -116,7 +116,7 @@ namespace OpenBve {
 			string RailwayFolder = GetRailwayFolder(CurrentRouteFile);
 			string ObjectFolder = OpenBveApi.Path.CombineDirectory(RailwayFolder, "Object");
 			string SoundFolder = OpenBveApi.Path.CombineDirectory(RailwayFolder, "Sound");
-			string CompatibilityFolder = OpenBveApi.Path.CombineDirectory(Application.StartupPath, "Compatibility");
+			// string CompatibilityFolder = OpenBveApi.Path.CombineDirectory(Application.StartupPath, "Compatibility");
 			// reset
 			Game.Reset();
 			Game.MinimalisticSimulation = true;
@@ -150,11 +150,11 @@ namespace OpenBve {
 			}
 			// starting track position
 			System.Threading.Thread.Sleep(1); if (Cancel) return;
-			int FirstStationIndex = -1;
+			// int FirstStationIndex = -1;
 			double FirstStationPosition = 0.0;
 			for (int i = 0; i < Game.Stations.Length; i++) {
 				if (Game.Stations[i].Stops.Length != 0) {
-					FirstStationIndex = i;
+					// FirstStationIndex = i;
 					FirstStationPosition = Game.Stations[i].Stops[Game.Stations[i].Stops.Length - 1].TrackPosition;
 					if (Game.Stations[i].ArrivalTime < 0.0) {
 						if (Game.Stations[i].DepartureTime < 0.0) {

--- a/source/RouteViewer/ObjectManager.cs
+++ b/source/RouteViewer/ObjectManager.cs
@@ -334,7 +334,7 @@ namespace OpenBve {
 			double ledangle;
 			if (led) {
 				if (UpdateFunctions) {
-					double lastangle = Object.LEDFunction.LastResult;
+					// double lastangle = Object.LEDFunction.LastResult;
 					ledangle = Object.LEDFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, Object.CurrentState);
 				} else {
 					ledangle = Object.LEDFunction.LastResult;
@@ -1429,7 +1429,7 @@ namespace OpenBve {
 			Object = new StaticObject();
 			Object.StartingDistance = float.MaxValue;
 			Object.EndingDistance = float.MinValue;
-			bool brightnesschange = Brightness != 1.0;
+			// bool brightnesschange = Brightness != 1.0;
 			// vertices
 			Object.Mesh.Vertices = new World.Vertex[Prototype.Mesh.Vertices.Length];
 			for (int j = 0; j < Prototype.Mesh.Vertices.Length; j++) {

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -1914,27 +1914,29 @@ namespace OpenBve {
 												Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else if (Arguments.Length < 1) {
 												Interface.AddMessage(Interface.MessageType.Error, false, Command + " is expected to have one argument at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-											} else if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
-												if (Interface.ContainsInvalidPathChars(Arguments[0])) {
-													Interface.AddMessage(Interface.MessageType.Error, false, "FileName " + Arguments[0] + " contains illegal characters in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-												} else {
-													while (CommandIndex1 >= Data.TimetableDaytime.Length) {
-														int n = Data.TimetableDaytime.Length;
-														Array.Resize<int>(ref Data.TimetableDaytime, n << 1);
-														for (int i = n; i < Data.TimetableDaytime.Length; i++) {
-															Data.TimetableDaytime[i] = -1;
-														}
-													}
-													string f = OpenBveApi.Path.CombineFile(TrainPath, Arguments[0]);
-													if (!System.IO.File.Exists(f)) {
-														f = OpenBveApi.Path.CombineFile(ObjectPath, Arguments[0]);
-													}
-													if (System.IO.File.Exists(f)) {
-														Data.TimetableDaytime[CommandIndex1] = TextureManager.RegisterTexture(f, TextureManager.TextureWrapMode.ClampToEdge, TextureManager.TextureWrapMode.ClampToEdge, true);
-														TextureManager.UseTexture(Data.TimetableDaytime[CommandIndex1], TextureManager.UseMode.Normal);
-													}
-												}
-											}
+											} 
+											// Code was always unreachable because this is routeviewer //
+											// else if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
+											// 	if (Interface.ContainsInvalidPathChars(Arguments[0])) {
+											// 		Interface.AddMessage(Interface.MessageType.Error, false, "FileName " + Arguments[0] + " contains illegal characters in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+											// 	} else {
+											// 		while (CommandIndex1 >= Data.TimetableDaytime.Length) {
+											// 			int n = Data.TimetableDaytime.Length;
+											// 			Array.Resize<int>(ref Data.TimetableDaytime, n << 1);
+											// 			for (int i = n; i < Data.TimetableDaytime.Length; i++) {
+											// 				Data.TimetableDaytime[i] = -1;
+											// 			}
+											// 		}
+											// 		string f = OpenBveApi.Path.CombineFile(TrainPath, Arguments[0]);
+											// 		if (!System.IO.File.Exists(f)) {
+											// 			f = OpenBveApi.Path.CombineFile(ObjectPath, Arguments[0]);
+											// 		}
+											// 		if (System.IO.File.Exists(f)) {
+											// 			Data.TimetableDaytime[CommandIndex1] = TextureManager.RegisterTexture(f, TextureManager.TextureWrapMode.ClampToEdge, TextureManager.TextureWrapMode.ClampToEdge, true);
+											// 			TextureManager.UseTexture(Data.TimetableDaytime[CommandIndex1], TextureManager.UseMode.Normal);
+											// 		}
+											// 	}
+											// }
 										}
 									} break;
 								case "train.timetable.night":
@@ -1944,27 +1946,29 @@ namespace OpenBve {
 												Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex is expected to be non-negativ in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else if (Arguments.Length < 1) {
 												Interface.AddMessage(Interface.MessageType.Error, false, Command + " is expected to have one argument at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-											} else if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
-												if (Interface.ContainsInvalidPathChars(Arguments[0])) {
-													Interface.AddMessage(Interface.MessageType.Error, false, "FileName " + Arguments[0] + " contains illegal characters in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-												} else {
-													while (CommandIndex1 >= Data.TimetableNighttime.Length) {
-														int n = Data.TimetableNighttime.Length;
-														Array.Resize<int>(ref Data.TimetableNighttime, n << 1);
-														for (int i = n; i < Data.TimetableNighttime.Length; i++) {
-															Data.TimetableNighttime[i] = -1;
-														}
-													}
-													string f = OpenBveApi.Path.CombineFile(TrainPath, Arguments[0]);
-													if (!System.IO.File.Exists(f)) {
-														f = OpenBveApi.Path.CombineFile(ObjectPath, Arguments[0]);
-													}
-													if (System.IO.File.Exists(f)) {
-														Data.TimetableNighttime[CommandIndex1] = TextureManager.RegisterTexture(f, TextureManager.TextureWrapMode.ClampToEdge, TextureManager.TextureWrapMode.ClampToEdge, false);
-														TextureManager.UseTexture(Data.TimetableNighttime[CommandIndex1], TextureManager.UseMode.Normal);
-													}
-												}
-											}
+											} 
+											// Code was always unreachable because this is routeviewer //
+											// else if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
+											// 	if (Interface.ContainsInvalidPathChars(Arguments[0])) {
+											// 		Interface.AddMessage(Interface.MessageType.Error, false, "FileName " + Arguments[0] + " contains illegal characters in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+											// 	} else {
+											// 		while (CommandIndex1 >= Data.TimetableNighttime.Length) {
+											// 			int n = Data.TimetableNighttime.Length;
+											// 			Array.Resize<int>(ref Data.TimetableNighttime, n << 1);
+											// 			for (int i = n; i < Data.TimetableNighttime.Length; i++) {
+											// 				Data.TimetableNighttime[i] = -1;
+											// 			}
+											// 		}
+											// 		string f = OpenBveApi.Path.CombineFile(TrainPath, Arguments[0]);
+											// 		if (!System.IO.File.Exists(f)) {
+											// 			f = OpenBveApi.Path.CombineFile(ObjectPath, Arguments[0]);
+											// 		}
+											// 		if (System.IO.File.Exists(f)) {
+											// 			Data.TimetableNighttime[CommandIndex1] = TextureManager.RegisterTexture(f, TextureManager.TextureWrapMode.ClampToEdge, TextureManager.TextureWrapMode.ClampToEdge, false);
+											// 			TextureManager.UseTexture(Data.TimetableNighttime[CommandIndex1], TextureManager.UseMode.Normal);
+											// 		}
+											// 	}
+											// }
 										}
 									} break;
 									// structure
@@ -3847,14 +3851,14 @@ namespace OpenBve {
 													ttidx = -1;
 												} else {
 													if (ttidx < 0) {
-														if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
-															Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex is expected to be non-negative in Track.Sta at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-														}
+														// if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
+														// 	Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex is expected to be non-negative in Track.Sta at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+														// }
 														ttidx = -1;
 													} else if (ttidx >= Data.TimetableDaytime.Length & ttidx >= Data.TimetableNighttime.Length) {
-														if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
-															Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex references textures not loaded in Track.Sta at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-														}
+														// if (Program.CurrentProgramType == Program.ProgramType.OpenBve) {
+														// 	Interface.AddMessage(Interface.MessageType.Error, false, "TimetableIndex references textures not loaded in Track.Sta at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+														// }
 														ttidx = -1;
 													}
 													tdt = ttidx >= 0 & ttidx < Data.TimetableDaytime.Length ? Data.TimetableDaytime[ttidx] : -1;

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -5382,35 +5382,35 @@ namespace OpenBve {
 									World.Rotate(ref Direction2, cosag, sinag);
 								}
 								double a2 = 0.0;
-								double c2 = Data.BlockInterval;
-								double h2 = 0.0;
+								// double c2 = Data.BlockInterval;
+								// double h2 = 0.0;
 								if (Data.Blocks[i + 1].CurrentTrackState.CurveRadius != 0.0 & Data.Blocks[i + 1].Pitch != 0.0) {
 									double d2 = Data.BlockInterval;
 									double p2 = Data.Blocks[i + 1].Pitch;
 									double r2 = Data.Blocks[i + 1].CurrentTrackState.CurveRadius;
 									double s2 = d2 / Math.Sqrt(1.0 + p2 * p2);
-									h2 = s2 * p2;
+									// h2 = s2 * p2;
 									double b2 = s2 / Math.Abs(r2);
-									c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
+									// c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
 									a2 = 0.5 * (double)Math.Sign(r2) * b2;
 									World.Rotate(ref Direction2, Math.Cos(-a2), Math.Sin(-a2));
 								} else if (Data.Blocks[i + 1].CurrentTrackState.CurveRadius != 0.0) {
 									double d2 = Data.BlockInterval;
 									double r2 = Data.Blocks[i + 1].CurrentTrackState.CurveRadius;
 									double b2 = d2 / Math.Abs(r2);
-									c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
+									// c2 = Math.Sqrt(2.0 * r2 * r2 * (1.0 - Math.Cos(b2)));
 									a2 = 0.5 * (double)Math.Sign(r2) * b2;
 									World.Rotate(ref Direction2, Math.Cos(-a2), Math.Sin(-a2));
 								} else if (Data.Blocks[i + 1].Pitch != 0.0) {
-									double p2 = Data.Blocks[i + 1].Pitch;
-									double d2 = Data.BlockInterval;
-									c2 = d2 / Math.Sqrt(1.0 + p2 * p2);
-									h2 = c2 * p2;
+									// double p2 = Data.Blocks[i + 1].Pitch;
+									// double d2 = Data.BlockInterval;
+									// c2 = d2 / Math.Sqrt(1.0 + p2 * p2);
+									// h2 = c2 * p2;
 								}
-								double TrackYaw2 = Math.Atan2(Direction2.X, Direction2.Y);
-								double TrackPitch2 = Math.Atan(Data.Blocks[i + 1].Pitch);
-								World.Transformation GroundTransformation2 = new World.Transformation(TrackYaw2, 0.0, 0.0);
-								World.Transformation TrackTransformation2 = new World.Transformation(TrackYaw2, TrackPitch2, 0.0);
+								// double TrackYaw2 = Math.Atan2(Direction2.X, Direction2.Y);
+								// double TrackPitch2 = Math.Atan(Data.Blocks[i + 1].Pitch);
+								// World.Transformation GroundTransformation2 = new World.Transformation(TrackYaw2, 0.0, 0.0);
+								// World.Transformation TrackTransformation2 = new World.Transformation(TrackYaw2, TrackPitch2, 0.0);
 								double x2 = Data.Blocks[i + 1].Rail[j].RailEndX;
 								double y2 = Data.Blocks[i + 1].Rail[j].RailEndY;
 								World.Vector3D offset2 = new World.Vector3D(Direction2.Y * x2, y2, -Direction2.X * x2);

--- a/source/RouteViewer/Parsers/WaveParser.cs
+++ b/source/RouteViewer/Parsers/WaveParser.cs
@@ -122,7 +122,7 @@ namespace OpenBve {
 					} else {
 						throw new InvalidDataException("Invalid chunk ID in " + fileTitle);
 					}
-					uint headerCkSize = ReadUInt32(reader, endianness);
+					ReadUInt32(reader, endianness); //uint headerCkSize
 					uint formType = ReadUInt32(reader, endianness);
 					if (formType != 0x45564157) {
 						throw new InvalidDataException("Unsupported format in " + fileTitle);
@@ -145,7 +145,7 @@ namespace OpenBve {
 							if (dwSamplesPerSec >= 0x80000000) {
 								throw new InvalidDataException("Unsupported dwSamplesPerSec in " + fileTitle);
 							}
-							uint dwAvgBytesPerSec = ReadUInt32(reader, endianness);
+							ReadUInt32(reader, endianness); // uint dwAvgBytesPerSec = 
 							ushort wBlockAlign = ReadUInt16(reader, endianness);
 							if (wFormatTag == 1) {
 								// PCM
@@ -175,7 +175,7 @@ namespace OpenBve {
 								if (wBitsPerSample != 4) {
 									throw new InvalidDataException("Unsupported wBitsPerSample in " + fileTitle);
 								}
-								ushort cbSize = ReadUInt16(reader, endianness);
+								ReadUInt16(reader, endianness); // ushort cbSize = 
 								MicrosoftAdPcmData adpcmData = new MicrosoftAdPcmData();
 								adpcmData.SamplesPerBlock = ReadUInt16(reader, endianness);
 								if (adpcmData.SamplesPerBlock == 0 | adpcmData.SamplesPerBlock > 2 * ((int)wBlockAlign - 6)) {

--- a/source/RouteViewer/Renderer.Loading.cs
+++ b/source/RouteViewer/Renderer.Loading.cs
@@ -148,7 +148,7 @@ namespace OpenBve
 
 			// VERSION NUMBER
 			// place the version above the first division
-			int versionTop = logoBottom + blankHeight - fontHeight;
+			// int versionTop = logoBottom + blankHeight - fontHeight;
 			//RenderString(Fonts.SmallFontSize, "Version " + typeof(Renderer).Assembly.GetName().Version,new Point(halfWidth, versionTop), TextAlignment.TopMiddle, Color128.White);
 			// for the moment, do not show any URL; would go right below the first division
 			//			DrawString(Fonts.SmallFont, "https://sites.google.com/site/openbvesim/home",

--- a/source/RouteViewer/Renderer.Primitives.cs
+++ b/source/RouteViewer/Renderer.Primitives.cs
@@ -40,7 +40,7 @@ namespace OpenBve
 					GL.Color4(color.Value.R, color.Value.G, color.Value.B, color.Value.A);
 				}
 				GL.Begin(PrimitiveType.Quads);
-				if(TextureManager.Textures[texture].VFlip == true)
+				if(TextureManager.Texture.VFlip == true)
 				{
 					GL.TexCoord2(0.0f, 1.0f);
 					GL.Vertex2(point.X, point.Y);
@@ -52,18 +52,18 @@ namespace OpenBve
 					GL.Vertex2(point.X, point.Y + size.Height);
 					GL.End();
 				}
-				else
-				{
-					GL.TexCoord2(0.0f, 0.0f);
-					GL.Vertex2(point.X, point.Y);
-					GL.TexCoord2(1.0f, 0.0f);
-					GL.Vertex2(point.X + size.Width, point.Y);
-					GL.TexCoord2(1.0f, 1.0f);
-					GL.Vertex2(point.X + size.Width, point.Y + size.Height);
-					GL.TexCoord2(0.0f, 1.0f);
-					GL.Vertex2(point.X, point.Y + size.Height);
-					GL.End();
-				}
+				// else
+				// {
+				// 	GL.TexCoord2(0.0f, 0.0f);
+				// 	GL.Vertex2(point.X, point.Y);
+				// 	GL.TexCoord2(1.0f, 0.0f);
+				// 	GL.Vertex2(point.X + size.Width, point.Y);
+				// 	GL.TexCoord2(1.0f, 1.0f);
+				// 	GL.Vertex2(point.X + size.Width, point.Y + size.Height);
+				// 	GL.TexCoord2(0.0f, 1.0f);
+				// 	GL.Vertex2(point.X, point.Y + size.Height);
+				// 	GL.End();
+				// }
 				
 			}
 			GL.Disable(EnableCap.Blend);

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -406,7 +406,6 @@ namespace OpenBve {
 			// texture
 			int OpenGlNighttimeTextureIndex = Material.NighttimeTextureIndex >= 0 ? TextureManager.UseTexture(Material.NighttimeTextureIndex, TextureManager.UseMode.Normal) : 0;
 			int OpenGlDaytimeTextureIndex = Material.DaytimeTextureIndex >= 0 ? TextureManager.UseTexture(Material.DaytimeTextureIndex, TextureManager.UseMode.Normal) : 0;
-			bool nl = false;
 			if (OpenGlDaytimeTextureIndex != 0) {
 				if (!TexturingEnabled) {
 					GL.Enable(EnableCap.Texture2D);
@@ -467,19 +466,19 @@ namespace OpenBve {
 			int FaceType = Face.Flags & World.MeshFace.FaceTypeMask;
 			switch (FaceType) {
 				case World.MeshFace.FaceTypeTriangles:
-					GL.Begin(BeginMode.Triangles);
+					GL.Begin(PrimitiveType.Triangles);
 					break;
 				case World.MeshFace.FaceTypeTriangleStrip:
-					GL.Begin(BeginMode.TriangleStrip);
+					GL.Begin(PrimitiveType.TriangleStrip);
 					break;
 				case World.MeshFace.FaceTypeQuads:
-					GL.Begin(BeginMode.Quads);
+					GL.Begin(PrimitiveType.Quads);
 					break;
 				case World.MeshFace.FaceTypeQuadStrip:
-					GL.Begin(BeginMode.QuadStrip);
+					GL.Begin(PrimitiveType.QuadStrip);
 					break;
 				default:
-					GL.Begin(BeginMode.Polygon);
+					GL.Begin(PrimitiveType.Polygon);
 					break;
 			}
 			if (Material.GlowAttenuationData != 0) {
@@ -535,19 +534,19 @@ namespace OpenBve {
 				SetAlphaFunc(AlphaFunction.Greater, 0.0f);
 				switch (FaceType) {
 					case World.MeshFace.FaceTypeTriangles:
-						GL.Begin(BeginMode.Triangles);
+						GL.Begin(PrimitiveType.Triangles);
 						break;
 					case World.MeshFace.FaceTypeTriangleStrip:
-						GL.Begin(BeginMode.TriangleStrip);
+						GL.Begin(PrimitiveType.TriangleStrip);
 						break;
 					case World.MeshFace.FaceTypeQuads:
-						GL.Begin(BeginMode.Quads);
+						GL.Begin(PrimitiveType.Quads);
 						break;
 					case World.MeshFace.FaceTypeQuadStrip:
-						GL.Begin(BeginMode.QuadStrip);
+						GL.Begin(PrimitiveType.QuadStrip);
 						break;
 					default:
-						GL.Begin(BeginMode.Polygon);
+						GL.Begin(PrimitiveType.Polygon);
 						break;
 				}
 				float alphafactor;
@@ -591,7 +590,7 @@ namespace OpenBve {
 					AlphaTestEnabled = false;
 				}
 				for (int j = 0; j < Face.Vertices.Length; j++) {
-					GL.Begin(BeginMode.Lines);
+					GL.Begin(PrimitiveType.Lines);
 					GL.Color4(inv255 * (float)Material.Color.R, inv255 * (float)Material.Color.G, inv255 * (float)Material.Color.B, 1.0f);
 					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
 					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X + Face.Vertices[j].Normal.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y + Face.Vertices[j].Normal.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z + Face.Vertices[j].Normal.Z - CameraZ));
@@ -699,7 +698,7 @@ namespace OpenBve {
 					for (int i = 0; i < n; i++) {
 						int j = (i + 1) % n;
 						// side wall
-						GL.Begin(BeginMode.Quads);
+						GL.Begin(PrimitiveType.Quads);
 						GL.TexCoord2(textureX, 0.005f);
 						GL.Vertex3(top[i].X, top[i].Y, top[i].Z);
 						GL.TexCoord2(textureX, 0.995f);
@@ -710,7 +709,7 @@ namespace OpenBve {
 						GL.Vertex3(top[j].X, top[j].Y, top[j].Z);
 						GL.End();
 						// top cap
-						GL.Begin(BeginMode.Triangles);
+						GL.Begin(PrimitiveType.Triangles);
 						GL.TexCoord2(textureX, 0.005f);
 						GL.Vertex3(top[i].X, top[i].Y, top[i].Z);
 						GL.TexCoord2(textureX + textureIncrement, 0.005f);
@@ -902,7 +901,7 @@ namespace OpenBve {
 				t[4] = new World.Vector2D[] { new World.Vector2D(0.0, 1.0), new World.Vector2D(0.0, 0.0), new World.Vector2D(1.0, 0.0), new World.Vector2D(1.0, 1.0) };
 				t[5] = new World.Vector2D[] { new World.Vector2D(0.0, 1.0), new World.Vector2D(0.0, 0.0), new World.Vector2D(1.0, 0.0), new World.Vector2D(1.0, 1.0) };
 				for (int i = 0; i < 6; i++) {
-					GL.Begin(BeginMode.Quads);
+					GL.Begin(PrimitiveType.Quads);
 					GL.Color3(1.0, 1.0, 1.0);
 					for (int j = 0; j < 4; j++) {
 						GL.TexCoord2(t[i][j].X, t[i][j].Y);
@@ -912,7 +911,7 @@ namespace OpenBve {
 				}
 			} else {
 				for (int i = 0; i < 6; i++) {
-					GL.Begin(BeginMode.Quads);
+					GL.Begin(PrimitiveType.Quads);
 					GL.Color3(1.0, 1.0, 1.0);
 					for (int j = 0; j < 4; j++) {
 						GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -189,8 +189,10 @@ namespace OpenBve
 		internal static bool LoadingRemakeCurrent = false;
 
 		private static readonly object jobLock = new object();
+#pragma warning disable 0649
 		private static Queue<ThreadStart> jobs;
 		private static Queue<object> locks;
+#pragma warning restore 0649
 
 		/// <summary>This method is used during loading to run commands requiring an OpenGL context in the main render loop</summary>
 		/// <param name="job">The OpenGL command</param>

--- a/source/RouteViewer/TextureManager.cs
+++ b/source/RouteViewer/TextureManager.cs
@@ -51,7 +51,7 @@ namespace OpenBve
 			internal bool LoadImmediately;
 			//Grabbing the framebuffer directly as a texture is vertically flipped due to the way openGL works...
 			//Nasty hacky workaround tells the renderer to use vertically flipped texture coords
-			internal bool VFlip;
+			internal const bool VFlip = true;
 		}
 		internal static Texture[] Textures = new Texture[16];
 		private const int MaxCyclesUntilUnload = 4;
@@ -250,7 +250,6 @@ namespace OpenBve
 				CycleTime = 0.0;
 				for (int i = 0; i < Textures.Length; i++)
 				{
-					bool ul = false;
 					if (Textures[i] != null)
 					{
 						if (Textures[i].Loaded & !Textures[i].DontAllowUnload)

--- a/source/RouteViewer/TrainManagerR.cs
+++ b/source/RouteViewer/TrainManagerR.cs
@@ -10,6 +10,9 @@ using System;
 namespace OpenBve {
 	internal static class TrainManager {
 
+// Silence the absurd amount of unused variable warnings
+#pragma warning disable 0649
+
 		// structures
 		internal struct Axle {
 			internal TrackManager.TrackFollower Follower;
@@ -420,6 +423,8 @@ namespace OpenBve {
 			//internal double PretrainAheadTimetable;
 			//internal double InternalTimerTimeElapsed;
 		}
+
+#pragma warning restore 0649
 
 		// trains
 		internal static Train[] Trains = new Train[] { };

--- a/source/RouteViewer/WorldR.cs
+++ b/source/RouteViewer/WorldR.cs
@@ -381,7 +381,7 @@ namespace OpenBve {
 		internal static CameraAlignment CameraCurrentAlignment;
 		internal static CameraAlignment CameraAlignmentDirection;
 		internal static CameraAlignment CameraAlignmentSpeed;
-		internal static double CameraSpeed;
+		internal const double CameraSpeed = 0.0;
 		internal const double CameraInteriorTopSpeed = 1.0;
 		internal const double CameraInteriorTopAngularSpeed = 2.0;
 		internal const double CameraExteriorTopSpeed = 50.0;

--- a/source/Sound.Flac/Decoder.cs
+++ b/source/Sound.Flac/Decoder.cs
@@ -179,7 +179,7 @@ namespace Flac {
 					 * block may be shorter than the stream blocksize; its starting sample number will be calculated as the frame number 
 					 * times the previous frame's blocksize, or zero if it is the first frame). 
 					 */
-					ulong sampleOrFrameNumber = (ulong)reader.ReadUTF8EncodedInteger();
+					reader.ReadUTF8EncodedInteger(); // ulong sampleOrFrameNumber = (ulong)
 					if (blockNumberOfSamples == 6) {
 						blockNumberOfSamples = (int)reader.ReadByte() + 1;
 					} else if (blockNumberOfSamples == 7) {
@@ -292,9 +292,6 @@ namespace Flac {
 							int[] blockSamples = new int[blockNumberOfSamples];
 							for (int j = 0; j < predictorOrder; j++) {
 								blockSamples[j] = FromTwosComplement(reader.ReadBits((int)subframeBitsPerSample), (uint)1 << subframeBitsPerSample);
-								if (blockSamples[j] != 0) {
-									int asdgfefe = blockSamples[j];
-								}
 							}
 							int coefficientPrecision = (int)reader.ReadBits(4) + 1;
 							if (coefficientPrecision == 16) {

--- a/source/Sound.Flac/Decoder.cs
+++ b/source/Sound.Flac/Decoder.cs
@@ -179,6 +179,11 @@ namespace Flac {
 					 * block may be shorter than the stream blocksize; its starting sample number will be calculated as the frame number 
 					 * times the previous frame's blocksize, or zero if it is the first frame). 
 					 */
+
+					/*
+					 * TODO:
+					 * Throw if the there are variable frame lengths as they are unsupported
+					 */
 					reader.ReadUTF8EncodedInteger(); // ulong sampleOrFrameNumber = (ulong)
 					if (blockNumberOfSamples == 6) {
 						blockNumberOfSamples = (int)reader.ReadByte() + 1;

--- a/source/Sound.Flac/Plugin.cs
+++ b/source/Sound.Flac/Plugin.cs
@@ -9,7 +9,7 @@ namespace Plugin {
 		// --- members ---
 		
 		/// <summary>The host that loaded the plugin.</summary>
-		private HostInterface CurrentHost = null;
+		// private HostInterface CurrentHost = null;
 		
 		
 		// --- functions ---
@@ -17,7 +17,7 @@ namespace Plugin {
 		/// <summary>Called when the plugin is loaded.</summary>
 		/// <param name="host">The host that loaded the plugin.</param>
 		public override void Load(HostInterface host) {
-			CurrentHost = host;
+			// CurrentHost = host;
 		}
 		
 		/// <summary>Checks whether the plugin can load the specified sound.</summary>

--- a/source/Sound.RiffWave/Plugin.cs
+++ b/source/Sound.RiffWave/Plugin.cs
@@ -9,7 +9,7 @@ namespace Plugin {
 		// --- members ---
 		
 		/// <summary>The host that loaded the plugin.</summary>
-		private HostInterface CurrentHost = null;
+		// private HostInterface CurrentHost = null;
 		
 		
 		// --- functions ---
@@ -17,7 +17,7 @@ namespace Plugin {
 		/// <summary>Called when the plugin is loaded.</summary>
 		/// <param name="host">The host that loaded the plugin.</param>
 		public override void Load(HostInterface host) {
-			CurrentHost = host;
+			// CurrentHost = host;
 		}
 		
 		/// <summary>Checks whether the plugin can load the specified sound.</summary>
@@ -36,7 +36,7 @@ namespace Plugin {
 						} else {
 							return false;
 						}
-						uint headerCkSize = ReadUInt32(reader, endianness);
+						ReadUInt32(reader, endianness); // uint headerCkSize = 
 						uint formType = ReadUInt32(reader, endianness);
 						if (formType != 0x45564157) {
 							return false;

--- a/source/Texture.Ace/Plugin.Parser.cs
+++ b/source/Texture.Ace/Plugin.Parser.cs
@@ -422,7 +422,7 @@ namespace Plugin {
 						throw new InvalidDataException();
 					}
 					byte flg = reader.ReadByte();
-					int fcheck = flg & 31;
+					// int fcheck = flg & 31;
 					if ((256 * cmf + flg) % 31 != 0) {
 						throw new InvalidDataException();
 					}

--- a/source/Texture.Ace/Plugin.cs
+++ b/source/Texture.Ace/Plugin.cs
@@ -9,7 +9,7 @@ namespace Plugin {
 		// --- members ---
 		
 		/// <summary>The host that loaded the plugin.</summary>
-		private HostInterface CurrentHost = null;
+		// private HostInterface CurrentHost = null;
 		
 		
 		// --- functions ---
@@ -17,7 +17,7 @@ namespace Plugin {
 		/// <summary>Called when the plugin is loaded.</summary>
 		/// <param name="host">The host that loaded the plugin.</param>
 		public override void Load(HostInterface host) {
-			CurrentHost = host;
+			// CurrentHost = host;
 		}
 		
 		/// <summary>Queries the dimensions of a texture.</summary>


### PR DESCRIPTION
In this pull I have all of the different warnings being either fixed or silenced. There were huge sections of problems on MSVC#, with some files exceeding 300 variable unused warnings. I have silenced them on mass and have removed unnecessary variable declarations. I have made sure that any function that had side effects still gets called, the return value is just thrown away. I have left the variable name in a comment next to it so that if we need this information later it would be easy to put back in. Most of the problems were in the ObjectViewer/RouteViewer, but there were a few things in the OpenBVE source. 