### PR TITLE
Fix: typo

### DIFF
--- a/source/OpenBVE/Simulation/TrainManager/Station.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Station.cs
@@ -381,7 +381,7 @@ namespace OpenBve
 								Train.Cars[j].Doors[0].AnticipatedReopen = false;
 							}
 						}
-						if (Train.Cars[j].Doors[1].AnticipatedReopen && Train.Cars[j].Doors[1].State == Train.Cars[j].Doors[0].InterferingObjectRate)
+						if (Train.Cars[j].Doors[1].AnticipatedReopen && Train.Cars[j].Doors[1].State == Train.Cars[j].Doors[1].InterferingObjectRate)
 						{
 							if (Train.Cars[j].Doors[1].NextReopenTime == 0.0)
 							{


### PR DESCRIPTION
This PR fix typo.
Because of this typo the door on the right side reopened and closed indefinitely at the station.