### PR TITLE
Change: Use API readonly vector defines where possible

### DIFF
--- a/source/CarXMLConvertor/Convert.SoundCfg.cs
+++ b/source/CarXMLConvertor/Convert.SoundCfg.cs
@@ -13,7 +13,7 @@ namespace CarXmlConvertor
 	    private static MainForm mainForm;
 	    internal static Vector3 DriverPosition = new Vector3(0, 1, 0);
 	    //3D center of the car
-	    internal static Vector3 center = new Vector3(0.0, 0.0, 0.0);
+	    internal static Vector3 center = Vector3.Zero;
 		//Positioned to the left of the car, but centered Y & Z
 	    internal static Vector3 left = new Vector3(-1.3, 0.0, 0.0);
 		//Positioned to the right of the car, but centered Y & Z

--- a/source/ObjectViewer/Parsers/AnimatedObjectParser.cs
+++ b/source/ObjectViewer/Parsers/AnimatedObjectParser.cs
@@ -44,7 +44,7 @@ namespace OpenBve {
 						case "[include]":
 							{
 								i++;
-								Vector3 position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 position = Vector3.Zero;
 								ObjectManager.UnifiedObject[] obj = new OpenBve.ObjectManager.UnifiedObject[4];
 								int objCount = 0;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal))) {
@@ -143,18 +143,18 @@ namespace OpenBve {
 							    {
 							        States = new ObjectManager.AnimatedObjectState[] {},
 							        CurrentState = -1,
-							        TranslateXDirection = new Vector3(1.0, 0.0, 0.0),
-							        TranslateYDirection = new Vector3(0.0, 1.0, 0.0),
-							        TranslateZDirection = new Vector3(0.0, 0.0, 1.0),
-							        RotateXDirection = new Vector3(1.0, 0.0, 0.0),
-							        RotateYDirection = new Vector3(0.0, 1.0, 0.0),
-							        RotateZDirection = new Vector3(0.0, 0.0, 1.0),
+							        TranslateXDirection = Vector3.Right,
+							        TranslateYDirection = Vector3.Down,
+							        TranslateZDirection = Vector3.Forward,
+							        RotateXDirection = Vector3.Right,
+							        RotateYDirection = Vector3.Down,
+							        RotateZDirection = Vector3.Forward,
 							        TextureShiftXDirection = new Vector2(1.0, 0.0),
 							        TextureShiftYDirection = new Vector2(0.0, 1.0),
 							        RefreshRate = 0.0,
 							        ObjectIndex = -1
 							    };
-							    Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+							    Vector3 Position = Vector3.Zero;
 								bool timetableUsed = false;
 								string[] StateFiles = null;
 								string StateFunctionRpn = null;
@@ -498,7 +498,7 @@ namespace OpenBve {
 									                           Result.Objects[ObjectCount].TextureShiftYFunction != null & Result.Objects[ObjectCount].TextureShiftYDirection.Y != 0.0;
 									for (int k = 0; k < StateFiles.Length; k++)
 									{
-										Result.Objects[ObjectCount].States[k].Position = new Vector3(0.0, 0.0, 0.0);
+										Result.Objects[ObjectCount].States[k].Position = Vector3.Zero;
 										if (StateFiles[k] != null)
 										{
 											Result.Objects[ObjectCount].States[k].Object = ObjectManager.LoadStaticObject(StateFiles[k], Encoding, LoadMode, false, ForceTextureRepeatX, ForceTextureRepeatY);

--- a/source/ObjectViewer/Parsers/CsvB3dObjectParser.cs
+++ b/source/ObjectViewer/Parsers/CsvB3dObjectParser.cs
@@ -1293,7 +1293,7 @@ namespace OpenBve {
 				Builder.Vertices[v + 2 * i + 0] = new Vertex(new Vector3(ux, g, uz));
 				Builder.Vertices[v + 2 * i + 1] = new Vertex(new Vector3(lx, -g, lz));
 				Vector3 normal = new Vector3(dx * ns, 0.0, dz * ns);
-				Vector3 s = Vector3.Cross(normal, new Vector3(0.0, 1.0, 0.0));
+				Vector3 s = Vector3.Cross(normal, Vector3.Down);
 				normal.Rotate(s, cosa, sina);
 				Normals[2 * i + 0] = new Vector3(normal);
 				Normals[2 * i + 1] = new Vector3(normal);

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -30,10 +30,10 @@ namespace OpenBve {
 	    internal static bool[] SkipArgs;
 
 		// mouse
-		internal static Vector3 MouseCameraPosition = new Vector3(0.0, 0.0, 0.0);
-		internal static Vector3 MouseCameraDirection = new Vector3(0.0, 0.0, 1.0);
-		internal static Vector3 MouseCameraUp = new Vector3(0.0, 1.0, 0.0);
-		internal static Vector3 MouseCameraSide = new Vector3(1.0, 0.0, 0.0);
+		internal static Vector3 MouseCameraPosition = Vector3.Zero;
+		internal static Vector3 MouseCameraDirection = Vector3.Forward;
+		internal static Vector3 MouseCameraUp = Vector3.Down;
+		internal static Vector3 MouseCameraSide = Vector3.Right;
 	    internal static int MouseButton;
 
 	    internal static int MoveX = 0;
@@ -200,7 +200,7 @@ namespace OpenBve {
 #endif
 				ObjectManager.UnifiedObject o = ObjectManager.LoadObject(Files[i], System.Text.Encoding.UTF8,
 					ObjectLoadMode.Normal, false, false, false);
-				ObjectManager.CreateObject(o, new Vector3(0.0, 0.0, 0.0),
+				ObjectManager.CreateObject(o, Vector3.Zero,
 					new Transformation(0.0, 0.0, 0.0), new Transformation(0.0, 0.0, 0.0), true, 0.0, 0.0, 25.0,
 					0.0);
 #if !DEBUG
@@ -237,9 +237,9 @@ namespace OpenBve {
                         double dx = 0.0025 * (double)(previousMouseState.X - currentMouseState.X);
                         double cosa = Math.Cos(dx);
                         double sina = Math.Sin(dx);
-						World.AbsoluteCameraDirection.Rotate(new Vector3(0.0, 1.0, 0.0), cosa, sina);
-	                    World.AbsoluteCameraUp.Rotate(new Vector3(0.0, 1.0, 0.0), cosa, sina);
-	                    World.AbsoluteCameraSide.Rotate(new Vector3(0.0, 1.0, 0.0), cosa, sina);
+						World.AbsoluteCameraDirection.Rotate(Vector3.Down, cosa, sina);
+	                    World.AbsoluteCameraUp.Rotate(Vector3.Down, cosa, sina);
+	                    World.AbsoluteCameraSide.Rotate(Vector3.Down, cosa, sina);
                     }
                     {
                         double dy = 0.0025 * (double)(previousMouseState.Y - currentMouseState.Y);
@@ -304,7 +304,7 @@ namespace OpenBve {
 										#endif
 	                    ObjectManager.UnifiedObject o = ObjectManager.LoadObject(Files[i], System.Text.Encoding.UTF8,
 	                        ObjectLoadMode.Normal, false, false, false);
-	                    ObjectManager.CreateObject(o, new Vector3(0.0, 0.0, 0.0),
+	                    ObjectManager.CreateObject(o, Vector3.Zero,
 	                        new Transformation(0.0, 0.0, 0.0), new Transformation(0.0, 0.0, 0.0), true, 0.0,
 	                        0.0, 25.0, 0.0);
 #if !DEBUG
@@ -349,7 +349,7 @@ namespace OpenBve {
 #endif
 					            ObjectManager.UnifiedObject o = ObjectManager.LoadObject(Files[i], System.Text.Encoding.UTF8,
 						            ObjectLoadMode.Normal, false, false, false);
-					            ObjectManager.CreateObject(o, new Vector3(0.0, 0.0, 0.0),
+					            ObjectManager.CreateObject(o, Vector3.Zero,
 						            new Transformation(0.0, 0.0, 0.0), new Transformation(0.0, 0.0, 0.0), true, 0.0, 0.0, 25.0,
 						            0.0);
 #if !DEBUG

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -287,11 +287,11 @@ namespace OpenBve
                     GL.Disable(EnableCap.Lighting);
                 }
                 GL.Color3(1.0, 0.0, 0.0);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(100.0, 0.01, 0.01), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(100.0, 0.01, 0.01), cx, cy, cz);
                 GL.Color3(0.0, 1.0, 0.0);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 100.0, 0.01), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 100.0, 0.01), cx, cy, cz);
                 GL.Color3(0.0, 0.0, 1.0);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 0.01, 100.0), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 0.01, 100.0), cx, cy, cz);
                 if (LightingEnabled)
                 {
                     GL.Enable(EnableCap.Lighting);
@@ -416,11 +416,11 @@ namespace OpenBve
                 GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
                 GL.Enable(EnableCap.Blend);
                 GL.Color4(1.0, 0.0, 0.0, 0.2);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(100.0, 0.01, 0.01), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(100.0, 0.01, 0.01), cx, cy, cz);
                 GL.Color4(0.0, 1.0, 0.0, 0.2);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 100.0, 0.01), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 100.0, 0.01), cx, cy, cz);
                 GL.Color4(0.0, 0.0, 1.0, 0.2);
-                RenderBox(new Vector3(0.0, 0.0, 0.0), new Vector3(0.0, 0.0, 1.0), new Vector3(0.0, 1.0, 0.0), new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 0.01, 100.0), cx, cy, cz);
+                RenderBox(Vector3.Zero, Vector3.Right, Vector3.Down, new Vector3(1.0, 0.0, 0.0), new Vector3(0.01, 0.01, 100.0), cx, cy, cz);
             }
 	        RenderOverlays();
 	        LastBoundTexture = null; //We bind the character texture, so must reset it at the end of the render sequence

--- a/source/ObjectViewer/WorldS.cs
+++ b/source/ObjectViewer/WorldS.cs
@@ -361,46 +361,37 @@ namespace OpenBve {
 			if (q) {
 				UpdateViewingDistances();
 			}
-			double dx = World.CameraTrackFollower.WorldDirection.X;
-			double dy = World.CameraTrackFollower.WorldDirection.Y;
-			double dz = World.CameraTrackFollower.WorldDirection.Z;
-			double ux = World.CameraTrackFollower.WorldUp.X;
-			double uy = World.CameraTrackFollower.WorldUp.Y;
-			double uz = World.CameraTrackFollower.WorldUp.Z;
-			double sx = World.CameraTrackFollower.WorldSide.X;
-			double sy = World.CameraTrackFollower.WorldSide.Y;
-			double sz = World.CameraTrackFollower.WorldSide.Z;
-			double tx = World.CameraCurrentAlignment.Position.X;
-			double ty = World.CameraCurrentAlignment.Position.Y;
-			double tz = World.CameraCurrentAlignment.Position.Z;
-			double dx2 = dx, dy2 = dy, dz2 = dz;
-			double ux2 = ux, uy2 = uy, uz2 = uz;
-			double cx = World.CameraTrackFollower.WorldPosition.X + sx * tx + ux2 * ty + dx2 * tz;
-			double cy = World.CameraTrackFollower.WorldPosition.Y + sy * tx + uy2 * ty + dy2 * tz;
-			double cz = World.CameraTrackFollower.WorldPosition.Z + sz * tx + uz2 * ty + dz2 * tz;
+
+			Vector3 dF = new Vector3(CameraTrackFollower.WorldDirection);
+			Vector3 uF = new Vector3(CameraTrackFollower.WorldUp);
+			Vector3 sF = new Vector3(CameraTrackFollower.WorldSide);
+			Vector3 pF = new Vector3(CameraCurrentAlignment.Position);
+			Vector3 dx2 = new Vector3(dF);
+			Vector3 ux2 = new Vector3(uF);
 			if (World.CameraCurrentAlignment.Yaw != 0.0) {
 				double cosa = Math.Cos(World.CameraCurrentAlignment.Yaw);
 				double sina = Math.Sin(World.CameraCurrentAlignment.Yaw);
-				World.Rotate(ref dx, ref dy, ref dz, ux, uy, uz, cosa, sina);
-				World.Rotate(ref sx, ref sy, ref sz, ux, uy, uz, cosa, sina);
+				dF.Rotate(uF, cosa, sina);
+				sF.Rotate(uF, cosa, sina);
 			}
 			double p = World.CameraCurrentAlignment.Pitch;
 			if (p != 0.0) {
 				double cosa = Math.Cos(-p);
 				double sina = Math.Sin(-p);
-				World.Rotate(ref dx, ref dy, ref dz, sx, sy, sz, cosa, sina);
-				World.Rotate(ref ux, ref uy, ref uz, sx, sy, sz, cosa, sina);
+				dF.Rotate(sF, cosa, sina);
+				uF.Rotate(sF, cosa, sina);
+				uF.Rotate(sF, cosa, sina);
 			}
 			if (World.CameraCurrentAlignment.Roll != 0.0) {
 				double cosa = Math.Cos(-World.CameraCurrentAlignment.Roll);
 				double sina = Math.Sin(-World.CameraCurrentAlignment.Roll);
-				World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-				World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+				uF.Rotate(dF, cosa, sina);
+				sF.Rotate(dF, cosa, sina);
 			}
-			AbsoluteCameraPosition = new Vector3(cx, cy, cz);
-			AbsoluteCameraDirection = new Vector3(dx, dy, dz);
-			AbsoluteCameraUp = new Vector3(ux, uy, uz);
-			AbsoluteCameraSide = new Vector3(sx, sy, sz);
+			AbsoluteCameraPosition = new Vector3(CameraTrackFollower.WorldPosition.X + sF.X * pF.X + ux2.X * pF.Y + dx2.X * pF.Z, CameraTrackFollower.WorldPosition.Y + sF.Y * pF.X + ux2.Y * pF.Y + dx2.Y * pF.Z, CameraTrackFollower.WorldPosition.Z + sF.Z * pF.X + ux2.Z * pF.Y + dx2.Z * pF.Z);
+			AbsoluteCameraDirection = dF;
+			AbsoluteCameraUp = uF;
+			AbsoluteCameraSide = sF;
 		}
 		private static void AdjustAlignment(ref double Source, double Direction, ref double Speed, double TimeElapsed) {
 			AdjustAlignment(ref Source, Direction, ref Speed, TimeElapsed, false);
@@ -467,18 +458,6 @@ namespace OpenBve {
 			World.ForwardViewingDistance = d * max;
 			World.BackwardViewingDistance = -d * min;
 			ObjectManager.UpdateVisibility(World.CameraTrackFollower.TrackPosition + World.CameraCurrentAlignment.Position.Z, true);
-		}
-
-		// ================================
-		
-		internal static void Rotate(ref double px, ref double py, ref double pz, double dx, double dy, double dz, double cosa, double sina) {
-			double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-			dx *= t; dy *= t; dz *= t;
-			double oc = 1.0 - cosa;
-			double x = (cosa + oc * dx * dx) * px + (oc * dx * dy - sina * dz) * py + (oc * dx * dz + sina * dy) * pz;
-			double y = (cosa + oc * dy * dy) * py + (oc * dx * dy + sina * dz) * px + (oc * dy * dz - sina * dx) * pz;
-			double z = (cosa + oc * dz * dz) * pz + (oc * dx * dz - sina * dy) * px + (oc * dy * dz + sina * dx) * py;
-			px = x; py = y; pz = z;
 		}
 	}
 }

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -98,7 +98,7 @@ namespace OpenBve
 									try {
 #endif
                         ObjectManager.UnifiedObject o = ObjectManager.LoadObject(Program.Files[i], System.Text.Encoding.UTF8, ObjectLoadMode.Normal, false, false, false);
-                        ObjectManager.CreateObject(o, new Vector3(0.0, 0.0, 0.0),
+                        ObjectManager.CreateObject(o, Vector3.Zero,
                             new Transformation(0.0, 0.0, 0.0), new Transformation(0.0, 0.0, 0.0), true, 0.0,
                             0.0, 25.0, 0.0);
 #if !DEBUG

--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -117,11 +117,11 @@ namespace OpenBve {
 							var WorldSound = (ObjectManager.WorldSound)Sources[i].Parent;
 							//TODO: Calculate speed...
 							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
-							velocity = Vector3.Null;
+							velocity = Vector3.Zero;
 							break;
 						default:
 							position = Sources[i].Position;
-							velocity = Vector3.Null;
+							velocity = Vector3.Zero;
 							break;
 					}
 					Vector3 positionDifference = position - listenerPosition;
@@ -299,7 +299,7 @@ namespace OpenBve {
 					listenerVelocity = car.Specs.CurrentSpeed * Vector3.Normalize(diff);
 				}
 			} else {
-				listenerVelocity = Vector3.Null;
+				listenerVelocity = Vector3.Zero;
 			}
 			AL.Listener(ALListener3f.Position, 0.0f, 0.0f, 0.0f);
 			AL.Listener(ALListener3f.Velocity, (float)listenerVelocity.X, (float)listenerVelocity.Y, (float)listenerVelocity.Z);
@@ -538,11 +538,11 @@ namespace OpenBve {
 						case SoundType.AnimatedObject:
 							var WorldSound = (ObjectManager.WorldSound)source.Parent;
 							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
-							velocity = Vector3.Null;
+							velocity = Vector3.Zero;
 							break;
 						default:
 							position = source.Position;
-							velocity = Vector3.Null;
+							velocity = Vector3.Zero;
 							break;
 					}
 					position -= listenerPosition;

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObjectCollection.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObjectCollection.cs
@@ -34,11 +34,8 @@ namespace OpenBve
 				}
 				if (anyfree && !allfree && Objects.Length > 1)
 				{
-					var X = new Vector3(1.0, 0.0, 0.0);
-					var Y = new Vector3(0.0, 1.0, 0.0);
-					var Z = new Vector3(0.0, 0.0, 1.0);
 					//Optimise a little: If *all* are free of functions, this can safely be converted into a static object without regard to below
-					if (AuxTransformation.X != X || AuxTransformation.Y != Y || AuxTransformation.Z != Z)
+					if (AuxTransformation.X != Vector3.Right || AuxTransformation.Y != Vector3.Down || AuxTransformation.Z != Vector3.Forward)
 					{
 						//HACK:
 						//An animated object containing a mix of functions and non-functions and using yaw, pitch or roll must not be converted into a mix

--- a/source/OpenBVE/Game/TrackManager/TrackManager.Track.cs
+++ b/source/OpenBVE/Game/TrackManager/TrackManager.Track.cs
@@ -44,10 +44,10 @@ namespace OpenBve
 				this.CurveCantTangent = 0.0;
 				this.AdhesionMultiplier = 1.0;
 				this.CsvRwAccuracyLevel = 2.0;
-				this.WorldPosition = new Vector3(0.0, 0.0, 0.0);
-				this.WorldDirection = new Vector3(0.0, 0.0, 1.0);
-				this.WorldUp = new Vector3(0.0, 1.0, 0.0);
-				this.WorldSide = new Vector3(1.0, 0.0, 0.0);
+				this.WorldPosition = Vector3.Zero;
+				this.WorldDirection = Vector3.Forward;
+				this.WorldUp = Vector3.Down;
+				this.WorldSide = Vector3.Right;
 				this.Events = new GeneralEvent[] { };
 			}
 		}

