### PR TITLE
Add Station XML parser and Request stops

### DIFF
--- a/documentation/HTML/menu.html
+++ b/documentation/HTML/menu.html
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-
-<!-- Mirrored from www.trainsimframework.org/develop/menu.html by HTTrack Website Copier/3.x [XR&CO'2010], Sat, 05 May 2012 22:30:02 GMT -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <link rel="SHORTCUT ICON" href="../Images/favicon.png" />
@@ -24,7 +22,8 @@
 <a href="route_csv.html" target="main">The CSV route</a><br />
 <p style="margin-left: 10px"><a href="route_dynamiclight.html" target="main">Adding Dynamic Lighting</a><br>
 <a href="route_dynamicbackground.html" target="main">Dynamic & Object Based Backgrounds</a><br>
-<a href="route_marker.html" target="main">Scripted Markers</a></p>
+<a href="route_marker.html" target="main">Scripted Markers</a><br>
+<a href="route_marker.html" target="main">XML Stations & Request Stops</a></p>
 
 <a href="route_rw.html" target="main">The RW route</a><br />
 <a href="tutorial_ats.html" target="main">Tutorial: Using ATS</a><br />
@@ -65,6 +64,4 @@
 <br />
 </font>
 </body>
-
-<!-- Mirrored from www.trainsimframework.org/develop/menu.html by HTTrack Website Copier/3.x [XR&CO'2010], Sat, 05 May 2012 22:30:27 GMT -->
 </html>

--- a/documentation/HTML/route_stationxml.html
+++ b/documentation/HTML/route_stationxml.html
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="SHORTCUT ICON" href="../Images/favicon.png" />
+<meta name="keywords" content="openBVE,homepage" />
+<title>XML Stations & Request Stops</title>
+</head>
+<body style="font-family:sans-serif;font-size:small">
+<font size="+2" color="#0080FF">The XML Station Format</font><br />
+<table style="border:0px none;margin-left:10pt;margin-right:10pt;">
+<tr><td><font size="-1" color="#808080">
+
+</font></td></tr></table>
+<br />This page describes the principles and implementation of the XML based station format.<br /><br /><table><tr style="height: 4px;"><td /></tr></table>
+<font size="+1" color="#0080FF">■ Dynamic Backgrounds: Basic Principles</font><hr />
+<table style="border:0px none;margin-left:10pt;margin-right:10pt;">
+<tr><td><font size="-1" color="#808080">
+
+</font></td></tr></table>
+
+A station within openBVE, when combined with one or more <em>.Stop</em> commands, defines a point at which trains call. <br>
+
+Each station which you wish to use must be setup using a Station XML file an example of which is shown below:
+<br>
+<textarea rows="16" cols="110" style="border:2;">
+<?xml version="1.0" encoding="utf-8"?>
+<openBVE xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<openBVE>
+	<Station>
+		<Name>Dockyard</Name>
+		<ArrivalTime>12.3130</ArrivalTime>
+		<DepartureTime>12.3150</DepartureTime>
+		<Doors>Left</Doors>
+		<ForcedRedSignal>False</ForcedRedSignal>
+		<PassengerRatio>10</PassengerRatio>
+	</Station>
+</openBVE>
+</textarea>
+<br>
+
+
+<table><tr style="height: 4px;"><td /></tr></table>
+<font size="+1" color="#0080FF">■ The basic station</font><hr />
+<table style="border:0px none;margin-left:10pt;margin-right:10pt;">
+<tr><td><font size="-1" color="#808080">
+
+</font></td></tr></table>
+The following basic attributes are required for all stations:<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;Name&gt;</b> <em>StationName</em> <b>&lt;&#47;Name&gt;</b></font></td></tr>
+</table>
+<b>StationName</b> sets the textual string by which this station is referred to in timetables, in-game messages etc.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;ArrivalTime&gt;</b> <em>Time</em> <b>&lt;&#47;ArrivalTime&gt;</b></font></td></tr>
+</table>
+<b>Time</b> sets the time at which the player's train is expected to arrive at this station. <em>Note:</em> When this parameter is omitted, the player is permitted to arrive at any time.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;DepartureTime&gt;</b> <em>Time</em> <b>&lt;&#47;DepartureTime&gt;</b></font></td></tr>
+</table>
+<b>Time</b> sets the time at which the player's train is expected to depart this station. <em>Note:</em> When this parameter is omitted, the player is permitted to depart at any time.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;Doors&gt;</b> <em>Value</em> <b>&lt;&#47;Doors&gt;</b></font></td></tr>
+</table>
+<b>Doors</b> controls the side on which the train doors are to open. Valid values are:<p>
+<b>Left , L or -1</b>  : The left-hand doors are to open.<br>
+<b>Right, R or 1</b>   : The right-hand doors are to open.<br>
+<b>None, N or 0</b>    : No doors open at this station.<br>
+<em>Note:</em> If omitted, no doors open.
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;ForcedRedSignal&gt;</b> <em>True / False</em> <b>&lt;&#47;ForcedRedSignal&gt;</b></font></td></tr>
+</table>
+If <em>ForcedRedSignal</em> is set to <b>True</b> , then the signal associated with this station will be held at Red (Aspect 0) until the scheduled departure time.<p>
+</font></td></tr></table>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;PassengerRatio&gt;</b> <em>Ratio</em> <b>&lt;&#47;PassengerRatio&gt;</b></font></td></tr>
+</table>
+<b>Ratio</b> sets the approximate ratio of passengers on-board the train from this point onwards. As a reference, <b>100</b> represents a train with normal amount of passengers, while <b>250</b> represents an over-crowded train. Values in-between <b>0</b> and <b>250</b> should be used.<p>
+</font></td></tr></table>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;ArrivalSound&gt;</b> <em>Sound</em> <b>&lt;&#47;ArrivalSound&gt;</b></font></td></tr>
+</table>
+<b>Sound</b> should be the path of the sound-file to be played upon arrival at this station, relative to the <em>Sound</em> folder.<p>
+</font></td></tr></table>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;DepartureSound&gt;</b> <em>Sound</em> <b>&lt;&#47;DepartureSound&gt;</b></font></td></tr>
+</table>
+<b>Sound</b> should be the path of the sound-file to be played upon departure from this station, relative to the <em>Sound</em> folder.<p>
+</font></td></tr></table>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;StopDuration&gt;</b> <em>Duration</em> <b>&lt;&#47;StopDuration&gt;</b></font></td></tr>
+</table>
+<b>Duration</b> should be the minimum stop duration in seconds, to include both the door opening and closing times. The default value is <b>15</b>.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;TimeTableIndex&gt;</b> <em>Index</em> <b>&lt;&#47;TimeTableIndex&gt;</b></font></td></tr>
+</table>
+<b>Inddex</b> sets the timetable to be shown from this station on as defined via <em>Train.Timetable(TimetableIndex)</em><p>
+
+<table><tr style="height: 4px;"><td /></tr></table>
+<font size="+1" color="#0080FF">■ Creating a Request Stop</font><hr />
+<table style="border:0px none;margin-left:10pt;margin-right:10pt;">
+<tr><td><font size="-1" color="#808080">
+
+</font></td></tr></table>
+Creating a request stop requires one further section to be added within your <em>&lt;Station&gt;</em> section:<p>
+<br>
+<textarea rows="6" cols="110" style="border:2;">
+<RequestStop>
+	<Probability>50</Probability>
+	<Distance>700</Distance>
+	<StopMessage>You will need to stop at Dockyard today.</StopMessage>
+	<PassMessage>No passengers for Dockyard.</PassMessage>
+</RequestStop>
+</textarea>
+<br>
+The following basic attributes are supported for this section:<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;EarlyTime&gt;</b> <em>Time</em> <b>&lt;&#47;EarlyTime&gt;</b></font></td></tr>
+</table>
+<b>Time</b> sets the time before which the <em>Early</em> probabilities / message will be used. <em>Note:</em> May be omitted.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;LateTime&gt;</b> <em>Time</em> <b>&lt;&#47;LateTime&gt;</b></font></td></tr>
+</table>
+<b>Time</b> sets the time before which the <em>Late</em> probabilities / message will be used. <em>Note:</em> May be omitted.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;Distance&gt;</b> <em>DistanceInMeters</em> <b>&lt;&#47;Distance&gt;</b></font></td></tr>
+</table>
+<b>DistanceInMeters</b> sets the distance in meters before this station that the Request Stop roll will be made. <em>Note:</em> This distance must be less than that to the previous station.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;StopMessage&gt;</b> <em>Message</em> <b>&lt;&#47;StopMessage&gt;</b></font></td></tr>
+</table>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;PassMessage&gt;</b> <em>Message</em> <b>&lt;&#47;PassMessage&gt;</b></font></td></tr>
+</table>
+<b>Message</b> sets the textual message to be displayed in the upper left of the screen when the request stop is triggered, depending on whether we are to stop at or pass this station.<br>
+Alternatively, if you require a specific message when the player is early/ late, the following sub-attributes are supported:<br>
+
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;Early&gt;</b> <em>Message</em> <b>&lt;&#47;Early&gt;</b></font></td></tr>
+</table>
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;OnTime&gt;</b> <em>Message</em> <b>&lt;&#47;OnTime&gt;</b></font></td></tr>
+</table>
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;Late&gt;</b> <em>Message</em> <b>&lt;&#47;Late&gt;</b></font></td></tr>
+</table><br>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;Probability&gt;</b> <em>Value</em> <b>&lt;&#47;Probability&gt;</b></font></td></tr>
+</table>
+<b>Probability</b> should be an integer from <b>0</b> to <b>100</b> , representing the approximate probability that this stop may be requested.<br>
+Alternatively, if you require a specific probability when the player is early/ late, the following sub-attributes are supported:<br>
+
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;Early&gt;</b> <em>Value</em> <b>&lt;&#47;Early&gt;</b></font></td></tr>
+</table>
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;OnTime&gt;</b> <em>Value</em> <b>&lt;&#47;OnTime&gt;</b></font></td></tr>
+</table>
+<table border="0" style="margin-left:20px">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#4274f4"><b>&lt;Late&gt;</b> <em>Value</em> <b>&lt;&#47;Late&gt;</b></font></td></tr>
+</table>
+<em>Note:</em> If only one or two of the specific probabilities above are set, the others are assumed to have a zero-probability and thus will not trigger.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;MaxCars&gt;</b> <em>Cars</em> <b>&lt;&#47;MaxCars&gt;</b></font></td></tr>
+</table>
+<b>Cars</b> sets the maximum length of a train before this request stop is automatically skipped. <em>Note:</em> No message is displayed in this case.<p>
+<table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>&lt;AIBehaviour&gt;</b> <em>Value</em> <b>&lt;&#47;AIBehaviour&gt;</b></font></td></tr>
+</table>
+<b>Value</b> controls the behaviour of the default AI driver towards this request stop. Valid values are:<p>
+<b>FullSpeed or 0</b>     : If the request stop is not triggered, the AI driver ignores it and passes at linespeed.<br>
+<b>NormalBrake or 1</b>   : If the request stop is not triggered, the AI driver brakes to ~10mph as it passes through the station.<br>
+<em>Note:</em> May be overriden by plugins implementing an AI method.<p>
+
+</body>
+
+
+</html>

--- a/source/OpenBVE/Audio/Sounds.cs
+++ b/source/OpenBVE/Audio/Sounds.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Windows.Forms;
 using OpenTK;
 using OpenTK.Audio.OpenAL;
@@ -253,6 +254,27 @@ namespace OpenBve {
 			Sources[SourceCount] = new SoundSource(buffer, buffer.Radius, pitch, volume, position, train, car, looped);
 			SourceCount++;
 			return Sources[SourceCount - 1];
+		}
+
+		/// <summary>Plays a car sound.</summary>
+		/// <param name="sound">The car sound.</param>
+		/// <param name="pitch">The pitch change factor.</param>
+		/// <param name="volume">The volume change factor.</param>
+		/// <param name="train">The train the sound is attached to.</param>
+		/// <param name="car">The car in the train the sound is attached to.</param>
+		/// <param name="looped">Whether to play the sound in a loop.</param>
+		/// <returns>The sound source.</returns>
+		internal static void PlayCarSound(TrainManager.CarSound sound, double pitch, double volume, TrainManager.Train train, int car, bool looped)
+		{
+			if (sound.Buffer == null)
+			{
+				return;
+			}
+			if (train == null)
+			{
+				throw new InvalidDataException("A train and car must be specified");
+			}
+			sound.Source = PlaySound(sound.Buffer, pitch, volume, sound.Position, train, car, looped);
 		}
 		
 		/// <summary>Stops the specified sound source.</summary>

--- a/source/OpenBVE/Game/AI.cs
+++ b/source/OpenBVE/Game/AI.cs
@@ -375,7 +375,7 @@ namespace OpenBve
                             if (tp + lookahead <= stp) break;
                             for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
                             {
-                                if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
+                                if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent && !Train.NextStopSkipped)
                                 {
                                     TrackManager.StationStartEvent e = (TrackManager.StationStartEvent)TrackManager.CurrentTrack.Elements[i].Events[j];
                                     if (StopsAtStation(e.StationIndex, Train) & Train.LastStation != e.StationIndex)
@@ -476,7 +476,7 @@ namespace OpenBve
                                         }
                                     }
                                 }
