### PR TITLE
New: Add microphone input

### DIFF
--- a/assets/Controls/Default keyboard assignment.controls
+++ b/assets/Controls/Default keyboard assignment.controls
@@ -34,6 +34,7 @@ MAIN_BREAKER, keyboard, B, 0
 ENGINE_START, keyboard, E, 0
 ENGINE_STOP, keyboard, E, 2
 DEVICE_CONSTSPEED, keyboard, BackSpace, 0
+PLAY_MIC_SOUNDS, keyboard, W, 0
 SECURITY_S, keyboard, Space, 0
 SECURITY_A1, keyboard, Insert, 0
 SECURITY_A2, keyboard, Delete, 0

--- a/source/OpenBVE/Audio/Sounds.SoundSource.cs
+++ b/source/OpenBVE/Audio/Sounds.SoundSource.cs
@@ -140,12 +140,20 @@ namespace OpenBve {
 			internal int OpenAlSourceName;
 			/// <summary>The position.</summary>
 			internal OpenBveApi.Math.Vector3 Position { get; private set; }
+			/// <summary>Backward tolerance of position</summary>
+			internal double BackwardTolerance;
+			/// <summary>Forward tolerance of position</summary>
+			internal double ForwardTolerance;
 
 			// --- constructors ---
 			/// <summary>Creates a new microphone source.</summary>
 			/// <param name="position">The position.</param>
-			internal MicSource(OpenBveApi.Math.Vector3 position) {
+			/// <param name="backwardTolerance">allowed tolerance in the backward direction</param>
+			/// <param name="forwardTolerance">allowed tolerance in the forward direction</param>
+			internal MicSource(OpenBveApi.Math.Vector3 position, double backwardTolerance, double forwardTolerance) {
 				this.Position = position;
+				this.BackwardTolerance = backwardTolerance;
+				this.ForwardTolerance = forwardTolerance;
 				AL.GenSources(1, out OpenAlSourceName);
 
 				// Prepare for monitoring the playback state.

--- a/source/OpenBVE/Audio/Sounds.SoundSource.cs
+++ b/source/OpenBVE/Audio/Sounds.SoundSource.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenBve {
+﻿using OpenTK.Audio.OpenAL;
+
+namespace OpenBve {
 	internal static partial class Sounds {
 		
 		/// <summary>Represents the state of a sound source.</summary>
@@ -130,6 +132,30 @@
 				}
 			}
 		}
-		
+
+		/// <summary>Represents a microphone source</summary>
+		private class MicSource {
+			// --- members ---
+			/// <summary>The OpenAL source name. Only valid if the sound is playing.</summary>
+			internal int OpenAlSourceName;
+			/// <summary>The position.</summary>
+			internal OpenBveApi.Math.Vector3 Position { get; private set; }
+
+			// --- constructors ---
+			/// <summary>Creates a new microphone source.</summary>
+			/// <param name="position">The position.</param>
+			internal MicSource(OpenBveApi.Math.Vector3 position) {
+				this.Position = position;
+				AL.GenSources(1, out OpenAlSourceName);
+
+				// Prepare for monitoring the playback state.
+				int dummyBuffer = AL.GenBuffer();
+				AL.BufferData(dummyBuffer, OpenAlMic.SampleFormat, MicStore, 0, OpenAlMic.SampleFrequency);
+				AL.SourceQueueBuffer(OpenAlSourceName, dummyBuffer);
+				AL.SourcePlay(OpenAlSourceName);
+
+				AL.Source(OpenAlSourceName, ALSourceb.SourceRelative, true);
+			}
+		}
 	}
 }

--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -266,6 +266,8 @@ namespace OpenBve {
 				OuterRadiusFactor = OuterRadiusFactorMaximum;
 				OuterRadiusFactorSpeed = 0.0;
 			}
+
+			RecAndPlay(listenerPosition, true, 0.0);
 		}
 		
 		private class SoundSourceAttenuation : IComparable<SoundSourceAttenuation> {
@@ -555,6 +557,108 @@ namespace OpenBve {
 						AL.Source(source.OpenAlSourceName, ALSourceb.Looping, source.Looped);
 						AL.SourcePlay(source.OpenAlSourceName);
 						source.State = SoundSourceState.Playing;
+					}
+				}
+			}
+
+			RecAndPlay(listenerPosition, false, clampFactor);
+		}
+
+		private static void RecAndPlay(Vector3 listenerPosition, bool IsLinear, double clampFactor) {
+			if (OpenAlMic == null) {
+				return;
+			}
+
+			// If the microphone sound playback is invalid, stop recording.
+			if (!IsPlayingMicSounds) {
+				if (OpenAlMic.IsRunning) {
+					OpenAlMic.Stop();
+				}
+				return;
+			}
+
+			// Start recording.
+			if (!OpenAlMic.IsRunning) {
+				OpenAlMic.Start();
+			}
+
+			// Make sure that the source is playing.
+			int sample;
+			int[] states = new int[MicSources.Count];
+
+			for (int i = 0; i < MicSources.Count; i++) {
+				AL.GetSource(MicSources[i].OpenAlSourceName, ALGetSourcei.BuffersProcessed, out states[i]);
+			}
+
+			// Get the number of buffers that can be recorded.
+			sample = OpenAlMic.AvailableSamples;
+
+			for (int i = 0; i < MicSources.Count; i++) {
+				// When playback is completed and recording is possible.
+				if (sample > 0 && states[i] == 1) {
+					// Store the recorded data in the buffer.
+					OpenAlMic.ReadSamples(MicStore, sample);
+
+					// Apply the recording data to the buffer.
+					int buffer = AL.GenBuffer();
+					AL.BufferData(buffer, OpenAlMic.SampleFormat, MicStore, MicStore.Length, OpenAlMic.SampleFrequency);
+
+					// Apply buffer to source.
+					AL.SourceQueueBuffer(MicSources[i].OpenAlSourceName, buffer);
+
+					// Delete the buffer where playback has ended.
+					UnloadMicBuffers(MicSources[i].OpenAlSourceName, states[i]);
+
+					Vector3 positionDifference = MicSources[i].Position - listenerPosition;
+					double distance = positionDifference.Norm();
+					double innerRadius = 15.0;
+					double gain = 1.0;
+
+					if (GlobalMute) {
+						gain = 0.0;
+					} else {
+						if (World.CameraMode == CameraViewMode.Interior | World.CameraMode == CameraViewMode.InteriorLookAhead) {
+							innerRadius *= 0.5;
+						}
+						if (IsLinear) {
+							double outerRadius = OuterRadiusFactor * innerRadius;
+							if (distance < outerRadius) {
+								if (distance <= innerRadius) {
+									gain = Sources[i].Volume;
+								} else {
+									gain = (distance - outerRadius) / (innerRadius - outerRadius);
+									gain *= Sources[i].Volume;
+								}
+								gain = 3.0 * gain * gain - 2.0 * gain * gain * gain;
+							} else {
+								gain = 0.0;
+							}
+							if (gain <= GainThreshold) {
+								gain = 0.0;
+							} else {
+								gain = (gain - GainThreshold) / (1.0 - GainThreshold);
+							}
+						} else {
+							if (distance < 2.0 * innerRadius) {
+								gain = 1.0 - distance * distance * (4.0 * innerRadius - distance) / (16.0 * innerRadius * innerRadius * innerRadius);
+							} else {
+								gain = innerRadius / distance;
+							}
+							if (gain <= 0.0) {
+								gain = 0.0;
+							}
+							gain -= clampFactor * distance * distance;
+							if (gain <= 0.0) {
+								gain = 0.0;
+							}
+						}
+					}
+
+					AL.Source(MicSources[i].OpenAlSourceName, ALSource3f.Position, (float)positionDifference.X, (float)positionDifference.Y, (float)positionDifference.Z);
+					AL.Source(MicSources[i].OpenAlSourceName, ALSourcef.Gain, (float)gain);
+
+					if (AL.GetSourceState(MicSources[i].OpenAlSourceName) != ALSourceState.Playing) {
+						AL.SourcePlay(MicSources[i].OpenAlSourceName);
 					}
 				}
 			}

--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -594,6 +594,10 @@ namespace OpenBve {
 			sample = OpenAlMic.AvailableSamples;
 
 			for (int i = 0; i < MicSources.Count; i++) {
+				if (listenerPosition.Z < MicSources[i].Position.Z - MicSources[i].BackwardTolerance || listenerPosition.Z > MicSources[i].Position.Z + MicSources[i].ForwardTolerance) {
+					continue;
+				}
+
 				// When playback is completed and recording is possible.
 				if (sample > 0 && states[i] == 1) {
 					// Store the recorded data in the buffer.
@@ -623,11 +627,8 @@ namespace OpenBve {
 						if (IsLinear) {
 							double outerRadius = OuterRadiusFactor * innerRadius;
 							if (distance < outerRadius) {
-								if (distance <= innerRadius) {
-									gain = Sources[i].Volume;
-								} else {
+								if (distance > innerRadius) {
 									gain = (distance - outerRadius) / (innerRadius - outerRadius);
-									gain *= Sources[i].Volume;
 								}
 								gain = 3.0 * gain * gain - 2.0 * gain * gain * gain;
 							} else {

--- a/source/OpenBVE/Audio/Sounds.cs
+++ b/source/OpenBVE/Audio/Sounds.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
 using OpenTK;
+using OpenTK.Audio;
 using OpenTK.Audio.OpenAL;
 using OpenBveApi.Interface;
 
@@ -34,6 +36,24 @@ namespace OpenBve
 
 		/// <summary>Whether all sounds are mute.</summary>
 		internal static bool GlobalMute = false;
+
+		/// <summary>Whether to play microphone sound or not.</summary>
+		internal static bool IsPlayingMicSounds = false;
+
+		/// <summary>Sampling rate of a microphone</summary>
+		private const int SamplingRate = 44100;
+
+		/// <summary>Buffer size of a microphone</summary>
+		private const int BufferSize = 4410;
+
+		/// <summary>The current OpenAL AudioCapture device.</summary>
+		private static AudioCapture OpenAlMic = null;
+
+		/// <summary>A list of all microphone sources.</summary>
+		private static List<MicSource> MicSources = new List<MicSource>();
+
+		/// <summary>Buffer for storing recorded data.</summary>
+		private static byte[] MicStore = new byte[BufferSize * 2];
 
 
 		// --- linear distance clamp model ---
@@ -81,6 +101,7 @@ namespace OpenBve
 			OuterRadiusFactor = Math.Sqrt(OuterRadiusFactorMinimum * OuterRadiusFactorMaximum);
 			OuterRadiusFactorSpeed = 0.0;
 			OpenAlDevice = Alc.OpenDevice(null);
+			OpenAlMic = new AudioCapture(AudioCapture.DefaultDevice, SamplingRate, ALFormat.Mono16, BufferSize);
 			if (OpenAlDevice != IntPtr.Zero)
 			{
 				OpenAlContext = Alc.CreateContext(OpenAlDevice, (int[])null);
@@ -100,6 +121,8 @@ namespace OpenBve
 				}
 				Alc.CloseDevice(OpenAlDevice);
 				OpenAlDevice = IntPtr.Zero;
+				OpenAlMic.Dispose();
+				OpenAlMic = null;
 				MessageBox.Show(Translations.GetInterfaceString("errors_sound_openal_context"), Translations.GetInterfaceString("program_title"), MessageBoxButtons.OK, MessageBoxIcon.Hand);
 				return;
 			}
@@ -112,6 +135,7 @@ namespace OpenBve
 		{
 			StopAllSounds();
 			UnloadAllBuffers();
+			UnloadAllMicBuffers();
 			if (OpenAlContext != ContextHandle.Zero)
 			{
 				Alc.MakeContextCurrent(ContextHandle.Zero);
@@ -122,6 +146,11 @@ namespace OpenBve
 			{
 				Alc.CloseDevice(OpenAlDevice);
 				OpenAlDevice = IntPtr.Zero;
+			}
+			if (OpenAlMic != null)
+			{
+				OpenAlMic.Dispose();
+				OpenAlMic = null;
 			}
 		}
 
@@ -233,6 +262,29 @@ namespace OpenBve
 			}
 		}
 
+		/// <summary>Unloads the specified microphone buffer.</summary>
+		/// <param name="source"></param>
+		/// <param name="number"></param>
+		private static void UnloadMicBuffers(int source, int number)
+		{
+			if (number > 0)
+			{
+				int[] buffers = AL.SourceUnqueueBuffers(source, number);
+				AL.DeleteBuffers(buffers);
+			}
+		}
+
+		/// <summary>Unloads all microphone buffers immediately.</summary>
+		private static void UnloadAllMicBuffers()
+		{
+			foreach (var source in MicSources)
+			{
+				int state;
+				AL.GetSource(source.OpenAlSourceName, ALGetSourcei.BuffersProcessed, out state);
+				UnloadMicBuffers(source.OpenAlSourceName, state);
+			}
+		}
+
 
 		// --- play or stop sounds ---
 
@@ -312,6 +364,13 @@ namespace OpenBve
 				throw new InvalidDataException("A train and car must be specified");
 			}
 			sound.Source = PlaySound(sound.Buffer, pitch, volume, sound.Position, train, car, looped);
+		}
+
+		/// <summary>Register the position to play microphone input.</summary>
+		/// <param name="position">The position.</param>
+		internal static void PlayMicSound(OpenBveApi.Math.Vector3 position)
+		{
+			MicSources.Add(new MicSource(position));
 		}
 
 		/// <summary>Stops the specified sound source.</summary>

--- a/source/OpenBVE/Audio/Sounds.cs
+++ b/source/OpenBVE/Audio/Sounds.cs
@@ -368,9 +368,11 @@ namespace OpenBve
 
 		/// <summary>Register the position to play microphone input.</summary>
 		/// <param name="position">The position.</param>
-		internal static void PlayMicSound(OpenBveApi.Math.Vector3 position)
+		/// <param name="backwardTolerance">allowed tolerance in the backward direction</param>
+		/// <param name="forwardTolerance">allowed tolerance in the forward direction</param>
+		internal static void PlayMicSound(OpenBveApi.Math.Vector3 position, double backwardTolerance, double forwardTolerance)
 		{
-			MicSources.Add(new MicSource(position));
+			MicSources.Add(new MicSource(position, backwardTolerance, forwardTolerance));
 		}
 
 		/// <summary>Stops the specified sound source.</summary>

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -776,18 +776,26 @@ namespace OpenBve
 							{
 								if (Data.Blocks[i].SoundEvents[k].Type == SoundType.World)
 								{
-									if (Data.Blocks[i].SoundEvents[k].SoundBuffer != null)
+									if (Data.Blocks[i].SoundEvents[k].SoundBuffer != null || Data.Blocks[i].SoundEvents[k].IsMicSound)
 									{
-										double d = Data.Blocks[i].SoundEvents[k].TrackPosition - StartingDistance;
-										double dx = Data.Blocks[i].SoundEvents[k].X;
-										double dy = Data.Blocks[i].SoundEvents[k].Y;
+										var SoundEvent = Data.Blocks[i].SoundEvents[k];
+										double d = SoundEvent.TrackPosition - StartingDistance;
+										double dx = SoundEvent.X;
+										double dy = SoundEvent.Y;
 										double wa = Math.Atan2(Direction.Y, Direction.X) - planar;
 										Vector3 w = new Vector3(Math.Cos(wa), Math.Tan(updown), Math.Sin(wa));
 										w.Normalize();
 										Vector3 s = new Vector3(Direction.Y, 0.0, -Direction.X);
 										Vector3 u = Vector3.Cross(w, s);
 										Vector3 wpos = pos + new Vector3(s.X * dx + u.X * dy + w.X * d, s.Y * dx + u.Y * dy + w.Y * d, s.Z * dx + u.Z * dy + w.Z * d);
-										Sounds.PlaySound(Data.Blocks[i].SoundEvents[k].SoundBuffer, 1.0, 1.0, wpos, true);
+										if (SoundEvent.IsMicSound)
+										{
+											Sounds.PlayMicSound(wpos);
+										}
+										else
+										{
+											Sounds.PlaySound(SoundEvent.SoundBuffer, 1.0, 1.0, wpos, true);
+										}
 									}
 								}
 							}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -790,7 +790,7 @@ namespace OpenBve
 										Vector3 wpos = pos + new Vector3(s.X * dx + u.X * dy + w.X * d, s.Y * dx + u.Y * dy + w.Y * d, s.Z * dx + u.Z * dy + w.Z * d);
 										if (SoundEvent.IsMicSound)
 										{
-											Sounds.PlayMicSound(wpos);
+											Sounds.PlayMicSound(wpos, SoundEvent.BackwardTolerance, SoundEvent.ForwardTolerance);
 										}
 										else
 										{

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -143,6 +143,7 @@
 			internal double Radius;
 #pragma warning restore 414
 			internal double Speed;
+			internal bool IsMicSound;
 		}
 		private struct Transponder
 		{

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -144,6 +144,8 @@
 #pragma warning restore 414
 			internal double Speed;
 			internal bool IsMicSound;
+			internal double ForwardTolerance;
+			internal double BackwardTolerance;
 		}
 		private struct Transponder
 		{

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -4952,6 +4952,27 @@ namespace OpenBve {
 											}
 										}
 									} break;
+								case "track.micsound":
+									{
+										if (!PreviewOnly) {
+											double x = 0.0, y = 0.0;
+											if (Arguments.Length >= 1 && Arguments[0].Length > 0 & !NumberFormats.TryParseDoubleVb6(Arguments[0], UnitOfLength, out x)) {
+												Interface.AddMessage(MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												x = 0.0;
+											}
+											if (Arguments.Length >= 2 && Arguments[1].Length > 0 & !NumberFormats.TryParseDoubleVb6(Arguments[1], UnitOfLength, out y)) {
+												Interface.AddMessage(MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												y = 0.0;
+											}
+											int n = Data.Blocks[BlockIndex].SoundEvents.Length;
+											Array.Resize<Sound>(ref Data.Blocks[BlockIndex].SoundEvents, n + 1);
+											Data.Blocks[BlockIndex].SoundEvents[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].SoundEvents[n].Type = SoundType.World;
+											Data.Blocks[BlockIndex].SoundEvents[n].X = x;
+											Data.Blocks[BlockIndex].SoundEvents[n].Y = y;
+											Data.Blocks[BlockIndex].SoundEvents[n].IsMicSound = true;
+										}
+									} break;
 								case "track.pretrain":
 									{
 										if (!PreviewOnly) {

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -4955,7 +4955,7 @@ namespace OpenBve {
 								case "track.micsound":
 									{
 										if (!PreviewOnly) {
-											double x = 0.0, y = 0.0;
+											double x = 0.0, y = 0.0, back = 0.0, front = 0.0;
 											if (Arguments.Length >= 1 && Arguments[0].Length > 0 & !NumberFormats.TryParseDoubleVb6(Arguments[0], UnitOfLength, out x)) {
 												Interface.AddMessage(MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												x = 0.0;
@@ -4964,6 +4964,20 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												y = 0.0;
 											}
+											if (Arguments.Length >= 3 && Arguments[2].Length > 0 & !NumberFormats.TryParseDoubleVb6(Arguments[2], UnitOfLength, out back)) {
+												Interface.AddMessage(MessageType.Error, false, "BackwardTolerance is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												back = 0.0;
+											} else if (back < 0.0) {
+												Interface.AddMessage(MessageType.Error, false, "BackwardTolerance is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												back = 0.0;
+											}
+											if (Arguments.Length >= 4 && Arguments[3].Length > 0 & !NumberFormats.TryParseDoubleVb6(Arguments[3], UnitOfLength, out front)) {
+												Interface.AddMessage(MessageType.Error, false, "ForwardTolerance is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												front = 0.0;
+											} else if (front < 0.0) {
+												Interface.AddMessage(MessageType.Error, false, "ForwardTolerance is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												front = 0.0;
+											}
 											int n = Data.Blocks[BlockIndex].SoundEvents.Length;
 											Array.Resize<Sound>(ref Data.Blocks[BlockIndex].SoundEvents, n + 1);
 											Data.Blocks[BlockIndex].SoundEvents[n].TrackPosition = Data.TrackPosition;
@@ -4971,6 +4985,8 @@ namespace OpenBve {
 											Data.Blocks[BlockIndex].SoundEvents[n].X = x;
 											Data.Blocks[BlockIndex].SoundEvents[n].Y = y;
 											Data.Blocks[BlockIndex].SoundEvents[n].IsMicSound = true;
+											Data.Blocks[BlockIndex].SoundEvents[n].BackwardTolerance = back;
+											Data.Blocks[BlockIndex].SoundEvents[n].ForwardTolerance = front;
 										}
 									} break;
 								case "track.pretrain":

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1372,6 +1372,9 @@ namespace OpenBve
 										}
 										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Doors[1].ButtonPressed = true;
 										break;
+									case Translations.Command.PlayMicSounds:
+										Sounds.IsPlayingMicSounds = !Sounds.IsPlayingMicSounds;
+										break;
 //We only want to mark these as obsolete for new users of the API
 #pragma warning disable 618
 									case Translations.Command.SecurityS:

--- a/source/OpenBveApi/Interface/Input/Commands.CommandInfo.cs
+++ b/source/OpenBveApi/Interface/Input/Commands.CommandInfo.cs
@@ -80,6 +80,7 @@
 			new CommandInfo(Command.HornSecondary, CommandType.Digital, "HORN_SECONDARY"),
 			new CommandInfo(Command.HornMusic, CommandType.Digital, "HORN_MUSIC"),
 			new CommandInfo(Command.DeviceConstSpeed, CommandType.Digital, "DEVICE_CONSTSPEED"),
+			new CommandInfo(Command.PlayMicSounds, CommandType.Digital, "PLAY_MIC_SOUNDS"),
 
 //We only want to mark these as obsolete for new users of the API
 #pragma warning disable 618

--- a/source/OpenBveApi/Interface/Input/Commands.cs
+++ b/source/OpenBveApi/Interface/Input/Commands.cs
@@ -68,6 +68,8 @@ namespace OpenBveApi.Interface {
 			LocoBrakeIncrease,
 			/// <summary>Decreases the locomotive brake notch</summary>
 			LocoBrakeDecrease,
+			/// <summary>Activate microphone audio playback</summary>
+			PlayMicSounds,
 
 			//Simulation controls
 			/// <summary>Change to the interior (Cab) camera mode</summary>


### PR DESCRIPTION
This PR adds the syntax called Track.MicSound that plays the sound from the microphone on the simulation.

The usage of this syntax is as follows.
`Track.MicSound(X, Y, BackwardTolerance; ForwardTolerance)`

Specify the range to be played by BackwardTolerance and ForwardTolerance.

The PLAY_MIC_SOUNDS command toggles playback on and off.

The PLAY_MIC_SOUNDS command is assigned to W key by default.