### PR TITLE
Fix Monodevelop on Fresh Build and Add Travis-ci Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ matrix:
     - os: linux
       dist: trusty
       mono: latest
-      script: make publish
+      script: make all-release
     - os: osx
       mono: latest
       before_install: brew install hudochenkov/sshpass/sshpass
-      script: make publish
+      script: make all-release
 
     - os: linux
       dist: precise
       mono: 3.2.8
-      script: make publish
+      script: make all-release
 
     - os: linux
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,39 @@ matrix:
     - os: linux
       dist: precise
       mono: latest
+      script: make publish
     - os: linux
       dist: trusty
       mono: latest
+      script: make publish
     - os: osx
       mono: latest
       before_install: brew install hudochenkov/sshpass/sshpass
+      script: make publish
 
     - os: linux
       dist: precise
       mono: 3.2.8
+      script: make publish
+
+    - os: linux
+      dist: precise
+      mono: latest
+      solution: OpenBVE.sln
+    - os: linux
+      dist: trusty
+      mono: latest
+      solution: OpenBVE.sln
+    - os: osx
+      mono: latest
+      before_install: brew install hudochenkov/sshpass/sshpass
+      solution: OpenBVE.sln
+
+    - os: linux
+      dist: precise
+      mono: 3.2.8
+      solution: OpenBVE.sln
  
-script:
-  - make publish
 after_success:
 #Export SSH password for whichever platform we are building on
  - test $TRAVIS_PULL_REQUEST == "false" && (test $TRAVIS_BRANCH == "master" || test $TRAVIS_TAG) && export SSHPASS=$DEPLOY_PASS

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -332,7 +332,7 @@
     <PreBuildEvent Condition=" '$(OS)' != 'Unix' ">set textTemplatingPath="%25CommonProgramFiles(x86)%25\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe"
 if %25textTemplatingPath%25=="\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe" set textTemplatingPath="%25CommonProgramFiles%25\Microsoft Shared\TextTemplating\$(VisualStudioVersion)\texttransform.exe"
 %25textTemplatingPath%25 "$(ProjectDir)\Properties\AssemblyInfo.tt"</PreBuildEvent>
-    <PreBuildEvent Condition=" '$(OS)' == 'Unix' ">$(ProjectDir)Properties/AssemblyInfo.sh</PreBuildEvent>
+    <PreBuildEvent Condition=" '$(OS)' == 'Unix' ">bash $(ProjectDir)Properties/AssemblyInfo.sh</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Copy in dependancies and child projects -->
@@ -341,7 +341,7 @@ if %25textTemplatingPath%25=="\Microsoft Shared\TextTemplating\$(VisualStudioVer
 	</PostBuildEvent>
     <!-- NOTE: Whilst AtsPluginProxy.dll is Windows specific, we still want to copy it in the auto-generated nightly builds -->
     <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">
-		cp -rf "$(SolutionDir)assets/*" "$(TargetDir)Data"
+		cp -rf "$(SolutionDir)assets/." "$(TargetDir)Data/"
 	</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -96,7 +96,7 @@
       xcopy /E /Y "$(SolutionDir)dependencies" "$(TargetDir)"
     </PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' == 'Unix' ">
-      cp -r "$(SolutionDir)dependencies" "$(TargetDir)"
+      cp -r "$(SolutionDir)dependencies/." "$(TargetDir)"
     </PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I've fixed problems with dependency copying on xbuild, as well as adding travis-ci tests on all platforms using xbuild.