-                                else if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent)
+                                else if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationStartEvent && !Train.NextStopSkipped)
                                 {
                                     // station start
                                     if (Train.Station == -1)
@@ -505,7 +505,7 @@ namespace OpenBve
                                         }
                                     }
                                 }
-                                else if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationEndEvent)
+                                else if (TrackManager.CurrentTrack.Elements[i].Events[j] is TrackManager.StationEndEvent && !Train.NextStopSkipped)
                                 {
                                     // station end
                                     if (Train.Station == -1)

--- a/source/OpenBVE/Game/Station.cs
+++ b/source/OpenBVE/Game/Station.cs
@@ -36,7 +36,13 @@ namespace OpenBve
 			/// <summary>The player train stops at this station, AI trains do not</summary>
 			PlayerStop = 2,
 			/// <summary>The player train passes this station, AI trains stop</summary>
-			PlayerPass = 3
+			PlayerPass = 3,
+			/// <summary>This station is a random request stop for all trains</summary>
+			AllRequestStop = 4,
+			/// <summary>This station is a random request stop for the player train only</summary>
+			PlayerRequestStop = 5
+
+
 		}
 
 		/// <summary>Defines the available station types</summary>
@@ -44,7 +50,8 @@ namespace OpenBve
 		{
 			Normal = 0,
 			ChangeEnds = 1,
-			Terminal = 2
+			Terminal = 2,
+			RequestStop = 3
 		}
 
 		/// <summary>Defines a station</summary>