--- a/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
+++ b/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
@@ -81,11 +81,11 @@ namespace OpenBve
 							D.Normalize();
 							double cosa = Math.Cos(a);
 							double sina = Math.Sin(a);
-							World.Rotate(ref D, 0.0, 1.0, 0.0, cosa, sina);
+							D.Rotate(Vector3.Down, cosa, sina);
 							WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + c * D.X;
 							WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + h;
 							WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + c * D.Z;
-							World.Rotate(ref D, 0.0, 1.0, 0.0, cosa, sina);
+							D.Rotate(Vector3.Down, cosa, sina);
 							WorldDirection.X = D.X;
 							WorldDirection.Y = p;
 							WorldDirection.Z = D.Z;
@@ -93,7 +93,7 @@ namespace OpenBve
 							double cos2a = Math.Cos(2.0 * a);
 							double sin2a = Math.Sin(2.0 * a);
 							WorldSide = CurrentTrack.Elements[i].WorldSide;
-							World.Rotate(ref WorldSide, 0.0, 1.0, 0.0, cos2a, sin2a);
+							WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
 							WorldUp = Vector3.Cross(WorldDirection, WorldSide);
 
 						}

--- a/source/OpenBVE/Graphics/Renderer/Structures.cs
+++ b/source/OpenBVE/Graphics/Renderer/Structures.cs
@@ -159,7 +159,7 @@ namespace OpenBve
 				this.List = new ObjectList();
 				this.OpenGlDisplayList = 0;
 				this.OpenGlDisplayListAvailable = false;
