### PR TITLE
Change: Micro optimisations in the renderer

### DIFF
--- a/source/ObjectViewer/ObjectManager.cs
+++ b/source/ObjectViewer/ObjectManager.cs
@@ -1397,9 +1397,7 @@ namespace OpenBve
             {
                 for (int j = 0; j < AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials.Length; j++)
                 {
-                    AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.R * Brightness);
-                    AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.G * Brightness);
-                    AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.B * Brightness);
+	                AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color = Prototype.States[i].Object.Mesh.Materials[j].Color * Brightness;
                 }
                 for (int j = 0; j < AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Vertices.Length; j++)
                 {
@@ -1877,9 +1875,7 @@ namespace OpenBve
             for (int j = 0; j < Prototype.Mesh.Materials.Length; j++)
             {
                 Object.Mesh.Materials[j] = Prototype.Mesh.Materials[j];
-                Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.R * Brightness);
-                Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.G * Brightness);
-                Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.B * Brightness);
+                Object.Mesh.Materials[j].Color = Prototype.Mesh.Materials[j].Color * Brightness;
             }
             const double minBlockLength = 20.0;
             if (BlockLength < minBlockLength)

--- a/source/ObjectViewer/Parsers/WavefrontObjParser.cs
+++ b/source/ObjectViewer/Parsers/WavefrontObjParser.cs
@@ -425,7 +425,10 @@ namespace OpenBve
 						{
 							Interface.AddMessage(MessageType.Warning, false, "Invalid Alpha in Material Definition for " + mm.Key);
 						}
-						mm.Color.A = (byte)((1 - a) * 255);
+						byte cr = mm.Color.R;
+						byte cg = mm.Color.G;
+						byte cb = mm.Color.B;
+						mm.Color = new Color32(cr, cg, cb, (byte)((1 - a) * 255));
 						break;
 					case "map_kd":
 					case "map_ka":

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OpenBveApi.Colors;
 using OpenTK;
 using OpenTK.Graphics;
 using Vector3 = OpenBveApi.Math.Vector3;
@@ -271,12 +272,8 @@ namespace OpenBve
             }
             if (updatelight)
             {
-               Renderer.OptionAmbientColor.R = (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative * (2.0 - Program.LightingRelative));
-               Renderer.OptionAmbientColor.G = (byte)Math.Round(32.0 + 128.0 * 0.5 * (Program.LightingRelative + Program.LightingRelative * (2.0 - Program.LightingRelative)));
-                Renderer.OptionAmbientColor.B = (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative);
-                Renderer.OptionDiffuseColor.R = (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative);
-                Renderer.OptionDiffuseColor.G = (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative);
-                Renderer.OptionDiffuseColor.B = (byte)Math.Round(32.0 + 128.0 * Math.Sqrt(Program.LightingRelative));
+	            Renderer.OptionAmbientColor = new Color24((byte)Math.Round(32.0 + 128.0 * Program.LightingRelative * (2.0 - Program.LightingRelative)), (byte)Math.Round(32.0 + 128.0 * 0.5 * (Program.LightingRelative + Program.LightingRelative * (2.0 - Program.LightingRelative))), (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative));
+				Renderer.OptionDiffuseColor = new Color24((byte)Math.Round(32.0 + 128.0 * Program.LightingRelative), (byte)Math.Round(32.0 + 128.0 * Program.LightingRelative), (byte)Math.Round(32.0 + 128.0 * Math.Sqrt(Program.LightingRelative)));
                 Renderer.InitializeLighting();
             }
             Renderer.RenderScene();

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedObject.cs
@@ -860,9 +860,7 @@ namespace OpenBve
 					{
 						for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Materials.Length; j++)
 						{
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.R * Brightness);
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.G * Brightness);
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.B * Brightness);
+							currentObject.Object.States[i].Object.Mesh.Materials[j].Color = States[i].Object.Mesh.Materials[j].Color * Brightness;
 						}
 						for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Vertices.Length; j++)
 						{
@@ -913,9 +911,7 @@ namespace OpenBve
 					{
 						for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Materials.Length; j++)
 						{
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.R * Brightness);
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.G * Brightness);
-							currentObject.Object.States[i].Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)States[i].Object.Mesh.Materials[j].Color.B * Brightness);
+							currentObject.Object.States[i].Object.Mesh.Materials[j].Color = States[i].Object.Mesh.Materials[j].Color * Brightness;
 						}
 						for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Vertices.Length; j++)
 						{

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedWorldObject.StateSound.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/AnimatedWorldObject.StateSound.cs
@@ -194,9 +194,7 @@ namespace OpenBve
 				{
 					for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Materials.Length; j++)
 					{
-						currentObject.Object.States[i].Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)this.Object.States[i].Object.Mesh.Materials[j].Color.R * Brightness);
-						currentObject.Object.States[i].Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)this.Object.States[i].Object.Mesh.Materials[j].Color.G * Brightness);
-						currentObject.Object.States[i].Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)this.Object.States[i].Object.Mesh.Materials[j].Color.B * Brightness);
+						currentObject.Object.States[i].Object.Mesh.Materials[j].Color = this.Object.States[i].Object.Mesh.Materials[j].Color * Brightness;
 					}
 					for (int j = 0; j < currentObject.Object.States[i].Object.Mesh.Vertices.Length; j++)
 					{

--- a/source/OpenBVE/Game/ObjectManager/ObjectManager.StaticObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/ObjectManager.StaticObject.cs
@@ -390,9 +390,7 @@ namespace OpenBve
 				for (int j = 0; j < Prototype.Mesh.Materials.Length; j++)
 				{
 					Mesh.Materials[j] = Prototype.Mesh.Materials[j];
-					Mesh.Materials[j].Color.R = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.R * Brightness);
-					Mesh.Materials[j].Color.G = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.G * Brightness);
-					Mesh.Materials[j].Color.B = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.B * Brightness);
+					Mesh.Materials[j].Color = Prototype.Mesh.Materials[j].Color * Brightness;
 				}
 				const double minBlockLength = 20.0;
 				if (BlockLength < minBlockLength)

