### PR TITLE
Change: Attempt to force close the window under Mono

### DIFF
--- a/source/OpenBVE/Game/Menu.cs
+++ b/source/OpenBVE/Game/Menu.cs
@@ -667,7 +667,7 @@ namespace OpenBve
 								Reset();
 								Program.RestartArguments =
 									Interface.CurrentOptions.GameMode == Interface.GameMode.Arcade ? "/review" : "";
-								MainLoop.Quit = true;
+								MainLoop.Quit = MainLoop.QuitMode.ExitToMenu;
 								break;
 							case MenuTag.Control:               // CONTROL CUSTOMIZATION
 								PushMenu(MenuType.Control, ((MenuCommand)menu.Items[menu.Selection]).Data);
@@ -676,7 +676,7 @@ namespace OpenBve
 								break;
 							case MenuTag.Quit:                  // QUIT PROGRAMME
 								Reset();
-								MainLoop.Quit = true;
+								MainLoop.Quit = MainLoop.QuitMode.QuitProgram;
 								break;
 						}
 					}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -316,6 +316,12 @@ namespace OpenBve
 				e.Cancel = true;
 				Loading.Cancel = true;
 			}
+
+			if (MainLoop.Quit == MainLoop.QuitMode.ContinueGame && Program.CurrentlyRunningOnMono)
+			{
+				//More forcefully close under Mono, stuff *still* hanging around....
+				Environment.Exit(0);
+			}
 		}
 		/// <summary>This method is called once the route and train data have been preprocessed, in order to physically setup the simulation</summary>
 		private void SetupSimulation()

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -66,6 +66,10 @@ namespace OpenBve
 				if (MainLoop.Quit)
 				{
 					Close();
+					if (Program.CurrentlyRunningOnMono)
+					{
+						Environment.Exit(0);
+					}
 				}
 				//If the menu state has not changed, don't update the rendered simulation
 				return;
@@ -133,6 +137,10 @@ namespace OpenBve
 			if (MainLoop.Quit)
 			{
 				Program.currentGameWindow.Exit();
+				if (Program.CurrentlyRunningOnMono)
+				{
+					Environment.Exit(0);
+				}				
 			}
 			Renderer.UpdateLighting();
 			Renderer.RenderScene(TimeElapsed);

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -63,10 +63,10 @@ namespace OpenBve
 				//Renderer.UpdateLighting();
 				Renderer.RenderScene(TimeElapsed);
 				Program.currentGameWindow.SwapBuffers();
-				if (MainLoop.Quit)
+				if (MainLoop.Quit != MainLoop.QuitMode.ContinueGame)
 				{
 					Close();
-					if (Program.CurrentlyRunningOnMono)
+					if (Program.CurrentlyRunningOnMono && MainLoop.Quit == MainLoop.QuitMode.QuitProgram)
 					{
 						Environment.Exit(0);
 					}
@@ -134,10 +134,10 @@ namespace OpenBve
 			}
 
 			World.CameraAlignmentDirection = new World.CameraAlignment();
-			if (MainLoop.Quit)
+			if (MainLoop.Quit != MainLoop.QuitMode.ContinueGame)
 			{
 				Program.currentGameWindow.Exit();
-				if (Program.CurrentlyRunningOnMono)
+				if (Program.CurrentlyRunningOnMono && MainLoop.Quit == MainLoop.QuitMode.QuitProgram)
 				{
 					Environment.Exit(0);
 				}				

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -10,10 +10,15 @@ namespace OpenBve
 {
 	internal static partial class MainLoop
 	{
-
+		internal enum QuitMode
+		{
+			ContinueGame = 0,
+			QuitProgram = 1,
+			ExitToMenu = 2
+		}
 		// declarations
 		internal static bool LimitFramerate = false;
-		internal static bool Quit = false;
+		internal static QuitMode Quit = QuitMode.ContinueGame;
 		/// <summary>BlockKeyRepeat should be set to 'true' whilst processing a KeyUp or KeyDown event.</summary>
 		internal static bool BlockKeyRepeat;
 		/// <summary>The current simulation time-factor</summary>
@@ -87,7 +92,7 @@ namespace OpenBve
 
 		private static void OpenTKQuit(object sender, CancelEventArgs e)
 		{
-			Quit = true;
+			Quit = QuitMode.QuitProgram;
 		}
 
 		/********************

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -5289,7 +5289,6 @@
 			this.Name = "formMain";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
 			this.Text = "openBVE";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.formMain_FormClosing);
 			this.Load += new System.EventHandler(this.formMain_Load);
 			this.Shown += new System.EventHandler(this.formMain_Shown);
 			this.Resize += new System.EventHandler(this.formMain_Resize);

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -705,11 +705,13 @@ namespace OpenBve
 		// =====
 
 		// start
+		private readonly object StartGame = new Object();
+
 		private void buttonStart_Click(object sender, EventArgs e) {
 			if (Result.RouteFile != null & Result.TrainFolder != null) {
 				if (System.IO.File.Exists(Result.RouteFile) & System.IO.Directory.Exists(Result.TrainFolder)) {
 					Result.Start = true;
-					this.Close();
+					buttonClose_Click(StartGame, e);
 					//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 					//This fixes the main form failing to close on Linux
 					Application.DoEvents();

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Net;
 using System.Windows.Forms;
@@ -1353,8 +1354,19 @@ namespace OpenBve {
 			//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 			//This fixes the main form failing to close on Linux
 			Application.DoEvents();
+			if (Program.CurrentlyRunningOnMono)
+			{
+				//On some systems, the process *still* seems to hang around, so explicity issue the Environment.Exit() call
+				//https://github.com/leezer3/OpenBVE/issues/213
+				Environment.Exit(0);
+			}
 		}
 
+		protected override void OnFormClosing(FormClosingEventArgs e)
+		{
+			//Call the explicit closing method
+			buttonClose_Click(this, e);
+		}
 
 
 		// ======

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -1346,15 +1346,19 @@ namespace OpenBve {
 			}
 		}
 
-
-		// close
+		private bool Closing = false;
 		private void buttonClose_Click(object sender, EventArgs e)
 		{
-			this.Close();
+			Closing = true;
+			if (sender != null)
+			{
+				//Don't cause an infinite loop
+				this.Close();
+			}
 			//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 			//This fixes the main form failing to close on Linux
 			Application.DoEvents();
-			if (Program.CurrentlyRunningOnMono)
+			if (Program.CurrentlyRunningOnMono && sender != StartGame)
 			{
 				//On some systems, the process *still* seems to hang around, so explicity issue the Environment.Exit() call
 				//https://github.com/leezer3/OpenBVE/issues/213
@@ -1364,8 +1368,12 @@ namespace OpenBve {
 
 		protected override void OnFormClosing(FormClosingEventArgs e)
 		{
+			if (Closing)
+			{
+				return;
+			}
 			//Call the explicit closing method
-			buttonClose_Click(this, e);
+			buttonClose_Click(null, e);
 		}
 
 

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -1357,6 +1357,7 @@ namespace OpenBve {
 			}
 			//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 			//This fixes the main form failing to close on Linux
+			formMain_FormClosing(sender, new FormClosingEventArgs(CloseReason.UserClosing, false));
 			Application.DoEvents();
 			if (Program.CurrentlyRunningOnMono && sender != StartGame)
 			{


### PR DESCRIPTION
https://github.com/leezer3/OpenBVE/issues/213

Some systems seem to keep things hanging around after the game has terminated. Only seen this under Mono, and it appears to be a little random, so probably WM / DE related.

Therefore:
If we are running under Mono, specifically issue an **Environment.Exit(0);** call after the program should have successfully quit.