### PR TITLE
Destination event

### DIFF
--- a/documentation/HTML/route_csv.html
+++ b/documentation/HTML/route_csv.html
@@ -2136,6 +2136,27 @@ This command places an environmental sound effect at the specified location. The
 
 </font></td></tr></table>
 This command places a bumper. The train can collide with the bumper in both the forward and backward directions. Place this command at the beginning and the end of the route. An object is not automatically created, so use Track.FreeObj to create a visual representation of the bumper if necessary.
+
+<table><tr style="height: 2px;"><td /></tr></table>
+<hr />
+<br /><table border="0">
+<tr style="height:16"><td></td></tr>
+<tr><td bgcolor="#F0F0F0" style="font-family: monospace;border:1px dotted;color:#808080"><font color="#C00000"><b>Track.Destination</b> <em>Type</em>; <em>BeaconStructureIndex</em>; <em>NextDestination</em>; <em>PreviousDestination</em>; <em>TriggerOnce</em>; <font color="green"><em>X</em></font>; <font color="green"><em>Y</em></font>; <em>Yaw</em>; <em>Pitch</em>; <em>Roll</em></font></td></tr>
+</table>
+<table style="border:0px none;margin-left:10pt;margin-right:10pt;">
+<tr><td><font color="#808080">
+<b><em>Type</em></b>: Defines the types of trains for which this destination setter applies: <em>-1</em> for AI trains only, <em>0</em> for all trains and <em>1</em> for the player train only.<br />
+<b><em>BeaconStructureIndex</em></b>: A non-negative integer representing the object to be placed as defined via Structure.Beacon, or -1 to not place any object.<br />
+<b><em>NextDestination</em></b>: An integer representing the destination value set when passing over this beacon in a forwards direction, or <em>-1</em> to disable.<br />
+<b><em>PreviousDestination</em></b>: An integer representing the destination value set when passing over this beacon in a reverse direction, or <em>-1</em> to disable.<br />
+<b><em>TriggerOnce</em></b>: If set to <em>0</em>, this beacon will be triggered by all valid trains which pass over it. If set to <em>1</em>, it will be triggered by the first valid train only.<br />
+<b><font color="green"><em>X</em></font></b>: The X-coordinate at which to place the object, <b>by default</b> measured in <b>meters</b>. The default value is 0.<br />
+<b><font color="green"><em>Y</em></font></b>: The Y-coordinate at which to place the object, <b>by default</b> measured in <b>meters</b>. The default value is 0.<br />
+<b><em>Yaw</em></b>: The angle in degrees by which the object is rotated in the XZ-plane in clock-wise order when viewed from above. The default value is 0.<br />
+<b><em>Pitch</em></b>: The angle in degrees by which the object is rotated in the YZ-plane in clock-wise order when viewed from the left. The default value is 0.<br />
+<b><em>Roll</em></b>: The angle in degrees by which the object is rotated in the XY-plane in clock-wise order when viewed from behind. The default value is 0.
+</font></td></tr></table>
+This command places a special beacon, which sets the destination variable, available for use by plugins and animated objects. The object must have been loaded via Structure.Beacon(<em>BeaconStructureIndex</em>) prior to using this command.<br /><br /><hr />
 </body>
 
 <!-- Mirrored from www.trainsimframework.org/develop/route_csv.html by HTTrack Website Copier/3.x [XR&CO'2010], Sat, 05 May 2012 22:30:55 GMT -->

--- a/source/ObjectViewer/FunctionScripts.cs
+++ b/source/ObjectViewer/FunctionScripts.cs
@@ -15,7 +15,7 @@ namespace OpenBve {
 			CompareEqual, CompareUnequal, CompareLess, CompareGreater, CompareLessEqual, CompareGreaterEqual, CompareConditional,
 			LogicalNot, LogicalAnd, LogicalOr, LogicalNand, LogicalNor, LogicalXor,
 			TimeSecondsSinceMidnight, CameraDistance,CameraView,
-			TrainCars,
+			TrainCars, TrainDestination,
 			TrainSpeed, TrainSpeedometer, TrainAcceleration, TrainAccelerationMotor,
 			TrainSpeedOfCar, TrainSpeedometerOfCar, TrainAccelerationOfCar, TrainAccelerationMotorOfCar,
 			TrainDistance, TrainDistanceToCar, TrainTrackDistance, TrainTrackDistanceToCar, CurveRadius, FrontAxleCurveRadius, RearAxleCurveRadius, CurveCant, Odometer, OdometerOfCar,
@@ -280,6 +280,13 @@ namespace OpenBve {
 					case Instructions.TrainCars:
 						if (Train != null) {
 							Function.Stack[s] = (double)Train.Cars.Length;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
+					case Instructions.TrainDestination:
+						if (Train != null) {
+							Function.Stack[s] = (double)Train.Destination;
 						} else {
 							Function.Stack[s] = 0.0;
 						}
@@ -2394,6 +2401,10 @@ namespace OpenBve {
 						case "cars":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
 							Result.Instructions[n] = Instructions.TrainCars;
+							n++; s++; if (s >= m) m = s; break;
+						case "destination":
+							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
+							Result.Instructions[n] = Instructions.TrainDestination;
 							n++; s++; if (s >= m) m = s; break;
 						case "speed":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);

--- a/source/ObjectViewer/TrainManagerS.cs
+++ b/source/ObjectViewer/TrainManagerS.cs
@@ -399,6 +399,7 @@ namespace OpenBve {
 		internal class Train {
 			internal TrainState State;
 			internal Car[] Cars;
+			internal int Destination;
 			internal int DriverCar;
 			internal TrainSpecs Specs;
 			internal int CurrentSectionIndex;

--- a/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
@@ -1,0 +1,61 @@
+﻿namespace OpenBve
+{
+	internal static partial class TrackManager
+	{
+		/// <summary>Called when a train passes over a destination change event</summary>
+		internal class DestinationEvent : GeneralEvent
+		{
+			/// <summary>An optional data parameter passed to plugins recieving this event</summary>
+			internal readonly int NextDestination;
+			internal readonly int PreviousDestination;
+			internal readonly bool TriggerOnce;
+			internal int Type;
+
+			internal DestinationEvent(double trackPositionDelta, int type, int nextDestination, int previousDestination, bool triggerOnce)
+			{
+				this.TrackPositionDelta = trackPositionDelta;
+				this.DontTriggerAnymore = false;
+				this.NextDestination = nextDestination;
+				this.PreviousDestination = previousDestination;
+				this.TriggerOnce = triggerOnce;
+				this.Type = type;
+			}
+			internal override void Trigger(int Direction, EventTriggerType TriggerType, TrainManager.Train Train, int CarIndex)
+			{
+				if (this.Type == -1 && Train == TrainManager.PlayerTrain || this.Type == 1 && Train != TrainManager.PlayerTrain)
+				{
+					return;
+				}
+				if (this.DontTriggerAnymore)
+				{
+					return;
+				}
+				if (TriggerType == EventTriggerType.TrainFront)
+				{
+					if (Direction > 0)
+					{
+						if (NextDestination != -1)
+						{
+							Train.Destination = NextDestination;
+						}
+						if (TriggerOnce)
+						{
+							DontTriggerAnymore = true;
+						}
+					}
+					else
+					{
+						if (PreviousDestination != -1)
+						{
+							Train.Destination = PreviousDestination;
+						}
+						if (TriggerOnce)
+						{
+							DontTriggerAnymore = true;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
@@ -5,11 +5,14 @@
 		/// <summary>Called when a train passes over a destination change event</summary>
 		internal class DestinationEvent : GeneralEvent
 		{
-			/// <summary>An optional data parameter passed to plugins recieving this event</summary>
+			/// <summary>The destination value to set when passing over this event forwards, or -1 to disable</summary>
 			internal readonly int NextDestination;
+			/// <summary>The destination value to set when passing over this event backwards, or -1 to disable</summary>
 			internal readonly int PreviousDestination;
+			/// <summary>Whether this event should trigger once or multiple times</summary>
 			internal readonly bool TriggerOnce;
-			internal int Type;
+			/// <summary>Whether this event is triggered by AI only (-1), both (0) or player only (1)</summary>
+			internal readonly int Type;
 
 			internal DestinationEvent(double trackPositionDelta, int type, int nextDestination, int previousDestination, bool triggerOnce)
 			{

--- a/source/OpenBVE/Game/Game.cs
+++ b/source/OpenBVE/Game/Game.cs
@@ -60,6 +60,8 @@ namespace OpenBve {
 		internal static TrainStartMode TrainStart = TrainStartMode.EmergencyBrakesAts;
         /// <summary>The name of the current train</summary>
 		internal static string TrainName = "";
+		/// <summary>The initial destination for any train within the game</summary>
+		internal static int InitialDestination = -1;
 
 		// ================================
 

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
@@ -21,7 +21,7 @@ namespace OpenBve {
 			StackCopy, StackSwap,
 			MathRandom, MathRandomInt,
 			TimeSecondsSinceMidnight, CameraDistance,CameraView,
-			TrainCars,
+			TrainCars, TrainDestination,
 			TrainSpeed, TrainSpeedometer, TrainAcceleration, TrainAccelerationMotor,
 			TrainSpeedOfCar, TrainSpeedometerOfCar, TrainAccelerationOfCar, TrainAccelerationMotorOfCar,
 			TrainDistance, TrainDistanceToCar, TrainTrackDistance, TrainTrackDistanceToCar, CurveRadius, FrontAxleCurveRadius, RearAxleCurveRadius, CurveCant, Odometer, OdometerOfCar,
@@ -322,6 +322,13 @@ namespace OpenBve {
 					case Instructions.TrainCars:
 						if (Train != null) {
 							Function.Stack[s] = (double)Train.Cars.Length;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
+					case Instructions.TrainDestination:
+						if (Train != null) {
+							Function.Stack[s] = (double)Train.Destination;
 						} else {
 							Function.Stack[s] = 0.0;
 						}
@@ -2418,6 +2425,10 @@ namespace OpenBve {
 						case "cars":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
 							Result.Instructions[n] = Instructions.TrainCars;
+							n++; s++; if (s >= m) m = s; break;
+						case "destination":
+							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
+							Result.Instructions[n] = Instructions.TrainDestination;
 							n++; s++; if (s >= m) m = s; break;
 						case "speed":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.Objects.cs" />
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.PreprocessOptions.cs" />
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.RouteFixes.cs" />
+    <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.SignalData.cs" />
     <Compile Include="Parsers\Route\BVE\CsvRwRouteParser.Structures.cs" />
     <Compile Include="Parsers\Script\StationXMLParser.cs" />
     <Compile Include="Parsers\Script\DynamicBackgroundParser.cs" />

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Game\Events\EventTypes\SpeedLimit.cs" />
     <Compile Include="Game\Events\EventTypes\Station.cs" />
     <Compile Include="Game\Events\EventTypes\TrackEnd.cs" />
+    <Compile Include="Game\Events\EventTypes\DestinationChange.cs" />
     <Compile Include="Game\Events\EventTypes\Transponder.cs" />
     <Compile Include="Game\Markers.cs" />
     <Compile Include="Game\MessageManager.cs" />

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -1157,6 +1157,27 @@ namespace OpenBve
 									}
 								}
 							}
+							for (int k = 0; k < Data.Blocks[i].DestinationChanges.Length; k++)
+							{
+								ObjectManager.UnifiedObject obj = null;
+								int b = Data.Blocks[i].DestinationChanges[k].BeaconStructureIndex;
+								if (b >= 0 & Data.Structure.Beacon.ContainsKey(b))
+								{
+									obj = Data.Structure.Beacon[b];
+								}
+								if (obj != null)
+								{
+									double dx = Data.Blocks[i].DestinationChanges[k].X;
+									double dy = Data.Blocks[i].DestinationChanges[k].Y;
+									double dz = Data.Blocks[i].DestinationChanges[k].TrackPosition - StartingDistance;
+									Vector3 wpos = pos;
+									wpos.X += dx * RailTransformation.X.X + dy * RailTransformation.Y.X + dz * RailTransformation.Z.X;
+									wpos.Y += dx * RailTransformation.X.Y + dy * RailTransformation.Y.Y + dz * RailTransformation.Z.Y;
+									wpos.Z += dx * RailTransformation.X.Z + dy * RailTransformation.Y.Z + dz * RailTransformation.Z.Z;
+									double tpos = Data.Blocks[i].DestinationChanges[k].TrackPosition;
+									obj.CreateObject(wpos, RailTransformation, new World.Transformation(Data.Blocks[i].DestinationChanges[k].Yaw, Data.Blocks[i].DestinationChanges[k].Pitch, Data.Blocks[i].DestinationChanges[k].Roll), Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, tpos);
+								}
+							}
 						}
 						// sections/signals/transponders
 						if (j == 0)
@@ -1499,6 +1520,15 @@ namespace OpenBve
 							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.TransponderEvent(d, Data.Blocks[i].Transponder[j].Type, Data.Blocks[i].Transponder[j].Data, s, Data.Blocks[i].Transponder[j].ClipToFirstRedSection);
 							Data.Blocks[i].Transponder[j].Type = -1;
 						}
+					}
+					// Destination Change Evvents
+					for (int j = 0; j < Data.Blocks[i].DestinationChanges.Length; j++)
+					{
+						int n = i - Data.FirstUsedBlock;
+						int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
+						Array.Resize<TrackManager.GeneralEvent>(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
+						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - TrackManager.CurrentTrack.Elements[n].StartingTrackPosition;
+						TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
 					}
 				}
 			}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -1521,7 +1521,7 @@ namespace OpenBve
 							Data.Blocks[i].Transponder[j].Type = -1;
 						}
 					}
-					// Destination Change Evvents
+					// Destination Change Events
 					for (int j = 0; j < Data.Blocks[i].DestinationChanges.Length; j++)
 					{
 						int n = i - Data.FirstUsedBlock;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
@@ -122,6 +122,7 @@ namespace OpenBve
 							Blocks[i].Section = new Section[] { };
 							Blocks[i].Sound = new Sound[] { };
 							Blocks[i].Transponder = new Transponder[] { };
+							Blocks[i].DestinationChanges = new DestinationEvent[] { };
 							Blocks[i].RailFreeObj = new FreeObj[][] { };
 							Blocks[i].GroundFreeObj = new FreeObj[] { };
 							Blocks[i].PointsOfInterest = new PointOfInterest[] { };

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.SignalData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.SignalData.cs
@@ -1,0 +1,43 @@
+﻿namespace OpenBve
+{
+	internal partial class CsvRwRouteParser
+	{
+		/// <summary>An abstract signal - All signals must inherit from this class</summary>
+		private abstract class SignalData
+		{
+		}
+
+
+		// ---SIGNAL TYPES---
+
+		/// <summary>Defines a BVE 4 standard signal:
+		/// A signal has a face based mesh and glow
+		/// Textures are then substituted according to the aspect
+		/// </summary>
+		private class Bve4SignalData : SignalData
+		{
+			internal ObjectManager.StaticObject BaseObject;
+			internal ObjectManager.StaticObject GlowObject;
+			internal Textures.Texture[] SignalTextures;
+			internal Textures.Texture[] GlowTextures;
+		}
+		/// <summary>Defines a default Japanese signal (See the documentation)</summary>
+		private class CompatibilitySignalData : SignalData
+		{
+			internal readonly int[] Numbers;
+			internal readonly ObjectManager.StaticObject[] Objects;
+			internal CompatibilitySignalData(int[] Numbers, ObjectManager.StaticObject[] Objects)
+			{
+				this.Numbers = Numbers;
+				this.Objects = Objects;
+			}
+		}
+		/// <summary>Defines an animated signal object:
+		/// The object is provided with the aspect number, and then should deal with the rest
+		/// </summary>
+		private class AnimatedObjectSignalData : SignalData
+		{
+			internal ObjectManager.AnimatedObjectCollection Objects;
+		}
+	}
+}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -157,6 +157,20 @@
 			internal double Pitch;
 			internal double Roll;
 		}
+		private struct DestinationEvent
+		{
+			internal double TrackPosition;
+			internal int Type;
+			internal bool TriggerOnce;
+			internal int BeaconStructureIndex;
+			internal int NextDestination;
+			internal int PreviousDestination;
+			internal double X;
+			internal double Y;
+			internal double Yaw;
+			internal double Pitch;
+			internal double Roll;
+		}
 		private struct PointOfInterest
 		{
 			internal double TrackPosition;
@@ -196,6 +210,7 @@
 			internal Stop[] Stop;
 			internal Sound[] Sound;
 			internal Transponder[] Transponder;
+			internal DestinationEvent[] DestinationChanges;
 			internal PointOfInterest[] PointsOfInterest;
 			internal TrackManager.TrackElement CurrentTrackState;
 			internal double Pitch;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -71,6 +71,7 @@ namespace OpenBve {
 				Data.Blocks[0].Section = new Section[] {};
 				Data.Blocks[0].Sound = new Sound[] {};
 				Data.Blocks[0].Transponder = new Transponder[] {};
+				Data.Blocks[0].DestinationChanges = new DestinationEvent[] {};
 				Data.Blocks[0].PointsOfInterest = new PointOfInterest[] {};
 				Data.Markers = new Marker[] {};
 				Data.RequestStops = new StopRequest[] { };
@@ -1667,6 +1668,24 @@ namespace OpenBve {
 											}
 										}
 									} break;
+								case "train.destination":
+									{
+										if (PreviewOnly)
+										{
+											if (Arguments.Length < 1)
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, Command + " is expected to have one argument at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+											}
+											else
+											{
+												if (!NumberFormats.TryParseIntVb6(Arguments[0], out Game.InitialDestination))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Destination is expected to be an Integer in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												}
+											}
+										}
+									}
+									break;
 									// structure
 								case "structure.rail":
 									{
@@ -2673,6 +2692,7 @@ namespace OpenBve {
 								case "route.developerid":
 								case "train.folder":
 								case "train.file":
+								case "train.destination":
 								case "train.run":
 								case "train.rail":
 								case "train.flange":
@@ -3282,6 +3302,102 @@ namespace OpenBve {
 											Data.Blocks[BlockIndex].Signal[n].ShowPost = x != 0.0 & y < 0.0;
 										}
 									} break;
+								case "track.destination":
+									{
+										if (!PreviewOnly)
+										{
+											int type = 0;
+											if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out type))
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Type is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												type = 0;
+											}
+											if (type < -1 || type > 1)
+											{
+												Interface.AddMessage(Interface.MessageType.Error, false, "Type is expected to be in the range of -1 to 1 in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+											}
+											else
+											{
+												int structure = 0, nextDestination = 0, previousDestination = 0, triggerOnce = 0;
+												if (Arguments.Length >= 2 && Arguments[1].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[1], out structure))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "BeaconStructureIndex is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													structure = 0;
+												}
+												if (Arguments.Length >= 3 && Arguments[2].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[2], out nextDestination))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "NextDestination is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													nextDestination = 0;
+												}
+												if (Arguments.Length >= 4 && Arguments[3].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[3], out previousDestination))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "PreviousDestination is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													previousDestination = 0;
+												}
+												if (Arguments.Length >= 5 && Arguments[4].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[4], out triggerOnce))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "TriggerOnce is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													previousDestination = 0;
+												}
+												if (structure < -1)
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "BeaconStructureIndex is expected to be non-negative or -1 in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													structure = -1;
+												}
+												else if (structure >= 0 && !Data.Structure.Beacon.ContainsKey(structure))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "BeaconStructureIndex " + structure + " references an object not loaded in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													structure = -1;
+												}
+												if (triggerOnce < 0 || triggerOnce > 1)
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "TriggerOnce is expected to be in the range of 0 to 1 in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													triggerOnce = 0;
+												}
+												double x = 0.0, y = 0.0;
+												double yaw = 0.0, pitch = 0.0, roll = 0.0;
+												if (Arguments.Length >= 6 && Arguments[5].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[5], UnitOfLength, out x))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "X is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													x = 0.0;
+												}
+												if (Arguments.Length >= 7 && Arguments[6].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[6], UnitOfLength, out y))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Y is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													y = 0.0;
+												}
+												if (Arguments.Length >= 8 && Arguments[7].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[7], out yaw))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Yaw is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													yaw = 0.0;
+												}
+												if (Arguments.Length >= 9 && Arguments[8].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[8], out pitch))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Pitch is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													pitch = 0.0;
+												}
+												if (Arguments.Length >= 10 && Arguments[9].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[9], out roll))
+												{
+													Interface.AddMessage(Interface.MessageType.Error, false, "Roll is invalid in Track.Destination at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+													roll = 0.0;
+												}
+												int n = Data.Blocks[BlockIndex].DestinationChanges.Length;
+												Array.Resize<DestinationEvent>(ref Data.Blocks[BlockIndex].DestinationChanges, n + 1);
+												Data.Blocks[BlockIndex].DestinationChanges[n].TrackPosition = Data.TrackPosition;
+												Data.Blocks[BlockIndex].DestinationChanges[n].Type = type;
+												Data.Blocks[BlockIndex].DestinationChanges[n].TriggerOnce = triggerOnce != 0;
+												Data.Blocks[BlockIndex].DestinationChanges[n].PreviousDestination = previousDestination;
+												Data.Blocks[BlockIndex].DestinationChanges[n].BeaconStructureIndex = structure;
+												Data.Blocks[BlockIndex].DestinationChanges[n].NextDestination = nextDestination;
+												Data.Blocks[BlockIndex].DestinationChanges[n].X = x;
+												Data.Blocks[BlockIndex].DestinationChanges[n].Y = y;
+												Data.Blocks[BlockIndex].DestinationChanges[n].Yaw = yaw * 0.0174532925199433;
+												Data.Blocks[BlockIndex].DestinationChanges[n].Pitch = pitch * 0.0174532925199433;
+												Data.Blocks[BlockIndex].DestinationChanges[n].Roll = roll * 0.0174532925199433;
+											}
+										}
+									}
+									break;
 								case "track.beacon":
 									{
 										if (!PreviewOnly) {
@@ -3291,7 +3407,7 @@ namespace OpenBve {
 												type = 0;
 											}
 											if (type < 0) {
-												Interface.AddMessage(Interface.MessageType.Error, false, "Type is expected to be non-positive in Track.Beacon at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												Interface.AddMessage(Interface.MessageType.Error, false, "Type is expected to be non-negative in Track.Beacon at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
 												int structure = 0, section = 0, optional = 0;
 												if (Arguments.Length >= 2 && Arguments[1].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[1], out structure)) {

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -7,38 +7,6 @@ using OpenBveApi.Math;
 
 namespace OpenBve {
 	internal partial class CsvRwRouteParser {
-		/// <summary>An abstract signal - All signals must inherit from this class</summary>
-		private abstract class SignalData { }
-
-
-		// ---SIGNAL TYPES---
-
-		/// <summary>Defines a BVE 4 standard signal:
-		/// A signal has a face based mesh and glow
-		/// Textures are then substituted according to the aspect
-		/// </summary>
-		private class Bve4SignalData : SignalData {
-			internal ObjectManager.StaticObject BaseObject;
-			internal ObjectManager.StaticObject GlowObject;
-			internal Textures.Texture[] SignalTextures;
-			internal Textures.Texture[] GlowTextures;
-		}
-		/// <summary>Defines a default Japanese signal (See the documentation)</summary>
-		private class CompatibilitySignalData : SignalData {
-			internal readonly int[] Numbers;
-			internal readonly ObjectManager.StaticObject[] Objects;
-			internal CompatibilitySignalData(int[] Numbers, ObjectManager.StaticObject[] Objects) {
-				this.Numbers = Numbers;
-				this.Objects = Objects;
-			}
-		}
-		/// <summary>Defines an animated signal object:
-		/// The object is provided with the aspect number, and then should deal with the rest
-		/// </summary>
-		private class AnimatedObjectSignalData : SignalData {
-			internal ObjectManager.AnimatedObjectCollection Objects;
-		}
-
 		internal static string ObjectPath;
 		internal static string SoundPath;
 		internal static string TrainPath;

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -21,6 +21,9 @@ namespace OpenBve
 			internal TrainPassengers Passengers;
 			internal int LastStation;
 			internal int Station;
+
+			internal int Destination = -1;
+
 			internal bool StationFrontCar;
 			internal bool StationRearCar;
 			internal TrainStopState StationState;
@@ -41,9 +44,13 @@ namespace OpenBve
 			internal string[] PowerNotchDescriptions;
 			internal string[] BrakeNotchDescriptions;
 			internal string[] ReverserDescriptions;
+			/// <summary>The max width used in px for the power notch HUD string</summary>
 			internal int MaxPowerNotchWidth = 48;
+			/// <summary>The max width used in px for the brake notch HUD string</summary>
 			internal int MaxBrakeNotchWidth = 48;
+			/// <summary>The max width used in px for the reverser HUD string</summary>
 			internal int MaxReverserWidth = 48;
+			/// <summary>The absolute on-disk path to the train's folder</summary>
 			internal string TrainFolder;
 
 			internal void Initialize()

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -214,7 +214,7 @@ namespace OpenBve {
 			System.Threading.Thread.Sleep(1); if (Cancel) return;
 			TrainManager.Trains = new TrainManager.Train[Game.PrecedingTrainTimeDeltas.Length + 1 + (Game.BogusPretrainInstructions.Length != 0 ? 1 : 0)];
 			for (int k = 0; k < TrainManager.Trains.Length; k++) {
-				TrainManager.Trains[k] = new TrainManager.Train {TrainIndex = k};
+				TrainManager.Trains[k] = new TrainManager.Train {TrainIndex = k, Destination = Game.InitialDestination};
 				if (k == TrainManager.Trains.Length - 1 & Game.BogusPretrainInstructions.Length != 0) {
 					TrainManager.Trains[k].State = TrainManager.TrainState.Bogus;
 				} else {

--- a/source/OpenBVE/System/Plugins/PluginManager.cs
+++ b/source/OpenBVE/System/Plugins/PluginManager.cs
@@ -154,7 +154,7 @@ namespace OpenBve {
 				 * 
 				 */
 				CurrentCameraViewMode = (CameraViewMode)World.CameraMode;
-				ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, (DoorInterlockStates)this.Train.Specs.DoorInterlockState, new Time(totalTime), new Time(elapsedTime), currentRouteStations, CurrentCameraViewMode, Interface.CurrentLanguageCode);
+				ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, (DoorInterlockStates)this.Train.Specs.DoorInterlockState, new Time(totalTime), new Time(elapsedTime), currentRouteStations, CurrentCameraViewMode, Interface.CurrentLanguageCode, this.Train.Destination);
 				LastTime = Game.SecondsSinceMidnight;
 				Elapse(data);
 				this.PluginMessage = data.DebugMessage;
@@ -165,6 +165,7 @@ namespace OpenBve {
 				 * */
 				this.PluginValid = true;
 				SetHandles(data.Handles, true);
+				this.Train.Destination = data.Destination;
 			}
 			/// <summary>Gets the driver handles.</summary>
 			/// <returns>The driver handles.</returns>

--- a/source/OpenBveApi/Runtime.cs
+++ b/source/OpenBveApi/Runtime.cs
@@ -666,6 +666,8 @@ namespace OpenBveApi.Runtime {
 		private readonly CameraViewMode MyCameraViewMode;
 		/// <summary>The current interface language code.</summary>
 		private readonly string MyLanguageCode;
+		/// <summary>The current destination code</summary>
+		private int CurrentDestination;
 		// --- constructors ---
 		/// <summary>Creates a new instance of this class.</summary>
 		/// <param name="vehicle">The state of the train.</param>
@@ -677,7 +679,8 @@ namespace OpenBveApi.Runtime {
 		/// <param name="stations">The current route's list of stations.</param>
 		/// <param name="cameraView">The current camera view mode</param>
 		/// <param name="languageCode">The current language code</param>
-		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, DoorInterlockStates doorinterlock, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode) {
+		/// <param name="destination">The current destination</param>
+		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, DoorInterlockStates doorinterlock, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode, int destination) {
 			this.MyVehicle = vehicle;
 			this.MyPrecedingVehicle = precedingVehicle;
 			this.MyHandles = handles;
@@ -688,6 +691,7 @@ namespace OpenBveApi.Runtime {
 			this.MyStations = stations;
 			this.MyCameraViewMode = cameraView;
 			this.MyLanguageCode = languageCode;
+			this.CurrentDestination = destination;
 		}
 
 
@@ -778,6 +782,14 @@ namespace OpenBveApi.Runtime {
 			get
 			{
 				return this.MyLanguageCode;
+			}
+		}
+		/// <summary>Gets the destination variable as set by the plugin</summary>
+		public int Destination
+		{
+			get
+			{
+				return this.CurrentDestination;
 			}
 		}
 	}

--- a/source/RouteViewer/FunctionScripts.cs
+++ b/source/RouteViewer/FunctionScripts.cs
@@ -15,7 +15,7 @@ namespace OpenBve {
 			CompareEqual, CompareUnequal, CompareLess, CompareGreater, CompareLessEqual, CompareGreaterEqual, CompareConditional,
 			LogicalNot, LogicalAnd, LogicalOr, LogicalNand, LogicalNor, LogicalXor,
 			TimeSecondsSinceMidnight, CameraDistance,CameraView,
-			TrainCars,
+			TrainCars, TrainDestination,
 			TrainSpeed, TrainSpeedometer, TrainAcceleration, TrainAccelerationMotor,
 			TrainSpeedOfCar, TrainSpeedometerOfCar, TrainAccelerationOfCar, TrainAccelerationMotorOfCar,
 			TrainDistance, TrainDistanceToCar, TrainTrackDistance, TrainTrackDistanceToCar, CurveRadius, FrontAxleCurveRadius, RearAxleCurveRadius, CurveCant, Odometer, OdometerOfCar,
@@ -280,6 +280,13 @@ namespace OpenBve {
 					case Instructions.TrainCars:
 						if (Train != null) {
 							Function.Stack[s] = (double)Train.Cars.Length;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
+					case Instructions.TrainDestination:
+						if (Train != null) {
+							Function.Stack[s] = (double)Train.Destination;
 						} else {
 							Function.Stack[s] = 0.0;
 						}
@@ -2394,6 +2401,10 @@ namespace OpenBve {
 						case "cars":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
 							Result.Instructions[n] = Instructions.TrainCars;
+							n++; s++; if (s >= m) m = s; break;
+						case "destination":
+							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);
+							Result.Instructions[n] = Instructions.TrainDestination;
 							n++; s++; if (s >= m) m = s; break;
 						case "speed":
 							if (n >= Result.Instructions.Length) Array.Resize<Instructions>(ref Result.Instructions, Result.Instructions.Length << 1);

--- a/source/RouteViewer/TrainManagerR.cs
+++ b/source/RouteViewer/TrainManagerR.cs
@@ -441,6 +441,7 @@ namespace OpenBve {
 			//internal bool Disposed;
 			//internal bool IsBogusTrain;
 			internal Car[] Cars;
+			internal int Destination;
 			//internal Coupler[] Couplers;
 			internal int DriverCar;
 			internal TrainSpecs Specs;


### PR DESCRIPTION
This PR implements destinations for trains.

### Routefile Code
Train.Destination(__InitialDestination__) 
__InitialDestination__ should be an integer, representing the initial destination displayed by the train at the first stop

---

Track.Destination(__Type__ , __BeaconStructureIndex__ , __NextDestination__ , __PreviousDestination__ , __TriggerOnce__ , __X__ , __Y__ , __Yaw__ , __Pitch__ , __Roll__)
__Type__ should be one of the following: _-1_ : AI trains only _0_ : All trains _1_ : Player train only
__BeaconStructureIndex__ should be the index of any beacon object previously declared, or -1 to show no visible marker.
__NextDestination__ represents the destination to change to when passing over this beacon forwards, or _-1_ to not change.
__PreviousDestination__ represents the destination to change to when passing over this beacon in reverse, or _-1_ to not change.
__X, Y , Z, Pitch , Roll__ control the positioning of the associated object (if in use)