### PR TITLE
Fix: crash when loading

### DIFF
--- a/source/OpenBVE/Graphics/Fonts.cs
+++ b/source/OpenBVE/Graphics/Fonts.cs
@@ -145,7 +145,10 @@ namespace OpenBve {
 				int lo = value & 0xFF;
 				if (this.Tables[hi] == null || this.Tables[hi].Texture == null)
 				{
-					this.Tables[hi] = new OpenGlFontTable(this.Font, hi << 8);
+					lock (Illustrations.Locker)
+					{
+						this.Tables[hi] = new OpenGlFontTable(this.Font, hi << 8);
+					}
 				}
 				texture = this.Tables[hi].Texture;
 				data = this.Tables[hi].Characters[lo];


### PR DESCRIPTION
This PR fix crash when loading.
Occasionally, OpenBVE will abnormally terminate with the following crash log when loading.
[OpenBVE Crash- 2019.2.28[08.08].log](https://github.com/leezer3/OpenBVE/files/2912696/OpenBVE.Crash-.2019.2.28.08.08.log)
When I debug, the program stops with the following code.
https://github.com/leezer3/OpenBVE/blob/master/source/OpenBVE/System/Functions/Illustrations.cs#L303
I thought that GDI+ is not thread-safe and that problems have occurred with other Draw-like functions that are not locked.
When I locked the following function it no longer crashes.
https://github.com/leezer3/OpenBVE/blob/master/source/OpenBVE/Graphics/Fonts.cs#L45
This function is called during loading.