--- a/source/OpenBVE/Graphics/Renderer.cs
+++ b/source/OpenBVE/Graphics/Renderer.cs
@@ -52,6 +52,14 @@ namespace OpenBve
 		internal static bool OptionWireframe = false;
 		internal static bool OptionBackfaceCulling = true;
 
+		/*
+		 * These default positions are used every frame by openGL
+		 * Keep them here as opposed to re-creating the new array
+		 * each time for a minor speedup
+		 */
+		private static readonly float[] defaultEmissiveState = {0.0f, 0.0f, 0.0f, 1.0f};
+		private static readonly float[] defaultLightPosition = {0.7f, 0.7f, 0.7f, 1.0f};
+
 		// interface options
 		/// <summary>Whether the clock overlay is currently displayed</summary>
 		internal static bool OptionClock = false;
@@ -117,9 +125,9 @@ namespace OpenBve
 				LoadTexturesImmediately = LoadTextureImmediatelyMode.Yes;
 			}
 			// set up camera
-			double cx = World.AbsoluteCameraPosition.X;
-			double cy = World.AbsoluteCameraPosition.Y;
-			double cz = World.AbsoluteCameraPosition.Z;
+			//double cx = World.AbsoluteCameraPosition.X;
+			//double cy = World.AbsoluteCameraPosition.Y;
+			//double cz = World.AbsoluteCameraPosition.Z;
 			double dx = World.AbsoluteCameraDirection.X;
 			double dy = World.AbsoluteCameraDirection.Y;
 			double dz = World.AbsoluteCameraDirection.Z;
@@ -208,7 +216,7 @@ namespace OpenBve
 							{
 								if (StaticOpaque[i].List.Faces[j] != null)
 								{
-									RenderFace(ref StaticOpaque[i].List.Faces[j], cx, cy, cz);
+									RenderFace(ref StaticOpaque[i].List.Faces[j], World.AbsoluteCameraPosition);
 								}
 							}
 						}
@@ -239,7 +247,7 @@ namespace OpenBve
 								{
 									if (StaticOpaque[i].List.Faces[j] != null)
 									{
-										RenderFace(ref StaticOpaque[i].List.Faces[j], cx, cy, cz);
+										RenderFace(ref StaticOpaque[i].List.Faces[j], World.AbsoluteCameraPosition);
 									}
 								}
 								GL.EndList();
@@ -275,7 +283,7 @@ namespace OpenBve
 			ResetOpenGlState();
 			for (int i = 0; i < DynamicOpaque.FaceCount; i++)
 			{
-				RenderFace(ref DynamicOpaque.Faces[i], cx, cy, cz);
+				RenderFace(ref DynamicOpaque.Faces[i], World.AbsoluteCameraPosition);
 			}
 			// dynamic alpha
 			ResetOpenGlState();
@@ -287,7 +295,7 @@ namespace OpenBve
 				SetAlphaFunc(AlphaFunction.Greater, 0.0f);
 				for (int i = 0; i < DynamicAlpha.FaceCount; i++)
 				{
-					RenderFace(ref DynamicAlpha.Faces[i], cx, cy, cz);
+					RenderFace(ref DynamicAlpha.Faces[i], World.AbsoluteCameraPosition);
 				}
 			}
 			else
@@ -302,7 +310,7 @@ namespace OpenBve
 					{
 						if (ObjectManager.Objects[DynamicAlpha.Faces[i].ObjectIndex].Mesh.Materials[r].Color.A == 255)
 						{
-							RenderFace(ref DynamicAlpha.Faces[i], cx, cy, cz);
+							RenderFace(ref DynamicAlpha.Faces[i], World.AbsoluteCameraPosition);
 						}
 					}
 				}