-				this.WorldPosition = new Vector3(0.0, 0.0, 0.0);
+				this.WorldPosition = Vector3.Zero;
 				this.Update = true;
 			}
 		}

--- a/source/OpenBVE/OldCode/World.cs
+++ b/source/OpenBVE/OldCode/World.cs
@@ -743,18 +743,10 @@ namespace OpenBve {
 					}
 				}
 				// camera
-				double cx = World.CameraTrackFollower.WorldPosition.X;
-				double cy = World.CameraTrackFollower.WorldPosition.Y;
-				double cz = World.CameraTrackFollower.WorldPosition.Z;
-				double dx = World.CameraTrackFollower.WorldDirection.X;
-				double dy = World.CameraTrackFollower.WorldDirection.Y;
-				double dz = World.CameraTrackFollower.WorldDirection.Z;
-				double ux = World.CameraTrackFollower.WorldUp.X;
-				double uy = World.CameraTrackFollower.WorldUp.Y;
-				double uz = World.CameraTrackFollower.WorldUp.Z;
-				double sx = World.CameraTrackFollower.WorldSide.X;
-				double sy = World.CameraTrackFollower.WorldSide.Y;
-				double sz = World.CameraTrackFollower.WorldSide.Z;
+				Vector3 cF = new Vector3(CameraTrackFollower.WorldPosition);
+				Vector3 dF = new Vector3(CameraTrackFollower.WorldDirection);
+				Vector3 uF = new Vector3(CameraTrackFollower.WorldUp);
+				Vector3 sF = new Vector3(CameraTrackFollower.WorldSide);
 				double lookaheadYaw;
 				double lookaheadPitch;
 				if (CameraMode == CameraViewMode.InteriorLookAhead) {
@@ -767,17 +759,17 @@ namespace OpenBve {
 					TrackManager.TrackFollower f = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].FrontAxle.Follower;
 					f.TriggerType = TrackManager.EventTriggerType.None;
 					f.Update(f.TrackPosition + d, true, false);
-					double rx = f.WorldPosition.X - cx + World.CameraTrackFollower.WorldSide.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
-					double ry = f.WorldPosition.Y - cy + World.CameraTrackFollower.WorldSide.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
-					double rz = f.WorldPosition.Z - cz + World.CameraTrackFollower.WorldSide.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
+					double rx = f.WorldPosition.X - cF.X + World.CameraTrackFollower.WorldSide.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.X * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
+					double ry = f.WorldPosition.Y - cF.Y + World.CameraTrackFollower.WorldSide.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.Y * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
+					double rz = f.WorldPosition.Z - cF.Z + World.CameraTrackFollower.WorldSide.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection.Z * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z;
 					World.Normalize(ref rx, ref ry, ref rz);
-					double t = dz * (sy * ux - sx * uy) + dy * (-sz * ux + sx * uz) + dx * (sz * uy - sy * uz);
+					double t = dF.Z * (sF.Y * uF.X - sF.X * uF.Y) + dF.Y * (-sF.Z * uF.X + sF.X * uF.Z) + dF.X * (sF.Z * uF.Y - sF.Y * uF.Z);
 					if (t != 0.0) {
 						t = 1.0 / t;
 
-						double tx = (rz * (-dy * ux + dx * uy) + ry * (dz * ux - dx * uz) + rx * (-dz * uy + dy * uz)) * t;
-						double ty = (rz * (dy * sx - dx * sy) + ry * (-dz * sx + dx * sz) + rx * (dz * sy - dy * sz)) * t;
-						double tz = (rz * (sy * ux - sx * uy) + ry * (-sz * ux + sx * uz) + rx * (sz * uy - sy * uz)) * t;
+						double tx = (rz * (-dF.Y * uF.X + dF.X * uF.Y) + ry * (dF.Z * uF.X - dF.X * uF.Z) + rx * (-dF.Z * uF.Y + dF.Y * uF.Z)) * t;
+						double ty = (rz * (dF.Y * sF.X - dF.X * sF.Y) + ry * (-dF.Z * sF.X + dF.X * sF.Z) + rx * (dF.Z * sF.Y - dF.Y * sF.Z)) * t;
+						double tz = (rz * (sF.Y * uF.X - sF.X * uF.Y) + ry * (-sF.Z * uF.X + sF.X * uF.Z) + rx * (sF.Z * uF.Y - sF.Y * uF.Z)) * t;
 						lookaheadYaw = tx * tz != 0.0 ? Math.Atan2(tx, tz) : 0.0;
 						if (ty < -1.0) {
 							lookaheadPitch = -0.5 * Math.PI;
@@ -796,11 +788,8 @@ namespace OpenBve {
 				}
 				{
 					// cab pitch and yaw
-					double tx = World.CameraCurrentAlignment.Position.X;
-					double ty = World.CameraCurrentAlignment.Position.Y;
-					double tz = World.CameraCurrentAlignment.Position.Z;
-					double dx2 = dx, dy2 = dy, dz2 = dz;
-					double ux2 = ux, uy2 = uy, uz2 = uz;
+					Vector3 d2 = new Vector3(dF);
+					Vector3 u2 = new Vector3(uF);
 					if ((World.CameraMode == CameraViewMode.Interior | World.CameraMode == World.CameraViewMode.InteriorLookAhead) & TrainManager.PlayerTrain != null) {
 						int c = TrainManager.PlayerTrain.DriverCar;
 						if (c >= 0) {
@@ -808,14 +797,14 @@ namespace OpenBve {
 								double a = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].DriverPitch;
 								double cosa = Math.Cos(-a);
 								double sina = Math.Sin(-a);
-								World.Rotate(ref dx2, ref dy2, ref dz2, sx, sy, sz, cosa, sina);
-								World.Rotate(ref ux2, ref uy2, ref uz2, sx, sy, sz, cosa, sina);
+								d2.Rotate(sF, cosa, sina);
+								u2.Rotate(sF, cosa, sina);
 							}
 						}
 					}
-					cx += sx * tx + ux2 * ty + dx2 * tz;
-					cy += sy * tx + uy2 * ty + dy2 * tz;
-					cz += sz * tx + uz2 * ty + dz2 * tz;
+					cF.X += sF.X * CameraCurrentAlignment.Position.X + u2.X * CameraCurrentAlignment.Position.Y + d2.X * CameraCurrentAlignment.Position.Z;
+					cF.Y += sF.Y * CameraCurrentAlignment.Position.X + u2.Y * CameraCurrentAlignment.Position.Y + d2.Y * CameraCurrentAlignment.Position.Z;
+					cF.Z += sF.Z * CameraCurrentAlignment.Position.X + u2.Z * CameraCurrentAlignment.Position.Y + d2.Z * CameraCurrentAlignment.Position.Z;
 				}
 				// yaw, pitch, roll
 				double headYaw = World.CameraCurrentAlignment.Yaw + lookaheadYaw;
@@ -846,70 +835,70 @@ namespace OpenBve {
 						// body pitch
 						double ry = (Math.Cos(-bodyPitch) - 1.0) * bodyHeight;
 						double rz = Math.Sin(-bodyPitch) * bodyHeight;
-						cx += dx * rz + ux * ry;
-						cy += dy * rz + uy * ry;
-						cz += dz * rz + uz * ry;
+						cF.X += dF.X * rz + uF.X * ry;
+						cF.Y += dF.Y * rz + uF.Y * ry;
+						cF.Z += dF.Z * rz + uF.Z * ry;
 						if (bodyPitch != 0.0) {
 							double cosa = Math.Cos(-bodyPitch);
 							double sina = Math.Sin(-bodyPitch);
-							World.Rotate(ref dx, ref dy, ref dz, sx, sy, sz, cosa, sina);
-							World.Rotate(ref ux, ref uy, ref uz, sx, sy, sz, cosa, sina);
+							dF.Rotate(sF, cosa, sina);
+							uF.Rotate(sF, cosa, sina);
 						}
 					}
 					{
 						// body roll
 						double rx = Math.Sin(bodyRoll) * bodyHeight;
 						double ry = (Math.Cos(bodyRoll) - 1.0) * bodyHeight;
-						cx += sx * rx + ux * ry;
-						cy += sy * rx + uy * ry;
-						cz += sz * rx + uz * ry;
+						cF.X += sF.X * rx + uF.X * ry;
+						cF.Y += sF.Y * rx + uF.Y * ry;
+						cF.Z += sF.Z * rx + uF.Z * ry;
 						if (bodyRoll != 0.0) {
 							double cosa = Math.Cos(-bodyRoll);
 							double sina = Math.Sin(-bodyRoll);
-							World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-							World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+							uF.Rotate(dF, cosa, sina);
+							sF.Rotate(dF, cosa, sina);
 						}
 					}
 					{
 						// head yaw
 						double rx = Math.Sin(headYaw) * headHeight;
 						double rz = (Math.Cos(headYaw) - 1.0) * headHeight;
-						cx += sx * rx + dx * rz;
-						cy += sy * rx + dy * rz;
-						cz += sz * rx + dz * rz;
+						cF.X += sF.X * rx + dF.X * rz;
+						cF.Y += sF.Y * rx + dF.Y * rz;
+						cF.Z += sF.Z * rx + dF.Z * rz;
 						if (headYaw != 0.0) {
 							double cosa = Math.Cos(headYaw);
 							double sina = Math.Sin(headYaw);
-							World.Rotate(ref dx, ref dy, ref dz, ux, uy, uz, cosa, sina);
-							World.Rotate(ref sx, ref sy, ref sz, ux, uy, uz, cosa, sina);
+							dF.Rotate(uF, cosa, sina);
+							sF.Rotate(uF, cosa, sina);
 						}
 					}
 					{
 						// head pitch
 						double ry = (Math.Cos(-headPitch) - 1.0) * headHeight;
 						double rz = Math.Sin(-headPitch) * headHeight;
-						cx += dx * rz + ux * ry;
-						cy += dy * rz + uy * ry;
-						cz += dz * rz + uz * ry;
+						cF.X += dF.X * rz + uF.X * ry;
+						cF.Y += dF.Y * rz + uF.Y * ry;
+						cF.Z += dF.Z * rz + uF.Z * ry;
 						if (headPitch != 0.0) {
 							double cosa = Math.Cos(-headPitch);
 							double sina = Math.Sin(-headPitch);
-							World.Rotate(ref dx, ref dy, ref dz, sx, sy, sz, cosa, sina);
-							World.Rotate(ref ux, ref uy, ref uz, sx, sy, sz, cosa, sina);
+							dF.Rotate(sF, cosa, sina);
+							uF.Rotate(sF, cosa, sina);
 						}
 					}
 					{
 						// head roll
 						double rx = Math.Sin(headRoll) * headHeight;
 						double ry = (Math.Cos(headRoll) - 1.0) * headHeight;
-						cx += sx * rx + ux * ry;
-						cy += sy * rx + uy * ry;
-						cz += sz * rx + uz * ry;
+						cF.X += sF.X * rx + uF.X * ry;
+						cF.Y += sF.Y * rx + uF.Y * ry;
+						cF.Z += sF.Z * rx + uF.Z * ry;
 						if (headRoll != 0.0) {
 							double cosa = Math.Cos(-headRoll);
 							double sina = Math.Sin(-headRoll);
-							World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-							World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+							uF.Rotate(dF, cosa, sina);
+							sF.Rotate(dF, cosa, sina);
 						}
 					}
 				} else {
@@ -920,27 +909,27 @@ namespace OpenBve {
 					if (totalYaw != 0.0) {
 						double cosa = Math.Cos(totalYaw);
 						double sina = Math.Sin(totalYaw);
-						World.Rotate(ref dx, ref dy, ref dz, ux, uy, uz, cosa, sina);
-						World.Rotate(ref sx, ref sy, ref sz, ux, uy, uz, cosa, sina);
+						dF.Rotate(uF, cosa, sina);
+						sF.Rotate(uF, cosa, sina);
 					}
 					if (totalPitch != 0.0) {
 						double cosa = Math.Cos(-totalPitch);
 						double sina = Math.Sin(-totalPitch);
-						World.Rotate(ref dx, ref dy, ref dz, sx, sy, sz, cosa, sina);
-						World.Rotate(ref ux, ref uy, ref uz, sx, sy, sz, cosa, sina);
+						dF.Rotate(sF, cosa, sina);
+						uF.Rotate(sF, cosa, sina);
 					}
 					if (totalRoll != 0.0) {
 						double cosa = Math.Cos(-totalRoll);
 						double sina = Math.Sin(-totalRoll);
-						World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-						World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+						uF.Rotate(dF, cosa, sina);
+						sF.Rotate(dF, cosa, sina);
 					}
 				}
 				// finish
-				AbsoluteCameraPosition = new Vector3(cx, cy, cz);
-				AbsoluteCameraDirection = new Vector3(dx, dy, dz);
-				AbsoluteCameraUp = new Vector3(ux, uy, uz);
-				AbsoluteCameraSide = new Vector3(sx, sy, sz);
+				AbsoluteCameraPosition = cF;
+				AbsoluteCameraDirection = dF;
+				AbsoluteCameraUp = uF;
+				AbsoluteCameraSide = sF;
 			}
 		}
 		private static void AdjustAlignment(ref double Source, double Direction, ref double Speed, double TimeElapsed) {

--- a/source/OpenBVE/Parsers/Object/BVE/AnimatedObjectParser.cs
+++ b/source/OpenBVE/Parsers/Object/BVE/AnimatedObjectParser.cs
@@ -51,7 +51,7 @@ namespace OpenBve
 						case "[include]":
 							{
 								i++;
-								Vector3 position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 position = Vector3.Zero;
 								ObjectManager.UnifiedObject[] obj = new OpenBve.ObjectManager.UnifiedObject[4];
 								int objCount = 0;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal)))