--- a/source/OpenBVE/Game/Station.cs
+++ b/source/OpenBVE/Game/Station.cs
@@ -121,16 +121,16 @@ namespace OpenBve
 		/// <summary>Indicates whether the player's train stops at a station.</summary>
 		internal static bool PlayerStopsAtStation(int StationIndex)
 		{
-			return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerStop;
+			return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerStop | Stations[StationIndex].StopMode == StationStopMode.PlayerRequestStop | Stations[StationIndex].StopMode == StationStopMode.AllRequestStop;
 		}
 		/// <summary>Indicates whether a train stops at a station.</summary>
 		internal static bool StopsAtStation(int StationIndex, TrainManager.Train Train)
 		{
 			if (Train == TrainManager.PlayerTrain)
 			{
-				return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerStop;
+				return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerStop | Stations[StationIndex].StopMode == StationStopMode.PlayerRequestStop | Stations[StationIndex].StopMode == StationStopMode.AllRequestStop;
 			}
-			return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerPass;
+			return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerPass | Stations[StationIndex].StopMode == StationStopMode.AllRequestStop;
 		}
 	}
 }

--- a/source/OpenBVE/OldCode/TrackManager.cs
+++ b/source/OpenBVE/OldCode/TrackManager.cs
@@ -230,6 +230,7 @@ namespace OpenBve {
 								
 								//If our train can stop at this station, set it's index accordingly
 								Train.Station = StationIndex;
+								Train.NextStopSkipped = TrainManager.StopSkipMode.None;
 							}
 							else
 							{
@@ -237,7 +238,11 @@ namespace OpenBve {
 								if (FullSpeed)
 								{
 									//Pass at linespeed, rather than braking as if for stop
-									Train.NextStopSkipped = true;
+									Train.NextStopSkipped = TrainManager.StopSkipMode.Linespeed;
+								}
+								else
+								{
+									Train.NextStopSkipped = TrainManager.StopSkipMode.Decelerate;
 								}
 							}
 							//Play sound
@@ -259,7 +264,11 @@ namespace OpenBve {
 							if (FullSpeed)
 							{
 								//Pass at linespeed, rather than braking as if for stop
-								Train.NextStopSkipped = true;
+								Train.NextStopSkipped = TrainManager.StopSkipMode.Linespeed;
+							}
+							else
+							{
+								Train.NextStopSkipped = TrainManager.StopSkipMode.Decelerate;
 							}
 							//If message is not empty, add it
 							if (!string.IsNullOrEmpty(stop.PassMessage) && Train == TrainManager.PlayerTrain)
@@ -317,7 +326,7 @@ namespace OpenBve {
 						Train.Station = -1;
 					} else if (Direction > 0)
 					{
-						if (Train.Station == StationIndex || Train.NextStopSkipped == true)
+						if (Train.Station == StationIndex || Train.NextStopSkipped != TrainManager.StopSkipMode.None)
 						{
 							return;
 						}
@@ -357,11 +366,11 @@ namespace OpenBve {
 					if (Direction < 0) {
 						Train.Station = this.StationIndex;
 						Train.StationRearCar = true;
-						if (!Train.NextStopSkipped)
+						if (Train.NextStopSkipped != TrainManager.StopSkipMode.None)
 						{
 							Train.LastStation = this.StationIndex;
 						}
-						Train.NextStopSkipped = false;
+						Train.NextStopSkipped = TrainManager.StopSkipMode.None;
 					} else if (Direction > 0) {
 						if (Train.Station == StationIndex) {
 							if (Train == TrainManager.PlayerTrain) {

--- a/source/OpenBVE/OldCode/TrackManager.cs
+++ b/source/OpenBVE/OldCode/TrackManager.cs
@@ -198,7 +198,7 @@ namespace OpenBve {
 				if (TriggerType == EventTriggerType.FrontCarFrontAxle)
 				{
 					RequestStop stop; //Temp probability value
-					if (Early.Time != -1 && Game.SecondsSinceMidnight > Early.Time)
+					if (Early.Time != -1 && Game.SecondsSinceMidnight < Early.Time)
 					{
 						stop = Early;
 					}

--- a/source/OpenBVE/OldCode/TrackManager.cs
+++ b/source/OpenBVE/OldCode/TrackManager.cs
@@ -217,6 +217,7 @@ namespace OpenBve {
 					if (MaxCars != 0 && Train.Cars.Length > MaxCars)
 					{
 						//Check whether our train length is valid for this before doing anything else
+						//Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[2], 1.0, 1.0, Train, Train.DriverCar, false);
 						return;
 					}
 					if (Direction > 0)
@@ -244,15 +245,17 @@ namespace OpenBve {
 								{
 									Train.NextStopSkipped = TrainManager.StopSkipMode.Decelerate;
 								}
+								//Play sound
+								Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Train, Train.DriverCar, false);
+								//If message is not empty, add it
+								if (!string.IsNullOrEmpty(stop.PassMessage) && Train == TrainManager.PlayerTrain)
+								{
+									Game.AddMessage(stop.PassMessage, MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.White, Game.SecondsSinceMidnight + 10.0, null);
+								}
+								return;
 							}
 							//Play sound
-							int d = Train.DriverCar;
-							Sounds.SoundBuffer buffer = Train.Cars[d].Sounds.Halt.Buffer;
-							if (buffer != null)
-							{
-								OpenBveApi.Math.Vector3 pos = Train.Cars[d].Sounds.Halt.Position;
-
-							}
+							Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[0], 1.0, 1.0, Train, Train.DriverCar, false);
 							//If message is not empty, add it
 							if (!string.IsNullOrEmpty(stop.StopMessage) && Train == TrainManager.PlayerTrain)
 							{
@@ -261,6 +264,7 @@ namespace OpenBve {
 						}
 						else
 						{
+							Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Train, Train.DriverCar, false);
 							if (FullSpeed)
 							{
 								//Pass at linespeed, rather than braking as if for stop

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -453,6 +453,7 @@ namespace OpenBve
 			internal Game.GeneralAI AI;
 			internal double InternalTimerTimeElapsed;
 			internal bool Derailed;
+			internal bool NextStopSkipped = false;
 
 			/// <summary>Call this method to derail a car</summary>
 			/// <param name="CarIndex">The car index to derail</param>

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -270,6 +270,7 @@ namespace OpenBve
 			internal CarSound[] Flange;
 			internal double[] FlangeVolume;
 			internal CarSound Halt;
+			internal CarSound[] RequestStop;
 			internal Horn[] Horns;
 			internal CarSound Loop;
 			internal CarSound MasterControllerUp;
@@ -490,7 +491,6 @@ namespace OpenBve
 			}
 
 			/// <summary>Initializes a train with the default (empty) set of car sounds</summary>
-			/// <param name="train">The train</param>
 			internal void InitializeCarSounds()
 			{
 				// initialize
@@ -525,6 +525,12 @@ namespace OpenBve
 						new TrainManager.Horn(),
 						new TrainManager.Horn(),
 						new TrainManager.Horn()
+					};
+					Cars[i].Sounds.RequestStop = new CarSound[]
+					{
+						CarSound.Empty,
+						CarSound.Empty,
+						CarSound.Empty
 					};
 					Cars[i].Sounds.Loop = TrainManager.CarSound.Empty;
 					Cars[i].Sounds.MasterControllerUp = TrainManager.CarSound.Empty;

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -422,6 +422,15 @@ namespace OpenBve
 			Bogus = 3
 		}
 
+		internal enum StopSkipMode
+		{
+			/// <summary>This stop is not skipped</summary>
+			None = 0,
+			/// <summary>The train decelerates through the station to a near stop</summary>
+			Decelerate = 1,
+			/// <summary>The train skips the stop at linespeed</summary>
+			Linespeed = 2
+		}
 
 		/// <summary>The root class for a train within the simulation</summary>
 		public class Train
@@ -453,7 +462,7 @@ namespace OpenBve
 			internal Game.GeneralAI AI;
 			internal double InternalTimerTimeElapsed;
 			internal bool Derailed;
-			internal bool NextStopSkipped = false;
+			internal StopSkipMode NextStopSkipped = StopSkipMode.None;
 
 			/// <summary>Call this method to derail a car</summary>
 			/// <param name="CarIndex">The car index to derail</param>

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.Functions.cs" />
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.Objects.cs" />
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.Structures.cs" />
+    <Compile Include="Parsers\Script\StationXMLParser.cs" />
     <Compile Include="Parsers\Script\DynamicBackgroundParser.cs" />
     <Compile Include="Parsers\Script\DynamicLightParser.cs" />
     <Compile Include="Parsers\Script\MarkerScriptParser.cs" />

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -115,6 +115,19 @@
 			internal double EndingPosition;
 			internal MessageManager.Message Message;
 		}
+
+		internal struct StopRequest
+		{
+			internal double Distance;
+			internal int Probability;
+			internal int StationIndex;
+			internal int MaxNumberOfCars;
+			internal double TrackPosition;
+			internal double EarlyTime;
+			internal double LateTime;
+			internal string StopMessage;
+			internal string PassMessage;
+		}
 		private enum SoundType { World, TrainStatic, TrainDynamic }
 		private struct Sound
 		{

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -119,14 +119,13 @@
 		internal struct StopRequest
 		{
 			internal double Distance;
-			internal int Probability;
 			internal int StationIndex;
 			internal int MaxNumberOfCars;
 			internal double TrackPosition;
-			internal double EarlyTime;
-			internal double LateTime;
-			internal string StopMessage;
-			internal string PassMessage;
+			internal TrackManager.RequestStop Early;
+			internal TrackManager.RequestStop OnTime;
+			internal TrackManager.RequestStop Late;
+			internal bool FullSpeed;
 		}
 		private enum SoundType { World, TrainStatic, TrainDynamic }
 		private struct Sound

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -4163,6 +4163,18 @@ namespace OpenBve {
 										CurrentStop = -1;
 										DepartureSignalUsed = false;
 									} break;
+								case "track.stationxml":
+									string fn = Path.CombineFile(System.IO.Path.GetDirectoryName(FileName), Arguments[0]);
+									if (!System.IO.File.Exists(fn))
+									{
+										Interface.AddMessage(Interface.MessageType.Error, true, "Station XML file " + fn + " not found in Track.StationXML at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+										break;
+									}
+									CurrentStation++;
+									Array.Resize<Game.Station>(ref Game.Stations, CurrentStation + 1);
+									Game.Stations[CurrentStation] = StationXMLParser.ReadStationXML(fn, PreviewOnly, Data.TimetableDaytime, Data.TimetableNighttime, CurrentStation, ref Data.Blocks[BlockIndex].StationPassAlarm);
+									Data.Blocks[BlockIndex].Station = CurrentStation;
+									break;
 								case "track.buffer":
 									{
 										if (!PreviewOnly) {

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -5397,7 +5397,7 @@ namespace OpenBve {
 						{
 							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
 							Array.Resize<TrackManager.GeneralEvent>(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.RequestStopEvent(Data.RequestStops[j].StationIndex, Data.RequestStops[j].Probability, Data.RequestStops[j].MaxNumberOfCars, Data.RequestStops[j].StopMessage, Data.RequestStops[j].PassMessage);
+							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.RequestStopEvent(Data.RequestStops[j].StationIndex, Data.RequestStops[j].MaxNumberOfCars, Data.RequestStops[j].FullSpeed, Data.RequestStops[j].OnTime , Data.RequestStops[j].Early, Data.RequestStops[j].Late);
 						}
 						
 					}

--- a/source/OpenBVE/Parsers/Script/StationXMLParser.cs
+++ b/source/OpenBVE/Parsers/Script/StationXMLParser.cs
@@ -1,0 +1,377 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+using OpenBveApi.Math;
+using OpenBveApi;
+
+namespace OpenBve
+{
+	class StationXMLParser
+	{
+		public static Game.Station ReadStationXML(string fileName, bool PreviewOnly, Textures.Texture[] daytimeTimetableTextures, Textures.Texture[] nighttimeTimetableTextures, int CurrentStation, ref bool passAlarm)
+		{
+			Game.Station station = new Game.Station();
+			//The current XML file to load
+			XmlDocument currentXML = new XmlDocument();
+			//Load the object's XML file 
+			currentXML.Load(fileName);
+			string Path = System.IO.Path.GetDirectoryName(fileName);
+			double[] UnitOfLength = { 1.0 };
+			//Check for null
+			if (currentXML.DocumentElement != null)
+			{
+				XmlNodeList DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Station");
+				//Check this file actually contains OpenBVE light definition nodes
+				if (DocumentNodes != null)
+				{
+					foreach (XmlNode n in DocumentNodes)
+					{
+						if (n.HasChildNodes)
+						{
+							foreach (XmlNode c in n.ChildNodes)
+							{
+
+								//string[] Arguments = c.InnerText.Split(',');
+								switch (c.Name.ToLowerInvariant())
+								{
+									case "name":
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											station.Name = c.InnerText;
+										}
+										else
+										{
+											Interface.AddMessage(Interface.MessageType.Error, false, "Station name was empty in XML file " + fileName);
+										}
+										break;
+									case "arrivaltime":
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											if (string.Equals(c.InnerText, "P", StringComparison.OrdinalIgnoreCase) | string.Equals(c.InnerText, "L", StringComparison.OrdinalIgnoreCase))
+											{
+												station.StopMode = Game.StationStopMode.AllPass;
+											}
+											else if (string.Equals(c.InnerText, "B", StringComparison.OrdinalIgnoreCase))
+											{
+												station.StopMode = Game.StationStopMode.PlayerPass;
+											}
+											else if (c.InnerText.StartsWith("B:", StringComparison.InvariantCultureIgnoreCase))
+											{
+												station.StopMode = Game.StationStopMode.PlayerPass;
+												if (!Interface.TryParseTime(c.InnerText.Substring(2).TrimStart(), out station.ArrivalTime))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Station arrivaltime was invalid in XML file " + fileName);
+													station.ArrivalTime = -1.0;
+												}
+											}
+											else if (string.Equals(c.InnerText, "S", StringComparison.OrdinalIgnoreCase))
+											{
+												station.StopMode = Game.StationStopMode.PlayerStop;
+											}
+											else if (c.InnerText.StartsWith("S:", StringComparison.InvariantCultureIgnoreCase))
+											{
+												station.StopMode = Game.StationStopMode.PlayerStop;
+												if (!Interface.TryParseTime(c.InnerText.Substring(2).TrimStart(), out station.ArrivalTime))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Station arrivaltime was invalid in XML file " + fileName);
+													station.ArrivalTime = -1.0;
+												}
+											}
+											else if (!Interface.TryParseTime(c.InnerText, out station.ArrivalTime))
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Station arrivaltime was invalid in XML file " + fileName);
+												station.ArrivalTime = -1.0;
+											}
+										}
+										break;
+									case "departuretime":
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											if (string.Equals(c.InnerText, "T", StringComparison.OrdinalIgnoreCase) | string.Equals(c.InnerText, "=", StringComparison.OrdinalIgnoreCase))
+											{
+												station.StationType = Game.StationType.Terminal;
+											}
+											else if (c.InnerText.StartsWith("T:", StringComparison.InvariantCultureIgnoreCase))
+											{
+												station.StationType = Game.StationType.Terminal;
+												if (!Interface.TryParseTime(c.InnerText.Substring(2).TrimStart(), out station.DepartureTime))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Station departure time was invalid in XML file " + fileName);
+													station.DepartureTime = -1.0;
+												}
+											}
+											else if (string.Equals(c.InnerText, "C", StringComparison.OrdinalIgnoreCase))
+											{
+												station.StationType = Game.StationType.ChangeEnds;
+											}
+											else if (c.InnerText.StartsWith("C:", StringComparison.InvariantCultureIgnoreCase))
+											{
+												station.StationType = Game.StationType.ChangeEnds;
+												if (!Interface.TryParseTime(c.InnerText.Substring(2).TrimStart(), out station.DepartureTime))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Station departure time was invalid in XML file " + fileName);
+													station.DepartureTime = -1.0;
+												}
+											}
+											else if (!Interface.TryParseTime(c.InnerText, out station.DepartureTime))
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Station departure time was invalid in XML file " + fileName);
+												station.DepartureTime = -1.0;
+											}
+										}
+										break;
+									case "passalarm":
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											if (c.InnerText.ToLowerInvariant() == "1" || c.InnerText.ToLowerInvariant() == "true")
+											{
+												passAlarm = true;
+											}
+											else
+											{
+												passAlarm = false;
+											}
+										}
+										break;
+									case "doors":
+										int door = 0;
+										bool doorboth = false;
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											switch (c.InnerText.ToUpperInvariant())
+											{
+												case "L":
+													door = -1;
+													break;
+												case "R":
+													door = 1;
+													break;
+												case "N":
+													door = 0;
+													break;
+												case "B":
+													doorboth = true;
+													break;
+												default:
+													if (!NumberFormats.TryParseIntVb6(c.InnerText, out door))
+													{
+														Interface.AddMessage(Interface.MessageType.Error, false, "Door side was invalid in XML file " + fileName);
+														door = 0;
+													}
+													break;
+											}
+										}
+										station.OpenLeftDoors = door < 0.0 | doorboth;
+										station.OpenRightDoors = door > 0.0 | doorboth;
+										break;
+									case "forcedredsignal":
+										if (!string.IsNullOrEmpty(c.InnerText))
+										{
+											if (c.InnerText.ToLowerInvariant() == "1" || c.InnerText.ToLowerInvariant() == "true")
+											{
+												station.ForceStopSignal = true;
+											}
+											else
+											{
+												station.ForceStopSignal = false;
+											}
+										}
+										break;
+									case "system":
+										switch (c.InnerText.ToLowerInvariant())
+										{
+											case "0":
+											case "ATS":
+												station.SafetySystem = Game.SafetySystem.Ats;
+												break;
+											case "1":
+											case "ATC":
+												station.SafetySystem = Game.SafetySystem.Atc;
+												break;
+											default:
+												Interface.AddMessage(Interface.MessageType.Error, false, "An invalid station safety system was specified in XML file " + fileName);
+												station.SafetySystem = Game.SafetySystem.Ats;
+												break;
+										}
+										break;
+									case "arrivalsound":
+										string arrSound = string.Empty;
+										double arrRadius = 30.0;
+										if (!c.HasChildNodes)
+										{
+											foreach (XmlNode cc in c.ChildNodes)
+											{
+												switch (c.Name.ToLowerInvariant())
+												{
+													case "filename":
+														try
+														{
+															arrSound = OpenBveApi.Path.CombineFile(Path, cc.InnerText);
+														}
+														catch
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Arrival sound filename is invalid in XML file " + fileName);
+														}
+														break;
+													case "radius":
+														if (!double.TryParse(cc.InnerText, out arrRadius))
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Arrival sound radius was invalid in XML file " + fileName);
+														}
+														break;
+												}
+											}
+										}
+										else
+										{
+											try
+											{
+												arrSound = OpenBveApi.Path.CombineFile(Path, c.InnerText);
+											}
+											catch
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Arrival sound filename is invalid in XML file " + fileName);
+											}
+											
+										}
+										if (File.Exists(arrSound))
+										{
+											station.ArrivalSoundBuffer = Sounds.RegisterBuffer(arrSound, arrRadius);
+										}
+										else
+										{
+											Interface.AddMessage(Interface.MessageType.Error, false, "Arrival sound file does not exist in XML file " + fileName);
+										}
+										break;
+									case "stopduration":
+										double stopDuration;
+										if (!double.TryParse(c.InnerText, out stopDuration))
+										{
+											Interface.AddMessage(Interface.MessageType.Error, false, "Stop duration is invalid in XML file " + fileName);
+										}
+										else
+										{
+											if (stopDuration < 5.0)
+											{
+												stopDuration = 5.0;
+											}
+											station.StopTime = stopDuration;
+										}
+										break;
+									case "passengerratio":
+										double ratio;
+										if (!double.TryParse(c.InnerText, out ratio))
+										{
+											Interface.AddMessage(Interface.MessageType.Error, false, "Passenger ratio is invalid in XML file " + fileName);
+										}
+										else
+										{
+											if (ratio < 0.0)
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Passenger ratio must be non-negative in XML file " + fileName);
+												ratio = 100.0;
+											}
+											station.PassengerRatio = ratio;
+										}
+										break;
+									case "departuresound":
+										string depSound = string.Empty;
+										double depRadius = 30.0;
+										if (!c.HasChildNodes)
+										{
+											foreach (XmlNode cc in c.ChildNodes)
+											{
+												switch (c.Name.ToLowerInvariant())
+												{
+													case "filename":
+														try
+														{
+															depSound = OpenBveApi.Path.CombineFile(Path, cc.InnerText);
+														}
+														catch
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Departure sound filename is invalid in XML file " + fileName);
+														}
+														break;
+													case "radius":
+														if (!double.TryParse(cc.InnerText, out depRadius))
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Departure sound radius was invalid in XML file " + fileName);
+														}
+														break;
+												}
+											}
+										}
+										else
+										{
+											try
+											{
+												depSound = OpenBveApi.Path.CombineFile(Path, c.InnerText);
+											}
+											catch
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Departure sound filename is invalid in XML file " + fileName);
+											}
+
+										}
+										if (File.Exists(depSound))
+										{
+											station.ArrivalSoundBuffer = Sounds.RegisterBuffer(depSound, depRadius);
+										}
+										else
+										{
+											Interface.AddMessage(Interface.MessageType.Error, false, "Departure sound file does not exist in XML file " + fileName);
+										}
+										break;
+									case "timetableindex":
+										if (!PreviewOnly)
+										{
+											int ttidx = -1;
+											if (!string.IsNullOrEmpty(c.InnerText))
+											{
+												if(NumberFormats.TryParseIntVb6(c.InnerText, out ttidx))
+												{
+													if (ttidx < 0)
+													{
+														Interface.AddMessage(Interface.MessageType.Error, false, "Timetable index must be non-negative in XML file " + fileName);
+														ttidx = -1;
+													}
+													else if (ttidx >= daytimeTimetableTextures.Length & ttidx >= nighttimeTimetableTextures.Length)
+													{
+														Interface.AddMessage(Interface.MessageType.Error, false, "Timetable index references a non-loaded texture in XML file " + fileName);
+														ttidx = -1;
+													}
+													station.TimetableDaytimeTexture = ttidx >= 0 & ttidx < daytimeTimetableTextures.Length ? daytimeTimetableTextures[ttidx] : null;
+													station.TimetableNighttimeTexture = ttidx >= 0 & ttidx < nighttimeTimetableTextures.Length ? nighttimeTimetableTextures[ttidx] : null;
+													break;
+												}
+											}
+											if (ttidx == -1)
+											{
+												if (CurrentStation > 0)
+												{
+													station.TimetableDaytimeTexture = Game.Stations[CurrentStation - 1].TimetableDaytimeTexture;
+													station.TimetableNighttimeTexture = Game.Stations[CurrentStation - 1].TimetableNighttimeTexture;
+												}
+												else if (daytimeTimetableTextures.Length > 0 & nighttimeTimetableTextures.Length > 0)
+												{
+													station.TimetableDaytimeTexture = daytimeTimetableTextures[0];
+													station.TimetableNighttimeTexture = nighttimeTimetableTextures[0];
+												}
+											}
+										}
+										break;
+								}
+							}
+							
+
+						}
+					}
+
+				}
+			}
+			//We couldn't find any valid XML, so return false
+			throw new InvalidDataException();
+		}
+	}
+}