@@ -320,7 +328,7 @@ namespace OpenBve
 							UnsetAlphaFunc();
 							additive = true;
 						}
-						RenderFace(ref DynamicAlpha.Faces[i], cx, cy, cz);
+						RenderFace(ref DynamicAlpha.Faces[i], World.AbsoluteCameraPosition);
 					}
 					else
 					{
@@ -329,7 +337,7 @@ namespace OpenBve
 							SetAlphaFunc(AlphaFunction.Less, 1.0f);
 							additive = false;
 						}
-						RenderFace(ref DynamicAlpha.Faces[i], cx, cy, cz);
+						RenderFace(ref DynamicAlpha.Faces[i], World.AbsoluteCameraPosition);
 					}
 				}
 			}
@@ -368,13 +376,13 @@ namespace OpenBve
 					GL.Enable(EnableCap.Lighting); LightingEnabled = true;
 				}
 				OptionLighting = true;
-				GL.Light(LightName.Light0, LightParameter.Ambient, new float[] { 0.7f, 0.7f, 0.7f, 1.0f });
-				GL.Light(LightName.Light0, LightParameter.Diffuse, new float[] { 0.7f, 0.7f, 0.7f, 1.0f });
+				GL.Light(LightName.Light0, LightParameter.Ambient, defaultLightPosition);
+				GL.Light(LightName.Light0, LightParameter.Diffuse, defaultLightPosition);
 				// overlay opaque
 				SetAlphaFunc(AlphaFunction.Greater, 0.9f);
 				for (int i = 0; i < OverlayOpaque.FaceCount; i++)
 				{
-					RenderFace(ref OverlayOpaque.Faces[i], cx, cy, cz);
+					RenderFace(ref OverlayOpaque.Faces[i], World.AbsoluteCameraPosition);
 				}
 				// overlay alpha
 				OverlayAlpha.SortPolygons();
@@ -385,7 +393,7 @@ namespace OpenBve
 					SetAlphaFunc(AlphaFunction.Greater, 0.0f);
 					for (int i = 0; i < OverlayAlpha.FaceCount; i++)
 					{
-						RenderFace(ref OverlayAlpha.Faces[i], cx, cy, cz);
+						RenderFace(ref OverlayAlpha.Faces[i], World.AbsoluteCameraPosition);
 					}
 				}
 				else
@@ -400,7 +408,7 @@ namespace OpenBve
 						{
 							if (ObjectManager.Objects[OverlayAlpha.Faces[i].ObjectIndex].Mesh.Materials[r].Color.A == 255)
 							{
-								RenderFace(ref OverlayAlpha.Faces[i], cx, cy, cz);
+								RenderFace(ref OverlayAlpha.Faces[i], World.AbsoluteCameraPosition);
 							}
 						}
 					}
@@ -418,7 +426,7 @@ namespace OpenBve
 								UnsetAlphaFunc();
 								additive = true;
 							}
-							RenderFace(ref OverlayAlpha.Faces[i], cx, cy, cz);
+							RenderFace(ref OverlayAlpha.Faces[i], World.AbsoluteCameraPosition);
 						}
 						else
 						{
@@ -427,7 +435,7 @@ namespace OpenBve
 								SetAlphaFunc(AlphaFunction.Less, 1.0f);
 								additive = false;
 							}
-							RenderFace(ref OverlayAlpha.Faces[i], cx, cy, cz);
+							RenderFace(ref OverlayAlpha.Faces[i], World.AbsoluteCameraPosition);
 						}
 					}
 				}
@@ -453,7 +461,7 @@ namespace OpenBve
 				OverlayAlpha.SortPolygons();
 				for (int i = 0; i < OverlayAlpha.FaceCount; i++)
 				{
-					RenderFace(ref OverlayAlpha.Faces[i], cx, cy, cz);
+					RenderFace(ref OverlayAlpha.Faces[i], World.AbsoluteCameraPosition);
 				}
 
 			}
@@ -484,7 +492,7 @@ namespace OpenBve
 		/// <summary> Stores the last bound OpenGL texture</summary>
 		internal static OpenGlTexture LastBoundTexture = null;
 
-		private static void RenderFace(ref ObjectFace Face, double CameraX, double CameraY, double CameraZ)
+		private static void RenderFace(ref ObjectFace Face, Vector3 Camera)
 		{
 			if (CullEnabled)
 			{
@@ -503,9 +511,9 @@ namespace OpenBve
 				}
 			}
 			int r = (int)ObjectManager.Objects[Face.ObjectIndex].Mesh.Faces[Face.FaceIndex].Material;
