### PR TITLE
Fix: Issue where the order of RGBA's array was incorrect at Texture.Dds.dll

### DIFF
--- a/source/Plugins/Texture.Dds/Plugin.Parser.cs
+++ b/source/Plugins/Texture.Dds/Plugin.Parser.cs
@@ -101,10 +101,10 @@ namespace Plugin
 			byte[] textureData = new byte[size];
 	        for (int i = 0; i < size; i += 4)
 	        {
-		        textureData[i] = rawData[i + 2]; // blue
+		        textureData[i] = rawData[i]; // red
 		        textureData[i + 1] = rawData[i + 1]; // green
-		        textureData[i + 2] = rawData[i];   // red
-		        textureData[i + 3] = rawData[i + 3];
+		        textureData[i + 2] = rawData[i + 2]; // blue
+		        textureData[i + 3] = rawData[i + 3]; // alpha
 	        }
 	        myTexture = new Texture(width, height, 32, textureData, null);
         }


### PR DESCRIPTION
This PR fix issue that DDS picture's texture color is not good. (#289 )