--- a/source/OpenBVE/Parsers/Script/StationXMLParser.cs
+++ b/source/OpenBVE/Parsers/Script/StationXMLParser.cs
@@ -8,10 +8,11 @@ namespace OpenBve
 {
 	class StationXMLParser
 	{
-		public static Game.Station ReadStationXML(string fileName, bool PreviewOnly, Textures.Texture[] daytimeTimetableTextures, Textures.Texture[] nighttimeTimetableTextures, int CurrentStation, ref bool passAlarm)
+		public static Game.Station ReadStationXML(string fileName, bool PreviewOnly, Textures.Texture[] daytimeTimetableTextures, Textures.Texture[] nighttimeTimetableTextures, int CurrentStation, ref bool passAlarm, ref CsvRwRouteParser.StopRequest stopRequest)
 		{
 			Game.Station station = new Game.Station();
 			station.Stops = new Game.StationStop[] { };
+			stopRequest.Probability = 75;
 			//The current XML file to load
 			XmlDocument currentXML = new XmlDocument();
 			//Load the object's XML file 
@@ -324,6 +325,70 @@ namespace OpenBve
 												}
 											}
 										}
+										break;
+									case "requeststop":
+										station.StationType = Game.StationType.RequestStop;
+										foreach (XmlNode cc in c.ChildNodes)
+										{
+											switch (cc.Name.ToLowerInvariant())
+											{
+												case "distance":
+													if (!string.IsNullOrEmpty(cc.InnerText))
+													{
+														double d;
+														if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out d))
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Request stop distance is invalid in XML file " + fileName);
+															break;
+														}
+														stopRequest.TrackPosition -= Math.Abs(d);
+													}
+													break;
+												case "earlytime":
+													if (!string.IsNullOrEmpty(cc.InnerText))
+													{
+														if (!Interface.TryParseTime(cc.InnerText, out stopRequest.EarlyTime))
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Request stop early time was invalid in XML file " + fileName);
+														}
+													}
+													break;
+												case "latetime":
+													if (!string.IsNullOrEmpty(cc.InnerText))
+													{
+														if (!Interface.TryParseTime(cc.InnerText, out stopRequest.LateTime))
+														{
+															Interface.AddMessage(Interface.MessageType.Error, false, "Request stop late time was invalid in XML file " + fileName);
+														}
+													}
+													break;
+												case "stopmessage":
+													if (!string.IsNullOrEmpty(cc.InnerText))
+													{
+														stopRequest.StopMessage = cc.InnerText;
+													}
+													break;
+												case "passmessage":
+													if (!string.IsNullOrEmpty(cc.InnerText))
+													{
+														stopRequest.PassMessage = cc.InnerText;
+													}
+													break;
+												case "probability":
+													if (!NumberFormats.TryParseIntVb6(cc.InnerText, out stopRequest.Probability))
+													{
+														Interface.AddMessage(Interface.MessageType.Error, false, "Request stop probability was invalid in XML file " + fileName);
+													}
+													break;
+												case "maxcars":
+													if (!NumberFormats.TryParseIntVb6(cc.InnerText, out stopRequest.MaxNumberOfCars))
+													{
+														Interface.AddMessage(Interface.MessageType.Error, false, "Request stop maximum cars was invalid in XML file " + fileName);
+													}
+													break;
+											}
+										}
+										
 										break;
 								}
 							}