-			RenderFace(ref ObjectManager.Objects[Face.ObjectIndex].Mesh.Materials[r], ObjectManager.Objects[Face.ObjectIndex].Mesh.Vertices, Face.Wrap, ref ObjectManager.Objects[Face.ObjectIndex].Mesh.Faces[Face.FaceIndex], CameraX, CameraY, CameraZ);
+			RenderFace(ref ObjectManager.Objects[Face.ObjectIndex].Mesh.Materials[r], ObjectManager.Objects[Face.ObjectIndex].Mesh.Vertices, Face.Wrap, ref ObjectManager.Objects[Face.ObjectIndex].Mesh.Faces[Face.FaceIndex], Camera);
 		}
-		private static void RenderFace(ref World.MeshMaterial Material, VertexTemplate[] Vertices, OpenGlTextureWrapMode wrap, ref World.MeshFace Face, double CameraX, double CameraY, double CameraZ)
+		private static void RenderFace(ref World.MeshMaterial Material, VertexTemplate[] Vertices, OpenGlTextureWrapMode wrap, ref World.MeshFace Face, Vector3 Camera)
 		{
 			// texture
 			if (Material.DaytimeTexture != null)
@@ -602,7 +610,7 @@ namespace OpenBve
 			}
 			if (Material.GlowAttenuationData != 0)
 			{
-				float alphafactor = (float)GetDistanceFactor(Vertices, ref Face, Material.GlowAttenuationData, CameraX, CameraY, CameraZ);
+				float alphafactor = (float)GetDistanceFactor(Vertices, ref Face, Material.GlowAttenuationData, Camera);
 				if (OptionWireframe)
 				{
 					GL.Color4(inv255 * (float)Material.Color.R * factor, inv255 * Material.Color.G * factor, inv255 * (float)Material.Color.B * factor, 1.0f);
@@ -630,7 +638,7 @@ namespace OpenBve
 			}
 			else
 			{
-				GL.Material(MaterialFace.FrontAndBack, MaterialParameter.Emission, new float[] { 0.0f, 0.0f, 0.0f, 1.0f });
+				GL.Material(MaterialFace.FrontAndBack, MaterialParameter.Emission, defaultEmissiveState);
 			}
 			if (Material.DaytimeTexture != null)
 			{
@@ -638,27 +646,27 @@ namespace OpenBve
 				{
 					for (int j = 0; j < Face.Vertices.Length; j++)
 					{
-						GL.Normal3(Face.Vertices[j].Normal.X, Face.Vertices[j].Normal.Y, Face.Vertices[j].Normal.Z);
-						GL.TexCoord2(Vertices[Face.Vertices[j].Index].TextureCoordinates.X, Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
+						GL.Normal3((float)Face.Vertices[j].Normal.X, (float)Face.Vertices[j].Normal.Y, (float)Face.Vertices[j].Normal.Z);
+						GL.TexCoord2((float)Vertices[Face.Vertices[j].Index].TextureCoordinates.X, (float)Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
 						if (Vertices[Face.Vertices[j].Index] is ColoredVertex)
 						{
 							ColoredVertex v = (ColoredVertex) Vertices[Face.Vertices[j].Index];
 							GL.Color3(v.Color.R, v.Color.G, v.Color.B);
 						}
-						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
+						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
 					}
 				}
 				else
 				{
 					for (int j = 0; j < Face.Vertices.Length; j++)
 					{
-						GL.TexCoord2(Vertices[Face.Vertices[j].Index].TextureCoordinates.X, Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
+						GL.TexCoord2((float)Vertices[Face.Vertices[j].Index].TextureCoordinates.X, (float)Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
 						if (Vertices[Face.Vertices[j].Index] is ColoredVertex)
 						{
 							ColoredVertex v = (ColoredVertex) Vertices[Face.Vertices[j].Index];
 							GL.Color3(v.Color.R, v.Color.G, v.Color.B);
 						}
-						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
+						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
 					}
 				}
 			}
@@ -668,13 +676,13 @@ namespace OpenBve
 				{
 					for (int j = 0; j < Face.Vertices.Length; j++)
 					{
-						GL.Normal3(Face.Vertices[j].Normal.X, Face.Vertices[j].Normal.Y, Face.Vertices[j].Normal.Z);
+						GL.Normal3((float)Face.Vertices[j].Normal.X, (float)Face.Vertices[j].Normal.Y, (float)Face.Vertices[j].Normal.Z);
 						if (Vertices[Face.Vertices[j].Index] is ColoredVertex)
 						{
 							ColoredVertex v = (ColoredVertex) Vertices[Face.Vertices[j].Index];
 							GL.Color3(v.Color.R, v.Color.G, v.Color.B);
 						}
-						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
+						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
 					}
 				}
 				else
@@ -686,7 +694,7 @@ namespace OpenBve
 							ColoredVertex v = (ColoredVertex) Vertices[Face.Vertices[j].Index];
 							GL.Color3(v.Color.R, v.Color.G, v.Color.B);
 						}
-						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
+						GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
 					}
 				}
 			}
@@ -728,7 +736,7 @@ namespace OpenBve
 				float alphafactor;
 				if (Material.GlowAttenuationData != 0)
 				{
-					alphafactor = (float)GetDistanceFactor(Vertices, ref Face, Material.GlowAttenuationData, CameraX, CameraY, CameraZ);
+					alphafactor = (float)GetDistanceFactor(Vertices, ref Face, Material.GlowAttenuationData, Camera);
 					float blend = inv255 * (float)Material.DaytimeNighttimeBlend + 1.0f - OptionLightingResultingAmount;
 					if (blend > 1.0f) blend = 1.0f;
 					alphafactor *= blend;
@@ -753,17 +761,17 @@ namespace OpenBve
 				}
 				else
 				{
-					GL.Material(MaterialFace.FrontAndBack, MaterialParameter.Emission, new float[] { 0.0f, 0.0f, 0.0f, 1.0f });
+					GL.Material(MaterialFace.FrontAndBack, MaterialParameter.Emission, defaultEmissiveState);
 				}
 				for (int j = 0; j < Face.Vertices.Length; j++)
 				{
-					GL.TexCoord2(Vertices[Face.Vertices[j].Index].TextureCoordinates.X, Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
+					GL.TexCoord2((float)Vertices[Face.Vertices[j].Index].TextureCoordinates.X, (float)Vertices[Face.Vertices[j].Index].TextureCoordinates.Y);
 					if (Vertices[Face.Vertices[j].Index] is ColoredVertex)
 					{
 						ColoredVertex v = (ColoredVertex) Vertices[Face.Vertices[j].Index];
 						GL.Color3(v.Color.R, v.Color.G, v.Color.B);
 					}
-					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
+					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
 				}
 				GL.End();
 				RestoreAlphaFunc();
@@ -784,8 +792,8 @@ namespace OpenBve
 				{
 					GL.Begin(PrimitiveType.Lines);
 					GL.Color4(inv255 * (float)Material.Color.R, inv255 * (float)Material.Color.G, inv255 * (float)Material.Color.B, 1.0f);
-					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - CameraZ));
-					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X + Face.Vertices[j].Normal.X - CameraX), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y + Face.Vertices[j].Normal.Y - CameraY), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z + Face.Vertices[j].Normal.Z - CameraZ));
+					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z - Camera.Z));
+					GL.Vertex3((float)(Vertices[Face.Vertices[j].Index].Coordinates.X + Face.Vertices[j].Normal.X - Camera.X), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Y + Face.Vertices[j].Normal.Y - Camera.Y), (float)(Vertices[Face.Vertices[j].Index].Coordinates.Z + Face.Vertices[j].Normal.Z - Camera.Z));
 					GL.End();
 				}
 			}

