### PR TITLE
Fix: Issue that ConstantSpeed Device doesn't work

### DIFF
--- a/source/OpenBVE/Simulation/TrainManager/Car/ConstantSpeedDevice.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/ConstantSpeedDevice.cs
@@ -30,17 +30,15 @@
 					this.CurrentAccelerationOutput = Acceleration;
 					return;
 				}
-				if (Game.SecondsSinceMidnight < this.NextUpdateTime)
+				if (Game.SecondsSinceMidnight >= this.NextUpdateTime)
 				{
-					return;
+					this.NextUpdateTime = Game.SecondsSinceMidnight + UpdateInterval;
+					this.CurrentAccelerationOutput -= 0.8 * this.Car.Specs.CurrentAcceleration * (double)ReverserPosition;
+					if (this.CurrentAccelerationOutput < 0.0)
+					{
+						this.CurrentAccelerationOutput = 0.0;
+					}
 				}
-				this.NextUpdateTime = Game.SecondsSinceMidnight + UpdateInterval;
-				this.CurrentAccelerationOutput -= 0.8 * this.Car.Specs.CurrentAcceleration * (double)ReverserPosition;
-				if (this.CurrentAccelerationOutput < 0.0)
-				{
-					this.CurrentAccelerationOutput = 0.0;
-				}
-
 				if (Acceleration > CurrentAccelerationOutput)
 				{
 					Acceleration = CurrentAccelerationOutput;


### PR DESCRIPTION
This PR fixes problems that ConstantSpeed device doesn't work, which occurs after 1.5.2.3.