--- a/source/OpenBVE/Parsers/Script/StationXMLParser.cs
+++ b/source/OpenBVE/Parsers/Script/StationXMLParser.cs
@@ -331,6 +331,7 @@ namespace OpenBve
 										break;
 									case "requeststop":
 										station.StationType = Game.StationType.RequestStop;
+										station.StopMode = Game.StationStopMode.AllRequestStop;
 										foreach (XmlNode cc in c.ChildNodes)
 										{
 											switch (cc.Name.ToLowerInvariant())
@@ -349,6 +350,9 @@ namespace OpenBve
 															stopRequest.FullSpeed = false;
 															break;
 													}
+													break;
+												case "playeronly":
+													station.StopMode = Game.StationStopMode.PlayerRequestStop;
 													break;
 												case "distance":
 													if (!string.IsNullOrEmpty(cc.InnerText))
@@ -405,14 +409,13 @@ namespace OpenBve
 																		stopRequest.Late.StopMessage = cd.InnerText;
 																	}
 																	break;
+																case "#text":
+																	stopRequest.Early.StopMessage = cc.InnerText;
+																	stopRequest.OnTime.StopMessage = cc.InnerText;
+																	stopRequest.Late.StopMessage = cc.InnerText;
+																	break;
 															}
 														}
-													}
-													else if (!string.IsNullOrEmpty(cc.InnerText))
-													{
-														stopRequest.Early.StopMessage = cc.InnerText;
-														stopRequest.OnTime.StopMessage = cc.InnerText;
-														stopRequest.Late.StopMessage = cc.InnerText;
 													}
 													break;
 												case "passmessage":