--- a/source/OpenBVE/Graphics/Renderer.cs
+++ b/source/OpenBVE/Graphics/Renderer.cs
@@ -125,16 +125,7 @@ namespace OpenBve
 				LoadTexturesImmediately = LoadTextureImmediatelyMode.Yes;
 			}
 			// set up camera
-			//double cx = World.AbsoluteCameraPosition.X;
-			//double cy = World.AbsoluteCameraPosition.Y;
-			//double cz = World.AbsoluteCameraPosition.Z;
-			double dx = World.AbsoluteCameraDirection.X;
-			double dy = World.AbsoluteCameraDirection.Y;
-			double dz = World.AbsoluteCameraDirection.Z;
-			double ux = World.AbsoluteCameraUp.X;
-			double uy = World.AbsoluteCameraUp.Y;
-			double uz = World.AbsoluteCameraUp.Z;
-			Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, World.AbsoluteCameraDirection.X, World.AbsoluteCameraDirection.Y, World.AbsoluteCameraDirection.Z, World.AbsoluteCameraUp.X, World.AbsoluteCameraUp.Y, World.AbsoluteCameraUp.Z);
 			GL.MatrixMode(MatrixMode.Modelview);
 			GL.LoadMatrix(ref lookat);
 			GL.Light(LightName.Light0, LightParameter.Position, new float[] { (float)OptionLightPosition.X, (float)OptionLightPosition.Y, (float)OptionLightPosition.Z, 0.0f });
@@ -146,9 +137,7 @@ namespace OpenBve
 				float frc = 1.0f - fr;
 				Game.CurrentFog.Start = Game.PreviousFog.Start * frc + Game.NextFog.Start * fr;
 				Game.CurrentFog.End = Game.PreviousFog.End * frc + Game.NextFog.End * fr;
