### PR TITLE
Door interlocking via train plugin API

### DIFF
--- a/source/OpenBVE/Game/AI.cs
+++ b/source/OpenBVE/Game/AI.cs
@@ -218,7 +218,7 @@ namespace OpenBve
                         if (Train.Station >= 0 & Train.StationState == TrainManager.TrainStopState.Completed)
                         {
                             // ready for departure - close doors
-                            if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
+                            if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
                             {
                                 TrainManager.CloseTrainDoors(Train, true, true);
                             }
@@ -229,7 +229,7 @@ namespace OpenBve
                         else
                         {
                             // not at station - close doors
-                            if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
+                            if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
                             {
                                 TrainManager.CloseTrainDoors(Train, true, true);
                             }
@@ -239,7 +239,7 @@ namespace OpenBve
                 else if (Train.Station >= 0 && stopIndex >= 0 && Train.StationDistanceToStopPoint < Stations[Train.Station].Stops[stopIndex].BackwardTolerance && (StopsAtStation(Train.Station, Train) & (Stations[Train.Station].OpenLeftDoors | Stations[Train.Station].OpenRightDoors) & Math.Abs(Train.Specs.CurrentAverageSpeed) < 0.25 & Train.StationState == TrainManager.TrainStopState.Pending))
                 {
                     // arrived at station - open doors
-                    if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
+                    if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
                     {
                         TrainManager.OpenTrainDoors(Train, Stations[Train.Station].OpenLeftDoors, Stations[Train.Station].OpenRightDoors);
                     }

--- a/source/OpenBVE/OldCode/PluginManager.cs
+++ b/source/OpenBVE/OldCode/PluginManager.cs
@@ -130,10 +130,11 @@ namespace OpenBve {
                  * 
                  */
 			    CurrentCameraViewMode = (OpenBveApi.Runtime.CameraViewMode)World.CameraMode;
-				ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, new Time(totalTime), new Time(elapsedTime), currentRouteStations, CurrentCameraViewMode, Interface.CurrentLanguageCode);
+				ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, (DoorInterlockStates)this.Train.Specs.DoorInterlockState, new Time(totalTime), new Time(elapsedTime), currentRouteStations, CurrentCameraViewMode, Interface.CurrentLanguageCode);
 				LastTime = Game.SecondsSinceMidnight;
 				Elapse(data);
 				this.PluginMessage = data.DebugMessage;
+				this.Train.Specs.DoorInterlockState = (TrainManager.DoorInterlockStates)data.DoorInterlockState;
 			    DisableTimeAcceleration = data.DisableTimeAcceleration;
 				/*
 				 * Set the virtual handles.

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -392,6 +392,8 @@ namespace OpenBve
 			internal PassAlarmType PassAlarm;
 			internal DoorMode DoorOpenMode;
 			internal DoorMode DoorCloseMode;
+			internal DoorInterlockStates DoorInterlockState;
+			internal bool DoorClosureAttempted;
 		}
 
 		

--- a/source/OpenBVE/Simulation/TrainManager/Doors.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Doors.cs
@@ -17,6 +17,15 @@ namespace OpenBve
 			internal double DoorLockDuration;
 		}
 
+		/// <summary>The states of the door lock.</summary>
+		internal enum DoorInterlockStates
+		{
+			/// <summary>The train doors are unlocked.</summary>
+			Unlocked = 0,
+			/// <summary>The train doors are locked.</summary>
+			Locked = 1,
+		}
+
 		/// <summary>The potential states of the train's doors.</summary>
 		[Flags]
 		internal enum TrainDoorState

--- a/source/OpenBVE/Simulation/TrainManager/Station.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Station.cs
@@ -47,7 +47,7 @@ namespace OpenBve
 					{
 						Train.StationDepartureSoundPlayed = false;
 						// automatically open doors
-						if (Train.Specs.DoorOpenMode != DoorMode.Manual)
+						if (Train.Specs.DoorOpenMode != DoorMode.Manual & Train.Specs.DoorInterlockState == DoorInterlockStates.Unlocked)
 						{
 							if ((GetDoorsState(Train, Game.Stations[i].OpenLeftDoors, Game.Stations[i].OpenRightDoors) & TrainDoorState.AllOpened) == 0)
 							{
@@ -99,6 +99,7 @@ namespace OpenBve
 								// arrival
 								Train.StationState = TrainStopState.Boarding;
 								Train.StationAdjust = false;
+								Train.Specs.DoorClosureAttempted = false;
 								Sounds.StopSound(Train.Cars[Train.DriverCar].Sounds.Halt.Source);
 								Sounds.SoundBuffer buffer = Game.Stations[i].ArrivalSoundBuffer;
 								if (buffer != null)
@@ -219,13 +220,14 @@ namespace OpenBve
 				else if (Train.StationState == TrainStopState.Boarding)
 				{
 					// automatically close doors
-					if (Train.Specs.DoorCloseMode != DoorMode.Manual & Game.Stations[i].StationType == Game.StationType.Normal)
+					if (Train.Specs.DoorCloseMode != DoorMode.Manual & Train.Specs.DoorInterlockState == DoorInterlockStates.Unlocked & Game.Stations[i].StationType == Game.StationType.Normal)
 					{
 						if (Game.SecondsSinceMidnight >= Train.StationDepartureTime - 1.0 / Train.Cars[Train.DriverCar].Specs.DoorCloseFrequency)
 						{
 							if ((GetDoorsState(Train, true, true) & TrainDoorState.AllClosed) == 0)
 							{
 								CloseTrainDoors(Train, true, true);
+								Train.Specs.DoorClosureAttempted = true;
 							}
 						}
 					}
@@ -345,13 +347,14 @@ namespace OpenBve
 				Train.StationState = TrainStopState.Pending;
 			}
 			// automatically close doors
-			if (Train.Specs.DoorCloseMode == DoorMode.Automatic)
+			if (Train.Specs.DoorCloseMode != DoorMode.Manual & Train.Specs.DoorInterlockState == DoorInterlockStates.Unlocked & !Train.Specs.DoorClosureAttempted)
 			{
 				if (Train.Station == -1 | Train.StationState == TrainStopState.Completed)
 				{
 					if ((GetDoorsState(Train, true, true) & TrainDoorState.AllClosed) == 0)
 					{
 						CloseTrainDoors(Train, true, true);
+						Train.Specs.DoorClosureAttempted = true;
 					}
 				}
 			}

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1319,7 +1319,7 @@ namespace OpenBve
 											 TrainManager.TrainDoorState.Opened) == 0)
 										{
 											if (TrainManager.PlayerTrain.Specs.DoorOpenMode !=
-												TrainManager.DoorMode.Automatic)
+											    TrainManager.DoorMode.Automatic && TrainManager.PlayerTrain.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
 											{
 												TrainManager.OpenTrainDoors(TrainManager.PlayerTrain, true, false);
 											}
@@ -1327,7 +1327,7 @@ namespace OpenBve
 										else
 										{
 											if (TrainManager.PlayerTrain.Specs.DoorCloseMode !=
-												TrainManager.DoorMode.Automatic)
+												TrainManager.DoorMode.Automatic && TrainManager.PlayerTrain.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
 											{
 												TrainManager.CloseTrainDoors(TrainManager.PlayerTrain, true, false);
 											}
@@ -1339,7 +1339,7 @@ namespace OpenBve
 											 TrainManager.TrainDoorState.Opened) == 0)
 										{
 											if (TrainManager.PlayerTrain.Specs.DoorOpenMode !=
-												TrainManager.DoorMode.Automatic)
+												TrainManager.DoorMode.Automatic && TrainManager.PlayerTrain.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
 											{
 												TrainManager.OpenTrainDoors(TrainManager.PlayerTrain, false, true);
 											}
@@ -1347,7 +1347,7 @@ namespace OpenBve
 										else
 										{
 											if (TrainManager.PlayerTrain.Specs.DoorCloseMode !=
-												TrainManager.DoorMode.Automatic)
+												TrainManager.DoorMode.Automatic && TrainManager.PlayerTrain.Specs.DoorInterlockState == TrainManager.DoorInterlockStates.Unlocked)
 											{
 												TrainManager.CloseTrainDoors(TrainManager.PlayerTrain, false, true);
 											}

--- a/source/OpenBveApi/Runtime.cs
+++ b/source/OpenBveApi/Runtime.cs
@@ -597,7 +597,7 @@ namespace OpenBveApi.Runtime {
 			this.MyConstSpeed = constSpeed;
 		}
 	}
-	
+
 	/// <summary>Represents data given to the plugin in the Elapse call.</summary>
 	public class ElapseData {
 		// --- members ---
@@ -607,6 +607,8 @@ namespace OpenBveApi.Runtime {
 		private readonly PrecedingVehicleState MyPrecedingVehicle;
 		/// <summary>The virtual handles.</summary>
 		private Handles MyHandles;
+		/// <summary>The state of the door interlock.</summary>
+		private DoorInterlockStates MyDoorInterlockState;
 		/// <summary>The current absolute time.</summary>
 		private readonly Time MyTotalTime;
 		/// <summary>The elapsed time since the last call to Elapse.</summary>
@@ -631,10 +633,11 @@ namespace OpenBveApi.Runtime {
 		/// <param name="stations">The current route's list of stations.</param>
 		/// <param name="cameraView">The current camera view mode</param>
 		/// <param name="languageCode">The current language code</param>
-		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode) {
+		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, DoorInterlockStates doorinterlock, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode) {
 			this.MyVehicle = vehicle;
 			this.MyPrecedingVehicle = precedingVehicle;
 			this.MyHandles = handles;
+			this.MyDoorInterlockState = doorinterlock;
 			this.MyTotalTime = totalTime;
 			this.MyElapsedTime = elapsedTime;
 			this.MyDebugMessage = null;
@@ -664,6 +667,18 @@ namespace OpenBveApi.Runtime {
 			}
 			set {
 				this.MyHandles = value;
+			}
+		}
+		/// <summary>Gets or sets the state of the door lock.</summary>
+		public DoorInterlockStates DoorInterlockState
+		{
+			get
+			{
+				return this.MyDoorInterlockState;
+			}
+			set
+			{
+				this.MyDoorInterlockState = value;
 			}
 		}
 		/// <summary>Gets the absolute in-game time.</summary>
@@ -835,6 +850,13 @@ namespace OpenBveApi.Runtime {
 		FlyByZooming
 	}
 
+	/// <summary>Represents the states of the door interlock.</summary>
+	public enum DoorInterlockStates
+	{		/// <summary>The train doors are unlocked.</summary>
+		Unlocked = 0,
+		/// <summary>The train doors are locked.</summary>
+		Locked = 1,
+	}
 
 	// --- door change ---
 	


### PR DESCRIPTION
Train plugins can now lock the doors and prevent them from opening or closing. This is done using ElapseData.DoorInterlockState, which can be set to "Unlocked" (normal operation) or "Locked" (the train plugin is blocking the doors).

Trains with automatic doors will open or close them as soon as DoorInterlockState changes to "Unlocked", but won't attempt to close the doors again if the user overrides the system and opens them again (semi-automatic trains). A new boolean in the train's specs called "DoorClosureAttempted" allows OpenBVE to know whether this has happened or not.