### PR TITLE
Change: Create matrix methods in openBVE API & use these

### DIFF
--- a/source/ObjectViewer/ObjectViewer.csproj
+++ b/source/ObjectViewer/ObjectViewer.csproj
@@ -39,6 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>false</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using OpenBveApi.World;
 using OpenBveApi.FileSystem;
 using OpenBveApi.Interface;
+using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenTK;
 using OpenTK.Graphics;
@@ -146,8 +147,14 @@ namespace OpenBve {
             World.AspectRatio = (double)Renderer.ScreenWidth / (double)Renderer.ScreenHeight;
             World.HorizontalViewingAngle = 2.0 * Math.Atan(Math.Tan(0.5 * World.VerticalViewingAngle) * World.AspectRatio);
             GL.MatrixMode(MatrixMode.Projection);
-            Matrix4d perspective = Matrix4d.CreatePerspectiveFieldOfView(World.VerticalViewingAngle, World.AspectRatio, 0.2, 1000.0);
-            GL.LoadMatrix(ref perspective);
+            Matrix4D perspective = Matrix4D.CreatePerspectiveFieldOfView(World.VerticalViewingAngle, World.AspectRatio, 0.2, 1000.0);
+            unsafe
+            {
+	            double* matrixPointer = &perspective.Row0.X;
+	            {
+		            GL.LoadMatrix(matrixPointer);
+	            }
+            }
             GL.Scale(-1, 1, 1);
             GL.MatrixMode(MatrixMode.Modelview);
             GL.LoadIdentity();

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -15,6 +15,7 @@ using Vector3 = OpenBveApi.Math.Vector3;
 using OpenBveApi.Objects;
 using OpenBveApi.Graphics;
 using OpenBveApi.Interface;
+using OpenBveApi.Math;
 
 namespace OpenBve
 {
@@ -181,8 +182,15 @@ namespace OpenBve
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
             GL.PushMatrix();
             GL.ClearColor(0.67f, 0.67f, 0.67f, 1.0f);
-            var mat = Matrix4d.LookAt(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0);
-            GL.MultMatrix(ref mat);
+            Matrix4D mat = Matrix4D.LookAt(Vector3.Zero, Vector3.Forward, Vector3.Down);
+            unsafe
+            {
+	            double* matrixPointer = &mat.Row0.X;
+	            {
+		            GL.MultMatrix(matrixPointer);
+	            }
+            }
+
             GL.PopMatrix();
             TransparentColorDepthSorting = Interface.CurrentOptions.TransparencyMode == TransparencyMode.Quality & Interface.CurrentOptions.Interpolation != InterpolationMode.NearestNeighbor & Interface.CurrentOptions.Interpolation != InterpolationMode.Bilinear;
         }
@@ -244,8 +252,14 @@ namespace OpenBve
             }
 	        
             // setup camera
-            var mat = Matrix4d.LookAt(0.0, 0.0, 0.0, World.AbsoluteCameraDirection.X, World.AbsoluteCameraDirection.Y, World.AbsoluteCameraDirection.Z, World.AbsoluteCameraUp.X, World.AbsoluteCameraUp.Y, World.AbsoluteCameraUp.Z);
-            GL.MultMatrix(ref mat);
+            Matrix4D mat = Matrix4D.LookAt(Vector3.Zero, World.AbsoluteCameraDirection, World.AbsoluteCameraUp);
+            unsafe
+            {
+	            double* matrixPointer = &mat.Row0.X;
+	            {
+		            GL.MultMatrix(matrixPointer);
+	            }
+            }
             if (OptionLighting)
             {
                 GL.Light(LightName.Light0, LightParameter.Position, new float[] { (float)OptionLightPosition.X, (float)OptionLightPosition.Y, (float)OptionLightPosition.Z, 0.0f });

--- a/source/OpenBVE/Graphics/Renderer.cs
+++ b/source/OpenBVE/Graphics/Renderer.cs
@@ -1,5 +1,6 @@
 ﻿using OpenBveApi.Colors;
 using OpenBveApi.Graphics;
+using OpenBveApi.Math;
 using OpenBveApi.Textures;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -117,15 +118,15 @@ namespace OpenBve
 				LoadTexturesImmediately = LoadTextureImmediatelyMode.Yes;
 			}
 			// set up camera
