### PR TITLE
Fix: Build error and reference error

### DIFF
--- a/source/ObjectViewer/ObjectViewer.csproj
+++ b/source/ObjectViewer/ObjectViewer.csproj
@@ -18,7 +18,6 @@
     <NoStdLib>False</NoStdLib>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,7 +59,7 @@
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Dependencies\OpenTK.dll</HintPath>
+      <HintPath>..\..\dependencies\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="SharpCompress, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/source/OpenBVE/OpenBve.csproj
+++ b/source/OpenBVE/OpenBve.csproj
@@ -84,22 +84,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CSScriptLibrary">
-      <HintPath>..\..\Dependencies\CSScriptLibrary.dll</HintPath>
+      <HintPath>..\..\dependencies\CSScriptLibrary.dll</HintPath>
     </Reference>
     <Reference Include="NUniversalCharDet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Dependencies\NUniversalCharDet.dll</HintPath>
+      <HintPath>..\..\dependencies\NUniversalCharDet.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Dependencies\OpenTK.dll</HintPath>
+      <HintPath>..\..\dependencies\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="PIEHid32Net">
       <HintPath>..\..\dependencies\PIEHid32Net.dll</HintPath>
     </Reference>
     <Reference Include="SharpCompress, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Dependencies\SharpCompress.dll</HintPath>
+      <HintPath>..\..\dependencies\SharpCompress.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -56,7 +56,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="SharpCompress">
-      <HintPath>..\..\Dependencies\SharpCompress.dll</HintPath>
+      <HintPath>..\..\dependencies\SharpCompress.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/source/Plugins/OpenBveAts/Train.cs
+++ b/source/Plugins/OpenBveAts/Train.cs
@@ -15,15 +15,15 @@ namespace Plugin {
 		internal class ReadOnlyHandles {
 			// --- properties ---
 			/// <summary>Gets or sets the reverser position.</summary>
-			internal int Reverser { get; }
+			internal int Reverser { get; private set; }
 			/// <summary>Gets or sets the power notch.</summary>
-			internal int PowerNotch { get; }
+			internal int PowerNotch { get; private set; }
 			/// <summary>Gets or sets the brake notch.</summary>
-			internal int BrakeNotch { get; }
+			internal int BrakeNotch { get; private set; }
 			/// <summary>Gets or sets the brake notch.</summary>
-			internal int LocoBrakeNotch { get; }
+			internal int LocoBrakeNotch { get; private set; }
 			/// <summary>Gets or sets whether the const speed system is enabled.</summary>
-			internal bool ConstSpeed { get; }
+			internal bool ConstSpeed { get; private set; }
 			// --- constructors ---
 			/// <summary>Creates a new instance of this class.</summary>
 			/// <param name="handles">The handles</param>

--- a/source/RouteViewer/RouteViewer.csproj
+++ b/source/RouteViewer/RouteViewer.csproj
@@ -15,7 +15,6 @@
     <NoStdLib>False</NoStdLib>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,7 +57,7 @@
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Dependencies\OpenTK.dll</HintPath>
+      <HintPath>..\..\dependencies\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
This PR fix build error and reference error.
- build error due to VS2013 (also Mono 3.2.8) not supporting get-only property
- reference error due to a typo in HintPath on monodevelop