@@ -183,18 +183,18 @@ namespace OpenBve
 								{
 									States = new ObjectManager.AnimatedObjectState[] {},
 									CurrentState = -1,
-									TranslateXDirection = new Vector3(1.0, 0.0, 0.0),
-									TranslateYDirection = new Vector3(0.0, 1.0, 0.0),
-									TranslateZDirection = new Vector3(0.0, 0.0, 1.0),
-									RotateXDirection = new Vector3(1.0, 0.0, 0.0),
-									RotateYDirection = new Vector3(0.0, 1.0, 0.0),
-									RotateZDirection = new Vector3(0.0, 0.0, 1.0),
+									TranslateXDirection = Vector3.Right,
+									TranslateYDirection = Vector3.Down,
+									TranslateZDirection = Vector3.Forward,
+									RotateXDirection = Vector3.Right,
+									RotateYDirection = Vector3.Down,
+									RotateZDirection = Vector3.Forward,
 									TextureShiftXDirection = new Vector2(1.0, 0.0),
 									TextureShiftYDirection = new Vector2(0.0, 1.0),
 									RefreshRate = 0.0,
 									ObjectIndex = -1
 								};
-								Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 Position = Vector3.Zero;
 								double RotateX = 0;
 								bool StaticXRotation = false;
 								double RotateY = 0;