-			double dx = World.AbsoluteCameraDirection.X;
-			double dy = World.AbsoluteCameraDirection.Y;
-			double dz = World.AbsoluteCameraDirection.Z;
-			double ux = World.AbsoluteCameraUp.X;
-			double uy = World.AbsoluteCameraUp.Y;
-			double uz = World.AbsoluteCameraUp.Z;
-			Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			Matrix4D lookat = Matrix4D.LookAt(Vector3.Zero, World.AbsoluteCameraDirection, World.AbsoluteCameraUp);
 			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref lookat);
+			unsafe
+			{
+				double* matrixPointer = &lookat.Row0.X;
+				{
+					GL.LoadMatrix(matrixPointer);
+				}
+			}
 			GL.Light(LightName.Light0, LightParameter.Position, new float[] { (float)OptionLightPosition.X, (float)OptionLightPosition.Y, (float)OptionLightPosition.Z, 0.0f });
 			// fog
 			double fd = Game.NextFog.TrackPosition - Game.PreviousFog.TrackPosition;
@@ -350,9 +351,15 @@ namespace OpenBve
 			}
 			GL.LoadIdentity();
 			UpdateViewport(ViewPortChangeMode.ChangeToCab);
-			lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			lookat = Matrix4D.LookAt(Vector3.Zero, World.AbsoluteCameraDirection, World.AbsoluteCameraUp);
 			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref lookat);
+			unsafe
+			{
+				double* matrixPointer = &lookat.Row0.X;
+				{
+					GL.LoadMatrix(matrixPointer);
+				}
+			}
 			if (World.CameraRestriction == Camera.RestrictionMode.NotAvailable)
 			{
 				// 3d cab

--- a/source/OpenBVE/Graphics/Renderer/Functions.cs
+++ b/source/OpenBVE/Graphics/Renderer/Functions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using OpenBveApi.Colors;
-using OpenTK;
+using OpenBveApi.Math;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using Vector3 = OpenBveApi.Math.Vector3;
@@ -120,9 +120,15 @@ namespace OpenBve
             GL.Disable(EnableCap.Texture2D); TexturingEnabled = false;
             HUD.LoadHUD();
             InitLoading();
-            Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0);
+            Matrix4D lookat = Matrix4D.LookAt(Vector3.Zero, Vector3.Forward, Vector3.Down);
             GL.MatrixMode(MatrixMode.Modelview);
-            GL.LoadMatrix(ref lookat);
+            unsafe
+            {
+	            double* matrixPointer = &lookat.Row0.X;
+	            {
+		            GL.LoadMatrix(matrixPointer);
+	            }
+            }
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             GL.Enable(EnableCap.Blend); BlendEnabled = true;
             GL.Disable(EnableCap.Lighting); LightingEnabled = false;
@@ -185,15 +191,27 @@ namespace OpenBve
 		    if (CurrentViewPortMode == ViewPortMode.Cab)
 		    {
 
-			    Matrix4d perspective = Matrix4d.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.025, 50.0);
-			    GL.MultMatrix(ref perspective);
+			    Matrix4D perspective = Matrix4D.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.025, 50.0);
+			    unsafe
+			    {
+				    double* matrixPointer = &perspective.Row0.X;
+				    {
+					    GL.MultMatrix(matrixPointer);
+				    }
+			    }
 		    }
 		    else
 		    {
 			    var b = BackgroundManager.CurrentBackground as BackgroundManager.BackgroundObject;
 			    var cd = b != null ? Math.Max(World.BackgroundImageDistance, b.ClipDistance) : World.BackgroundImageDistance;
-			    Matrix4d perspective = Matrix4d.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.5, cd);
-			    GL.MultMatrix(ref perspective);
+			    Matrix4D perspective = Matrix4D.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.5, cd);
+			    unsafe
+			    {
+				    double* matrixPointer = &perspective.Row0.X;
+				    {
+					    GL.MultMatrix(matrixPointer);
+				    }
+			    }
 		    }
 		    GL.MatrixMode(MatrixMode.Modelview);
 		    GL.LoadIdentity();

