### PR TITLE
New: Add alternate sound option for continuous handle movement

### DIFF
--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
@@ -618,8 +618,14 @@ namespace OpenBve
 										case "apply":
 											train.Cars[train.DriverCar].Sounds.BrakeHandleApply = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
 											break;
+										case "applyfast":
+											train.Cars[train.DriverCar].Sounds.BrakeHandleApplyFast = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
+											break;
 										case "release":
 											train.Cars[train.DriverCar].Sounds.BrakeHandleRelease = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
+											break;
+										case "releasefast":
+											train.Cars[train.DriverCar].Sounds.BrakeHandleReleaseFast = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
 											break;
 										case "min":
 											train.Cars[train.DriverCar].Sounds.BrakeHandleMin = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
@@ -655,8 +661,14 @@ namespace OpenBve
 										case "up":
 											train.Cars[train.DriverCar].Sounds.MasterControllerUp = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
 											break;
+										case "upfast":
+											train.Cars[train.DriverCar].Sounds.MasterControllerUpFast = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
+											break;
 										case "down":
 											train.Cars[train.DriverCar].Sounds.MasterControllerDown = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
+											break;
+										case "downfast":
+											train.Cars[train.DriverCar].Sounds.MasterControllerDownFast = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);
 											break;
 										case "min":
 											train.Cars[train.DriverCar].Sounds.MasterControllerMin = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), panel, SoundCfgParser.tinyRadius);

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
@@ -129,8 +129,14 @@ namespace OpenBve
 											case "apply":
 												ParseNode(cc, out car.Sounds.BrakeHandleApply, panel, SoundCfgParser.tinyRadius);
 												break;
+											case "applyfast":
+												ParseNode(cc, out car.Sounds.BrakeHandleApplyFast, panel, SoundCfgParser.tinyRadius);
+												break;
 											case "release":
 												ParseNode(cc, out car.Sounds.BrakeHandleRelease, panel, SoundCfgParser.tinyRadius);
+												break;
+											case "releasefast":
+												ParseNode(cc, out car.Sounds.BrakeHandleReleaseFast, panel, SoundCfgParser.tinyRadius);
 												break;
 											case "min":
 											case "minimum":
@@ -309,9 +315,17 @@ namespace OpenBve
 											case "increase":
 												ParseNode(cc, out car.Sounds.MasterControllerUp, panel, SoundCfgParser.tinyRadius);
 												break;
+											case "upfast":
+											case "increasefast":
+												ParseNode(cc, out car.Sounds.MasterControllerUpFast, panel, SoundCfgParser.tinyRadius);
+												break;
 											case "down":
 											case "decrease":
 												ParseNode(cc, out car.Sounds.MasterControllerDown, panel, SoundCfgParser.tinyRadius);
+												break;
+											case "downfast":
+											case "decreasefast":
+												ParseNode(cc, out car.Sounds.MasterControllerDownFast, panel, SoundCfgParser.tinyRadius);
 												break;
 											case "min":
 											case "minimum":

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSounds.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSounds.cs
@@ -13,11 +13,17 @@
 			internal CarSound AirZero;
 			internal CarSound Brake;
 			internal CarSound BrakeHandleApply;
+			internal CarSound BrakeHandleApplyFast;
 			internal CarSound BrakeHandleRelease;
+			internal CarSound BrakeHandleReleaseFast;
 			internal CarSound BrakeHandleMin;
 			internal CarSound BrakeHandleMax;
 			internal CarSound BreakerResume;
 			internal CarSound BreakerResumeOrInterrupt;
+			/// <summary>Whether the brake handle is being moved continuously</summary>
+			internal bool BrakeHandleFast;
+			/// <summary>Whether the power handle is being moved continuously</summary>
+			internal bool PowerHandleFast;
 			internal bool BreakerResumed;
 			internal CarSound CpEnd;
 			internal CarSound CpLoop;
@@ -31,7 +37,9 @@
 			
 			internal CarSound Loop;
 			internal CarSound MasterControllerUp;
+			internal CarSound MasterControllerUpFast;
 			internal CarSound MasterControllerDown;