@@ -440,21 +443,59 @@ namespace OpenBve
 																		stopRequest.Late.PassMessage = cd.InnerText;
 																	}
 																	break;
+																case "#text":
+																	stopRequest.Early.PassMessage = cc.InnerText;
+																	stopRequest.OnTime.PassMessage = cc.InnerText;
+																	stopRequest.Late.PassMessage = cc.InnerText;
+																	break;
 															}
 														}
 													}
-													else if (!string.IsNullOrEmpty(cc.InnerText))
-													{
-														stopRequest.Early.PassMessage = cc.InnerText;
-														stopRequest.OnTime.PassMessage = cc.InnerText;
-														stopRequest.Late.PassMessage = cc.InnerText;
-													}
 													break;
 												case "probability":
-													if (!NumberFormats.TryParseIntVb6(cc.InnerText, out stopRequest.OnTime.Probability))
+													foreach (XmlNode cd in cc.ChildNodes)
 													{
-														Interface.AddMessage(Interface.MessageType.Error, false, "Request stop probability was invalid in XML file " + fileName);
+														switch (cd.Name.ToLowerInvariant())
+														{
+															case "early":
+																if (!string.IsNullOrEmpty(cd.InnerText))
+																{
+																	if (!NumberFormats.TryParseIntVb6(cd.InnerText, out stopRequest.Early.Probability))
+																	{
+																		Interface.AddMessage(Interface.MessageType.Error, false, "Request stop early probability was invalid in XML file " + fileName);
+																	}
+																}
+																break;
+															case "ontime":
+																if (!string.IsNullOrEmpty(cd.InnerText))
+																{
+																	if (!NumberFormats.TryParseIntVb6(cd.InnerText, out stopRequest.OnTime.Probability))
+																	{
+
+																		Interface.AddMessage(Interface.MessageType.Error, false, "Request stop ontime probability was invalid in XML file " + fileName);
+																	}
+																}
+																break;
+															case "late":
+																if (!string.IsNullOrEmpty(cd.InnerText))
+																{
+																	if (!NumberFormats.TryParseIntVb6(cd.InnerText, out stopRequest.OnTime.Probability))
+																	{
+
+																		Interface.AddMessage(Interface.MessageType.Error, false, "Request stop late probability was invalid in XML file " + fileName);
+																	}
+																}
+																break;
+															case "#text":
+																if (!NumberFormats.TryParseIntVb6(cd.InnerText, out stopRequest.OnTime.Probability))
+																{
+
+																	Interface.AddMessage(Interface.MessageType.Error, false, "Request stop probability was invalid in XML file " + fileName);
+																}
+																break;
+														}
 													}