--- a/source/OpenBVE/Graphics/Renderer/Touch.cs
+++ b/source/OpenBVE/Graphics/Renderer/Touch.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenBveApi.Interface;
+using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Runtime;
 using OpenBveApi.Textures;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using Vector2 = OpenTK.Vector2;
+using Vector3 = OpenBveApi.Math.Vector3;
 
 namespace OpenBve
 {
@@ -157,8 +160,14 @@ namespace OpenBve
 			GL.MatrixMode(MatrixMode.Projection);
 			GL.LoadIdentity();
 			PickMatrix(new Vector2(Point.X, Viewport[3] - Point.Y), Delta, Viewport);
-			Matrix4d perspective = Matrix4d.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.025, 50.0);
-			GL.MultMatrix(ref perspective);
+			Matrix4D perspective = Matrix4D.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.025, 50.0);
+			unsafe
+			{
+				double* matrixPointer = &perspective.Row0.X;
+				{
+					GL.MultMatrix(matrixPointer);
+				}
+			}
 			GL.MatrixMode(MatrixMode.Modelview);
 			GL.LoadIdentity();
 		}
@@ -193,9 +202,15 @@ namespace OpenBve
 			double ux = World.AbsoluteCameraUp.X;
 			double uy = World.AbsoluteCameraUp.Y;
 			double uz = World.AbsoluteCameraUp.Z;
-			Matrix4d LookAt = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			Matrix4D LookAt = Matrix4D.LookAt(Vector3.Zero, World.AbsoluteCameraDirection, World.AbsoluteCameraUp);
 			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref LookAt);