@@ -802,7 +802,7 @@ namespace OpenBve
 									                           Result.Objects[ObjectCount].TextureShiftYFunction != null & Result.Objects[ObjectCount].TextureShiftYDirection.Y != 0.0;
 									for (int k = 0; k < StateFiles.Length; k++)
 									{
-										Result.Objects[ObjectCount].States[k].Position = new Vector3(0.0, 0.0, 0.0);
+										Result.Objects[ObjectCount].States[k].Position = Vector3.Zero;
 										if (StateFiles[k] != null)
 										{
 											Result.Objects[ObjectCount].States[k].Object = ObjectManager.LoadStaticObject(StateFiles[k], Encoding, LoadMode, false, ForceTextureRepeatX, ForceTextureRepeatY);
@@ -920,7 +920,7 @@ namespace OpenBve
 								{
 									Array.Resize<ObjectManager.WorldObject>(ref Result.Sounds, Result.Sounds.Length << 1);
 								}
-								Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 Position = Vector3.Zero;
 								string fileName = null;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal)))
 								{
@@ -1199,7 +1199,7 @@ namespace OpenBve
 								{
 									Array.Resize<ObjectManager.AnimatedObject>(ref Result.Objects, Result.Sounds.Length << 1);
 								}
-								Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 Position = Vector3.Zero;
 								string[] fileNames = new string[0];
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal)))
 								{

--- a/source/OpenBVE/Parsers/Object/BVE/CsvB3dObjectParser.cs
+++ b/source/OpenBVE/Parsers/Object/BVE/CsvB3dObjectParser.cs
@@ -1341,7 +1341,7 @@ namespace OpenBve {
 				Builder.Vertices[v + 2 * i + 0] = new Vertex(ux, g, uz);
 				Builder.Vertices[v + 2 * i + 1] = new Vertex(lx, -g, lz);
 				Vector3 normal = new Vector3(dx * ns, 0.0, dz * ns);
-				Vector3 s = Vector3.Cross(normal, new Vector3(0.0, 1.0, 0.0));
+				Vector3 s = Vector3.Cross(normal, Vector3.Down);
 				normal.Rotate(s, cosa, sina);
 				Normals[2 * i + 0] = new Vector3(normal);
 				Normals[2 * i + 1] = new Vector3(normal);

--- a/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
+++ b/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
@@ -563,8 +563,8 @@ namespace OpenBve {
 										double nx = n * w;
 										double ny = n * h;
 										int j = CreateElement(Train.Cars[Car].CarSections[0], LocationX - ox * nx, LocationY - oy * ny, nx, ny, new Vector2(ox, oy), (double)Layer * StackDistance, PanelResolution, PanelLeft, PanelRight, PanelTop, PanelBottom, PanelBitmapWidth, PanelBitmapHeight, PanelCenter, PanelOrigin, Train.Cars[Car].Driver, tday, tnight, Color, false);
-										Train.Cars[Car].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-										Train.Cars[Car].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+										Train.Cars[Car].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+										Train.Cars[Car].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 										Train.Cars[Car].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Car].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Car].CarSections[0].Elements[j].RotateXDirection);
 										string f;
 										switch (Subject.ToLowerInvariant()) {

--- a/source/OpenBVE/Parsers/Panel/PanelCfgParser.cs
+++ b/source/OpenBVE/Parsers/Panel/PanelCfgParser.cs
@@ -361,8 +361,8 @@ namespace OpenBve {
 												double w = (double)t.Width;
 												double h = (double)t.Height;
 												int j = CreateElement(Train, CenterX - Radius * w / h, CenterY + SemiHeight - Radius, 2.0 * Radius * w / h, 2.0 * Radius, FullWidth, FullHeight, WorldLeft, WorldTop, WorldWidth, WorldHeight, WorldZ + EyeDistance - (double)(4 + k) * StackDistance, Train.Cars[Train.DriverCar].Driver, t, NeedleColor[k], false);
-												Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-												Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+												Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+												Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 												Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection);
 												double c0 = (Angle * (Maximum - Minimum) - 2.0 * Minimum * Math.PI) / (Maximum - Minimum) + Math.PI;
 												double c1 = 2.0 * (Math.PI - Angle) / (Maximum - Minimum);
@@ -639,8 +639,8 @@ namespace OpenBve {
 										double w = (double)t.Width;
 										double h = (double)t.Height;
 										int j = CreateElement(Train, CenterX - Radius * w / h, CenterY + SemiHeight - Radius, 2.0 * Radius * w / h, 2.0 * Radius, FullWidth, FullHeight, WorldLeft, WorldTop, WorldWidth, WorldHeight, WorldZ + EyeDistance - 5.0 * StackDistance, Train.Cars[Train.DriverCar].Driver, t, Needle, false);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection);
 										double c0 = Angle + Math.PI;
 										double c1 = 2.0 * (Math.PI - Angle) / Maximum;
@@ -995,8 +995,8 @@ namespace OpenBve {
 										double w = (double)t.Width;
 										double h = (double)t.Height;
 										int j = CreateElement(Train, CenterX - Radius * w / h, CenterY + SemiHeight - Radius, 2.0 * Radius * w / h, 2.0 * Radius, FullWidth, FullHeight, WorldLeft, WorldTop, WorldWidth, WorldHeight, WorldZ + EyeDistance - 4.0 * StackDistance, Train.Cars[Train.DriverCar].Driver, t, Needle, false);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection);
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZFunction = FunctionScripts.GetFunctionScriptFromPostfixNotation("time 0.000277777777777778 * floor 0.523598775598298 *");
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDamping = new Damping(20.0, 0.4);
@@ -1012,8 +1012,8 @@ namespace OpenBve {
 										double w = (double)t.Width;
 										double h = (double)t.Height;
 										int j = CreateElement(Train, CenterX - Radius * w / h, CenterY + SemiHeight - Radius, 2.0 * Radius * w / h, 2.0 * Radius, FullWidth, FullHeight, WorldLeft, WorldTop, WorldWidth, WorldHeight, WorldZ + EyeDistance - 5.0 * StackDistance, Train.Cars[Train.DriverCar].Driver, t, Needle, false);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection);
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZFunction = FunctionScripts.GetFunctionScriptFromPostfixNotation("time 0.0166666666666667 * floor 0.10471975511966 *");
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDamping = new Damping(20.0, 0.4);
@@ -1029,8 +1029,8 @@ namespace OpenBve {
 										double w = (double)t.Width;
 										double h = (double)t.Height;
 										int j = CreateElement(Train, CenterX - Radius * w / h, CenterY + SemiHeight - Radius, 2.0 * Radius * w / h, 2.0 * Radius, FullWidth, FullHeight, WorldLeft, WorldTop, WorldWidth, WorldHeight, WorldZ + EyeDistance - 6.0 * StackDistance, Train.Cars[Train.DriverCar].Driver, t, Needle, false);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = new Vector3(0.0, 0.0, -1.0);
-										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection = Vector3.Backward;
+										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection = Vector3.Right;
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateYDirection = Vector3.Cross(Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDirection, Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateXDirection);
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZFunction = FunctionScripts.GetFunctionScriptFromPostfixNotation("time floor 0.10471975511966 *");
 										Train.Cars[Train.DriverCar].CarSections[0].Elements[j].RotateZDamping = new Damping(20.0, 0.4);

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -652,12 +652,10 @@ namespace OpenBve
 								double y2 = Data.Blocks[i + 1].Rails[j].RailEndY;
 								Vector3 offset2 = new Vector3(Direction2.Y * x2, y2, -Direction2.X * x2);
 								Vector3 pos2 = Position2 + offset2;
-								double rx = pos2.X - pos.X;
-								double ry = pos2.Y - pos.Y;
-								double rz = pos2.Z - pos.Z;
-								World.Normalize(ref rx, ref ry, ref rz);
-								RailTransformation.Z = new Vector3(rx, ry, rz);
-								RailTransformation.X = new Vector3(rz, 0.0, -rx);
+								Vector3 r = new Vector3(pos2.X - pos.X, pos2.Y - pos.Y, pos2.Z - pos.Z);
+								r.Normalize();
+								RailTransformation.Z = r;
+								RailTransformation.X = new Vector3(r.Z, 0.0, -r.X);
 								World.Normalize(ref RailTransformation.X.X, ref RailTransformation.X.Z);
 								RailTransformation.Y = Vector3.Cross(RailTransformation.Z, RailTransformation.X);
 								double dx = Data.Blocks[i + 1].Rails[j].RailEndX - Data.Blocks[i].Rails[j].RailStartX;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -149,7 +149,7 @@ namespace OpenBve
 				}
 			}
 			// create objects and track
-			Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+			Vector3 Position = Vector3.Zero;
 			Vector2 Direction = new Vector2(0.0, 1.0);
 			TrackManager.CurrentTrack = new TrackManager.Track { Elements = new TrackManager.TrackElement[] { } };
 			double CurrentSpeedLimit = double.PositiveInfinity;
@@ -472,10 +472,10 @@ namespace OpenBve
 							switch (Data.Blocks[i].SoundEvents[j].Type)
 							{
 								case SoundType.TrainStatic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, true, true, false, new Vector3(0.0, 0.0, 0.0), 0.0);
+									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
 									break;
 								case SoundType.TrainDynamic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, false, false, true, new Vector3(0.0, 0.0, 0.0), Data.Blocks[i].SoundEvents[j].Speed);
+									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].SoundEvents[j].Speed);
 									break;
 							}
 						}
@@ -2012,9 +2012,9 @@ namespace OpenBve
 									double cosg = Math.Cos(g);
 									double sing = Math.Sin(g);
 									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldDirection, 0.0, 1.0, 0.0, cosg, sing);
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldUp, 0.0, 1.0, 0.0, cosg, sing);
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldSide, 0.0, 1.0, 0.0, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 									p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
 									follower.Update(p - 1.0, true, false);
 									follower.Update(p, true, false);
@@ -2031,9 +2031,9 @@ namespace OpenBve
 									double cosg = Math.Cos(newAngle);
 									double sing = Math.Sin(newAngle);
 									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldDirection, 0.0, 1.0, 0.0, cosg, sing);
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldUp, 0.0, 1.0, 0.0, cosg, sing);
-									World.Rotate(ref TrackManager.CurrentTrack.Elements[i].WorldSide, 0.0, 1.0, 0.0, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 								}
 								// iterate again to further shorten track element length
 								p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve2.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve2.cs
@@ -12,7 +12,7 @@ namespace OpenBve
 		{
 			// set sound positions and radii
 			Vector3 front = new Vector3(0.0, 0.0, 0.5 * train.Cars[train.DriverCar].Length);
-			Vector3 center = new Vector3(0.0, 0.0, 0.0);
+			Vector3 center = Vector3.Zero;
 			Vector3 left = new Vector3(-1.3, 0.0, 0.0);
 			Vector3 right = new Vector3(1.3, 0.0, 0.0);
 			Vector3 cab = new Vector3(-train.Cars[train.DriverCar].Driver.X, train.Cars[train.DriverCar].Driver.Y, train.Cars[train.DriverCar].Driver.Z - 0.5);

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
@@ -18,7 +18,7 @@ namespace OpenBve
 			//Default sound positions and radii
 
 			//3D center of the car
-			Vector3 center = new Vector3(0.0, 0.0, 0.0);
+			Vector3 center = Vector3.Zero;
 			//Positioned to the left of the car, but centered Y & Z
 			Vector3 left = new Vector3(-1.3, 0.0, 0.0);
 			//Positioned to the right of the car, but centered Y & Z

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
@@ -29,7 +29,7 @@ namespace OpenBve
 		internal static void Parse(string fileName, ref TrainManager.Car car, bool isDriverCar)
 		{
 			//3D center of the car
-			Vector3 center = new Vector3(0.0, 0.0, 0.0);
+			Vector3 center = Vector3.Zero;
 			//Positioned to the left of the car, but centered Y & Z
 			Vector3 left = new Vector3(-1.3, 0.0, 0.0);
 			//Positioned to the right of the car, but centered Y & Z

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
@@ -135,7 +135,7 @@ namespace OpenBve
 						States = new ObjectManager.AnimatedObjectState[1]
 						
 					};
-					CarSections[j].Elements[0].States[0].Position = new Vector3(0.0, 0.0, 0.0);
+					CarSections[j].Elements[0].States[0].Position = Vector3.Zero;
 					CarSections[j].Elements[0].States[0].Object = s;
 					CarSections[j].Elements[0].CurrentState = 0;
 					CarSections[j].Elements[0].ObjectIndex = ObjectManager.CreateDynamicObject();

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
@@ -385,7 +385,7 @@ namespace OpenBve
 					CarSections[j].Elements = new ObjectManager.AnimatedObject[1];
 					CarSections[j].Elements[0] = new ObjectManager.AnimatedObject();
 					CarSections[j].Elements[0].States = new ObjectManager.AnimatedObjectState[1];
-					CarSections[j].Elements[0].States[0].Position = new Vector3(0.0, 0.0, 0.0);
+					CarSections[j].Elements[0].States[0].Position = Vector3.Zero;
 					CarSections[j].Elements[0].States[0].Object = s;
 					CarSections[j].Elements[0].CurrentState = 0;
 					CarSections[j].Elements[0].ObjectIndex = ObjectManager.CreateDynamicObject();

--- a/source/OpenBVE/Simulation/TrainManager/Car/CarSound.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/CarSound.cs
@@ -23,7 +23,7 @@ namespace OpenBve
 			}
 
 			/// <summary>Defines a default empty sound</summary>
