### PR TITLE
Fix: Issue that GameWindow doesn't close under mono

### DIFF
--- a/source/OpenBVE/Game/Menu.cs
+++ b/source/OpenBVE/Game/Menu.cs
@@ -687,7 +687,7 @@ namespace OpenBve
 								Reset();
 								Program.RestartArguments =
 									Interface.CurrentOptions.GameMode == Interface.GameMode.Arcade ? "/review" : "";
-								MainLoop.Quit = true;
+								MainLoop.Quit = MainLoop.QuitMode.ExitToMenu;
 								break;
 							case MenuTag.Control:               // CONTROL CUSTOMIZATION
 								PushMenu(MenuType.Control, ((MenuCommand)menu.Items[menu.Selection]).Data);
@@ -696,7 +696,7 @@ namespace OpenBve
 								break;
 							case MenuTag.Quit:                  // QUIT PROGRAMME
 								Reset();
-								MainLoop.Quit = true;
+								MainLoop.Quit = MainLoop.QuitMode.QuitProgram;
 								break;
 						}
 					}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -65,9 +65,13 @@ namespace OpenBve
 				//Renderer.UpdateLighting();
 				Renderer.RenderScene(TimeElapsed);
 				Program.currentGameWindow.SwapBuffers();
-				if (MainLoop.Quit)
+				if (MainLoop.Quit != MainLoop.QuitMode.ContinueGame)
 				{
 					Close();
+					if (Program.CurrentlyRunningOnMono && MainLoop.Quit == MainLoop.QuitMode.QuitProgram)
+					{
+						Environment.Exit(0);
+					}
 				}
 				//If the menu state has not changed, don't update the rendered simulation
 				return;
@@ -132,9 +136,13 @@ namespace OpenBve
 			}
 
 			World.CameraAlignmentDirection = new World.CameraAlignment();
-			if (MainLoop.Quit)
+			if (MainLoop.Quit != MainLoop.QuitMode.ContinueGame)
 			{
 				Program.currentGameWindow.Exit();
+				if (Program.CurrentlyRunningOnMono && MainLoop.Quit == MainLoop.QuitMode.QuitProgram)
+				{
+					Environment.Exit(0);
+				}				
 			}
 			Renderer.UpdateLighting();
 			Renderer.RenderScene(TimeElapsed);
@@ -331,6 +339,11 @@ namespace OpenBve
 				}
 			}
 			Textures.UnloadAllTextures();
+			if (MainLoop.Quit == MainLoop.QuitMode.ContinueGame && Program.CurrentlyRunningOnMono)
+			{
+				//More forcefully close under Mono, stuff *still* hanging around....
+				Environment.Exit(0);
+			}
 		}
 		/// <summary>This method is called once the route and train data have been preprocessed, in order to physically setup the simulation</summary>
 		private void SetupSimulation()

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -344,6 +344,7 @@ namespace OpenBve
 				//More forcefully close under Mono, stuff *still* hanging around....
 				Environment.Exit(0);
 			}
+			base.OnClosing(e);
 		}
 		/// <summary>This method is called once the route and train data have been preprocessed, in order to physically setup the simulation</summary>
 		private void SetupSimulation()

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -11,10 +11,15 @@ namespace OpenBve
 {
 	internal static partial class MainLoop
 	{
-
+		internal enum QuitMode
+		{
+			ContinueGame = 0,
+			QuitProgram = 1,
+			ExitToMenu = 2
+		}
 		// declarations
 		internal static bool LimitFramerate = false;
-		internal static bool Quit = false;
+		internal static QuitMode Quit = QuitMode.ContinueGame;
 		/// <summary>BlockKeyRepeat should be set to 'true' whilst processing a KeyUp or KeyDown event.</summary>
 		internal static bool BlockKeyRepeat;
 		/// <summary>The current simulation time-factor</summary>
@@ -90,7 +95,7 @@ namespace OpenBve
 
 		private static void OpenTKQuit(object sender, CancelEventArgs e)
 		{
-			Quit = true;
+			Quit = QuitMode.QuitProgram;
 		}
 
 		/********************

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -5427,7 +5427,6 @@
 			this.Name = "formMain";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
 			this.Text = "openBVE";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.formMain_FormClosing);
 			this.Load += new System.EventHandler(this.formMain_Load);
 			this.Shown += new System.EventHandler(this.formMain_Shown);
 			this.Resize += new System.EventHandler(this.formMain_Resize);

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -707,11 +707,13 @@ namespace OpenBve
 		// =====
 
 		// start
+		private readonly object StartGame = new Object();
+
 		private void buttonStart_Click(object sender, EventArgs e) {
 			if (Result.RouteFile != null & Result.TrainFolder != null) {
 				if (System.IO.File.Exists(Result.RouteFile) & System.IO.Directory.Exists(Result.TrainFolder)) {
 					Result.Start = true;
-					this.Close();
+					buttonClose_Click(StartGame, e);
 					//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 					//This fixes the main form failing to close on Linux
 					Application.DoEvents();

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Net;
 using System.Windows.Forms;
@@ -1306,16 +1307,36 @@ namespace OpenBve {
 			}
 		}
 
-
-		// close
+		private bool Closing = false;
 		private void buttonClose_Click(object sender, EventArgs e)
 		{
-			this.Close();
+			Closing = true;
+			if (sender != null)
+			{
+				//Don't cause an infinite loop
+				this.Close();
+			}
 			//HACK: Call Application.DoEvents() to force the message pump to process all pending messages when the form closes
 			//This fixes the main form failing to close on Linux
+			formMain_FormClosing(sender, new FormClosingEventArgs(CloseReason.UserClosing, false));
 			Application.DoEvents();
+			if (Program.CurrentlyRunningOnMono && sender != StartGame)
+			{
+				//On some systems, the process *still* seems to hang around, so explicity issue the Environment.Exit() call
+				//https://github.com/leezer3/OpenBVE/issues/213
+				Environment.Exit(0);
+			}
 		}
 
+		protected override void OnFormClosing(FormClosingEventArgs e)
+		{
+			if (Closing)
+			{
+				return;
+			}
+			//Call the explicit closing method
+			buttonClose_Click(null, e);
+		}
 
 
 		// ======


### PR DESCRIPTION
Even in our environment, the same problem as #213 is occurring.

This PR has made minor modifications to #214.

With this fix, mono has been correctly terminated in our environment.

Our environment is as follows.
- fedora 28 with mono 5.16.0.187
- Ubuntu 16.04.5 LTS with mono 5.14.0.177