+			unsafe
+			{
+				double* matrixPointer = &LookAt.Row0.X;
+				{
+					GL.LoadMatrix(matrixPointer);
+				}
+			}
 
 			if (LightingEnabled)
 			{

--- a/source/OpenBveApi/Math/Matrix4.cs
+++ b/source/OpenBveApi/Math/Matrix4.cs
@@ -1,8 +1,11 @@
-﻿using System.IO;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace OpenBveApi.Math
 {
 	/// <summary>Represents a 4x4 double-precision matrix</summary>
+	[StructLayout(LayoutKind.Sequential)]
 	public struct Matrix4D
 	{
 		/// <summary>The top row of the matrix</summary>
@@ -107,6 +110,166 @@ namespace OpenBveApi.Math
 			if (a.Row2 != b.Row2) return true;
 			if (a.Row3 != b.Row3) return true;
 			return false;
+		}
+
+		/// <summary>Builds a camera-space to world-space matrix</summary>
+		/// <param name="eyePosition">The eye position</param>
+		/// <param name="targetPosition">The target position in world-space</param>
+		/// <param name="Up">The world-space up vector</param>
+		/// <returns>The matrix which transforms camera space to world-space</returns>
+		public static Matrix4D LookAt(Vector3 eyePosition, Vector3 targetPosition, Vector3 Up)
+		{
+			Vector3 z;
+			if (eyePosition == Vector3.Zero && targetPosition == Vector3.Zero)
+			{
+				z = Vector3.Zero;
+			}
+			else
+			{
+				z = Vector3.Normalize(eyePosition - targetPosition);
+			}
+			Vector3 x = Vector3.Cross(Up, z);
+			Vector3 y = Vector3.Cross(z, x);
+
+
+			Matrix4D rotationMatrix = new Matrix4D
+			{
+				Row0 = new Vector4(x.X, y.X, z.X, 0.0),
+				Row1 = new Vector4(x.Y, y.Y, z.Y, 0.0),
+				Row2 = new Vector4(x.Z, y.Z, z.Z, 0.0),
+				Row3 = new Vector4(0.0, 0.0,0.0,1.0)
+			};
+			Matrix4D translationMatrix = NoTransformation;
+			translationMatrix.Row3 = new Vector4(-eyePosition.X, -eyePosition.Y, -eyePosition.Z, 1.0);
+			return translationMatrix * rotationMatrix;
+		}
+		/// <summary>Creates a perspective matrix</summary>
+		/// <param name="fieldOfViewY">The field of view Y angle in radians</param>
+		/// <param name="aspectRatio">The aspect ratio</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns></returns>
+		public static Matrix4D Perspective(double fieldOfViewY, double aspectRatio, double zNear, double zFar)
+		{
+			double yMax = zNear * System.Math.Tan(fieldOfViewY * System.Math.PI / 6.28319); //360 degrees in radians
+			double yMin = -yMax;
+			double xMin = yMin * aspectRatio;
+			double xMax = yMax * aspectRatio;
+
+			return Frustum(xMin, xMax, yMin, yMax, zNear, zFar);
+		}
+
+		/// <summary>Creates a matrix which transforms camera space to the viewing frustrum</summary>
+		/// <param name="left">The left side of the frustrum</param>
+		/// <param name="right">The right side of the frustrum</param>
+		/// <param name="bottom">The bottom of the frustrum</param>
+		/// <param name="top">The top of the frustrum</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns></returns>
+		public static Matrix4D Frustum(double left, double right, double bottom, double top, double zNear, double zFar)
+		{
+			double inverseRightLeft = 1.0 / (right - left);
+			double inverseTopBottom = 1.0 / (top - bottom);
+			double inverseFarNear = 1.0 / (zFar - zNear);
+			return new Matrix4D(new Vector4 (2.0 * zNear * inverseRightLeft, 0.0, 0.0, 0.0),
+				new Vector4 (0.0, 2.0 * zNear * inverseTopBottom, 0.0, 0.0),
+				new Vector4 ((right + left) * inverseRightLeft, (top + bottom) * inverseTopBottom, -(zFar + zNear) * inverseFarNear, -1.0),
+				new Vector4 (0.0, 0.0, -2.0 * zFar * zNear * inverseFarNear, 0.0));
+		}
+
+		/// <summary>Creates a perspective projection matrix</summary>
+		/// <param name="fieldOfViewY">The field of view Y angle in radians</param>
+		/// <param name="aspectRatio">The aspect ratio</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns>The perspective projection matrix</returns>
+		public static Matrix4D CreatePerspectiveFieldOfView(double fieldOfViewY, double aspectRatio, double zNear, double zFar)
+		{
+			//https://www.cs.rit.edu/usr/local/pub/wrc/graphics/doc/opengl/books/blue/gluPerspective.html
+			if (fieldOfViewY <= 0 || fieldOfViewY > System.Math.PI)
+			{
+				throw new ArgumentOutOfRangeException("fieldOfViewY", "fieldOfViewY must be positive and less than Pi");
+			}
+			if (aspectRatio <= 0)
+			{
+				throw new ArgumentOutOfRangeException("aspectRatio", "aspectRatio must be positive");
+			}
+			if (zNear <= 0)
+			{
+				throw new ArgumentOutOfRangeException("zNear", "zNear must be positive");
+			}
+			if (zFar <= 0)
+			{
+				throw new ArgumentOutOfRangeException("zFar", "zFar must be positive");
+			}
+			
+			double yMax = zNear * System.Math.Tan(fieldOfViewY * System.Math.PI / 6.28319); //360 degrees in radians
+			double yMin = -yMax;
+			double xMin = yMin * aspectRatio;
+			double xMax = yMax * aspectRatio;
+
+			return CreatePerspectiveOffCenter(xMin, xMax, yMin, yMax, zNear, zFar);
+		}
+
+		/// <summary>Creates a perspective projection matrix, assuming that the eye is located at 0,0,0</summary>
+		/// <param name="left">The left side of the frustrum</param>
+		/// <param name="right">The right side of the frustrum</param>
+		/// <param name="bottom">The bottom of the frustrum</param>
+		/// <param name="top">The top of the frustrum</param>
+		/// <param name="zNear">Distance to the near clip plane</param>
+		/// <param name="zFar">Distance to the far clip plane</param>
+		/// <returns>The perspective projection matrix</returns>
+		public static Matrix4D CreatePerspectiveOffCenter(double left, double right, double bottom, double top, double zNear, double zFar)
+		{
+			//https://www.cs.rit.edu/usr/local/pub/wrc/graphics/doc/opengl/books/blue/glFrustum.html
+			if (zNear <= 0)
+			{
+				throw new ArgumentOutOfRangeException("zNear", "zNear must be positive");
+			}
+			if (zFar <= 0)
+			{
+				throw new ArgumentOutOfRangeException("zFar", "zFar must be positive");
+			}
+			if (zNear >= zFar)
+			{
+				throw new ArgumentOutOfRangeException("zNear", "zNear must be less than or equal to zFar");
+			}
+
+			double x = (2.0 * zNear) / (right - left);
+			double y = (2.0 * zNear) / (top - bottom);
+			double a = (right + left) / (right - left);
+			double b = (top + bottom) / (top - bottom);
+			double c = -(zFar + zNear) / (zFar - zNear);
+			double d = -(2.0 * zFar * zNear) / (zFar - zNear);
+			//Remember that we assume the eye is located at 0,0,0
+			return new Matrix4D(new Vector4(x, 0, 0, 0), new Vector4(0, y, 0, 0), new Vector4(a, b, c, -1), new Vector4(0, 0, d, 0));
+		}
+
+		/// <summary>Multiplies two matrices</summary>
+		/// <param name="left">The left matrix</param>
+		/// <param name="right">The right matrix</param>
+		/// <returns>The new multiplied matrix</returns>
+		public static Matrix4D operator *(Matrix4D left, Matrix4D right)
+		{
+			Matrix4D result = new Matrix4D();
+			result.Row0.X = (((left.Row0.X * right.Row0.X) + (left.Row0.Y * right.Row1.X)) + (left.Row0.Z * right.Row2.X)) + (left.Row0.W * right.Row3.X);
+			result.Row0.Y = (((left.Row0.X * right.Row0.Y) + (left.Row0.Y * right.Row1.Y)) + (left.Row0.Z * right.Row2.Y)) + (left.Row0.W * right.Row3.Y);
+			result.Row0.Z = (((left.Row0.X * right.Row0.Z) + (left.Row0.Y * right.Row1.Z)) + (left.Row0.Z * right.Row2.Z)) + (left.Row0.W * right.Row3.Z);
+			result.Row0.W = (((left.Row0.X * right.Row0.W) + (left.Row0.Y * right.Row1.W)) + (left.Row0.Z * right.Row2.W)) + (left.Row0.W * right.Row3.W);
+			result.Row1.X = (((left.Row1.X * right.Row0.X) + (left.Row1.Y * right.Row1.X)) + (left.Row1.Z * right.Row2.X)) + (left.Row1.W * right.Row3.X);
+			result.Row1.Y = (((left.Row1.X * right.Row0.Y) + (left.Row1.Y * right.Row1.Y)) + (left.Row1.Z * right.Row2.Y)) + (left.Row1.W * right.Row3.Y);
+			result.Row1.Z = (((left.Row1.X * right.Row0.Z) + (left.Row1.Y * right.Row1.Z)) + (left.Row1.Z * right.Row2.Z)) + (left.Row1.W * right.Row3.Z);
+			result.Row1.W = (((left.Row1.X * right.Row0.W) + (left.Row1.Y * right.Row1.W)) + (left.Row1.Z * right.Row2.W)) + (left.Row1.W * right.Row3.W);
+			result.Row2.X = (((left.Row2.X * right.Row0.X) + (left.Row2.Y * right.Row1.X)) + (left.Row2.Z * right.Row2.X)) + (left.Row2.W * right.Row3.X);
+			result.Row2.Y = (((left.Row2.X * right.Row0.Y) + (left.Row2.Y * right.Row1.Y)) + (left.Row2.Z * right.Row2.Y)) + (left.Row2.W * right.Row3.Y);
+			result.Row2.Z = (((left.Row2.X * right.Row0.Z) + (left.Row2.Y * right.Row1.Z)) + (left.Row2.Z * right.Row2.Z)) + (left.Row2.W * right.Row3.Z);
+			result.Row2.W = (((left.Row2.X * right.Row0.W) + (left.Row2.Y * right.Row1.W)) + (left.Row2.Z * right.Row2.W)) + (left.Row2.W * right.Row3.W);
+			result.Row3.X = (((left.Row3.X * right.Row0.X) + (left.Row3.Y * right.Row1.X)) + (left.Row3.Z * right.Row2.X)) + (left.Row3.W * right.Row3.X);
+			result.Row3.Y = (((left.Row3.X * right.Row0.Y) + (left.Row3.Y * right.Row1.Y)) + (left.Row3.Z * right.Row2.Y)) + (left.Row3.W * right.Row3.Y);
+			result.Row3.Z = (((left.Row3.X * right.Row0.Z) + (left.Row3.Y * right.Row1.Z)) + (left.Row3.Z * right.Row2.Z)) + (left.Row3.W * right.Row3.Z);
+			result.Row3.W = (((left.Row3.X * right.Row0.W) + (left.Row3.Y * right.Row1.W)) + (left.Row3.Z * right.Row2.W)) + (left.Row3.W * right.Row3.W);
+			return result;
 		}
 		
 

--- a/source/OpenBveApi/Math/Vector4.cs
+++ b/source/OpenBveApi/Math/Vector4.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace OpenBveApi.Math
 {
 	/// <summary>Represents a 4-dimensional vector</summary>
+	[StructLayout(LayoutKind.Sequential)]
 	public struct Vector4
 	{
 		/// <summary>The x-coordinate.</summary>

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -55,9 +55,10 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\dependencies\OpenTK.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SharpCompress">
       <HintPath>..\..\dependencies\SharpCompress.dll</HintPath>

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -11,6 +11,7 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.Windows.Forms;
 using OpenBveApi.FileSystem;
+using OpenBveApi.Math;
 using OpenBveApi.Textures;
 using OpenTK;
 using OpenTK.Graphics;
@@ -137,8 +138,14 @@ namespace OpenBve {
 			World.HorizontalViewingAngle = 2.0 * Math.Atan(Math.Tan(0.5 * World.VerticalViewingAngle) * World.AspectRatio);
 			GL.MatrixMode(MatrixMode.Projection);
 			GL.LoadIdentity();
-			Matrix4d perspective =  Matrix4d.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.2, 1000.0);
-			GL.MultMatrix(ref perspective);
+			Matrix4D perspective = Matrix4D.Perspective(World.VerticalViewingAngle, -World.AspectRatio, 0.2, 1000.0);
+			unsafe
+			{
+				double* matrixPointer = &perspective.Row0.X;
+				{
+					GL.MultMatrix(matrixPointer);
+				}
+			}
 			GL.MatrixMode(MatrixMode.Modelview);
 			GL.LoadIdentity();
 		}

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 using OpenBveApi.Colors;
 using OpenBveApi.Graphics;
 using OpenBveApi.Interface;
+using OpenBveApi.Math;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using Vector3 = OpenBveApi.Math.Vector3;
@@ -159,10 +160,15 @@ namespace OpenBve {
 			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 			GL.PushMatrix();
 			GL.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-			Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0);
-			//TODO: May be required??
+			Matrix4D mat = Matrix4D.LookAt(Vector3.Zero, Vector3.Forward, Vector3.Down);
 			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref lookat);
+			unsafe
+			{
+				double* matrixPointer = &mat.Row0.X;
+				{
+					GL.LoadMatrix(matrixPointer);
+				}
+			}
 			GL.PopMatrix();
 			TransparentColorDepthSorting = Interface.CurrentOptions.TransparencyMode == TransparencyMode.Quality& Interface.CurrentOptions.Interpolation != InterpolationMode.NearestNeighbor & Interface.CurrentOptions.Interpolation != InterpolationMode.Bilinear;
 		}
@@ -233,11 +239,16 @@ namespace OpenBve {
 			double ux = World.AbsoluteCameraUp.X;
 			double uy = World.AbsoluteCameraUp.Y;
 			double uz = World.AbsoluteCameraUp.Z;
-			Matrix4d lookat = Matrix4d.LookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
 			GL.MatrixMode(MatrixMode.Modelview);
-			//TODO: May be required
-			GL.LoadMatrix(ref lookat);
-			//Glu.gluLookAt(0.0, 0.0, 0.0, dx, dy, dz, ux, uy, uz);
+			Matrix4D mat = Matrix4D.LookAt(Vector3.Zero, World.AbsoluteCameraDirection, World.AbsoluteCameraUp);
+			unsafe
+			{
+				double* matrixPointer = &mat.Row0.X;
+				{
+					GL.LoadMatrix(matrixPointer);
+				}
+			}
+
 			if (OptionLighting) {
 				GL.Light(LightName.Light0, LightParameter.Position, new float[] { (float)OptionLightPosition.X, (float)OptionLightPosition.Y, (float)OptionLightPosition.Z, 0.0f });
 			}

--- a/source/RouteViewer/RouteViewer.csproj
+++ b/source/RouteViewer/RouteViewer.csproj
@@ -35,7 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/source/RouteViewer/System/Functions/Plugins.cs
+++ b/source/RouteViewer/System/Functions/Plugins.cs
@@ -97,16 +97,18 @@ namespace OpenBve
 #endif
 					Plugin plugin = new Plugin(file);
 					Assembly assembly;
+					Type[] types;
 					try
 					{
 						assembly = Assembly.LoadFile(file);
+						types = assembly.GetTypes();
 					}
 					catch
 					{
 						builder.Append("Plugin ").Append(Path.GetFileName(file)).AppendLine(" is not a .Net assembly.");
 						continue;
 					}
-					Type[] types = assembly.GetTypes();
+					
 					bool iruntime = false;
 					foreach (Type type in types)
 					{


### PR DESCRIPTION
This PR changes the matrix operations to use native API copies.

Don't know if this will be merged, any other opinions welcome.

### Benefits:
* This makes it much easier to move away from openTK (and potentially openGL) if ever required- We can now do the world / camera space conversions internally.
* Less messing around with constructors, we just pass the required native API structs.
* Performance change should be nil.

### Drawbacks:
* This is very much a partial implementation of the functions in question, only pulling in precisely what we're using at the minute.
* Much less testing coverage. (This is relatively simple matrix math, so unless I've stuffed things up we shouldn't need testing.....)
* Increases the API size for a potentially questionable benefit: It's likely that we could pull these in from another library should we choose to go in that direction.
* A couple of hacks to account for existing API behaviour.
* Nil performance change (?)