### PR TITLE
New: Basic route viewer mode for the main program

### DIFF
--- a/source/OpenBVE/Graphics/Renderer/Overlays.HUD.cs
+++ b/source/OpenBVE/Graphics/Renderer/Overlays.HUD.cs
@@ -47,6 +47,10 @@ namespace OpenBve
 			switch (Command)
 			{
 				case "reverser":
+					if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+					{
+						return;
+					}
 					if (TrainManager.PlayerTrain.Handles.Reverser.Driver < 0)
 					{
 						sc = MessageColor.Orange;
@@ -86,7 +90,7 @@ namespace OpenBve
 					Element.TransitionState = 0.0;
 					break;
 				case "power":
-					if (TrainManager.PlayerTrain.Handles.SingleHandle)
+					if (TrainManager.PlayerTrain.Handles.SingleHandle || Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
 					{
 						return;
 					}
@@ -118,7 +122,7 @@ namespace OpenBve
 					Element.TransitionState = 0.0;
 					break;
 				case "brake":
-					if (TrainManager.PlayerTrain.Handles.SingleHandle)
+					if (TrainManager.PlayerTrain.Handles.SingleHandle || Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
 					{
 						return;
 					}
@@ -229,7 +233,7 @@ namespace OpenBve
 					Element.TransitionState = 0.0;
 					break;
 				case "locobrake":
-					if (!TrainManager.PlayerTrain.Handles.HasLocoBrake)
+					if (!TrainManager.PlayerTrain.Handles.HasLocoBrake || Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
 					{
 						return;
 					}
@@ -305,7 +309,7 @@ namespace OpenBve
 					Element.TransitionState = 0.0;
 					break;
 				case "single":
-					if (!TrainManager.PlayerTrain.Handles.SingleHandle)
+					if (!TrainManager.PlayerTrain.Handles.SingleHandle || Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
 					{
 						return;
 					}
@@ -373,7 +377,10 @@ namespace OpenBve
 					break;
 				case "doorsleft":
 				case "doorsright":
-				{
+					if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+					{
+						return;
+					}
 					if ((LeftDoors & TrainManager.TrainDoorState.AllClosed) == 0 | (RightDoors & TrainManager.TrainDoorState.AllClosed) == 0)
 					{
 						Element.TransitionState -= speed * TimeElapsed;
@@ -384,6 +391,7 @@ namespace OpenBve
 						Element.TransitionState += speed * TimeElapsed;
 						if (Element.TransitionState > 1.0) Element.TransitionState = 1.0;
 					}
+
 					TrainManager.TrainDoorState Doors = Command == "doorsleft" ? LeftDoors : RightDoors;
 					if ((Doors & TrainManager.TrainDoorState.Mixed) != 0)
 					{
@@ -401,49 +409,62 @@ namespace OpenBve
 					{
 						sc = MessageColor.Blue;
 					}
+
 					t = Command == "doorsleft" ? Translations.QuickReferences.DoorsLeft : Translations.QuickReferences.DoorsRight;
-				} break;
+					break;
 				case "stopleft":
 				case "stopright":
 				case "stopnone":
-				{
-					int s = TrainManager.PlayerTrain.Station;
-					if (s >= 0 && Game.PlayerStopsAtStation(s) && Interface.CurrentOptions.GameMode != Interface.GameMode.Expert)
+					if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
 					{
-						bool cond;
-						if (Command == "stopleft")
+						return;
+					}
+
+					{
+						int s = TrainManager.PlayerTrain.Station;
+						if (s >= 0 && Game.PlayerStopsAtStation(s) && Interface.CurrentOptions.GameMode != Interface.GameMode.Expert)
 						{
-							cond = Game.Stations[s].OpenLeftDoors;
-						}
-						else if (Command == "stopright")
-						{
-							cond = Game.Stations[s].OpenRightDoors;
-						}
-						else
-						{
-							cond = !Game.Stations[s].OpenLeftDoors & !Game.Stations[s].OpenRightDoors;
-						}
-						if (TrainManager.PlayerTrain.StationState == TrainManager.TrainStopState.Pending & cond)
-						{
-							Element.TransitionState -= speed * TimeElapsed;
-							if (Element.TransitionState < 0.0) Element.TransitionState = 0.0;
+							bool cond;
+							if (Command == "stopleft")
+							{
+								cond = Game.Stations[s].OpenLeftDoors;
+							}
+							else if (Command == "stopright")
+							{
+								cond = Game.Stations[s].OpenRightDoors;
+							}
+							else
+							{
+								cond = !Game.Stations[s].OpenLeftDoors & !Game.Stations[s].OpenRightDoors;
+							}
+
+							if (TrainManager.PlayerTrain.StationState == TrainManager.TrainStopState.Pending & cond)
+							{
+								Element.TransitionState -= speed * TimeElapsed;
+								if (Element.TransitionState < 0.0) Element.TransitionState = 0.0;
+							}
+							else
+							{
+								Element.TransitionState += speed * TimeElapsed;
+								if (Element.TransitionState > 1.0) Element.TransitionState = 1.0;
+							}
 						}
 						else
 						{
 							Element.TransitionState += speed * TimeElapsed;
 							if (Element.TransitionState > 1.0) Element.TransitionState = 1.0;
 						}
+	
+						t = Element.Text;
 					}
-					else
-					{
-						Element.TransitionState += speed * TimeElapsed;
-						if (Element.TransitionState > 1.0) Element.TransitionState = 1.0;
-					}
-					t = Element.Text;
-				} break;
+					break;
 				case "stoplefttick":
 				case "stoprighttick":
 				case "stopnonetick":
+					if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+					{
+						return;
+					}
 				{
 					int s = TrainManager.PlayerTrain.Station;
 					if (s >= 0 && Game.PlayerStopsAtStation(s) && Interface.CurrentOptions.GameMode != Interface.GameMode.Expert)

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Forms;
 using OpenBveApi.Interface;
 using OpenBveApi.Objects;
+using OpenTK.Graphics.ES11;
 
 namespace OpenBve
 {
@@ -153,6 +154,10 @@ namespace OpenBve
 		/// <param name="TimeElapsed">The time elapsed since the last call to this function</param>
 		internal static void UpdateTrains(double TimeElapsed)
 		{
+			if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+			{
+				return;
+			}
 			for (int i = 0; i < Trains.Length; i++) {
 				Trains[i].Update(TimeElapsed);
 			}

--- a/source/OpenBVE/Parsers/Train/TrainDatParser.cs
+++ b/source/OpenBVE/Parsers/Train/TrainDatParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Windows.Forms;
 using OpenBve.BrakeSystems;

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -656,14 +656,23 @@ namespace OpenBve
 			// initialize camera
 			if (World.CameraRestriction == Camera.RestrictionMode.NotAvailable)
 			{
-				World.CameraMode = CameraViewMode.InteriorLookAhead;
+				World.CameraMode = Interface.CurrentOptions.GameMode != Interface.GameMode.Developer ? CameraViewMode.InteriorLookAhead : CameraViewMode.Track;
 			}
-			//Place the initial camera in the driver car
-			TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].UpdateCamera();
-			World.CameraTrackFollower.Update(-1.0, true, false);
-			ObjectManager.UpdateVisibility(World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z);
-			World.CameraSavedExterior = new World.CameraAlignment(new OpenBveApi.Math.Vector3(-2.5, 1.5, -15.0), 0.3, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
-			World.CameraSavedTrack = new World.CameraAlignment(new OpenBveApi.Math.Vector3(-3.0, 2.5, 0.0), 0.3, 0.0, 0.0, TrainManager.PlayerTrain.Cars[0].FrontAxle.Follower.TrackPosition - 10.0, 1.0);
+			if (Interface.CurrentOptions.GameMode != Interface.GameMode.Developer)
+			{
+				//Place the initial camera in the driver car
+				TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].UpdateCamera();
+				World.CameraTrackFollower.Update(-1.0, true, false);
+				ObjectManager.UpdateVisibility(World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z);
+				World.CameraSavedExterior = new World.CameraAlignment(new OpenBveApi.Math.Vector3(-2.5, 1.5, -15.0), 0.3, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
+				World.CameraSavedTrack = new World.CameraAlignment(new OpenBveApi.Math.Vector3(-3.0, 2.5, 0.0), 0.3, 0.0, 0.0, TrainManager.PlayerTrain.Cars[0].FrontAxle.Follower.TrackPosition - 10.0, 1.0);
+			}
+			else
+			{
+				World.CameraSavedExterior = new World.CameraAlignment(new OpenBveApi.Math.Vector3(0, 2.5, -5.0), 0.0, 0.0, 0.0, World.CameraTrackFollower.TrackPosition, 1.0);
+				World.CameraCurrentAlignment = World.CameraSavedExterior;
+			}
+			
 			// signalling sections
 			for (int i = 0; i < TrainManager.Trains.Length; i++)
 			{

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -635,6 +635,13 @@ namespace OpenBve
 										Game.Menu.PushMenu(Menu.MenuType.Quit);
 										break;
 									case Translations.Command.CameraInterior:
+										if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+										{
+											Game.AddMessage("Interior camera is unavailable in Route Viewer mode.",
+												MessageManager.MessageDependency.CameraView, Interface.GameMode.Developer,
+												MessageColor.White, Game.SecondsSinceMidnight + 2.0, null);
+											return;
+										}
 										// camera: interior
 										MainLoop.SaveCameraSettings();
 										bool lookahead = false;
@@ -876,6 +883,12 @@ namespace OpenBve
 										break;
 									case Translations.Command.CameraReset:
 										// camera: reset
+										if (Interface.CurrentOptions.GameMode == Interface.GameMode.Developer)
+										{
+											World.CameraSavedExterior = new World.CameraAlignment(new OpenBveApi.Math.Vector3(0, 2.5, -5.0), 0.0, 0.0, 0.0, World.CameraTrackFollower.TrackPosition, 1.0);
+											World.CameraCurrentAlignment = World.CameraSavedExterior;
+											return;
+										}
 										if (World.CameraMode == CameraViewMode.Interior |
 											World.CameraMode == CameraViewMode.InteriorLookAhead)
 										{

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -168,7 +168,34 @@ namespace OpenBve {
 			}
 			Complete = true;
 		}
-		private static void LoadEverythingThreaded() {
+
+		private static void LoadEverythingThreaded()
+		{
+			LoadRouteFile();
+			if (Interface.CurrentOptions.GameMode != Interface.GameMode.Developer)
+			{
+				LoadTrains();
+			}
+			else
+			{
+
+				TrainManager.Trains = new TrainManager.Train[1];
+				TrainManager.Trains[0] = new TrainManager.Train(TrainManager.TrainState.Pending)
+				{
+					Cars = new TrainManager.Car[1]
+				};
+				TrainManager.Trains[0].Cars[0] = new TrainManager.Car(TrainManager.Trains[0], 0);
+				TrainManager.PlayerTrain = TrainManager.Trains[0];
+				//TrainDatParser.ParseTrainData(String.Empty, Encoding.UTF8, TrainManager.Trains[0]);
+				//TrainManager.PlayerTrain = TrainManager.Trains[0];
+				//TrainManager.PlayerTrain.PlaceCars(0.0);
+				//CurrentTrainFolder = String.Empty;
+				//LoadTrains();
+			}
+		}
+
+		private static void LoadRouteFile()
+		{
 			Program.FileSystem.AppendToLogFile("Loading route file: " + CurrentRouteFile);
 			string RailwayFolder = GetRailwayFolder(CurrentRouteFile);
 			string ObjectFolder = OpenBveApi.Path.CombineDirectory(RailwayFolder, "Object");
@@ -177,7 +204,7 @@ namespace OpenBve {
 			Game.Reset(true);
 			Game.MinimalisticSimulation = true;
 			// screen
-			World.CameraTrackFollower = new TrackManager.TrackFollower{ Train = null, CarIndex = -1 };
+			World.CameraTrackFollower = new TrackManager.TrackFollower {Train = null, CarIndex = -1};
 			World.CameraMode = CameraViewMode.Interior;
 			//First, check the format of the route file
 			//RW routes were written for BVE1 / 2, and have a different command syntax
@@ -186,21 +213,31 @@ namespace OpenBve {
 			CsvRwRouteParser.ParseRoute(CurrentRouteFile, IsRW, CurrentRouteEncoding, CurrentTrainFolder, ObjectFolder, SoundFolder, false);
 			Thread createIllustrations = new Thread(Game.RouteInformation.LoadInformation) {IsBackground = true};
 			createIllustrations.Start();
-			System.Threading.Thread.Sleep(1); if (Cancel) return;
+			System.Threading.Thread.Sleep(1);
+			if (Cancel) return;
 			Game.CalculateSeaLevelConstants();
-			if (Game.BogusPretrainInstructions.Length != 0) {
+			if (Game.BogusPretrainInstructions.Length != 0)
+			{
 				double t = Game.BogusPretrainInstructions[0].Time;
 				double p = Game.BogusPretrainInstructions[0].TrackPosition;
-				for (int i = 1; i < Game.BogusPretrainInstructions.Length; i++) {
-					if (Game.BogusPretrainInstructions[i].Time > t) {
+				for (int i = 1; i < Game.BogusPretrainInstructions.Length; i++)
+				{
+					if (Game.BogusPretrainInstructions[i].Time > t)
+					{
 						t = Game.BogusPretrainInstructions[i].Time;
-					} else {
+					}
+					else
+					{
 						t += 1.0;
 						Game.BogusPretrainInstructions[i].Time = t;
 					}
-					if (Game.BogusPretrainInstructions[i].TrackPosition > p) {
+
+					if (Game.BogusPretrainInstructions[i].TrackPosition > p)
+					{
 						p = Game.BogusPretrainInstructions[i].TrackPosition;
-					} else {
+					}
+					else
+					{
 						p += 1.0;
 						Game.BogusPretrainInstructions[i].TrackPosition = p;
 					}
@@ -212,9 +249,14 @@ namespace OpenBve {
 				//Log the fact that only a single station is present, as this is probably not right
 				Program.FileSystem.AppendToLogFile("The processed route file only contains a single station.");
 			}
+
 			Program.FileSystem.AppendToLogFile("Route file loaded successfully.");
 			RouteProgress = 1.0;
-			// initialize trains
+		}
+
+		private static void LoadTrains()
+		{
+		// initialize trains
 			System.Threading.Thread.Sleep(1); if (Cancel) return;
 			TrainManager.Trains = new TrainManager.Train[Game.PrecedingTrainTimeDeltas.Length + 1 + (Game.BogusPretrainInstructions.Length != 0 ? 1 : 0)];
 			for (int k = 0; k < TrainManager.Trains.Length; k++)

--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -46,6 +46,7 @@ namespace OpenBve
 			Arcade = 0,
 			Normal = 1,
 			Expert = 2,
+			Developer = 3
 		}
 
 		internal enum XParsers

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -103,10 +103,10 @@
 			this.checkBoxInputDeviceEnable = new System.Windows.Forms.CheckBox();
 			this.buttonInputDeviceConfig = new System.Windows.Forms.Button();
 			this.groupBoxObjectParser = new System.Windows.Forms.GroupBox();
-			this.labelXparser = new System.Windows.Forms.Label();
-			this.comboBoxXparser = new System.Windows.Forms.ComboBox();
 			this.labelObjparser = new System.Windows.Forms.Label();
 			this.comboBoxObjparser = new System.Windows.Forms.ComboBox();
+			this.labelXparser = new System.Windows.Forms.Label();
+			this.comboBoxXparser = new System.Windows.Forms.ComboBox();
 			this.groupBoxKioskMode = new System.Windows.Forms.GroupBox();
 			this.labelKioskTimeout = new System.Windows.Forms.Label();
 			this.numericUpDownKioskTimeout = new System.Windows.Forms.NumericUpDown();
@@ -473,6 +473,7 @@
 			this.panelOptions.SuspendLayout();
 			this.panelOptionsPage2.SuspendLayout();
 			this.groupBoxInputDevice.SuspendLayout();
+			this.groupBoxObjectParser.SuspendLayout();
 			this.groupBoxKioskMode.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownKioskTimeout)).BeginInit();
 			this.groupBoxAdvancedOptions.SuspendLayout();
@@ -622,6 +623,7 @@
 			this.comboboxMode.Name = "comboboxMode";
 			this.comboboxMode.Size = new System.Drawing.Size(144, 21);
 			this.comboboxMode.TabIndex = 11;
+			this.comboboxMode.SelectedIndexChanged += new System.EventHandler(this.comboboxMode_SelectedIndexChanged);
 			// 
 			// labelMode
 			// 
@@ -1540,6 +1542,27 @@
 			this.groupBoxObjectParser.TabStop = false;
 			this.groupBoxObjectParser.Text = "Object Parser";
 			// 
+			// labelObjparser
+			// 
+			this.labelObjparser.AutoSize = true;
+			this.labelObjparser.Location = new System.Drawing.Point(7, 48);
+			this.labelObjparser.Name = "labelObjparser";
+			this.labelObjparser.Size = new System.Drawing.Size(93, 13);
+			this.labelObjparser.TabIndex = 0;
+			this.labelObjparser.Text = "Obj Object Parser:";
+			// 
+			// comboBoxObjparser
+			// 
+			this.comboBoxObjparser.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxObjparser.FormattingEnabled = true;
+			this.comboBoxObjparser.Items.AddRange(new object[] {
+            "Original",
+            "Assimp"});
+			this.comboBoxObjparser.Location = new System.Drawing.Point(107, 44);
+			this.comboBoxObjparser.Name = "comboBoxObjparser";
+			this.comboBoxObjparser.Size = new System.Drawing.Size(190, 21);
+			this.comboBoxObjparser.TabIndex = 1;
+			// 
 			// labelXparser
 			// 
 			this.labelXparser.AutoSize = true;
@@ -1561,27 +1584,6 @@
 			this.comboBoxXparser.Name = "comboBoxXparser";
 			this.comboBoxXparser.Size = new System.Drawing.Size(190, 21);
 			this.comboBoxXparser.TabIndex = 1;
-			// 
-			// labelObjparser
-			// 
-			this.labelObjparser.AutoSize = true;
-			this.labelObjparser.Location = new System.Drawing.Point(7, 48);
-			this.labelObjparser.Name = "labelObjparser";
-			this.labelObjparser.Size = new System.Drawing.Size(84, 13);
-			this.labelObjparser.TabIndex = 0;
-			this.labelObjparser.Text = "Obj Object Parser:";
-			// 
-			// comboBoxObjparser
-			// 
-			this.comboBoxObjparser.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxObjparser.FormattingEnabled = true;
-			this.comboBoxObjparser.Items.AddRange(new object[] {
-            "Original",
-            "Assimp"});
-			this.comboBoxObjparser.Location = new System.Drawing.Point(107, 44);
-			this.comboBoxObjparser.Name = "comboBoxObjparser";
-			this.comboBoxObjparser.Size = new System.Drawing.Size(190, 21);
-			this.comboBoxObjparser.TabIndex = 1;
 			// 
 			// groupBoxKioskMode
 			// 
@@ -5632,6 +5634,8 @@
 			this.panelOptionsPage2.ResumeLayout(false);
 			this.groupBoxInputDevice.ResumeLayout(false);
 			this.groupBoxInputDevice.PerformLayout();
+			this.groupBoxObjectParser.ResumeLayout(false);
+			this.groupBoxObjectParser.PerformLayout();
 			this.groupBoxKioskMode.ResumeLayout(false);
 			this.groupBoxKioskMode.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownKioskTimeout)).EndInit();

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -265,7 +265,7 @@ namespace OpenBve {
 			}
 			// modes
 			comboboxMode.Items.Clear();
-			comboboxMode.Items.AddRange(new object[] { "", "", "" });
+			comboboxMode.Items.AddRange(new object[] { "", "", "", "" });
 			comboboxMode.SelectedIndex = Interface.CurrentOptions.GameMode == Interface.GameMode.Arcade ? 0 : Interface.CurrentOptions.GameMode == Interface.GameMode.Expert ? 2 : 1;
 			// review last game
 			{
@@ -639,6 +639,7 @@ namespace OpenBve {
 			comboboxMode.Items[0] = Translations.GetInterfaceString("mode_arcade");
 			comboboxMode.Items[1] = Translations.GetInterfaceString("mode_normal");
 			comboboxMode.Items[2] = Translations.GetInterfaceString("mode_expert");
+			comboboxMode.Items[3] = "Route Viewer";
 			/*
 			 * Localisation for strings in the game review pane
 			 */
@@ -1761,6 +1762,18 @@ namespace OpenBve {
 			using (formRaildriverCalibration f = new formRaildriverCalibration())
 			{
 				f.ShowDialog();
+			}
+		}
+
+		private void comboboxMode_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if (comboboxMode.SelectedIndex == 3)
+			{
+				groupboxTrainSelection.Visible = false;
+			}
+			else
+			{
+				groupboxTrainSelection.Visible = true;
 			}
 		}
 	}


### PR DESCRIPTION
This is a basic implementation of a viewer mode for the main openBVE program, eventually designed to replace Route Viewer.

**To Use:**
* Set the CurrentOptions.GameMode to developer. (Currently has to be done in-code, no UI option at the minute.

**Flaws:**
* ~~No event markers.~~
* Game is not paused by default. (Need to figure out the exact controls, so we can essentially just run the sim if people wish to test TOD based effects)
* ~~Requires Route Viewer overlays porting. (Should be a relatively quick job.....)~~