### PR TITLE
New: Add coupler stretch / compress sounds

### DIFF
--- a/source/CarXMLConvertor/Convert.SoundCfg.cs
+++ b/source/CarXMLConvertor/Convert.SoundCfg.cs
@@ -808,6 +808,42 @@ namespace CarXmlConvertor
                         }
                         i--;
                         break;
+                    case "[coupler]":
+	                    newLines.Add("<Coupler>");
+	                    i++; while (i < Lines.Length && !Lines[i].StartsWith("[", StringComparison.Ordinal))
+	                    {
+		                    int j = Lines[i].IndexOf("=", StringComparison.Ordinal);
+		                    if (j >= 0)
+		                    {
+			                    string a = Lines[i].Substring(0, j).TrimEnd();
+			                    string b = Lines[i].Substring(j + 1).TrimStart();
+			                    if (b.Length == 0 || Path.ContainsInvalidChars(b))
+			                    {
+				                    continue;
+			                    }
+			                    switch (a.ToLowerInvariant())
+			                    {
+				                    case "stretch":
+					                    newLines.Add("<Stretch>");
+					                    newLines.Add("<FileName>" + b + "</FileName>");
+					                    newLines.Add("<Position>"+ front + "</Position>");
+					                    newLines.Add("<Radius>2.0</Radius>");
+					                    newLines.Add("</Stretch>");
+					                    break;
+				                    case "compress":
+					                    newLines.Add("<Compress>");
+					                    newLines.Add("<FileName>" + b + "</FileName>");
+					                    newLines.Add("<Position>"+ front + "</Position>");
+					                    newLines.Add("<Radius>2.0</Radius>");
+					                    newLines.Add("</Compress>");
+					                    break;
+			                    }
+		                    }
+		                    i++;
+	                    }
+	                    i--;
+	                    newLines.Add("</Coupler>");
+	                    break;
                 }
             }
             newLines.Add("</CarSounds>");

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
@@ -810,6 +810,43 @@ namespace OpenBve
 							i++;
 						}
 						i--; break;
+					case "[coupler]":
+						i++; while (i < Lines.Count && !Lines[i].StartsWith("[", StringComparison.Ordinal))
+						{
+							int j = Lines[i].IndexOf("=", StringComparison.Ordinal);
+							if (j >= 0)
+							{
+								string a = Lines[i].Substring(0, j).TrimEnd();
+								string b = Lines[i].Substring(j + 1).TrimStart();
+								if (b.Length == 0 || Path.ContainsInvalidChars(b))
+								{
+									Interface.AddMessage(MessageType.Error, false, "FileName contains illegal characters or is empty at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+								}
+								else
+								{
+									switch (a.ToLowerInvariant())
+									{
+										case "compress":
+											for (int c = 0; c < train.Cars.Length; c++)
+											{
+												train.Cars[c].Sounds.CouplerCompress = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), front, SoundCfgParser.tinyRadius);
+											}
+											break;
+										case "stretch":
+											for (int c = 0; c < train.Cars.Length; c++)
+											{
+												train.Cars[c].Sounds.CouplerStretch = new TrainManager.CarSound(OpenBveApi.Path.CombineFile(trainFolder, b), front, SoundCfgParser.tinyRadius);
+											}
+											break;
+										default:
+											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+											break;
+									}
+								}
+							}
+							i++;
+						}
+						i--; break;
 				}
 			}
 			for (int i = 0; i < train.Cars.Length; i++)

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
@@ -481,6 +481,28 @@ namespace OpenBve
 										}
 									}
 									break;
+								case "coupler":
+									if (!c.ChildNodes.OfType<XmlElement>().Any())
+									{
+										Interface.AddMessage(MessageType.Error, false, "An empty list of suspension sounds was defined in in XML file " + fileName);
+										break;
+									}
+									foreach (XmlNode cc in c.ChildNodes)
+									{
+										switch (cc.Name.ToLowerInvariant())
+										{
+											case "compress":
+												ParseNode(cc, out car.Sounds.CouplerCompress, front, SoundCfgParser.smallRadius);
+												break;
+											case "stretch":
+												ParseNode(cc, out car.Sounds.CouplerStretch, front, SoundCfgParser.smallRadius);
+												break;
+											default:
+												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
+												break;
+										}
+									}
+									break;
 							}
 						}
 					}

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSounds.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSounds.cs
@@ -34,7 +34,12 @@
 			internal CarSound[] Flange;
 			internal double[] FlangeVolume;
 			internal CarSound Halt;
