### PR TITLE
New: Sounds can be attached to a TrackFollower

### DIFF
--- a/source/ObjectBender/ObjectBender.csproj
+++ b/source/ObjectBender/ObjectBender.csproj
@@ -46,7 +46,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <FileAlignment>4096</FileAlignment>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/source/ObjectViewer/ObjectViewer.csproj
+++ b/source/ObjectViewer/ObjectViewer.csproj
@@ -65,7 +65,7 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="formOptions.cs">

--- a/source/OpenBVE/Audio/Sounds.SoundBuffer.cs
+++ b/source/OpenBVE/Audio/Sounds.SoundBuffer.cs
@@ -18,17 +18,27 @@ namespace OpenBve {
 			internal double Duration;
 			/// <summary>Whether to ignore further attemps to load the sound after previous attempts have failed.</summary>
 			internal bool Ignore;
-			
+			/// <summary>The function script controlling this sound's volume.</summary>
+			internal FunctionScripts.FunctionScript PitchFunction;
+			/// <summary>The function script controlling this sound's volume.</summary>
+			internal FunctionScripts.FunctionScript VolumeFunction;
+
+			internal double InternalVolumeFactor;
+
 			/// <summary>Creates a new sound buffer</summary>
-			/// <param name="path">The on-disk path to the sound</param>
-			/// <param name="radius">The radius of the sound</param>
+			/// <param name="path">The on-disk path to the sound to load</param>
+			/// <param name="radius">The radius for this sound</param>
 			internal SoundBuffer(string path, double radius) {
 				this.Origin = new PathOrigin(path);
 				this.Radius = radius;
 				this.Loaded = false;
 				this.OpenAlBufferName = 0;
 				this.Duration = 0.0;
+				this.InternalVolumeFactor = 0.5;
 				this.Ignore = false;
+				this.PitchFunction = null;
+				this.VolumeFunction = null;
+				
 			}
 
 			/// <summary>Creates a new sound buffer</summary>
@@ -40,7 +50,54 @@ namespace OpenBve {
 				this.Loaded = false;
 				this.OpenAlBufferName = 0;
 				this.Duration = 0.0;
+				this.InternalVolumeFactor = 0.5;
 				this.Ignore = false;
+				this.PitchFunction = null;
+				this.VolumeFunction = null;
+			}
+			/// <summary>Creates a new uninitialized sound buffer</summary>
+			internal SoundBuffer()
+			{
+				this.Origin = null;
+				this.Radius = 0.0;
+				this.Loaded = false;
+				this.OpenAlBufferName = 0;
+				this.Duration = 0.0;
+				this.InternalVolumeFactor = 0.5;
+				this.Ignore = false;
+				this.PitchFunction = null;
+				this.VolumeFunction = null;
+			}
+
+			internal SoundBuffer(SoundOrigin origin)
+			{
+				this.Origin = origin;
+				this.Radius = 0.0;
+				this.Loaded = false;
+				this.OpenAlBufferName = 0;
+				this.Duration = 0.0;
+				this.InternalVolumeFactor = 0.5;
+				this.Ignore = false;
+				this.PitchFunction = null;
+				this.VolumeFunction = null;
+			}
+
+			/// <summary>Creates a clone of the specified sound buffer</summary>
+			/// <param name="b">The buffer to clone</param>
+			/// <returns>The new buffer</returns>
+			internal SoundBuffer Clone(SoundBuffer b)
+			{
+				return new SoundBuffer(b.Origin)
+				{
+					Radius = b.Radius,
+					Loaded = false,
+					OpenAlBufferName = 0,
+					Duration = b.Duration,
+					InternalVolumeFactor = b.InternalVolumeFactor,
+					Ignore = false,
+					PitchFunction = b.PitchFunction,
+					VolumeFunction = b.VolumeFunction
+				};
 			}
 
 			/// <summary>Attempts to load a new sound buffer</summary>

--- a/source/OpenBVE/Audio/Sounds.SoundSource.cs
+++ b/source/OpenBVE/Audio/Sounds.SoundSource.cs
@@ -44,8 +44,8 @@
 			internal double Volume;
 			/// <summary>The position. If a train and car are specified, the position is relative to the car, otherwise absolute.</summary>
 			internal OpenBveApi.Math.Vector3 Position;
-			/// <summary>The train this sound is attached to, or a null reference.</summary>
-			internal TrainManager.Train Train;
+			/// <summary>The parent object this sound is attached to, or a null reference.</summary>
+			internal object Parent;
 			/// <summary>The car this sound is attached to, or a null reference.</summary>
 			internal int Car;
 			/// <summary>Whether this sound plays in a loop.</summary>
@@ -64,24 +64,28 @@
 			/// <param name="pitch">The pitch change factor.</param>
 			/// <param name="volume">The volume change factor.</param>
 			/// <param name="position">The position. If a train and car are specified, the position is relative to the car, otherwise absolute.</param>
-			/// <param name="train">The train this sound source is attached to, or a null reference.</param>
+			/// <param name="parent">The parent object this sound source is attached to, or a null reference.</param>
 			/// <param name="car">The car this sound source is attached to, or a null reference.</param>
 			/// <param name="looped">Whether this sound source plays in a loop.</param>
-			internal SoundSource(SoundBuffer buffer, double radius, double pitch, double volume, OpenBveApi.Math.Vector3 position, TrainManager.Train train, int car, bool looped) {
+			internal SoundSource(SoundBuffer buffer, double radius, double pitch, double volume, OpenBveApi.Math.Vector3 position, object parent, int car, bool looped) {
 				this.Buffer = buffer;
 				this.Radius = radius;
 				this.Pitch = pitch;
 				this.Volume = volume;
 				this.Position = position;
-				this.Train = train;
+				this.Parent = parent;
 				this.Car = car;
 				this.Looped = looped;
 				this.State = SoundSourceState.PlayPending;
 				this.OpenAlSourceName = 0;
 				//Set the sound type to undefined to use Michelle's original processing
-				if (train != null)
+				if (parent is TrainManager.Train)
 				{
 					this.Type = SoundType.TrainCar;
+				}
+				else if (parent is ObjectManager.WorldSound)
+				{
+					this.Type = SoundType.AnimatedObject;
 				}
 				else
 				{
@@ -107,7 +111,7 @@
 				this.Pitch = pitch;
 				this.Volume = volume;
 				this.Position = position;
-				this.Train = train;
+				this.Parent = train;
 				this.Car = car;
 				this.Looped = looped;
 				this.State = SoundSourceState.PlayPending;

--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -4,6 +4,8 @@ using OpenTK.Audio.OpenAL;
 
 
 namespace OpenBve {
+	using OpenBveApi.Math;
+
 	internal static partial class Sounds {
 
 		/// <summary>Updates the sound component. Should be called every frame.</summary>
@@ -100,19 +102,26 @@ namespace OpenBve {
 					 * The sound is to be played or is already playing.
 					 * Calculate the sound gain.
 					 * */
+					OpenBveApi.Math.Vector3 direction;
 					OpenBveApi.Math.Vector3 position;
 					OpenBveApi.Math.Vector3 velocity;
 
 					switch (Sources[i].Type)
 					{
 						case SoundType.TrainCar:
-							OpenBveApi.Math.Vector3 direction;
-							Sources[i].Train.Cars[Sources[i].Car].CreateWorldCoordinates(Sources[i].Position.X, Sources[i].Position.Y, Sources[i].Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
-							velocity = Sources[i].Train.Cars[Sources[i].Car].Specs.CurrentSpeed * direction;
+							var Train = (TrainManager.Train)Sources[i].Parent;
+							Train.Cars[Sources[i].Car].CreateWorldCoordinates(Sources[i].Position.X, Sources[i].Position.Y, Sources[i].Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
+							velocity = Train.Cars[Sources[i].Car].Specs.CurrentSpeed * direction;
+							break;
+						case SoundType.AnimatedObject:
+							var WorldSound = (ObjectManager.WorldSound)Sources[i].Parent;
+							//TODO: Calculate speed...
+							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
+							velocity = Vector3.Null;
 							break;
 						default:
 							position = Sources[i].Position;
-							velocity = OpenBveApi.Math.Vector3.Null;
+							velocity = Vector3.Null;
 							break;
 					}
 					OpenBveApi.Math.Vector3 positionDifference = position - listenerPosition;
@@ -123,7 +132,7 @@ namespace OpenBve {
 						double distance = positionDifference.Norm();
 						double innerRadius = Sources[i].Radius;
 						if (World.CameraMode == World.CameraViewMode.Interior | World.CameraMode == World.CameraViewMode.InteriorLookAhead) {
-							if (Sources[i].Train != TrainManager.PlayerTrain || Sources[i].Car != TrainManager.PlayerTrain.DriverCar) {
+							if (Sources[i].Parent != TrainManager.PlayerTrain || Sources[i].Car != TrainManager.PlayerTrain.DriverCar) {
 								innerRadius *= 0.5;
 							}
 						}
@@ -377,17 +386,26 @@ namespace OpenBve {
 					 * to the list of sounds to be played.
 					 * */
 					OpenBveApi.Math.Vector3 position;
-					if (Sources[i].Train != null) {
-						OpenBveApi.Math.Vector3 direction;
-						Sources[i].Train.Cars[Sources[i].Car].CreateWorldCoordinates(Sources[i].Position.X, Sources[i].Position.Y, Sources[i].Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
-					} else {
-						position = Sources[i].Position;
+					switch (Sources[i].Type)
+					{
+						case SoundType.TrainCar:
+							OpenBveApi.Math.Vector3 direction;
+							var Train = (TrainManager.Train)Sources[i].Parent;
+							Train.Cars[Sources[i].Car].CreateWorldCoordinates(Sources[i].Position.X, Sources[i].Position.Y, Sources[i].Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
+							break;
+						case SoundType.AnimatedObject:
+							var WorldSound = (ObjectManager.WorldSound)Sources[i].Parent;
+							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
+							break;
+						default:
+							position = Sources[i].Position;
+							break;
 					}
 					OpenBveApi.Math.Vector3 positionDifference = position - listenerPosition;
 					double distance = positionDifference.Norm();
 					double radius = Sources[i].Radius;
 					if (World.CameraMode == World.CameraViewMode.Interior | World.CameraMode == World.CameraViewMode.InteriorLookAhead) {
-						if (Sources[i].Train != TrainManager.PlayerTrain || Sources[i].Car != TrainManager.PlayerTrain.DriverCar) {
+						if (Sources[i].Parent != TrainManager.PlayerTrain || Sources[i].Car != TrainManager.PlayerTrain.DriverCar) {
 							radius *= 0.5;
 						}
 					}
@@ -509,13 +527,23 @@ namespace OpenBve {
 					}
 					OpenBveApi.Math.Vector3 position;
 					OpenBveApi.Math.Vector3 velocity;
-					if (source.Train != null) {
-						OpenBveApi.Math.Vector3 direction;
-						source.Train.Cars[source.Car].CreateWorldCoordinates(source.Position.X, source.Position.Y, source.Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
-						velocity = source.Train.Cars[source.Car].Specs.CurrentSpeed * direction;
-					} else {
-						position = source.Position;
-						velocity = OpenBveApi.Math.Vector3.Null;
+					switch (source.Type)
+					{
+						case SoundType.TrainCar:
+							OpenBveApi.Math.Vector3 direction;
+							var Train = (TrainManager.Train)source.Parent;
+							Train.Cars[source.Car].CreateWorldCoordinates(source.Position.X, source.Position.Y, source.Position.Z, out position.X, out position.Y, out position.Z, out direction.X, out direction.Y, out direction.Z);
+							velocity = Train.Cars[source.Car].Specs.CurrentSpeed * direction;
+							break;
+						case SoundType.AnimatedObject:
+							var WorldSound = (ObjectManager.WorldSound)source.Parent;
+							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
+							velocity = OpenBveApi.Math.Vector3.Null;
+							break;
+						default:
+							position = source.Position;
+							velocity = OpenBveApi.Math.Vector3.Null;
+							break;
 					}
 					position -= listenerPosition;
 					AL.Source(source.OpenAlSourceName, ALSource3f.Position, (float)position.X, (float)position.Y, (float)position.Z);

--- a/source/OpenBVE/Audio/Sounds.cs
+++ b/source/OpenBVE/Audio/Sounds.cs
@@ -272,11 +272,30 @@ namespace OpenBve
 		/// <param name="pitch">The pitch change factor.</param>
 		/// <param name="volume">The volume change factor.</param>
 		/// <param name="position">The position. If a train and car are specified, the position is relative to the car, otherwise absolute.</param>
+		/// <param name="parent">The parent object the sound is attached to, or a null reference.</param>
+		/// <param name="looped">Whether to play the sound in a loop.</param>
+		/// <returns>The sound source.</returns>
+		internal static SoundSource PlaySound(SoundBuffer buffer, double pitch, double volume, OpenBveApi.Math.Vector3 position, object parent, bool looped)
+		{
+			if (Sources.Length == SourceCount)
+			{
+				Array.Resize<SoundSource>(ref Sources, Sources.Length << 1);
+			}
+			Sources[SourceCount] = new SoundSource(buffer, buffer.Radius, pitch, volume, position, parent, 0, looped);
+			SourceCount++;
+			return Sources[SourceCount - 1];
+		}
+
+		/// <summary>Plays a sound.</summary>
+		/// <param name="buffer">The sound buffer.</param>
+		/// <param name="pitch">The pitch change factor.</param>
+		/// <param name="volume">The volume change factor.</param>
+		/// <param name="position">The position. If a train and car are specified, the position is relative to the car, otherwise absolute.</param>
 		/// <param name="train">The train the sound is attached to, or a null reference.</param>
 		/// <param name="car">The car in the train the sound is attached to.</param>
 		/// <param name="looped">Whether to play the sound in a loop.</param>
 		/// <returns>The sound source.</returns>
-		internal static SoundSource PlaySound(SoundBuffer buffer, double pitch, double volume, OpenBveApi.Math.Vector3 position, TrainManager.Train train, int car, bool looped)
+		internal static SoundSource PlaySound(SoundBuffer buffer, double pitch, double volume, OpenBveApi.Math.Vector3 position, object train, int car, bool looped)
 		{
 			if (Sources.Length == SourceCount)
 			{
@@ -343,7 +362,7 @@ namespace OpenBve
 		{
 			for (int i = 0; i < SourceCount; i++)
 			{
-				if (Sources[i].Train == train)
+				if (Sources[i].Parent == train)
 				{
 					if (Sources[i].State == SoundSourceState.Playing)
 					{

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObjectCollection.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObjectCollection.cs
@@ -10,6 +10,7 @@ namespace OpenBve
 		{
 			/// <summary>The objects that this collection contains</summary>
 			internal AnimatedObject[] Objects;
+			internal WorldSound[] Sounds;
 
 			internal override void CreateObject(Vector3 Position, World.Transformation BaseTransformation, World.Transformation AuxTransformation,
 				int SectionIndex, bool AccurateObjectDisposal, double StartingDistance, double EndingDistance, double BlockLength,
@@ -79,6 +80,18 @@ namespace OpenBve
 							Objects[i].CreateObject(Position, BaseTransformation, AuxTransformation, SectionIndex, TrackPosition, Brightness);
 						}
 					}
+				}
+				if (this.Sounds == null)
+				{
+					return;
+				}
+				for (int i = 0; i < Sounds.Length; i++)
+				{
+					if (this.Sounds[i] == null)
+					{
+						continue;
+					}
+					Sounds[i].CreateSound(Sounds[i].Position, BaseTransformation, AuxTransformation, SectionIndex, TrackPosition);
 				}
 			}
 

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedWorldObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedWorldObject.cs
@@ -6,114 +6,81 @@ namespace OpenBve
 	/// <summary>The ObjectManager is the root class containing functions to load and manage objects within the simulation world</summary>
 	public static partial class ObjectManager
 	{
-		internal class AnimatedWorldObject
+		internal class AnimatedWorldObject : WorldObject
 		{
-			internal bool FollowsTrack = false;
-			internal TrackManager.TrackFollower FrontAxleFollower;
-			internal TrackManager.TrackFollower RearAxleFollower;
-			internal double FrontAxlePosition;
-			internal double RearAxlePosition;
-			/// <summary>Holds the properties for an animated object within the simulation world</summary>
-			internal Vector3 Position;
-			/// <summary>The object's relative track position</summary>
-			internal double TrackPosition;
-			internal Vector3 Direction;
-			internal Vector3 Up;
-			internal Vector3 Side;
+	
 			/// <summary>The actual animated object</summary>
 			internal AnimatedObject Object;
 			/// <summary>The signalling section the object refers to (Only relevant for objects placed using Track.Sig</summary>
 			internal int SectionIndex;
 			/// <summary>The curve radius at the object's track position</summary>
 			internal double Radius;
-			/// <summary>Whether the object is currently visible</summary>
-			internal bool Visible;
-			/*
-			 * NOT IMPLEMENTED, BUT REQUIRED LATER
-			 */
-			internal double CurrentRollDueToTopplingAngle = 0;
-			internal double CurrentRollDueToCantAngle = 0;
 
-			/// <summary>Updates the position and rotation of an animated object which follows a track</summary>
-			internal void UpdateTrackFollowingObject()
+			internal override void Update(double TimeElapsed, bool ForceUpdate)
 			{
-				//Get vectors
-				double dx, dy, dz;
-				double ux, uy, uz;
-				double sx, sy, sz;
+				const double extraRadius = 10.0;
+				double z = Object.TranslateZFunction == null ? 0.0 : Object.TranslateZFunction.LastResult;
+				double pa = TrackPosition + z - Radius - extraRadius;
+				double pb = TrackPosition + z + Radius + extraRadius;
+				double ta = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z - World.BackgroundImageDistance - World.ExtraViewingDistance;
+				double tb = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z + World.BackgroundImageDistance + World.ExtraViewingDistance;
+				bool visible = pb >= ta & pa <= tb;
+				if (visible | ForceUpdate)
 				{
-					dx = FrontAxleFollower.WorldPosition.X -
-					     RearAxleFollower.WorldPosition.X;
-					dy = FrontAxleFollower.WorldPosition.Y -
-					     RearAxleFollower.WorldPosition.Y;
-					dz = FrontAxleFollower.WorldPosition.Z -
-					     RearAxleFollower.WorldPosition.Z;
-					double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-					dx *= t;
-					dy *= t;
-					dz *= t;
-					t = 1.0 / Math.Sqrt(dx * dx + dz * dz);
-					double ex = dx * t;
-					double ez = dz * t;
-					sx = ez;
-					sy = 0.0;
-					sz = -ex;
-					World.Cross(dx, dy, dz, sx, sy, sz, out ux, out uy, out uz);
-				}
-
-				// apply position due to cant/toppling
-				{
-					double a = CurrentRollDueToTopplingAngle +
-					           CurrentRollDueToCantAngle;
-					double x = Math.Sign(a) * 0.5 * Game.RouteRailGauge * (1.0 - Math.Cos(a));
-					double y = Math.Abs(0.5 * Game.RouteRailGauge * Math.Sin(a));
-					double cx = sx * x + ux * y;
-					double cy = sy * x + uy * y;
-					double cz = sz * x + uz * y;
-					FrontAxleFollower.WorldPosition.X += cx;
-					FrontAxleFollower.WorldPosition.Y += cy;
-					FrontAxleFollower.WorldPosition.Z += cz;
-					RearAxleFollower.WorldPosition.X += cx;
-					RearAxleFollower.WorldPosition.Y += cy;
-					RearAxleFollower.WorldPosition.Z += cz;
-				}
-				// apply rolling
-				{
-					double a = CurrentRollDueToTopplingAngle -
-					           CurrentRollDueToCantAngle;
-					double cosa = Math.Cos(a);
-					double sina = Math.Sin(a);
-					World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
-					World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-					Up.X = ux;
-					Up.Y = uy;
-					Up.Z = uz;
-				}
-				Direction.X = dx;
-				Direction.Y = dy;
-				Direction.Z = dz;
-				Side.X = sx;
-				Side.Y = sy;
-				Side.Z = sz;
-			}
-
-			internal double UpdateTrackFollowerScript(bool IsPartOfTrain, TrainManager.Train Train, int CarIndex, int SectionIndex, double TrackPosition, Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, bool Overlay, bool UpdateFunctions, bool Show, double TimeElapsed)
-			{
-				double x = 0.0;
-				if (Object.TrackFollowerFunction != null)
-				{
-					if (UpdateFunctions)
+					if (Object.SecondsSinceLastUpdate >= Object.RefreshRate | ForceUpdate)
 					{
-						x = Object.TrackFollowerFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain,
-							TimeElapsed, Object.CurrentState);
+						double timeDelta = Object.SecondsSinceLastUpdate + TimeElapsed;
+						Object.SecondsSinceLastUpdate = 0.0;
+						TrainManager.Train train = null;
+						double trainDistance = double.MaxValue;
+						for (int j = 0; j < TrainManager.Trains.Length; j++)
+						{
+							if (TrainManager.Trains[j].State == TrainManager.TrainState.Available)
+							{
+								double distance;
+								if (TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition < TrackPosition)
+								{
+									distance = TrackPosition - TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition;
+								}
+								else if (TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition > TrackPosition)
+								{
+									distance = TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition - TrackPosition;
+								}
+								else
+								{
+									distance = 0;
+								}
+								if (distance < trainDistance)
+								{
+									train = TrainManager.Trains[j];
+									trainDistance = distance;
+								}
+							}
+						}
+						Object.Update(false, train, train == null ? 0 : train.DriverCar, SectionIndex, TrackPosition, Position, Direction, Up, Side, false, true, true, timeDelta, true);
 					}
 					else
 					{
-						x = Object.TrackFollowerFunction.LastResult;
+						Object.SecondsSinceLastUpdate += TimeElapsed;
+					}
+					if (!Visible)
+					{
+						Renderer.ShowObject(Object.ObjectIndex, Renderer.ObjectType.Dynamic);
+						Visible = true;
 					}
 				}
-				return x;
+				else
+				{
+					Object.SecondsSinceLastUpdate += TimeElapsed;
+					if (Visible)
+					{
+						Renderer.HideObject(Object.ObjectIndex);
+						Visible = false;
+					}
+				}
 			}
+
+			
 		}
 	}
 }

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using OpenBveApi.Math;
+
+namespace OpenBve
+{
+	/// <summary>The ObjectManager is the root class containing functions to load and manage objects within the simulation world</summary>
+	public static partial class ObjectManager
+	{
+		internal class TrackFollowingObject : WorldObject
+		{
+			/// <summary>The actual animated object</summary>
+			internal AnimatedObject Object;
+			/// <summary>The signalling section the object refers to (Only relevant for objects placed using Track.Sig</summary>
+			internal int SectionIndex;
+			/// <summary>The curve radius at the object's track position</summary>
+			internal double Radius;
+
+			internal TrackManager.TrackFollower FrontAxleFollower;
+			internal TrackManager.TrackFollower RearAxleFollower;
+			internal double FrontAxlePosition;
+			internal double RearAxlePosition;
+
+			internal double CurrentRollDueToTopplingAngle;
+			internal double CurrentRollDueToCantAngle;
+
+			internal override void Update(double TimeElapsed, bool ForceUpdate)
+			{
+				const double extraRadius = 10.0;
+				double z = Object.TranslateZFunction == null ? 0.0 : Object.TranslateZFunction.LastResult;
+				double pa = TrackPosition + z - Radius - extraRadius;
+				double pb = TrackPosition + z + Radius + extraRadius;
+				double ta = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z - World.BackgroundImageDistance - World.ExtraViewingDistance;
+				double tb = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z + World.BackgroundImageDistance + World.ExtraViewingDistance;
+				bool visible = pb >= ta & pa <= tb;
+				if (visible | ForceUpdate)
+				{
+					if (Object.SecondsSinceLastUpdate >= Object.RefreshRate | ForceUpdate)
+					{
+						double timeDelta = Object.SecondsSinceLastUpdate + TimeElapsed;
+						Object.SecondsSinceLastUpdate = 0.0;
+						TrainManager.Train train = null;
+						double trainDistance = double.MaxValue;
+						for (int j = 0; j < TrainManager.Trains.Length; j++)
+						{
+							if (TrainManager.Trains[j].State == TrainManager.TrainState.Available)
+							{
+								double distance;
+								if (TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition < TrackPosition)
+								{
+									distance = TrackPosition - TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition;
+								}
+								else if (TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition > TrackPosition)
+								{
+									distance = TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition - TrackPosition;
+								}
+								else
+								{
+									distance = 0;
+								}
+								if (distance < trainDistance)
+								{
+									train = TrainManager.Trains[j];
+									trainDistance = distance;
+								}
+							}
+						}
+						if (Visible)
+						{
+							//Calculate the distance travelled
+							double delta = UpdateTrackFollowerScript(false, train, train == null ? 0 : train.DriverCar, SectionIndex, TrackPosition, Position, Direction, Up, Side, false, true, true, timeDelta);
+							//Update the front and rear axle track followers
+							FrontAxleFollower.Update((TrackPosition + FrontAxlePosition) + delta, true, true);
+							RearAxleFollower.Update((TrackPosition + RearAxlePosition) + delta, true, true);
+							//Update the base object position
+							FrontAxleFollower.UpdateWorldCoordinates(false);
+							RearAxleFollower.UpdateWorldCoordinates(false);
+							UpdateObjectPosition();
+						}
+						//Update the actual animated object- This must be done last in case the user has used Translation or Rotation
+						Object.Update(false, train, train == null ? 0 : train.DriverCar, SectionIndex, FrontAxleFollower.TrackPosition, FrontAxleFollower.WorldPosition, Direction, Up, Side, false, true, true, timeDelta, true);
+					}
+					else
+					{
+						Object.SecondsSinceLastUpdate += TimeElapsed;
+					}
+					if (!Visible)
+					{
+						Renderer.ShowObject(Object.ObjectIndex, Renderer.ObjectType.Dynamic);
+						Visible = true;
+					}
+				}
+				else
+				{
+					Object.SecondsSinceLastUpdate += TimeElapsed;
+					if (Visible)
+					{
+						Renderer.HideObject(Object.ObjectIndex);
+						Visible = false;
+					}
+				}
+			}
+
+			/// <summary>Updates the position and rotation of an animated object which follows a track</summary>
+			private void UpdateObjectPosition()
+			{
+				//Get vectors
+				double dx, dy, dz;
+				double ux, uy, uz;
+				double sx, sy, sz;
+				{
+					dx = FrontAxleFollower.WorldPosition.X - RearAxleFollower.WorldPosition.X;
+					dy = FrontAxleFollower.WorldPosition.Y - RearAxleFollower.WorldPosition.Y;
+					dz = FrontAxleFollower.WorldPosition.Z - RearAxleFollower.WorldPosition.Z;
+					double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
+					dx *= t;
+					dy *= t;
+					dz *= t;
+					t = 1.0 / Math.Sqrt(dx * dx + dz * dz);
+					double ex = dx * t;
+					double ez = dz * t;
+					sx = ez;
+					sy = 0.0;
+					sz = -ex;
+					World.Cross(dx, dy, dz, sx, sy, sz, out ux, out uy, out uz);
+				}
+
+				// apply position due to cant/toppling
+				{
+					double a = CurrentRollDueToTopplingAngle + CurrentRollDueToCantAngle;
+					double x = Math.Sign(a) * 0.5 * Game.RouteRailGauge * (1.0 - Math.Cos(a));
+					double y = Math.Abs(0.5 * Game.RouteRailGauge * Math.Sin(a));
+					double cx = sx * x + ux * y;
+					double cy = sy * x + uy * y;
+					double cz = sz * x + uz * y;
+					FrontAxleFollower.WorldPosition.X += cx;
+					FrontAxleFollower.WorldPosition.Y += cy;
+					FrontAxleFollower.WorldPosition.Z += cz;
+					RearAxleFollower.WorldPosition.X += cx;
+					RearAxleFollower.WorldPosition.Y += cy;
+					RearAxleFollower.WorldPosition.Z += cz;
+				}
+				// apply rolling
+				{
+					double a = CurrentRollDueToTopplingAngle - CurrentRollDueToCantAngle;
+					double cosa = Math.Cos(a);
+					double sina = Math.Sin(a);
+					World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+					World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
+					Up.X = ux;
+					Up.Y = uy;
+					Up.Z = uz;
+				}
+				Direction.X = dx;
+				Direction.Y = dy;
+				Direction.Z = dz;
+				Side.X = sx;
+				Side.Y = sy;
+				Side.Z = sz;
+			}
+
+			private double UpdateTrackFollowerScript(bool IsPartOfTrain, TrainManager.Train Train, int CarIndex, int SectionIndex, double TrackPosition, Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, bool Overlay, bool UpdateFunctions, bool Show, double TimeElapsed)
+			{
+				double x = 0.0;
+				if (Object.TrackFollowerFunction != null)
+				{
+					if (UpdateFunctions)
+					{
+						x = Object.TrackFollowerFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, Object.CurrentState);
+					}
+					else
+					{
+						x = Object.TrackFollowerFunction.LastResult;
+					}
+				}
+				return x;
+			}
+		}
+	}
+}

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/WorldSound.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/WorldSound.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using OpenBveApi.Math;
+
+namespace OpenBve
+{
+	/// <summary>The ObjectManager is the root class containing functions to load and manage objects within the simulation world</summary>
+	public static partial class ObjectManager
+	{
+		/// <summary>Represents a world sound attached to an .animated file</summary>
+		internal class WorldSound : WorldObject
+		{
+			/// <summary>The sound buffer to play</summary>
+			internal Sounds.SoundBuffer Buffer;
+			/// <summary>The sound source for this file</summary>
+			internal Sounds.SoundSource Source;
+			/// <summary>The pitch to play the sound at</summary>
+			internal double currentPitch = 1.0;
+			/// <summary>The volume to play the sound at it's origin</summary>
+			internal double currentVolume = 1.0;
+			/// <summary>The track position</summary>
+			internal double currentTrackPosition = 0;
+			/// <summary>The track follower used to hold/ move the sound</summary>
+			internal TrackManager.TrackFollower Follower;
+			/// <summary>The function script controlling the sound's movement along the track, or a null reference</summary>
+			internal FunctionScripts.FunctionScript TrackFollowerFunction;
+			/// <summary>The function script controlling the sound's volume, or a null reference</summary>
+			internal FunctionScripts.FunctionScript VolumeFunction;
+			/// <summary>The function script controlling the sound's pitch, or a null reference</summary>
+			internal FunctionScripts.FunctionScript PitchFunction;
+
+			internal void CreateSound(Vector3 position, World.Transformation BaseTransformation, World.Transformation AuxTransformation, int SectionIndex, double trackPosition)
+			{
+				int a = AnimatedWorldObjectsUsed;
+				if (a >= AnimatedWorldObjects.Length)
+				{
+					Array.Resize<WorldObject>(ref AnimatedWorldObjects, AnimatedWorldObjects.Length << 1);
+				}
+				WorldSound snd = new WorldSound
+				{
+					Buffer = this.Buffer,
+					//Must clone the vector, not pass the reference
+					Position = new Vector3(position.X, position.Y, position.Z)
+				};
+				snd.currentTrackPosition = trackPosition;
+				snd.Follower.Update(trackPosition, true, true);
+				snd.TrackFollowerFunction = this.TrackFollowerFunction.Clone();
+				AnimatedWorldObjects[a] = snd;
+				AnimatedWorldObjectsUsed++;
+			}
+
+			internal override void Update(double TimeElapsed, bool ForceUpdate)
+			{
+				const double extraRadius = 10.0;
+				const double Radius = 25.0;
+
+				double pa = currentTrackPosition + Radius - extraRadius;
+				double pb = currentTrackPosition + Radius + extraRadius;
+				double ta = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z - World.BackgroundImageDistance - World.ExtraViewingDistance;
+				double tb = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z + World.BackgroundImageDistance + World.ExtraViewingDistance;
+				bool visible = pb >= ta & pa <= tb;
+				if (visible | ForceUpdate)
+				{
+					if (Game.MinimalisticSimulation || TimeElapsed > 0.05)
+					{
+						return;
+					}
+					TrainManager.Train train = null;
+					double trainDistance = double.MaxValue;
+					for (int j = 0; j < TrainManager.Trains.Length; j++)
+					{
+						if (TrainManager.Trains[j].State == TrainManager.TrainState.Available)
+						{
+							double distance;
+							if (TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition < this.Follower.TrackPosition)
+							{
+								distance = this.Follower.TrackPosition - TrainManager.Trains[j].Cars[0].FrontAxle.Follower.TrackPosition;
+							}
+							else if (TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition > this.Follower.TrackPosition)
+							{
+								distance = TrainManager.Trains[j].Cars[TrainManager.Trains[j].Cars.Length - 1].RearAxle.Follower.TrackPosition - this.Follower.TrackPosition;
+							}
+							else
+							{
+								distance = 0;
+							}
+							if (distance < trainDistance)
+							{
+								train = TrainManager.Trains[j];
+								trainDistance = distance;
+							}
+						}
+					}
+					if (this.TrackFollowerFunction != null)
+					{
+
+						double delta = this.TrackFollowerFunction.Perform(train, train == null ? 0 : train.DriverCar, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+						this.Follower.Update(this.currentTrackPosition + delta, true, true);
+						this.Follower.UpdateWorldCoordinates(false);
+					}
+					if (this.VolumeFunction != null)
+					{
+						this.currentVolume = this.VolumeFunction.Perform(train, train == null ? 0 : train.DriverCar, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+					}
+					if (this.PitchFunction != null)
+					{
+						this.currentPitch = this.PitchFunction.Perform(train, train == null ? 0 : train.DriverCar, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+					}
+					if (this.Source != null)
+					{
+						this.Source.Pitch = this.currentPitch;
+						this.Source.Volume = this.currentVolume;
+					}
+					if (!Sounds.IsPlaying(Source))
+					{
+						Source = Sounds.PlaySound(Buffer, 1.0, 1.0, Follower.WorldPosition + Position, this, true);
+					}
+				}
+				else
+				{
+					if (Sounds.IsPlaying(Source))
+					{
+						Sounds.StopSound(Source);
+					}
+				}
+				
+			}
+		}
+	}
+}

--- a/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
+++ b/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
@@ -19,6 +19,8 @@ namespace OpenBve
 		internal static double LastUpdatedTrackPosition = 0.0;
 		/// <summary>Holds all animated objects currently in use within the game world</summary>
 		internal static AnimatedWorldObject[] AnimatedWorldObjects = new AnimatedWorldObject[4];
+
+		internal static WorldSound[] WorldSounds = new WorldSound[0];
 		/// <summary>The total number of animated objects used</summary>
 		internal static int AnimatedWorldObjectsUsed = 0;
 
@@ -72,9 +74,9 @@ namespace OpenBve
 						{
 							if (AnimatedWorldObjects[i].Visible)
 							{
+								
 								//Calculate the distance travelled
 								double delta = AnimatedWorldObjects[i].UpdateTrackFollowerScript(false, train, train == null ? 0 : train.DriverCar, AnimatedWorldObjects[i].SectionIndex, AnimatedWorldObjects[i].TrackPosition, AnimatedWorldObjects[i].Position, AnimatedWorldObjects[i].Direction, AnimatedWorldObjects[i].Up, AnimatedWorldObjects[i].Side, false, true, true, timeDelta);
-
 								//Update the front and rear axle track followers
 								AnimatedWorldObjects[i].FrontAxleFollower.Update((AnimatedWorldObjects[i].TrackPosition + AnimatedWorldObjects[i].FrontAxlePosition) + delta, true, true);
 								AnimatedWorldObjects[i].RearAxleFollower.Update((AnimatedWorldObjects[i].TrackPosition + AnimatedWorldObjects[i].RearAxlePosition) + delta, true, true);
@@ -112,6 +114,32 @@ namespace OpenBve
 					{
 						Renderer.HideObject(AnimatedWorldObjects[i].Object.ObjectIndex);
 						AnimatedWorldObjects[i].Visible = false;
+					}
+				}
+			}
+
+			for (int i = 0; i < WorldSounds.Length; i++)
+			{
+				const double extraRadius = 10.0;
+				
+				double pa = WorldSounds[i].currentTrackPosition + AnimatedWorldObjects[i].Radius - extraRadius;
+				double pb = WorldSounds[i].currentTrackPosition + AnimatedWorldObjects[i].Radius + extraRadius;
+				double ta = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z - World.BackgroundImageDistance - World.ExtraViewingDistance;
+				double tb = World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z + World.BackgroundImageDistance + World.ExtraViewingDistance;
+				bool visible = pb >= ta & pa <= tb;
+				if (visible | ForceUpdate)
+				{
+					WorldSounds[i].Update(TimeElapsed);
+					if (!Sounds.IsPlaying(WorldSounds[i].Source))
+					{
+						WorldSounds[i].Source = Sounds.PlaySound(WorldSounds[i].Buffer, 1.0, 1.0, WorldSounds[i].Follower.WorldPosition + WorldSounds[i].Position, WorldSounds[i], true);
+					}
+				}
+				else
+				{
+					if (Sounds.IsPlaying(WorldSounds[i].Source))
+					{
+						Sounds.StopSound(WorldSounds[i].Source);
 					}
 				}
 			}

--- a/source/OpenBVE/Game/ObjectManager/WorldObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/WorldObject.cs
@@ -1,0 +1,25 @@
+﻿using OpenBveApi.Math;
+
+namespace OpenBve
+{
+	/// <summary>The ObjectManager is the root class containing functions to load and manage objects within the simulation world</summary>
+	public static partial class ObjectManager
+	{
+		/// <summary>Represents an abstract object or sound placed within the game world</summary>
+		internal abstract class WorldObject
+		{
+			/// <summary>The position vector for this object</summary>
+			internal Vector3 Position;
+			/// <summary>The track position for this object</summary>
+			internal double TrackPosition;
+			/// <summary>Whether the object is currently visible at the player's camera position</summary>
+			internal bool Visible;
+
+			internal Vector3 Direction;
+			internal Vector3 Up;
+			internal Vector3 Side;
+
+			internal abstract void Update(double TimeElapsed, bool ForceUpdate);
+		}
+	}
+}

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -133,12 +133,15 @@
     <Compile Include="Game\ObjectManager\AnimatedObjects\AnimatedObjectCollection.cs" />
     <Compile Include="Game\ObjectManager\AnimatedObjects\AnimatedWorldObject.cs" />
     <Compile Include="Game\ObjectManager\AnimatedObjects\AnimationScript.cs" />
+    <Compile Include="Game\ObjectManager\AnimatedObjects\TrackFollowingObject.cs" />
+    <Compile Include="Game\ObjectManager\AnimatedObjects\WorldSound.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.Damping.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.ObjectLoadMode.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.StaticObject.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.UnifiedObject.cs" />
     <Compile Include="Game\ObjectManager\ObjectManager.Visibility.cs" />
+    <Compile Include="Game\ObjectManager\WorldObject.cs" />
     <Compile Include="Game\PointsOfInterest.cs" />
     <Compile Include="Game\RouteInformation.cs" />
     <Compile Include="Game\RouteInfoOverlay.cs" />

--- a/source/OpenBVE/Simulation/TrainManager/Functions.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Functions.cs
@@ -33,13 +33,14 @@ namespace OpenBve
 			{
 				for (int i = 0; i < ObjectManager.AnimatedWorldObjects.Length; i++)
 				{
-					if (ObjectManager.AnimatedWorldObjects[i].FollowsTrack)
+					var obj = ObjectManager.AnimatedWorldObjects[i] as ObjectManager.TrackFollowingObject;
+					if (obj != null)
 					{
 						//Track followers should be reset if we jump between stations
-						ObjectManager.AnimatedWorldObjects[i].FrontAxleFollower.TrackPosition = ObjectManager.AnimatedWorldObjects[i].TrackPosition + ObjectManager.AnimatedWorldObjects[i].FrontAxlePosition;
-						ObjectManager.AnimatedWorldObjects[i].FrontAxleFollower.TrackPosition = ObjectManager.AnimatedWorldObjects[i].TrackPosition + ObjectManager.AnimatedWorldObjects[i].RearAxlePosition;
-						ObjectManager.AnimatedWorldObjects[i].FrontAxleFollower.UpdateWorldCoordinates(false);
-						ObjectManager.AnimatedWorldObjects[i].RearAxleFollower.UpdateWorldCoordinates(false);
+						obj.FrontAxleFollower.TrackPosition = ObjectManager.AnimatedWorldObjects[i].TrackPosition + obj.FrontAxlePosition;
+						obj.FrontAxleFollower.TrackPosition = ObjectManager.AnimatedWorldObjects[i].TrackPosition + obj.RearAxlePosition;
+						obj.FrontAxleFollower.UpdateWorldCoordinates(false);
+						obj.RearAxleFollower.UpdateWorldCoordinates(false);
 					}
 				 
 				}

--- a/source/OpenBVE/Simulation/TrainManager/Train/BrakeSystem.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/BrakeSystem.cs
@@ -374,52 +374,55 @@ namespace OpenBve
 					{
 						emergency = Train.Specs.CurrentEmergencyBrake.Actual;
 					}
-					double p; if (emergency)
+					double targetPressure; if (emergency)
 					{
-						p = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderEmergencyMaximumPressure;
+						//If EB is selected, then target pressure must be that required for EB
+						targetPressure = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderEmergencyMaximumPressure;
 					}
 					else
 					{
-						p = (double)Train.Specs.CurrentBrakeNotch.Actual / (double)Train.Specs.MaximumBrakeNotch;
-						p *= Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
+						//Otherwise [BVE2 / BVE4 train.dat format] work out target pressure as a proportion of the max notch:
+						targetPressure = (double)Train.Specs.CurrentBrakeNotch.Actual / (double)Train.Specs.MaximumBrakeNotch;
+						targetPressure *= Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
 					}
 					if (Train.Cars[CarIndex].Specs.IsMotorCar & !Train.Specs.CurrentEmergencyBrake.Actual & Train.Specs.CurrentReverser.Actual != 0)
 					{
-						// brake control system
+						//If we meet the conditions for brake control system to activate
 						if (Math.Abs(Train.Cars[CarIndex].Specs.CurrentSpeed) > Train.Cars[CarIndex].Specs.BrakeControlSpeed)
 						{
 							if (Train.Cars[CarIndex].Specs.ElectropneumaticType == EletropneumaticBrakeType.ClosingElectromagneticValve)
 							{
-								// closing electromagnetic valve (lock-out valve)
-								p = 0.0;
+								//When above the brake control speed, pressure to the BC is nil & electric brakes are used
+								//Thus target pressure must be zero
+								targetPressure = 0.0;
 							}
 							else if (Train.Cars[CarIndex].Specs.ElectropneumaticType == EletropneumaticBrakeType.DelayFillingControl)
 							{
-								// delay-filling control
-								//Variable f is never used, so don't calculate it
-								//double f = (double)Train.Specs.CurrentBrakeNotch.Actual / (double)Train.Specs.MaximumBrakeNotch;
+								//Motor is used to brake the train, until not enough deceleration, at which point the air brake is also used
 								double a = Train.Cars[CarIndex].Specs.MotorDeceleration;
-								double pr = p / Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
+								double pr = targetPressure / Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
 								double b = pr * Train.Cars[CarIndex].Specs.BrakeDecelerationAtServiceMaximumPressure(Train.Specs.CurrentBrakeNotch.Actual);
 								double d = b - a;
 								if (d > 0.0)
 								{
-									p = d / Train.Cars[CarIndex].Specs.BrakeDecelerationAtServiceMaximumPressure(Train.Specs.CurrentBrakeNotch.Actual);
-									if (p > 1.0) p = 1.0;
-									p *= Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
+									//Deceleration provided by the motor is not enough, so increase the BC target pressure
+									targetPressure = d / Train.Cars[CarIndex].Specs.BrakeDecelerationAtServiceMaximumPressure(Train.Specs.CurrentBrakeNotch.Actual);
+									if (targetPressure > 1.0) targetPressure = 1.0;
+									targetPressure *= Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderServiceMaximumPressure;
 								}
 								else
 								{
-									p = 0.0;
+									//Motor deceleration is enough, BC target pressure to zero
+									targetPressure = 0.0;
 								}
 							}
 						}
 					}
-					if (Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure > p + Tolerance | p == 0.0)
+					if (Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure > targetPressure + Tolerance | targetPressure == 0.0)
 					{
-						// brake cylinder release
+						//BC pressure is greater than the target pressure, so release pressure
 						double r = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderReleaseRate;
-						double d = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure - p;
+						double d = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure - targetPressure;
 						double m = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderEmergencyMaximumPressure;
 						r = GetRate(d / m, r * TimeElapsed);
 						if (r > Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure) r = Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure;
@@ -427,15 +430,15 @@ namespace OpenBve
 						// air sound
 						if (r > 0.0 & Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure < Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderSoundPlayedForPressure)
 						{
-							Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderSoundPlayedForPressure = p;
-							airsound = p < Tolerance ? 0 : Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure > m - Tolerance ? 2 : 1;
+							Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderSoundPlayedForPressure = targetPressure;
+							airsound = targetPressure < Tolerance ? 0 : Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure > m - Tolerance ? 2 : 1;
 						}
 						// pressure change
 						Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure -= r;
 					}
-					else if (Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure + Tolerance < p)
+					else if (Train.Cars[CarIndex].Specs.AirBrake.BrakeCylinderCurrentPressure + Tolerance < targetPressure)
 					{
-						// refill brake cylinder from auxillary reservoir
+						//BC pressure is less than target pressure, so increase pressure
 						double f = Train.Cars[CarIndex].Specs.AirBrake.AuxillaryReservoirBrakeCylinderCoefficient;
 						double r;
 						if (emergency)

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -53,14 +53,14 @@
     <DocumentationFile>..\..\bin_release\OpenBveApi.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="SharpCompress.Unsigned">
       <HintPath>..\..\Dependencies\SharpCompress.Unsigned.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Archives.cs" />

--- a/source/Plugins/OpenBveAts/OpenBveAts.csproj
+++ b/source/Plugins/OpenBveAts/OpenBveAts.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_debug\Data\Plugins\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/source/Plugins/Sound.Flac/Sound.Flac.csproj
+++ b/source/Plugins/Sound.Flac/Sound.Flac.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_release\Data\Plugins\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/source/Plugins/Sound.RiffWave/Sound.RiffWave.csproj
+++ b/source/Plugins/Sound.RiffWave/Sound.RiffWave.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_release\Data\Plugins\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/source/Plugins/Texture.Ace/Texture.Ace.csproj
+++ b/source/Plugins/Texture.Ace/Texture.Ace.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_release\Data\Plugins\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/Texture.BmpGifJpegPngTiff.csproj
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/Texture.BmpGifJpegPngTiff.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_release\Data\Plugins\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
This branch has the initial work for attaching sounds to a Track Following animated object.

Sample animated file to start with:
```
[Object]
position = -4,0,0
States = 16xx.b3d
TrackFollowerFunction = if[value == 0, value + 1000, if[trackdistance > -200,if[value < 0, value, value - 10 * delta], value]]
Sound=Steamer.wav
```

The sound for this is played looped at a constant 100% volume & pitch when the object is visible (Stopped if the state is -1), emanating from the object's front axle.
The sound radii at present is a constant 30m (As per other trains within the simulation), but before merging, this should be changed to allow the user to set the radii appropriately.

Bugs:
* ~~Something not quite right with the sound attachments at the minute, occasionally managing to get the wrong type set for a sound....~~