+													
 													break;
 												case "maxcars":
 													if (!NumberFormats.TryParseIntVb6(cc.InnerText, out stopRequest.MaxNumberOfCars))


### PR DESCRIPTION
This pull adds a parser, which loads a station's details from an XML file, using the new routefile command stationxml
e.g:

6500, .stationXML ..\includes\Dockyard.xml

```XML
<openBVE>
<Station>
<Name>Dockyard</Name>
<ArrivalTime>12.3130</ArrivalTime>
<DepartureTime>12.3150</DepartureTime>
<Doors>Left</Doors>
<ForcedRedSignal>False</ForcedRedSignal>
<PassengerRatio>10</PassengerRatio>
<RequestStop>
<Probability>50</Probability>
<Distance>700</Distance>
<StopMessage>You will need to stop at Dockyard today.</StopMessage>
<PassMessage>No passengers for Dockyard.</PassMessage>
</RequestStop>
</Station>
</openBVE>

```

All parameters from a standard .sta command are supported.
To set the station type:
```XML
<Type>ChangeEnds</Type>
```
or
```XML
<Type>Terminal</Type>
```

A **Request Stop** may be added using the <RequestStop> section.
__Parameters:__
* Probability: The chance this will be requested.
* Distance: The distance in meters prior to the station at which the stop request will be triggered.
* StopMessage: The textual message shown in the upper left when a stop is requested.
* PassMessage: The textual message shown in the upper left when a stop is NOT requested.


__TODO:__
* ~~Setup the random event roll to take account of time. The plumbing is already there, just needs to be hooked in and tested.~~
* Set autogen timetable to use request stops.
* Add plugin hook to the events.
* Add sound.cfg / xml entry for request stop and pass.