-			internal static readonly CarSound Empty = new CarSound(null, null, new Vector3(0.0, 0.0, 0.0));
+			internal static readonly CarSound Empty = new CarSound(null, null, Vector3.Zero);
 
 			/// <summary>Attempts to load a sound file into a car-sound</summary>
 			/// <param name="FileName">The sound to load</param>

--- a/source/OpenBVE/Simulation/World/Transformations.cs
+++ b/source/OpenBVE/Simulation/World/Transformations.cs
@@ -1,60 +1,9 @@
-﻿using System;
-using OpenBveApi.Math;
+﻿using OpenBveApi.Math;
 
 namespace OpenBve
 {
 	internal static partial class World
 	{
-		/// <summary>Rotates one vector based upon a second vector, input as induvidual co-ordinates</summary>
-		/// <param name="p">The vector to rotate</param>
-		/// <param name="dx">The X co-ordinate of the second vector</param>
-		/// <param name="dy">The Y co-ordinate of the second vector</param>
-		/// <param name="dz">The Z co-ordinate of the second vector</param>
-		/// <param name="cosa">The Cosine of the angle to rotate by</param>
-		/// <param name="sina">The Sine of the angle to rotate by</param>
-		internal static void Rotate(ref Vector3 p, double dx, double dy, double dz, double cosa, double sina)
-		{
-			double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-			dx *= t; dy *= t; dz *= t;
-			double oc = 1.0 - cosa;
-			double Opt1 = oc * dx * dy;
-			double Opt2 = sina * dz;
-			double Opt3 = oc * dy * dz;
-			double Opt4 = sina * dx;
-			double Opt5 = sina * dy;
-			double Opt6 = oc * dx * dz;
-			double x = (cosa + oc * dx * dx) * p.X + (Opt1 - Opt2) * p.Y + (Opt6 + Opt5) * p.Z;
-			double y = (cosa + oc * dy * dy) * p.Y + (Opt1 + Opt2) * p.X + (Opt3 - Opt4) * p.Z;
-			double z = (cosa + oc * dz * dz) * p.Z + (Opt6 - Opt5) * p.X + (Opt3 + Opt4) * p.Y;
-			p.X = x; p.Y = y; p.Z = z;
-		}
-
-		/// <summary>Rotates one vector based upon a second vector, both input as induvidual co-ordinates</summary>
-		/// <param name="px">The X co-ordinate of the first vector</param>
-		/// <param name="py">The Y co-ordinate of the first vector</param>
-		/// <param name="pz">The Z co-ordinate of the first vector</param>
-		/// <param name="dx">The X co-ordinate of the second vector</param>
-		/// <param name="dy">The Y co-ordinate of the second vector</param>
-		/// <param name="dz">The Z co-ordinate of the second vector</param>
-		/// <param name="cosa">The Cosine of the angle to rotate by</param>
-		/// <param name="sina">The Sine of the angle to rotate by</param>
-		internal static void Rotate(ref double px, ref double py, ref double pz, double dx, double dy, double dz, double cosa, double sina)
-		{
-			double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-			dx *= t; dy *= t; dz *= t;
-			double oc = 1.0 - cosa;
-			double Opt1 = oc * dx * dy;
-			double Opt2 = sina * dz;
-			double Opt3 = oc * dy * dz;
-			double Opt4 = sina * dx;
-			double Opt5 = sina * dy;
-			double Opt6 = oc * dx * dz;
-			double x = (cosa + oc * dx * dx) * px + (Opt1 - Opt2) * py + (Opt6 + Opt5) * pz;
-			double y = (cosa + oc * dy * dy) * py + (Opt1 + Opt2) * px + (Opt3 - Opt4) * pz;
-			double z = (cosa + oc * dz * dz) * pz + (Opt6 - Opt5) * px + (Opt3 + Opt4) * py;
-			px = x; py = y; pz = z;
-		}
-
 		internal static void RotatePlane(ref Vector3 Vector, double cosa, double sina)
 		{
 			double u = Vector.X * cosa - Vector.Z * sina;

--- a/source/OpenBveApi/Math/Vector3.cs
+++ b/source/OpenBveApi/Math/Vector3.cs
@@ -575,7 +575,7 @@ namespace OpenBveApi.Math {
 		// --- read-only fields ---
 		
 		/// <summary>Represents a null vector.</summary>
-		public static readonly Vector3 Null = new Vector3(0.0, 0.0, 0.0);
+		public static readonly Vector3 Zero = new Vector3(0.0, 0.0, 0.0);
 		
 		/// <summary>Represents a vector pointing left.</summary>
 		public static readonly Vector3 Left = new Vector3(-1.0, 0.0, 0.0);
@@ -587,7 +587,7 @@ namespace OpenBveApi.Math {
 		public static readonly Vector3 Up = new Vector3(0.0, -1.0, 0.0);
 		
 		/// <summary>Represents a vector pointing down.</summary>
-		public static readonly Vector3 Down = new Vector3(0.0, 1.0, 0.0);
+		public static readonly Vector3 Down = new Vector3(0.0 , 1.0, 0.0);
 		
 		/// <summary>Represents a vector pointing up.</summary>
 		public static readonly Vector3 Backward = new Vector3(0.0, 0.0, -1.0);

--- a/source/OpenBveApi/World/Orientation3.cs
+++ b/source/OpenBveApi/World/Orientation3.cs
@@ -30,7 +30,7 @@
 		// --- read-only fields ---
 		
 		/// <summary>Represents a null orientation.</summary>
-		public static readonly Orientation3 Null = new Orientation3(Vector3.Null, Vector3.Null, Vector3.Null);
+		public static readonly Orientation3 Null = new Orientation3(Vector3.Zero, Vector3.Zero, Vector3.Zero);
 		
 		/// <summary>Represents the default orientation with X = {1, 0, 0}, Y = {0, 1, 0} and Z = {0, 0, 1}.</summary>
 		public static readonly Orientation3 Default = new Orientation3(Vector3.Right, Vector3.Up, Vector3.Forward);

--- a/source/OpenBveApi/World/Transformations.cs
+++ b/source/OpenBveApi/World/Transformations.cs
@@ -20,23 +20,23 @@ namespace OpenBveApi.World
 		{
 			if (Yaw == 0.0 & Pitch == 0.0 & Roll == 0.0)
 			{
-				this.X = new Vector3(1.0, 0.0, 0.0);
-				this.Y = new Vector3(0.0, 1.0, 0.0);
-				this.Z = new Vector3(0.0, 0.0, 1.0);
+				this.X = Vector3.Right;
+				this.Y = Vector3.Down;
+				this.Z = Vector3.Forward;
 			}
 			else if (Pitch == 0.0 & Roll == 0.0)
 			{
 				double cosYaw = System.Math.Cos(Yaw);
 				double sinYaw = System.Math.Sin(Yaw);
 				this.X = new Vector3(cosYaw, 0.0, -sinYaw);
-				this.Y = new Vector3(0.0, 1.0, 0.0);
+				this.Y = Vector3.Down;
 				this.Z = new Vector3(sinYaw, 0.0, cosYaw);
 			}
 			else
 			{
-				X = new Vector3(1.0, 0.0, 0.0);
-				Y = new Vector3(0.0, 1.0, 0.0);
-				Z = new Vector3(0.0, 0.0, 1.0);
+				X = Vector3.Right;
+				Y = Vector3.Down;
+				Z = Vector3.Forward;
 				double cosYaw = System.Math.Cos(Yaw);
 				double sinYaw = System.Math.Sin(Yaw);
 				double cosPitch = System.Math.Cos(-Pitch);

--- a/source/RouteViewer/Audio/Sounds.Update.cs
+++ b/source/RouteViewer/Audio/Sounds.Update.cs
@@ -125,7 +125,7 @@ namespace OpenBve
 							break;
 						default:
 							position = Sources[i].Position;
-							velocity = OpenBveApi.Math.Vector3.Null;
+							velocity = OpenBveApi.Math.Vector3.Zero;
 							break;
 					}
 					OpenBveApi.Math.Vector3 positionDifference = position - listenerPosition;
@@ -355,7 +355,7 @@ namespace OpenBve
 			}
 			else
 			{
-				listenerVelocity = OpenBveApi.Math.Vector3.Null;
+				listenerVelocity = OpenBveApi.Math.Vector3.Zero;
 			}
 			AL.Listener(ALListener3f.Position, 0.0f, 0.0f, 0.0f);
 			AL.Listener(ALListener3f.Velocity, (float)listenerVelocity.X, (float)listenerVelocity.Y, (float)listenerVelocity.Z);
@@ -637,7 +637,7 @@ namespace OpenBve
 					else
 					{
 						position = source.Position;
-						velocity = OpenBveApi.Math.Vector3.Null;
+						velocity = OpenBveApi.Math.Vector3.Zero;
 					}
 					position -= listenerPosition;
 					AL.Source(source.OpenAlSourceName, ALSource3f.Position, (float)position.X, (float)position.Y, (float)position.Z);

--- a/source/RouteViewer/Parsers/AnimatedObjectParser.cs
+++ b/source/RouteViewer/Parsers/AnimatedObjectParser.cs
@@ -43,7 +43,7 @@ namespace OpenBve {
 						case "[include]":
 							{
 								i++;
-								Vector3 position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 position = Vector3.Zero;
 								ObjectManager.UnifiedObject[] obj = new OpenBve.ObjectManager.UnifiedObject[4];
 								int objCount = 0;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal))) {
@@ -139,17 +139,17 @@ namespace OpenBve {
 								Result.Objects[ObjectCount] = new ObjectManager.AnimatedObject();
 								Result.Objects[ObjectCount].States = new ObjectManager.AnimatedObjectState[] { };
 								Result.Objects[ObjectCount].CurrentState = -1;
-								Result.Objects[ObjectCount].TranslateXDirection = new Vector3(1.0, 0.0, 0.0);
-								Result.Objects[ObjectCount].TranslateYDirection = new Vector3(0.0, 1.0, 0.0);
-								Result.Objects[ObjectCount].TranslateZDirection = new Vector3(0.0, 0.0, 1.0);
-								Result.Objects[ObjectCount].RotateXDirection = new Vector3(1.0, 0.0, 0.0);
-								Result.Objects[ObjectCount].RotateYDirection = new Vector3(0.0, 1.0, 0.0);
-								Result.Objects[ObjectCount].RotateZDirection = new Vector3(0.0, 0.0, 1.0);
+								Result.Objects[ObjectCount].TranslateXDirection = Vector3.Right;
+								Result.Objects[ObjectCount].TranslateYDirection = Vector3.Down;
+								Result.Objects[ObjectCount].TranslateZDirection = Vector3.Forward;
+								Result.Objects[ObjectCount].RotateXDirection = Vector3.Right;
+								Result.Objects[ObjectCount].RotateYDirection = Vector3.Down;
+								Result.Objects[ObjectCount].RotateZDirection = Vector3.Forward;
 								Result.Objects[ObjectCount].TextureShiftXDirection = new Vector2(1.0, 0.0);
 								Result.Objects[ObjectCount].TextureShiftYDirection = new Vector2(0.0, 1.0);
 								Result.Objects[ObjectCount].RefreshRate = 0.0;
 								Result.Objects[ObjectCount].ObjectIndex = -1;
-								Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+								Vector3 Position = Vector3.Zero;
 								bool timetableUsed = false;
 								string[] StateFiles = null;
 								string StateFunctionRpn = null;
@@ -502,7 +502,7 @@ namespace OpenBve {
 									bool ForceTextureRepeatY = Result.Objects[ObjectCount].TextureShiftXFunction != null & Result.Objects[ObjectCount].TextureShiftXDirection.Y != 0.0 |
 									                           Result.Objects[ObjectCount].TextureShiftYFunction != null & Result.Objects[ObjectCount].TextureShiftYDirection.Y != 0.0;
 									for (int k = 0; k < StateFiles.Length; k++) {
-										Result.Objects[ObjectCount].States[k].Position = new Vector3(0.0, 0.0, 0.0);
+										Result.Objects[ObjectCount].States[k].Position = Vector3.Zero;
 										if (StateFiles[k] != null) {
 											Result.Objects[ObjectCount].States[k].Object = ObjectManager.LoadStaticObject(StateFiles[k], Encoding, LoadMode, false, ForceTextureRepeatX, ForceTextureRepeatY);
 											if (Result.Objects[ObjectCount].States[k].Object != null) {

--- a/source/RouteViewer/Parsers/CsvB3dObjectParser.cs
+++ b/source/RouteViewer/Parsers/CsvB3dObjectParser.cs
@@ -1092,7 +1092,7 @@ namespace OpenBve {
 				Builder.Vertices[v + 2 * i + 0] = new Vertex(ux, g, uz);
 				Builder.Vertices[v + 2 * i + 1] = new Vertex(lx, -g, lz);
 				Vector3 normal = new Vector3(dx * ns, 0.0, dz * ns);
-				Vector3 s = Vector3.Cross(normal, new Vector3(0.0, 1.0, 0.0));
+				Vector3 s = Vector3.Cross(normal, Vector3.Down);
 				normal.Rotate(s, cosa, sina);
 				Normals[2 * i + 0] = new Vector3(normal);
 				Normals[2 * i + 1] = new Vector3(normal);

--- a/source/RouteViewer/Parsers/CsvB3dObjectParser.cs
+++ b/source/RouteViewer/Parsers/CsvB3dObjectParser.cs
@@ -1349,32 +1349,6 @@ namespace OpenBve {
 		}
 
 		// apply shear
-		private static void ApplyShear(MeshBuilder Builder, double dx, double dy, double dz, double sx, double sy, double sz, double r) {
-			for (int j = 0; j < Builder.Vertices.Length; j++) {
-				double n = r * (dx * Builder.Vertices[j].Coordinates.X + dy * Builder.Vertices[j].Coordinates.Y + dz * Builder.Vertices[j].Coordinates.Z);
-				Builder.Vertices[j].Coordinates.X += sx * n;
-				Builder.Vertices[j].Coordinates.Y += sy * n;
-				Builder.Vertices[j].Coordinates.Z += sz * n;
-			}
-			for (int j = 0; j < Builder.Faces.Length; j++) {
-				for (int k = 0; k < Builder.Faces[j].Vertices.Length; k++) {
-					if (Builder.Faces[j].Vertices[k].Normal.X != 0.0f | Builder.Faces[j].Vertices[k].Normal.Y != 0.0f | Builder.Faces[j].Vertices[k].Normal.Z != 0.0f) {
-						double nx = (double)Builder.Faces[j].Vertices[k].Normal.X;
-						double ny = (double)Builder.Faces[j].Vertices[k].Normal.Y;
-						double nz = (double)Builder.Faces[j].Vertices[k].Normal.Z;
-						double n = r * (sx * nx + sy * ny + sz * nz);
-						nx -= dx * n;
-						ny -= dy * n;
-						nz -= dz * n;
-						World.Normalize(ref nx, ref ny, ref nz);
-						Builder.Faces[j].Vertices[k].Normal.X = (float)nx;
-						Builder.Faces[j].Vertices[k].Normal.Y = (float)ny;
-						Builder.Faces[j].Vertices[k].Normal.Z = (float)nz;
-					}
-				}
-			}
-		}
-		// apply shear
 		private static void ApplyShear(MeshBuilder Builder, Vector3 d, Vector3 s, double r) {
 			for (int j = 0; j < Builder.Vertices.Length; j++) {
 				double n = r * (d.X * Builder.Vertices[j].Coordinates.X + d.Y * Builder.Vertices[j].Coordinates.Y + d.Z * Builder.Vertices[j].Coordinates.Z);

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -5288,7 +5288,7 @@ namespace OpenBve {
 				}
 			}
 			// create objects and track
-			Vector3 Position = new Vector3(0.0, 0.0, 0.0);
+			Vector3 Position = Vector3.Zero;
 			Vector2 Direction = new Vector2(0.0, 1.0);
 			TrackManager.CurrentTrack = new TrackManager.Track();
 			TrackManager.CurrentTrack.Elements = new TrackManager.TrackElement[] { };
@@ -5436,7 +5436,7 @@ namespace OpenBve {
 						if (q) {
 							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
 							Array.Resize<TrackManager.GeneralEvent>(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, new Vector3(0.0, 0.0, 0.0), 12.5);
+							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, Vector3.Zero, 12.5);
 						}
 					}
 				}
@@ -5530,10 +5530,10 @@ namespace OpenBve {
 							double d = Data.Blocks[i].Sound[j].TrackPosition - StartingDistance;
 							switch (Data.Blocks[i].Sound[j].Type) {
 								case SoundType.TrainStatic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, new Vector3(0.0, 0.0, 0.0), 0.0);
+									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
 									break;
 								case SoundType.TrainDynamic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, new Vector3(0.0, 0.0, 0.0), Data.Blocks[i].Sound[j].Speed);
+									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].Sound[j].Speed);
 									break;
 							}
 						}
@@ -6652,9 +6652,9 @@ namespace OpenBve {
 									double cosg = Math.Cos(g);
 									double sing = Math.Sin(g);
 									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 									p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
 									TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
 									TrackManager.UpdateTrackFollower(ref follower, p, true, false);
@@ -6670,9 +6670,9 @@ namespace OpenBve {
 									double cosg = Math.Cos(newAngle);
 									double sing = Math.Sin(newAngle);
 									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(new Vector3(0.0, 1.0, 0.0), cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 								}
 								// iterate again to further shorten track element length
 								p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -5682,12 +5682,10 @@ namespace OpenBve {
 								double y2 = Data.Blocks[i + 1].Rail[j].RailEndY;
 								Vector3 offset2 = new Vector3(Direction2.Y * x2, y2, -Direction2.X * x2);
 								Vector3 pos2 = Position2 + offset2;
-								double rx = pos2.X - pos.X;
-								double ry = pos2.Y - pos.Y;
-								double rz = pos2.Z - pos.Z;
-								World.Normalize(ref rx, ref ry, ref rz);
-								RailTransformation.Z = new Vector3(rx, ry, rz);
-								RailTransformation.X = new Vector3(rz, 0.0, -rx);
+								Vector3 r = new Vector3(pos2.X - pos.X, pos2.Y - pos.Y, pos2.Z - pos.Z);
+								r.Normalize();
+								RailTransformation.Z = r;
+								RailTransformation.X = new Vector3(r.Z, 0.0, -r.X);
 								World.Normalize(ref RailTransformation.X.X, ref RailTransformation.X.Z);
 								RailTransformation.Y = Vector3.Cross(RailTransformation.Z, RailTransformation.X);
 								double dx = Data.Blocks[i + 1].Rail[j].RailEndX - Data.Blocks[i].Rail[j].RailStartX;
@@ -5747,14 +5745,12 @@ namespace OpenBve {
 									int m = Data.Blocks[i].RailPole[j].Mode;
 									double dx = -Data.Blocks[i].RailPole[j].Location * 3.8;
 									double wa = Math.Atan2(Direction.Y, Direction.X) - planar;
-									double wx = Math.Cos(wa);
-									double wy = Math.Tan(updown);
-									double wz = Math.Sin(wa);
-									World.Normalize(ref wx, ref wy, ref wz);
+									Vector3 w = new Vector3(Math.Cos(wa), Math.Tan(updown), Math.Sin(wa));
+									w.Normalize();
 									double sx = Direction.Y;
 									double sy = 0.0;
 									double sz = -Direction.X;
-									Vector3 wpos = pos + new Vector3(sx * dx + wx * dz, sy * dx + wy * dz, sz * dx + wz * dz);
+									Vector3 wpos = pos + new Vector3(sx * dx + w.X * dz, sy * dx + w.Y * dz, sz * dx + w.Z * dz);
 									int type = Data.Blocks[i].RailPole[j].Type;
 									ObjectManager.CreateObject(Data.Structure.Poles[m][type], wpos, RailTransformation, NullTransformation, Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, StartingDistance);
 								}

--- a/source/RouteViewer/TrackManagerR.cs
+++ b/source/RouteViewer/TrackManagerR.cs
@@ -304,10 +304,10 @@ namespace OpenBve {
 				this.CurveCantTangent = 0.0;
 				this.AdhesionMultiplier = 1.0;
 				this.CsvRwAccuracyLevel = 2.0;
-				this.WorldPosition = new Vector3(0.0, 0.0, 0.0);
-				this.WorldDirection = new Vector3(0.0, 0.0, 1.0);
-				this.WorldUp = new Vector3(0.0, 1.0, 0.0);
-				this.WorldSide = new Vector3(1.0, 0.0, 0.0);
+				this.WorldPosition = Vector3.Zero;
+				this.WorldDirection = Vector3.Forward;
+				this.WorldUp = Vector3.Down;
+				this.WorldSide = Vector3.Right;
 				this.Events = new GeneralEvent[] { };
 			}
 		}
@@ -374,11 +374,11 @@ namespace OpenBve {
 						D.Normalize();
 						double cosa = Math.Cos(a);
 						double sina = Math.Sin(a);
-						D.Rotate(new Vector3(0.0, 1.0, 0.0), cosa, sina);
+						D.Rotate(Vector3.Down, cosa, sina);
 						Follower.WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + c * D.X;
 						Follower.WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + h;
 						Follower.WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + c * D.Z;
-						D.Rotate(new Vector3(0.0, 1.0, 0.0), cosa, sina);
+						D.Rotate(Vector3.Down, cosa, sina);
 						Follower.WorldDirection.X = D.X;
 						Follower.WorldDirection.Y = p;
 						Follower.WorldDirection.Z = D.Z;
@@ -386,7 +386,7 @@ namespace OpenBve {
 						double cos2a = Math.Cos(2.0 * a);
 						double sin2a = Math.Sin(2.0 * a);
 						Follower.WorldSide = CurrentTrack.Elements[i].WorldSide;
-						Follower.WorldSide.Rotate(new Vector3(0.0, 1.0, 0.0), cos2a, sin2a);
+						Follower.WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
 						Follower.WorldUp = Vector3.Cross(Follower.WorldDirection, Follower.WorldSide);
 						Follower.CurveRadius = CurrentTrack.Elements[i].CurveRadius;
 					} else {

--- a/source/RouteViewer/WorldR.cs
+++ b/source/RouteViewer/WorldR.cs
@@ -358,46 +358,38 @@ namespace OpenBve {
 			if (q) {
 				UpdateViewingDistances();
 			}
-			double dx = World.CameraTrackFollower.WorldDirection.X;
-			double dy = World.CameraTrackFollower.WorldDirection.Y;
-			double dz = World.CameraTrackFollower.WorldDirection.Z;
-			double ux = World.CameraTrackFollower.WorldUp.X;
-			double uy = World.CameraTrackFollower.WorldUp.Y;
-			double uz = World.CameraTrackFollower.WorldUp.Z;
-			double sx = World.CameraTrackFollower.WorldSide.X;
-			double sy = World.CameraTrackFollower.WorldSide.Y;
-			double sz = World.CameraTrackFollower.WorldSide.Z;
-			double tx = World.CameraCurrentAlignment.Position.X;
-			double ty = World.CameraCurrentAlignment.Position.Y;
-			double tz = World.CameraCurrentAlignment.Position.Z;
-			double dx2 = dx, dy2 = dy, dz2 = dz;
-			double ux2 = ux, uy2 = uy, uz2 = uz;
-			double cx = World.CameraTrackFollower.WorldPosition.X + sx * tx + ux2 * ty + dx2 * tz;
-			double cy = World.CameraTrackFollower.WorldPosition.Y + sy * tx + uy2 * ty + dy2 * tz;
-			double cz = World.CameraTrackFollower.WorldPosition.Z + sz * tx + uz2 * ty + dz2 * tz;
+			Vector3 dF = new Vector3(CameraTrackFollower.WorldDirection);
+			Vector3 uF = new Vector3(CameraTrackFollower.WorldUp);
+			Vector3 sF = new Vector3(CameraTrackFollower.WorldSide);
+			Vector3 pF = new Vector3(CameraCurrentAlignment.Position);
+			Vector3 dx2 = new Vector3(dF);
+			Vector3 ux2 = new Vector3(uF);
+			double cx = World.CameraTrackFollower.WorldPosition.X + sF.X * pF.X + ux2.X * pF.Y + dx2.X * pF.Z;
+			double cy = World.CameraTrackFollower.WorldPosition.Y + sF.Y * pF.X + ux2.Y * pF.Y + dx2.Y * pF.Z;
+			double cz = World.CameraTrackFollower.WorldPosition.Z + sF.Z * pF.X + ux2.Z * pF.Y + dx2.Z * pF.Z;
 			if (World.CameraCurrentAlignment.Yaw != 0.0) {
 				double cosa = Math.Cos(World.CameraCurrentAlignment.Yaw);
 				double sina = Math.Sin(World.CameraCurrentAlignment.Yaw);
-				World.Rotate(ref dx, ref dy, ref dz, ux, uy, uz, cosa, sina);
-				World.Rotate(ref sx, ref sy, ref sz, ux, uy, uz, cosa, sina);
+				dF.Rotate(uF, cosa, sina);
+				sF.Rotate(uF, cosa, sina);
 			}
 			double p = World.CameraCurrentAlignment.Pitch;
 			if (p != 0.0) {
 				double cosa = Math.Cos(-p);
 				double sina = Math.Sin(-p);
-				World.Rotate(ref dx, ref dy, ref dz, sx, sy, sz, cosa, sina);
-				World.Rotate(ref ux, ref uy, ref uz, sx, sy, sz, cosa, sina);
+				dF.Rotate(sF, cosa, sina);
+				uF.Rotate(sF, cosa, sina);
 			}
 			if (World.CameraCurrentAlignment.Roll != 0.0) {
 				double cosa = Math.Cos(-World.CameraCurrentAlignment.Roll);
 				double sina = Math.Sin(-World.CameraCurrentAlignment.Roll);
-				World.Rotate(ref ux, ref uy, ref uz, dx, dy, dz, cosa, sina);
-				World.Rotate(ref sx, ref sy, ref sz, dx, dy, dz, cosa, sina);
+				uF.Rotate(dF, cosa, sina);
+				sF.Rotate(dF, cosa, sina);
 			}
 			AbsoluteCameraPosition = new Vector3(cx, cy, cz);
-			AbsoluteCameraDirection = new Vector3(dx, dy, dz);
-			AbsoluteCameraUp = new Vector3(ux, uy, uz);
-			AbsoluteCameraSide = new Vector3(sx, sy, sz);
+			AbsoluteCameraDirection = new Vector3(dF.X, dF.Y, dF.Z);
+			AbsoluteCameraUp = new Vector3(uF.X, uF.Y, uF.Z);
+			AbsoluteCameraSide = new Vector3(sF.X, sF.Y, sF.Z);
 		}
 		private static void AdjustAlignment(ref double Source, double Direction, ref double Speed, double TimeElapsed) {
 			AdjustAlignment(ref Source, Direction, ref Speed, TimeElapsed, false);
@@ -468,17 +460,6 @@ namespace OpenBve {
 
 		// ================================
 
-		// rotate
-		internal static void Rotate(ref double px, ref double py, ref double pz, double dx, double dy, double dz, double cosa, double sina) {
-			double t = 1.0 / Math.Sqrt(dx * dx + dy * dy + dz * dz);
-			dx *= t; dy *= t; dz *= t;
-			double oc = 1.0 - cosa;
-			double x = (cosa + oc * dx * dx) * px + (oc * dx * dy - sina * dz) * py + (oc * dx * dz + sina * dy) * pz;
-			double y = (cosa + oc * dy * dy) * py + (oc * dx * dy + sina * dz) * px + (oc * dy * dz - sina * dx) * pz;
-			double z = (cosa + oc * dz * dz) * pz + (oc * dx * dz - sina * dy) * px + (oc * dy * dz + sina * dx) * py;
-			px = x; py = y; pz = z;
-		}
-		
 		internal static void RotatePlane(ref Vector3 Vector, double cosa, double sina) {
 			double u = Vector.X * cosa - Vector.Z * sina;
 			double v = Vector.X * sina + Vector.Z * cosa;
@@ -492,13 +473,6 @@ namespace OpenBve {
 			if (t != 0.0) {
 				t = 1.0 / Math.Sqrt(t);
 				x *= t; y *= t;
-			}
-		}
-		internal static void Normalize(ref double x, ref double y, ref double z) {
-			double t = x * x + y * y + z * z;
-			if (t != 0.0) {
-				t = 1.0 / Math.Sqrt(t);
-				x *= t; y *= t; z *= t;
 			}
 		}
 	}


### PR DESCRIPTION
This PR is a slightly more extensive followup to the commits over the last few days.
https://github.com/leezer3/OpenBVE/commit/e051f97dfebbf47bfc5a6f4fc1ce10f2f3f31f5f
https://github.com/leezer3/OpenBVE/commit/4f5fd5191186cd57a90d9a59c9fa6270129ac944
https://github.com/leezer3/OpenBVE/commit/243448a5347d5226905503321b1c0756bfe6a201
https://github.com/leezer3/OpenBVE/commit/4af4adc89cf4b39817967282485d7418959d8356

All of this is partially micro-optimisation, and partially readability. 
We use a lot of pre-defined common vectors in places such as transformations etc.
These were already defined in the API, so it makes no sense to create a new copy.

It may produce a (minor) speedup, depending on exactly how the compiler optimises the old code.
The potential risk of this is updating something by reference accidentally.
As the API vectors are defined as readonly, this shouldn't happen (or compile for that matter), but test this a little more before merging.