-				Game.CurrentFog.Color.R = (byte)((float)Game.PreviousFog.Color.R * frc + (float)Game.NextFog.Color.R * fr);
-				Game.CurrentFog.Color.G = (byte)((float)Game.PreviousFog.Color.G * frc + (float)Game.NextFog.Color.G * fr);
-				Game.CurrentFog.Color.B = (byte)((float)Game.PreviousFog.Color.B * frc + (float)Game.NextFog.Color.B * fr);
+				Game.CurrentFog.Color = Game.PreviousFog.Color * frc + Game.NextFog.Color * fr;
 			}
 			else
 			{
@@ -361,7 +350,7 @@ namespace OpenBve
 			}
 			GL.LoadIdentity();
 			UpdateViewport(ViewPortChangeMode.ChangeToCab);
-			lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, World.AbsoluteCameraDirection.X, World.AbsoluteCameraDirection.Y, World.AbsoluteCameraDirection.Z, World.AbsoluteCameraUp.X, World.AbsoluteCameraUp.Y, World.AbsoluteCameraUp.Z);
 			GL.MatrixMode(MatrixMode.Modelview);
 			GL.LoadMatrix(ref lookat);
 			if (World.CameraRestriction == Camera.RestrictionMode.NotAvailable)

--- a/source/OpenBVE/Graphics/Renderer/Glow.cs
+++ b/source/OpenBVE/Graphics/Renderer/Glow.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Objects;
+﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 
 namespace OpenBve
 {
@@ -8,11 +9,9 @@ namespace OpenBve
 		/// <param name="Vertices">The verticies to which the glow is to be applied</param>
 		/// <param name="Face">The face which these vertices make up</param>
 		/// <param name="GlowAttenuationData">The current glow attenuation</param>
-		/// <param name="CameraX">The X-position of the camera</param>
-		/// <param name="CameraY">The Y-position of the camera</param>
-		/// <param name="CameraZ">The Z-position of the camera</param>
+		/// <param name="Camera">The camera position</param>
 		/// <returns></returns>
-		private static double GetDistanceFactor(VertexTemplate[] Vertices, ref World.MeshFace Face, ushort GlowAttenuationData, double CameraX, double CameraY, double CameraZ)
+		private static double GetDistanceFactor(VertexTemplate[] Vertices, ref World.MeshFace Face, ushort GlowAttenuationData, Vector3 Camera)
 		{
 			if (Face.Vertices.Length == 0)
 			{
@@ -22,19 +21,17 @@ namespace OpenBve
 			double halfdistance;
 			World.SplitGlowAttenuationData(GlowAttenuationData, out mode, out halfdistance);
 			int i = (int)Face.Vertices[0].Index;
-			double dx = Vertices[i].Coordinates.X - CameraX;
-			double dy = Vertices[i].Coordinates.Y - CameraY;
-			double dz = Vertices[i].Coordinates.Z - CameraZ;
+			Vector3 d = new Vector3(Vertices[i].Coordinates - Camera);
 			switch (mode)
 			{
 				case GlowAttenuationMode.DivisionExponent2:
 					{
-						double t = dx * dx + dy * dy + dz * dz;
+						double t = d.NormSquared();
 						return t / (t + halfdistance * halfdistance);
 					}
 				case GlowAttenuationMode.DivisionExponent4:
 					{
-						double t = dx * dx + dy * dy + dz * dz;
+						double t = d.NormSquared();
 						t *= t;
 						halfdistance *= halfdistance;
 						return t / (t + halfdistance * halfdistance);

--- a/source/OpenBVE/Parsers/Object/Generic/WavefrontObjParser.cs
+++ b/source/OpenBVE/Parsers/Object/Generic/WavefrontObjParser.cs
@@ -425,7 +425,10 @@ namespace OpenBve
 						{
 							Interface.AddMessage(MessageType.Warning, false, "Invalid Alpha in Material Definition for " + mm.Key);
 						}
-						mm.Color.A = (byte)((1 - a) * 255);
+						byte cr = mm.Color.R;
+						byte cg = mm.Color.G;
+						byte cb = mm.Color.B;
+						mm.Color = new Color32(cr, cg, cb, (byte)((1 - a) * 255));
 						break;
 					case "map_kd":
 					case "map_ka":

--- a/source/OpenBveApi/Graphics/Colors.cs
+++ b/source/OpenBveApi/Graphics/Colors.cs
@@ -56,6 +56,30 @@ namespace OpenBveApi.Colors {
 			return a.R != b.R | a.G != b.G | a.B != b.B;
 		}
 
+		/// <summary>Multiplies a color and a factor.</summary>
+		/// <param name="a">The color.</param>
+		/// <param name="b">The factor.</param>
+		/// <returns>The product of the color and the factor.</returns>
+		public static Color24 operator *(Color24 a, double b)
+		{
+			a.R *= (byte)b;
+			a.G *= (byte)b;
+			a.B *= (byte)b;
+			return a;
+		}
+
+		/// <summary>Adds two colors.</summary>
+		/// <param name="a">The first color.</param>
+		/// <param name="b">The second color.</param>
+		/// <returns>The resulting color.</returns>
+		public static Color24 operator +(Color24 a, Color24 b)
+		{
+			a.R += b.R;
+			a.G += b.G;
+			a.B += b.B;
+			return a;
+		}
+
 		/// <summary>Checks whether two colors are equal.</summary>
 		/// <param name="a">The first color.</param>
 		/// <param name="b">The second color.</param>

--- a/source/OpenBveApi/Graphics/Colors.cs
+++ b/source/OpenBveApi/Graphics/Colors.cs
@@ -14,11 +14,11 @@ namespace OpenBveApi.Colors {
 	public struct Color24 {
 		// --- members ---
 		/// <summary>The red component.</summary>
-		public byte R;
+		public readonly byte R;
 		/// <summary>The green component.</summary>
-		public byte G;
+		public readonly byte G;
 		/// <summary>The blue component.</summary>
-		public byte B;
+		public readonly byte B;
 		// --- constructors ---
 		/// <summary>Creates a new color.</summary>
 		/// <param name="r">The red component.</param>
@@ -62,10 +62,7 @@ namespace OpenBveApi.Colors {
 		/// <returns>The product of the color and the factor.</returns>
 		public static Color24 operator *(Color24 a, double b)
 		{
-			a.R *= (byte)b;
-			a.G *= (byte)b;
-			a.B *= (byte)b;
-			return a;
+			return new Color24((byte)((float)a.R * b), (byte)((float)a.G * b), (byte)((float)a.B * b));
 		}
 
 		/// <summary>Adds two colors.</summary>
@@ -74,10 +71,7 @@ namespace OpenBveApi.Colors {
 		/// <returns>The resulting color.</returns>
 		public static Color24 operator +(Color24 a, Color24 b)
 		{
-			a.R += b.R;
-			a.G += b.G;
-			a.B += b.B;
-			return a;
+			return new Color24((byte)(a.R + b.R), (byte)(a.G + b.G), (byte)(a.B + b.B));
 		}
 
 		/// <summary>Checks whether two colors are equal.</summary>
@@ -175,13 +169,13 @@ namespace OpenBveApi.Colors {
 	public struct Color32 {
 		// --- members ---
 		/// <summary>The red component.</summary>
-		public byte R;
+		public readonly byte R;
 		/// <summary>The green component.</summary>
-		public byte G;
+		public readonly byte G;
 		/// <summary>The blue component.</summary>
-		public byte B;
+		public readonly byte B;
 		/// <summary>The alpha component.</summary>
-		public byte A;
+		public readonly byte A;
 		// --- constructors ---
 		/// <summary>Creates a new color.</summary>
 		/// <param name="r">The red component.</param>
@@ -223,6 +217,16 @@ namespace OpenBveApi.Colors {
 			this.B = color.B;
 			this.A = 255;
 		}
+
+		/// <summary>Multiplies a color by a factor</summary>
+		/// <param name="a">The color</param>
+		/// <param name="b">The new factor</param>
+		/// <returns>The new color</returns>
+		public static Color32 operator *(Color32 a, double b)
+		{
+			return new Color32((byte)System.Math.Round((double)a.R * b), (byte)System.Math.Round((double)a.G * b), (byte)System.Math.Round((double)a.B * b));
+		}
+
 		// --- operators ---
 		/// <summary>Checks whether two colors are equal.</summary>
 		/// <param name="a">The first color.</param>
@@ -361,11 +365,11 @@ namespace OpenBveApi.Colors {
 	public struct Color96 {
 		// --- members ---
 		/// <summary>The red component.</summary>
-		public float R;
+		public readonly float R;
 		/// <summary>The green component.</summary>
-		public float G;
+		public readonly float G;
 		/// <summary>The blue component.</summary>
-		public float B;
+		public readonly float B;
 		// --- constructors ---
 		/// <summary>Creates a new color.</summary>
 		/// <param name="r">The red component.</param>
@@ -452,13 +456,13 @@ namespace OpenBveApi.Colors {
 	public struct Color128 {
 		// --- members ---
 		/// <summary>The red component.</summary>
-		public float R;
+		public readonly float R;
 		/// <summary>The green component.</summary>
-		public float G;
+		public readonly float G;
 		/// <summary>The blue component.</summary>
-		public float B;
+		public readonly float B;
 		/// <summary>The alpha component.</summary>
-		public float A;
+		public readonly float A;
 		// --- constructors ---
 		/// <summary>Creates a new color.</summary>
 		/// <param name="r">The red component.</param>

--- a/source/Plugins/Texture.Dds/Plugin.Parser.cs
+++ b/source/Plugins/Texture.Dds/Plugin.Parser.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.IO;
-using OpenBveApi.Colors;
 using OpenBveApi.Textures;
 
 namespace Plugin
@@ -1638,6 +1637,14 @@ namespace Plugin
             public ushort blue; //: 5;
             public ushort green; //: 6;
             public ushort red; //: 5;
+        }
+
+        private struct Color32
+        {
+	        internal byte R;
+	        internal byte G;
+	        internal byte B;
+	        internal byte A;
         }
 
         private struct DdsHeader

--- a/source/RouteViewer/ObjectManager.cs
+++ b/source/RouteViewer/ObjectManager.cs
@@ -655,10 +655,9 @@ namespace OpenBve {
 			}
 			double r = 0.0;
 			for (int i = 0; i < AnimatedWorldObjects[a].Object.States.Length; i++) {
-				for (int j = 0; j < AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials.Length; j++) {
-					AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.R * Brightness);
-					AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.G * Brightness);
-					AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)Prototype.States[i].Object.Mesh.Materials[j].Color.B * Brightness);
+				for (int j = 0; j < AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials.Length; j++)
+				{
+					AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Materials[j].Color = Prototype.States[i].Object.Mesh.Materials[j].Color * Brightness;
 				}
 				for (int j = 0; j < AnimatedWorldObjects[a].Object.States[i].Object.Mesh.Vertices.Length; j++) {
 					double x = Prototype.States[i].Object.Mesh.Vertices[j].Coordinates.X;
@@ -1417,9 +1416,7 @@ namespace OpenBve {
 			Object.Mesh.Materials = new World.MeshMaterial[Prototype.Mesh.Materials.Length];
 			for (int j = 0; j < Prototype.Mesh.Materials.Length; j++) {
 				Object.Mesh.Materials[j] = Prototype.Mesh.Materials[j];
-				Object.Mesh.Materials[j].Color.R = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.R * Brightness);
-				Object.Mesh.Materials[j].Color.G = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.G * Brightness);
-				Object.Mesh.Materials[j].Color.B = (byte)Math.Round((double)Prototype.Mesh.Materials[j].Color.B * Brightness);
+				Object.Mesh.Materials[j].Color = Prototype.Mesh.Materials[j].Color * Brightness;
 			}
 			const double minBlockLength = 20.0;
 			if (BlockLength < minBlockLength) {

--- a/source/RouteViewer/Parsers/WavefrontObjParser.cs
+++ b/source/RouteViewer/Parsers/WavefrontObjParser.cs
@@ -425,7 +425,10 @@ namespace OpenBve
 						{
 							Interface.AddMessage(MessageType.Warning, false, "Invalid Alpha in Material Definition for " + mm.Key);
 						}
-						mm.Color.A = (byte)((1 - a) * 255);
+						byte cr = mm.Color.R;
+						byte cg = mm.Color.G;
+						byte cb = mm.Color.B;
+						mm.Color = new Color32(cr, cg, cb, (byte)((1 - a) * 255));
 						break;
 					case "map_kd":
 					case "map_ka":

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -243,9 +243,7 @@ namespace OpenBve {
 				float frc = 1.0f - fr;
 				Game.CurrentFog.Start = Game.PreviousFog.Start * frc + Game.NextFog.Start * fr;
 				Game.CurrentFog.End = Game.PreviousFog.End * frc + Game.NextFog.End * fr;
-				Game.CurrentFog.Color.R = (byte)((float)Game.PreviousFog.Color.R * frc + (float)Game.NextFog.Color.R * fr);
-				Game.CurrentFog.Color.G = (byte)((float)Game.PreviousFog.Color.G * frc + (float)Game.NextFog.Color.G * fr);
-				Game.CurrentFog.Color.B = (byte)((float)Game.PreviousFog.Color.B * frc + (float)Game.NextFog.Color.B * fr);
+				Game.CurrentFog.Color = Game.PreviousFog.Color * frc + Game.NextFog.Color * fr;
 			} else {
 				Game.CurrentFog = Game.PreviousFog;
 				


### PR DESCRIPTION
This PR makes some marginal optimisations in the renderer.

TLDR:
openGL internally operates on a 4-byte (32-bit) byte alignment.
We already deliberately cast our vertex co-ordinates to float when passing them to openGL, this does the same for our normals & texture co-ordinates, which appear to have been overlooked for this.

It also makes a couple of arrays passed to openGL as default parameters static readonly, as opposed to re-creating every frame.

## Benchmarks:
### Previous:
```
2019-01-14 12:30:51 - OpenBve
Frames: 5463 - Time: 29640ms - Avg: 184.312 - Min: 164 - Max: 188
```
### New:
```
2019-01-14 12:28:15 - OpenBve
Frames: 5538 - Time: 29625ms - Avg: 186.937 - Min: 172 - Max: 191
```

FPS measurements are marginal mind, and we've definitely found in the past that the runtime caching things can have an effect. (Usually negated on the second load of the program)

This is sitting as PR for the minute until it's been a little more widely tested, just in case it causes lighting or texturing glitches on any edge cases.