+			internal CarSound MasterControllerDownFast;
 			internal CarSound MasterControllerMin;
 			internal CarSound MasterControllerMax;
 			/// <summary>Played once when all doors are closed</summary>

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.Handles.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.Handles.cs
@@ -50,7 +50,15 @@ namespace OpenBve
 					if (p > 0)
 					{
 						// down (not min)
-						Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.MasterControllerDown.Buffer;
+						Sounds.SoundBuffer buffer;
+						if ((Handles.Power.Driver - p > 2 | Cars[DriverCar].Sounds.PowerHandleFast) && Cars[DriverCar].Sounds.MasterControllerDownFast.Buffer != null)
+						{
+							buffer = Cars[DriverCar].Sounds.MasterControllerDownFast.Buffer;
+						}
+						else
+						{
+							buffer = Cars[DriverCar].Sounds.MasterControllerDown.Buffer;
+						}
 						if (buffer != null)
 						{
 							Vector3 pos = Cars[DriverCar].Sounds.MasterControllerDown.Position;
@@ -73,7 +81,15 @@ namespace OpenBve
 					if (p < Handles.Power.MaximumDriverNotch)
 					{
 						// up (not max)
-						Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.MasterControllerUp.Buffer;
+						Sounds.SoundBuffer buffer;
+						if ((Handles.Power.Driver - p > 2 | Cars[DriverCar].Sounds.PowerHandleFast) && Cars[DriverCar].Sounds.MasterControllerUpFast.Buffer != null)
+						{
+							buffer = Cars[DriverCar].Sounds.MasterControllerUpFast.Buffer;
+						}
+						else
+						{
+							buffer = Cars[DriverCar].Sounds.MasterControllerUp.Buffer;
+						}
 						if (buffer != null)
 						{
 							Vector3 pos = Cars[DriverCar].Sounds.MasterControllerUp.Position;
@@ -106,7 +122,14 @@ namespace OpenBve
 					if (b > 0)
 					{
 						// brake release (not min)
-						buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+						if ((Handles.Brake.Driver - b > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer != null)
+						{
+							buffer = Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer;
+						}
+						else
+						{
+							buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+						}
 						if (buffer != null)
 						{
 							Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleRelease.Position;
@@ -127,7 +150,16 @@ namespace OpenBve
 				else if (b > Handles.Brake.Driver)
 				{
 					// brake
-					Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+					Sounds.SoundBuffer buffer;
+					if ((b - Handles.Brake.Driver > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer != null)
+					{
+						buffer = Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer;
+					}
+					else
+					{
+						buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+					}
+					
 					if (buffer != null)
 					{
 						Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleApply.Position;
@@ -181,7 +213,14 @@ namespace OpenBve
 					if (b > 0)
 					{
 						// brake release (not min) 
-						buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+						if ((Handles.LocoBrake.Driver - b > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer != null)
+						{
+							buffer = Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer;
+						}
+						else
+						{
+							buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+						}
 						if (buffer != null)
 						{
 							Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleRelease.Position;
@@ -202,7 +241,15 @@ namespace OpenBve
 				else if (b > Handles.LocoBrake.Driver)
 				{
 					// brake 
-					Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+					Sounds.SoundBuffer buffer;
+					if ((b - Handles.LocoBrake.Driver > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer != null)
+					{
+						buffer = Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer;
+					}
+					else
+					{
+						buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+					}
 					if (buffer != null)
 					{
 						Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleApply.Position;
@@ -410,7 +457,15 @@ namespace OpenBve
 							if ((int) newState > 0)
 							{
 								// brake release (not min)
-								Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+								Sounds.SoundBuffer buffer;
+								if ((Handles.Brake.Driver - (int)newState > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer != null)
+								{
+									buffer = Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer;
+								}
+								else
+								{
+									buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+								}
 								if (buffer != null)
 								{
 									Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleRelease.Position;
@@ -431,7 +486,15 @@ namespace OpenBve
 						else if ((int) newState > (int) Handles.Brake.Driver)
 						{
 							// brake
-							Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+							Sounds.SoundBuffer buffer;
+							if (((int)newState - (int)Handles.Brake.Driver > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer != null)
+							{
+								buffer = Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer;
+							}
+							else
+							{
+								buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+							}
 							if (buffer != null)
 							{
 								Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleApply.Position;
@@ -478,7 +541,15 @@ namespace OpenBve
 							if ((int) newState > 0)
 							{
 								// brake release (not min)
-								Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+								Sounds.SoundBuffer buffer;
+								if ((Handles.Brake.Driver - (int)newState > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer != null)
+								{
+									buffer = Cars[DriverCar].Sounds.BrakeHandleReleaseFast.Buffer;
+								}
+								else
+								{
+									buffer = Cars[DriverCar].Sounds.BrakeHandleRelease.Buffer;
+								}
 								if (buffer != null)
 								{
 									Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleRelease.Position;
@@ -499,7 +570,15 @@ namespace OpenBve
 						else if ((int) newState > (int) Handles.LocoBrake.Driver)
 						{
 							// brake
-							Sounds.SoundBuffer buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+							Sounds.SoundBuffer buffer;
+							if (((int)newState - (int)Handles.LocoBrake.Driver > 2 | Cars[DriverCar].Sounds.BrakeHandleFast) && Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer != null)
+							{
+								buffer = Cars[DriverCar].Sounds.BrakeHandleApplyFast.Buffer;
+							}
+							else
+							{
+								buffer = Cars[DriverCar].Sounds.BrakeHandleApply.Buffer;
+							}
 							if (buffer != null)
 							{
 								Vector3 pos = Cars[DriverCar].Sounds.BrakeHandleApply.Position;

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using OpenBveApi.Colors;
 using OpenBveApi.Runtime;
 using OpenBveApi.Textures;
@@ -991,6 +991,7 @@ namespace OpenBve
 												}
 											}
 										}
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = true;
 										break;
 									case Translations.Command.SingleNeutral:
 										// single neutral
@@ -1000,6 +1001,7 @@ namespace OpenBve
 											if (p > 0)
 											{
 												TrainManager.PlayerTrain.ApplyNotch(-1, true, 0, true);
+												TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = true;
 											}
 											else
 											{
@@ -1021,6 +1023,7 @@ namespace OpenBve
 												{
 													TrainManager.PlayerTrain.ApplyNotch(0, true, -1, true);
 												}
+												TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = true;
 											}
 										}
 										break;
@@ -1048,6 +1051,8 @@ namespace OpenBve
 												}
 											}
 										}
+										//Set the brake handle fast movement bool at the end of the call in order to not catch it on the first movement
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = true;
 										break;
 									case Translations.Command.SingleEmergency:
 										// single emergency
@@ -1066,6 +1071,7 @@ namespace OpenBve
 												TrainManager.PlayerTrain.ApplyNotch(1, true, 0, true);
 											}
 										}
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = true;
 										break;
 									case Translations.Command.PowerDecrease:
 										// power decrease
@@ -1077,6 +1083,7 @@ namespace OpenBve
 												TrainManager.PlayerTrain.ApplyNotch(-1, true, 0, true);
 											}
 										}
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = true;
 										break;
 									case Translations.Command.BrakeIncrease:
 										// brake increase
@@ -1122,6 +1129,7 @@ namespace OpenBve
 												}
 											}
 										}
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = true;
 										break;
 									case Translations.Command.BrakeDecrease:
 										// brake decrease
@@ -1178,6 +1186,7 @@ namespace OpenBve
 												}
 											}
 										}
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = true;
 										break;
 									case Translations.Command.LocoBrakeIncrease:
 										if (TrainManager.PlayerTrain.Handles.LocoBrake is TrainManager.LocoAirBrakeHandle)
@@ -1734,6 +1743,25 @@ namespace OpenBve
 									Interface.DigitalControlState.ReleasedAcknowledged;
 								switch (Interface.CurrentControls[i].Command)
 								{
+									case Translations.Command.SingleBrake:
+									case Translations.Command.BrakeIncrease:
+									case Translations.Command.BrakeDecrease:
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = false;
+										break;
+									case Translations.Command.SinglePower:
+									case Translations.Command.PowerIncrease:
+									case Translations.Command.PowerDecrease:
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = false;
+										break;
+									case Translations.Command.SingleNeutral:
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.BrakeHandleFast = false;
+										TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Sounds.PowerHandleFast = false;
+										break;
+
+									/*
+									 * Keys after this point are used by the plugin API
+									 *
+									 */
 //We only want to mark these as obsolete for new users of the API
 #pragma warning disable 618
 									case Translations.Command.SecurityS:


### PR DESCRIPTION
This PR adds alternate handle sounds, played for when the handle is in continuous movement as per BVE5.

## New Parameters:

### Sound.cfg

**[Brake Handle]**
**ApplyFast** : Played on the second and subsequent continuous notch movement upto & including the notch before maximum.
**ReleaseFast** : Played on the second and subsequent continuous notch movement upto & including the notch before minimum.

**[Master Controller]**
**UpFast** : Played on the second and subsequent continuous notch movement upto & including the notch before maximum.
**DownFast** : Played on the second and subsequent continuous notch movement upto & including the notch before minimum.

### Sound.xml
**&lt;BrakeHandle&gt;**
**ApplyFast** : Played on the second and subsequent continuous notch movement upto & including the notch before maximum.
**ReleaseFast** : Played on the second and subsequent continuous notch movement upto & including the notch before minimum.

**&lt;MasterController&gt;**
**UpFast** : Played on the second and subsequent continuous notch movement upto & including the notch before maximum.
**DownFast** : Played on the second and subsequent continuous notch movement upto & including the notch before minimum.
