### PR TITLE
Fix: Issue that joystick is not automatically recognized on Linux

### DIFF
--- a/source/OpenBVE/System/Input/JoystickManager.cs
+++ b/source/OpenBVE/System/Input/JoystickManager.cs
@@ -61,14 +61,28 @@ namespace OpenBve {
 			{
 				//Load the list of attached openTK joysticks
 				var state = OpenTK.Input.Joystick.GetState(i);
-				var description = OpenTK.Input.Joystick.GetCapabilities(i).ToString();
-				if (description == "{Axes: 0; Buttons: 0; Hats: 0; IsConnected: True}")
+				var description = OpenTK.Input.Joystick.GetCapabilities(i);
+				if (description.ToString() == "{Axes: 0; Buttons: 0; Hats: 0; IsConnected: True}")
 				{
 					break;
 				}
 				//A joystick with 56 buttons and zero axis is likely the RailDriver, which is bugged in openTK
-				if (state.IsConnected && description != "{Axes: 0; Buttons: 56; Hats: 0; IsConnected: True}")
+				if (description.ToString() != "{Axes: 0; Buttons: 56; Hats: 0; IsConnected: True}")
 				{
+					if (Program.CurrentlyRunningOnMono)
+					{
+						if (description.AxisCount == 0 && description.ButtonCount == 0 && description.HatCount == 0)
+						{
+							continue;
+						}
+					}
+					else
+					{
+						if (!state.IsConnected)
+						{
+							continue;
+						}
+					}
 					StandardJoystick newJoystick = new StandardJoystick
 					{
 						Name = "Joystick" + i,


### PR DESCRIPTION
This PR fix issue that joystick is not automatically recognized on Linux.

I think that it is meaningless to check the value of IsConnected on Linux.

The reason is because there is the following comment to the [source code of OpenTK](https://github.com/opentk/opentk/blob/e911f0b7698e7bc32fa1c4eab37f9e50f7bd92a3/src/OpenTK/Platform/Linux/LinuxJoystick.cs#L413).

> Only mark the joystick as connected when we actually start receiving events.
Otherwise, the Xbox wireless receiver will register 4 joysticks even if no actual joystick is connected to the receiver.

Since the current program checks the value of IsConnected, OpenBVE will not be recognized unless some operation is done with the joystick.