-			
+			/// <summary>Played once when the coupler stretches</summary>
+			internal CarSound CouplerStretch;
+			internal bool couplerStretched;
+			/// <summary>Played once when the coupler compresses</summary>
+			internal CarSound CouplerCompress;
+			internal bool couplerCompressed;
 			internal CarSound Loop;
 			internal CarSound MasterControllerUp;
 			internal CarSound MasterControllerUpFast;

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -767,6 +767,12 @@ namespace OpenBve
 						double d = CenterOfCarPositions[i] - CenterOfCarPositions[i + 1] - 0.5 * (Cars[i].Length + Cars[i + 1].Length);
 						if (d < min)
 						{
+							if (min != max && Cars[i].Sounds.couplerCompressed == false && !Game.MinimalisticSimulation)
+							{
+								Cars[i].Sounds.couplerStretched = false;
+								Sounds.PlayCarSound(Cars[i].Sounds.CouplerCompress, 1.0, 1.0, this, i, false);
+								Cars[i].Sounds.couplerCompressed = true;
+							}
 							double t = min - d + 0.0001;
 							Cars[i].UpdateTrackFollowers(t, false, false);
 							CenterOfCarPositions[i] += t;
@@ -774,6 +780,12 @@ namespace OpenBve
 						}
 						else if (d > max & !Cars[i].Derailed & !Cars[i + 1].Derailed)
 						{
+							if (min != max && Cars[i].Sounds.couplerStretched == false && !Game.MinimalisticSimulation)
+							{
+								Cars[i].Sounds.couplerCompressed = false;
+								Sounds.PlayCarSound(Cars[i].Sounds.CouplerStretch, 1.0, 1.0, this, i, false);
+								Cars[i].Sounds.couplerStretched = true;
+							}
 							double t = d - max + 0.0001;
 							Cars[i].UpdateTrackFollowers(-t, false, false);
 							CenterOfCarPositions[i] -= t;
@@ -788,6 +800,12 @@ namespace OpenBve
 						double d = CenterOfCarPositions[i - 1] - CenterOfCarPositions[i] - 0.5 * (Cars[i].Length + Cars[i - 1].Length);
 						if (d < min)
 						{
+							if (min != max && Cars[i].Sounds.couplerCompressed == false && !Game.MinimalisticSimulation)
+							{
+								Cars[i].Sounds.couplerStretched = false;
+								Sounds.PlayCarSound(Cars[i].Sounds.CouplerCompress, 1.0, 1.0, this, i, false);
+								Cars[i].Sounds.couplerCompressed = true;
+							}
 							double t = min - d + 0.0001;
 							Cars[i].UpdateTrackFollowers(-t, false, false);
 							CenterOfCarPositions[i] -= t;
@@ -795,11 +813,31 @@ namespace OpenBve
 						}
 						else if (d > max & !Cars[i].Derailed & !Cars[i - 1].Derailed)
 						{
+							if (min != max && Cars[i].Sounds.couplerStretched == false &&  !Game.MinimalisticSimulation)
+							{
+								Cars[i].Sounds.couplerCompressed = false;
+								Sounds.PlayCarSound(Cars[i].Sounds.CouplerStretch, 1.0, 1.0, this, i, false);
+								Cars[i].Sounds.couplerStretched = true;
+							}
 							double t = d - max + 0.0001;
 							Cars[i].UpdateTrackFollowers(t, false, false);
-
 							CenterOfCarPositions[i] += t;
 							CouplerCollision[i - 1] = true;
+						}
+					}
+
+					if (Specs.CurrentAverageSpeed == 0.0)
+					{
+						for (int i = 0; i < Cars.Length; i++)
+						{
+							/*
+							 * Failsafe:
+							 * Reset the coupler stretch / compress states if stopped
+							 * This is important due to the fact that we don't simulate unbraked cars
+							 * at present, so compression doesn't always happen
+							 */
+							Cars[i].Sounds.couplerCompressed = false;
+							Cars[i].Sounds.couplerStretched = false;
 						}
 					}
 					// update speeds


### PR DESCRIPTION
This PR adds sounds played when the couplers stretch and compress.
These are ignored when the coupler distance is 0.

Sound.cfg:
```
[Coupler]
Stretch = file.wav
Compress = file.wav
```

Sound.xml
```XML
<Coupler>
    <Stretch>
        <FileName>file.wav</FileName>
        <Position>0,0,5</Position>
        <Radius>2.0</Radius>
    </Stretch>

    <Compress>
        <FileName>file.wav</FileName>
        <Position>0,0,5</Position>
        <Radius>2.0</Radius>
        </Compress>
</Coupler>
```

**Flaws:**
* The default coupler stretch / compress distance is 5cm- In a typical train, the slack is taken up almost instantly, and it doesn't sound perfect.
* We don't currently simulate unbraked cars, which means that the compress sound is only really heard as the train comes to a stand. 
* Using the default minimum radius, we can still hear more coupler sounds than I'd like. Perhaps drop the radius to 0.5?