### PR TITLE
Shared Renderer, Part 3

### DIFF
--- a/source/LibRender/LibRender.csproj
+++ b/source/LibRender/LibRender.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Camera\CameraAlignment.cs" />
     <Compile Include="Camera\CameraRestrictionMode.cs" />
+    <Compile Include="Primitives\Cube.cs" />
     <Compile Include="Primitives\Rectangle.cs" />
     <Compile Include="Renderer.cs" />
     <Compile Include="Lighting\LightDefinition.cs" />

--- a/source/LibRender/LibRender.csproj
+++ b/source/LibRender/LibRender.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Camera\CameraAlignment.cs" />
     <Compile Include="Camera\CameraRestrictionMode.cs" />
+    <Compile Include="Overlays\Keys.cs" />
     <Compile Include="Primitives\Cube.cs" />
     <Compile Include="Primitives\Rectangle.cs" />
     <Compile Include="Renderer.cs" />

--- a/source/LibRender/Overlays/Keys.cs
+++ b/source/LibRender/Overlays/Keys.cs
@@ -1,0 +1,32 @@
+﻿using System.Drawing;
+using OpenBveApi.Colors;
+using OpenBveApi.Graphics;
+
+namespace LibRender
+{
+	public static partial class Renderer
+	{
+		/// <summary>Draws a key overlay to the screen</summary>
+		/// <param name="Left">The left co-ordinate of the top key</param>
+		/// <param name="Top">The top co-ordinate of the top key</param>
+		/// <param name="Width">The width of the key overlay</param>
+		/// <param name="Font">The font to draw</param>
+		/// <param name="Keys">The key names</param>
+		public static void RenderKeys(int Left, int Top, int Width, OpenGlFont Font, string[][] Keys) {
+			int py = Top;
+			for (int y = 0; y < Keys.Length; y++) {
+				int px = Left;
+				for (int x = 0; x < Keys[y].Length; x++) {
+					if (Keys[y][x] != null) {
+						DrawRectangle(null, new Point(px -1, py -1), new Size(Width + 1, 17),  new Color128(0.25f,0.25f, 0.25f,0.5f));
+						DrawRectangle(null, new Point(px - 1, py - 1), new Size(Width - 1, 15), new Color128(0.75f, 0.75f, 0.75f, 0.5f));
+						DrawRectangle(null, new Point(px, py), new Size(Width, 16), new Color128(0.5f, 0.5f, 0.5f, 0.5f));
+						DrawString(Font, Keys[y][x], new Point(px -1 + Width /2, py + 7), TextAlignment.CenterMiddle, Color128.White);
+					}
+					px += Width + 4;
+				}
+				py += 20;
+			}
+		}
+	}
+}

--- a/source/LibRender/Primitives/Cube.cs
+++ b/source/LibRender/Primitives/Cube.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OpenBveApi.Math;
+using OpenBveApi.Textures;
+using OpenTK.Graphics.OpenGL;
+
+namespace LibRender
+{
+	public static partial class Renderer
+	{
+		/// <summary>Draws a 3D cube</summary>
+		/// <param name="Position">The position in world-space</param>
+		/// <param name="Direction">The direction vector</param>
+		/// <param name="Up">The up vector</param>
+		/// <param name="Side">The side vector</param>
+		/// <param name="Size">The size of the cube in M</param>
+		/// <param name="Camera">The camera position</param>
+		/// <param name="TextureIndex">The texture to apply</param>
+		public static void DrawCube(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double Size, Vector3 Camera, Texture TextureIndex)
+		{
+			
+			Vector3[] v = new Vector3[8];
+			v[0] = new Vector3(Size, Size, -Size);
+			v[1] = new Vector3(Size, -Size, -Size);
+			v[2] = new Vector3(-Size, -Size, -Size);
+			v[3] = new Vector3(-Size, Size, -Size);
+			v[4] = new Vector3(Size, Size, Size);
+			v[5] = new Vector3(Size, -Size, Size);
+			v[6] = new Vector3(-Size, -Size, Size);
+			v[7] = new Vector3(-Size, Size, Size);
+			for (int i = 0; i < 8; i++)
+			{
+				v[i].Rotate(Direction, Up, Side);
+				v[i] += Position - Camera;
+			}
+			int[][] Faces = new int[6][];
+			Faces[0] = new int[] { 0, 1, 2, 3 };
+			Faces[1] = new int[] { 0, 4, 5, 1 };
+			Faces[2] = new int[] { 0, 3, 7, 4 };
+			Faces[3] = new int[] { 6, 5, 4, 7 };
+			Faces[4] = new int[] { 6, 7, 3, 2 };
+			Faces[5] = new int[] { 6, 2, 1, 5 };
+			if (TextureIndex == null || !currentHost.LoadTexture(TextureIndex, OpenGlTextureWrapMode.ClampClamp))
+			{
+				GL.Disable(EnableCap.Texture2D);
+				for (int i = 0; i < 6; i++)
+				{
+					GL.Begin(PrimitiveType.Quads);
+					GL.Color3(1.0, 1.0, 1.0);
+					for (int j = 0; j < 4; j++)
+					{
+						GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
+					}
+					GL.End();
+				}
+				return;
+			}
+			GL.Enable(EnableCap.Texture2D);
+			GL.BindTexture(TextureTarget.Texture2D, TextureIndex.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp].Name);
+			Vector2[][] t = new Vector2[6][];
+				t[0] = new Vector2[] { new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0) };
+				t[1] = new Vector2[] { new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0) };
+				t[2] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
+				t[3] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
+				t[4] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
+				t[5] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
+			for (int i = 0; i < 6; i++)
+			{
+				GL.Begin(PrimitiveType.Quads);
+				GL.Color3(1.0, 1.0, 1.0);
+				for (int j = 0; j < 4; j++)
+				{
+					GL.TexCoord2(t[i][j].X, t[i][j].Y);
+					GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
+				}
+				GL.End();
+			}
+		}
+	}
+}

--- a/source/LibRender/Primitives/Cube.cs
+++ b/source/LibRender/Primitives/Cube.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using OpenBveApi.Math;
+﻿using OpenBveApi.Math;
 using OpenBveApi.Textures;
 using OpenTK.Graphics.OpenGL;
 
@@ -20,16 +16,28 @@ namespace LibRender
 		/// <param name="TextureIndex">The texture to apply</param>
 		public static void DrawCube(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double Size, Vector3 Camera, Texture TextureIndex)
 		{
-			
+			DrawCube(Position, Direction, Up, Side, new Vector3(Size, Size, Size), Camera, TextureIndex );
+		}
+
+		/// <summary>Draws a 3D cube</summary>
+		/// <param name="Position">The position in world-space</param>
+		/// <param name="Direction">The direction vector</param>
+		/// <param name="Up">The up vector</param>
+		/// <param name="Side">The side vector</param>
+		/// <param name="Size">A 3D vector describing the size of the cube</param>
+		/// <param name="Camera">The camera position</param>
+		/// <param name="TextureIndex">The texture to apply</param>
+		public static void DrawCube(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, Vector3 Size, Vector3 Camera, Texture TextureIndex)
+		{
 			Vector3[] v = new Vector3[8];
-			v[0] = new Vector3(Size, Size, -Size);
-			v[1] = new Vector3(Size, -Size, -Size);
-			v[2] = new Vector3(-Size, -Size, -Size);
-			v[3] = new Vector3(-Size, Size, -Size);
-			v[4] = new Vector3(Size, Size, Size);
-			v[5] = new Vector3(Size, -Size, Size);
-			v[6] = new Vector3(-Size, -Size, Size);
-			v[7] = new Vector3(-Size, Size, Size);
+			v[0] = new Vector3(Size.X, Size.Y, -Size.Z);
+			v[1] = new Vector3(Size.X, -Size.Y, -Size.Z);
+			v[2] = new Vector3(-Size.X, -Size.Y, -Size.Z);
+			v[3] = new Vector3(-Size.X, Size.Y, -Size.Z);
+			v[4] = new Vector3(Size.X, Size.Y, Size.Z);
+			v[5] = new Vector3(Size.X, -Size.Y, Size.Z);
+			v[6] = new Vector3(-Size.X, -Size.Y, Size.Z);
+			v[7] = new Vector3(-Size.X, Size.Y, Size.Z);
 			for (int i = 0; i < 8; i++)
 			{
 				v[i].Rotate(Direction, Up, Side);
@@ -48,7 +56,6 @@ namespace LibRender
 				for (int i = 0; i < 6; i++)
 				{
 					GL.Begin(PrimitiveType.Quads);
-					GL.Color3(1.0, 1.0, 1.0);
 					for (int j = 0; j < 4; j++)
 					{
 						GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);

--- a/source/LibRender/Primitives/Rectangle.cs
+++ b/source/LibRender/Primitives/Rectangle.cs
@@ -7,7 +7,7 @@ namespace LibRender
 {
 	public static partial class Renderer
 	{
-		/// <summary>Draws a rectangle.</summary>
+		/// <summary>Draws a simple 2D rectangle.</summary>
 		/// <param name="texture">The texture, or a null reference.</param>
 		/// <param name="point">The top-left coordinates in pixels.</param>
 		/// <param name="size">The size in pixels.</param>

--- a/source/LibRender/Renderer.cs
+++ b/source/LibRender/Renderer.cs
@@ -6,7 +6,8 @@ namespace LibRender
     {
 		/// <summary>The callback to the host application</summary>
 	    public static HostInterface currentHost;
-
+		/// <summary>Whether texturing is currently enabled in openGL</summary>
+		public static bool TexturingEnabled;
 		/// <summary>Holds the lock for GDI Plus functions</summary>
 		public static readonly object gdiPlusLock = new object();
     }

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -61,7 +61,7 @@ namespace OpenBve {
 	    {
 			CurrentlyRunOnMono = Type.GetType("Mono.Runtime") != null;
 			CurrentHost = new Host();
-		    
+			LibRender.Renderer.currentHost = CurrentHost;
 	        // file system
 	        FileSystem = FileSystem.FromCommandLineArgs(args);
 	        FileSystem.CreateFileSystem();

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -1094,6 +1094,7 @@ namespace OpenBve
                                 Array.Resize(ref AlphaList, AlphaList.Length << 1);
                                 Array.Resize(ref AlphaListDistance, AlphaList.Length);
                             }
+							AlphaList[AlphaListCount] = new ObjectFace();
                             AlphaList[AlphaListCount].ObjectIndex = ObjectIndex;
                             AlphaList[AlphaListCount].FaceIndex = i;
                             AlphaList[AlphaListCount].ObjectListIndex = ObjectListCount;
@@ -1109,6 +1110,7 @@ namespace OpenBve
                                 Array.Resize(ref TransparentColorList, TransparentColorList.Length << 1);
                                 Array.Resize(ref TransparentColorListDistance, TransparentColorList.Length);
                             }
+							TransparentColorList[TransparentColorListCount] = new ObjectFace();
                             TransparentColorList[TransparentColorListCount].ObjectIndex = ObjectIndex;
                             TransparentColorList[TransparentColorListCount].FaceIndex = i;
                             TransparentColorList[TransparentColorListCount].ObjectListIndex = ObjectListCount;
@@ -1123,6 +1125,7 @@ namespace OpenBve
                             {
                                 Array.Resize(ref OpaqueList, OpaqueList.Length << 1);
                             }
+							OpaqueList[OpaqueListCount] = new ObjectFace();
                             OpaqueList[OpaqueListCount].ObjectIndex = ObjectIndex;
                             OpaqueList[OpaqueListCount].FaceIndex = i;
                             OpaqueList[OpaqueListCount].ObjectListIndex = ObjectListCount;

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -841,7 +841,7 @@ namespace OpenBve
                 {
                     string[][] Keys;
                     Keys = new string[][] { new string[] { "F7" }, new string[] { "F8" }, new string[] { "F10" } };
-                    RenderKeys(4.0, 4.0, 20.0, Keys);
+                    LibRender.Renderer.RenderKeys(4, 4, 20, Fonts.SmallFont, Keys);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Open one or more objects", new Point(32,4),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the options window", new Point(32,24),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the train settings window", new Point(32, 44), TextAlignment.TopLeft, TextColor);
@@ -852,14 +852,14 @@ namespace OpenBve
 	                LibRender.Renderer.DrawString(Fonts.SmallFont, "Position: " + World.AbsoluteCameraPosition.X.ToString("0.00", Culture) + ", " + World.AbsoluteCameraPosition.Y.ToString("0.00", Culture) + ", " + World.AbsoluteCameraPosition.Z.ToString("0.00", Culture), new Point((int)(0.5 * ScreenWidth -88),4),TextAlignment.TopLeft, TextColor);
                     string[][] Keys;
                     Keys = new string[][] { new string[] { "F5" }, new string[] { "F7" }, new string[] { "del" }, new string[] { "F8" }, new string[] { "F10" } };
-                    RenderKeys(4.0, 4.0, 24.0, Keys);
+                    LibRender.Renderer.RenderKeys(4, 4, 24, Fonts.SmallFont, Keys);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Reload the currently open objects", new Point(32,4),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Open additional objects", new Point(32,24),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Clear currently open objects", new Point(32,44),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the options window", new Point(32,64),TextAlignment.TopLeft, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the train settings window", new Point(32, 84), TextAlignment.TopLeft, TextColor);
 					Keys = new string[][] { new string[] { "F" }, new string[] { "N" }, new string[] { "L" }, new string[] { "G" }, new string[] { "B" }, new string[] { "I" } };
-                    RenderKeys((double)ScreenWidth - 20.0, 4.0, 16.0, Keys);
+                    LibRender.Renderer.RenderKeys(ScreenWidth - 20, 4, 16, Fonts.SmallFont, Keys);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Wireframe: " + (Renderer.OptionWireframe ? "on" : "off"), new Point(ScreenWidth - 28,4),TextAlignment.TopRight, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Normals: " + (Renderer.OptionNormals ? "on" : "off"), new Point(ScreenWidth - 28,24),TextAlignment.TopRight, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Lighting: " + (Program.LightingTarget == 0 ? "night" : "day"), new Point(ScreenWidth - 28,44),TextAlignment.TopRight, TextColor);
@@ -867,15 +867,14 @@ namespace OpenBve
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Background: " + GetBackgroundColorName(), new Point(ScreenWidth - 28,84),TextAlignment.TopRight, TextColor);
                     LibRender.Renderer.DrawString(Fonts.SmallFont, "Hide interface", new Point(ScreenWidth - 28,104),TextAlignment.TopRight, TextColor);
                     Keys = new string[][] { new string[] { null, "W", null }, new string[] { "A", "S", "D" } };
-                    RenderKeys(4.0, (double)ScreenHeight - 40.0, 16.0, Keys);
+                    LibRender.Renderer.RenderKeys(4, ScreenHeight - 40, 16, Fonts.SmallFont, Keys);
                     Keys = new string[][] { new string[] { null, "↑", null }, new string[] { "←", "↓", "→" } };
-                    RenderKeys(0.5 * (double)ScreenWidth - 28.0, (double)ScreenHeight - 40.0, 16.0, Keys);
+                    LibRender.Renderer.RenderKeys((int)(0.5 * (double)ScreenWidth - 28), ScreenHeight - 40, 16, Fonts.SmallFont, Keys);
                     Keys = new string[][] { new string[] { null, "8", "9" }, new string[] { "4", "5", "6" }, new string[] { null, "2", "3" } };
-                    RenderKeys((double)ScreenWidth - 60.0, (double)ScreenHeight - 60.0, 16.0, Keys);
+                    LibRender.Renderer.RenderKeys(ScreenWidth - 60, ScreenHeight - 60, 16, Fonts.SmallFont, Keys);
                     if (Interface.MessageCount == 1)
                     {
-                        Keys = new string[][] { new string[] { "F9" } };
-                        RenderKeys(4.0, 112.0, 20.0, Keys);
+	                    LibRender.Renderer.RenderKeys(4, 112, 20, Fonts.SmallFont, new string[][] { new string[] { "F9" } });
 	                    if (Interface.LogMessages[0].Type != MessageType.Information)
 	                    {
 		                    LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the 1 error message recently generated.", new Point(32,112),TextAlignment.TopLeft, new Color128(1.0f, 0.5f, 0.5f));
@@ -889,8 +888,7 @@ namespace OpenBve
                     }
                     else if (Interface.MessageCount > 1)
                     {
-                        Keys = new string[][] { new string[] { "F9" } };
-                        RenderKeys(4.0, 112.0, 20.0, Keys);
+	                    LibRender.Renderer.RenderKeys(4, 112, 20, Fonts.SmallFont, new string[][] { new string[] { "F9" } });
 	                    bool error = false;
 	                    for (int i = 0; i < Interface.MessageCount; i++)
 	                    {
@@ -923,30 +921,6 @@ namespace OpenBve
 	        GL.Ortho(0.0, (double)ScreenWidth, 0.0, (double)ScreenHeight, -1.0, 1.0);
         }
 
-        // render keys
-        private static void RenderKeys(double Left, double Top, double Width, string[][] Keys)
-        {
-            double py = Top;
-            for (int y = 0; y < Keys.Length; y++)
-            {
-                double px = Left;
-                for (int x = 0; x < Keys[y].Length; x++)
-                {
-                    if (Keys[y][x] != null)
-                    {
-                        GL.Color4(0.25, 0.25, 0.25, 0.5);
-                        RenderOverlaySolid(px - 1.0, py - 1.0, px + Width + 1.0, py + 17.0);
-                        GL.Color4(0.75, 0.75, 0.75, 0.5);
-                        RenderOverlaySolid(px - 1.0, py - 1.0, px + Width - 1.0, py + 15.0);
-                        GL.Color4(0.5, 0.5, 0.5, 0.5);
-                        RenderOverlaySolid(px, py, px + Width, py + 16.0);
-                        LibRender.Renderer.DrawString(Fonts.SmallFont, Keys[y][x], new Point((int)(px + 2.0), (int)py), TextAlignment.TopLeft, Color128.White, true);
-                    }
-                    px += Width + 4.0;
-                }
-                py += 20.0;
-            }
-        }
 
         // render overlay solid
         private static void RenderOverlaySolid(double ax, double ay, double bx, double by)

--- a/source/ObjectViewer/RendererS.cs
+++ b/source/ObjectViewer/RendererS.cs
@@ -271,11 +271,11 @@ namespace OpenBve
                     GL.Disable(EnableCap.Lighting);
                 }
                 GL.Color3(1.0, 0.0, 0.0);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(100.0, 0.01, 0.01), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(100.0, 0.01, 0.01), World.AbsoluteCameraPosition, null);
                 GL.Color3(0.0, 1.0, 0.0);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 100.0, 0.01), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 100.0, 0.01), World.AbsoluteCameraPosition, null);
                 GL.Color3(0.0, 0.0, 1.0);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 0.01, 100.0), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 0.01, 100.0), World.AbsoluteCameraPosition, null);
                 if (LightingEnabled)
                 {
                     GL.Enable(EnableCap.Lighting);
@@ -421,11 +421,11 @@ namespace OpenBve
                 GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
                 GL.Enable(EnableCap.Blend);
                 GL.Color4(1.0, 0.0, 0.0, 0.2);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(100.0, 0.01, 0.01), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(100.0, 0.01, 0.01), World.AbsoluteCameraPosition, null);
                 GL.Color4(0.0, 1.0, 0.0, 0.2);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 100.0, 0.01), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 100.0, 0.01), World.AbsoluteCameraPosition, null);
                 GL.Color4(0.0, 0.0, 1.0, 0.2);
-                RenderBox(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 0.01, 100.0), World.AbsoluteCameraPosition);
+                LibRender.Renderer.DrawCube(Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 0.01, 100.0), World.AbsoluteCameraPosition, null);
             }
 	        RenderOverlays();
 	        LastBoundTexture = null; //We bind the character texture, so must reset it at the end of the render sequence
@@ -779,48 +779,7 @@ namespace OpenBve
 				}
 			}
 		}
-
-        // render cube
-        private static void RenderBox(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, Vector3 Size, Vector3 Camera)
-        {
-            if (TexturingEnabled)
-            {
-                GL.Disable(EnableCap.Texture2D);
-                TexturingEnabled = false;
-            }
-            Vector3[] v = new Vector3[8];
-            v[0] = new Vector3(Size.X, Size.Y, -Size.Z);
-            v[1] = new Vector3(Size.X, -Size.Y, -Size.Z);
-            v[2] = new Vector3(-Size.X, -Size.Y, -Size.Z);
-            v[3] = new Vector3(-Size.X, Size.Y, -Size.Z);
-            v[4] = new Vector3(Size.X, Size.Y, Size.Z);
-            v[5] = new Vector3(Size.X, -Size.Y, Size.Z);
-            v[6] = new Vector3(-Size.X, -Size.Y, Size.Z);
-            v[7] = new Vector3(-Size.X, Size.Y, Size.Z);
-            for (int i = 0; i < 8; i++)
-            {
-	            v[i].Rotate(Direction, Up, Side);
-	            v[i] += Position - Camera;
-            }
-            int[][] Faces = new int[6][];
-            Faces[0] = new int[] { 0, 1, 2, 3 };
-            Faces[1] = new int[] { 0, 4, 5, 1 };
-            Faces[2] = new int[] { 0, 3, 7, 4 };
-            Faces[3] = new int[] { 6, 5, 4, 7 };
-            Faces[4] = new int[] { 6, 7, 3, 2 };
-            Faces[5] = new int[] { 6, 2, 1, 5 };
-            for (int i = 0; i < 6; i++)
-            {
-                GL.Begin(PrimitiveType.Quads);
-                for (int j = 0; j < 4; j++)
-                {
-                    GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
-                }
-                GL.End();
-            }
-        }
-
-
+		
         // render overlays
         private static void RenderOverlays()
         {

--- a/source/OpenBVE/Graphics/Renderer/Events.cs
+++ b/source/OpenBVE/Graphics/Renderer/Events.cs
@@ -158,7 +158,7 @@ namespace OpenBve
 							f.WorldPosition.X += dx * f.WorldSide.X + dy * f.WorldUp.X + dz * f.WorldDirection.X;
 							f.WorldPosition.Y += dx * f.WorldSide.Y + dy * f.WorldUp.Y + dz * f.WorldDirection.Y;
 							f.WorldPosition.Z += dx * f.WorldSide.Z + dy * f.WorldUp.Z + dz * f.WorldDirection.Z;
-							RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera.X, Camera.Y, Camera.Z, t);
+							LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, t);
 						}
 					}
 				}
@@ -180,7 +180,7 @@ namespace OpenBve
 						f.WorldPosition.X += dy * f.WorldUp.X;
 						f.WorldPosition.Y += dy * f.WorldUp.Y;
 						f.WorldPosition.Z += dy * f.WorldUp.Z;
-						RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera.X, Camera.Y, Camera.Z, StopTexture);
+						LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, StopTexture);
 					}
 				}
 			}
@@ -200,78 +200,8 @@ namespace OpenBve
 					f.WorldPosition.X += dy * f.WorldUp.X;
 					f.WorldPosition.Y += dy * f.WorldUp.Y;
 					f.WorldPosition.Z += dy * f.WorldUp.Z;
-					RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera.X, Camera.Y, Camera.Z, BufferTexture);
+					LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, BufferTexture);
 				}
-			}
-		}
-		private static void RenderCube(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double Size, double CameraX, double CameraY, double CameraZ, Texture TextureIndex)
-		{
-			
-			Vector3[] v = new Vector3[8];
-			v[0] = new Vector3(Size, Size, -Size);
-			v[1] = new Vector3(Size, -Size, -Size);
-			v[2] = new Vector3(-Size, -Size, -Size);
-			v[3] = new Vector3(-Size, Size, -Size);
-			v[4] = new Vector3(Size, Size, Size);
-			v[5] = new Vector3(Size, -Size, Size);
-			v[6] = new Vector3(-Size, -Size, Size);
-			v[7] = new Vector3(-Size, Size, Size);
-			for (int i = 0; i < 8; i++)
-			{
-				v[i].Rotate(Direction, Up, Side);
-				v[i].X += Position.X - CameraX;
-				v[i].Y += Position.Y - CameraY;
-				v[i].Z += Position.Z - CameraZ;
-			}
-			int[][] Faces = new int[6][];
-			Faces[0] = new int[] { 0, 1, 2, 3 };
-			Faces[1] = new int[] { 0, 4, 5, 1 };
-			Faces[2] = new int[] { 0, 3, 7, 4 };
-			Faces[3] = new int[] { 6, 5, 4, 7 };
-			Faces[4] = new int[] { 6, 7, 3, 2 };
-			Faces[5] = new int[] { 6, 2, 1, 5 };
-			if (TextureIndex == null || !Textures.LoadTexture(TextureIndex, OpenGlTextureWrapMode.ClampClamp))
-			{
-				if (TexturingEnabled)
-				{
-					GL.Disable(EnableCap.Texture2D);
-					TexturingEnabled = false;
-				}
-				for (int i = 0; i < 6; i++)
-				{
-					GL.Begin(PrimitiveType.Quads);
-					GL.Color3(1.0, 1.0, 1.0);
-					for (int j = 0; j < 4; j++)
-					{
-						GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
-					}
-					GL.End();
-				}
-				return;
-			}
-			else
-			{
-				TexturingEnabled = true;
-				GL.Enable(EnableCap.Texture2D);
-			}
-			GL.BindTexture(TextureTarget.Texture2D, TextureIndex.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp].Name);
-			Vector2[][] t = new Vector2[6][];
-				t[0] = new Vector2[] { new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0) };
-				t[1] = new Vector2[] { new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0) };
-				t[2] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
-				t[3] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
-				t[4] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
-				t[5] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
-			for (int i = 0; i < 6; i++)
-			{
-				GL.Begin(PrimitiveType.Quads);
-				GL.Color3(1.0, 1.0, 1.0);
-				for (int j = 0; j < 4; j++)
-				{
-					GL.TexCoord2(t[i][j].X, t[i][j].Y);
-					GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
-				}
-				GL.End();
 			}
 		}
 	}

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -60,7 +60,7 @@ namespace OpenBve {
 		internal static void Main(string[] args)
 		{
 			CurrentHost = new Host();
-			
+			LibRender.Renderer.currentHost = CurrentHost;
 			commandLineArguments = args;
 			// platform and mono
 			CurrentlyRunOnMono = Type.GetType("Mono.Runtime") != null;
@@ -104,7 +104,6 @@ namespace OpenBve {
 			Interface.CurrentOptions.ObjectOptimizationBasicThreshold = 1000;
 			Interface.CurrentOptions.ObjectOptimizationFullThreshold = 250;
 			// application
-
 			currentGraphicsMode = new GraphicsMode(new ColorFormat(8, 8, 8, 8), 24, 8, Interface.CurrentOptions.AntialiasingLevel);
 			currentGameWindow = new RouteViewer(Renderer.ScreenWidth, Renderer.ScreenHeight, currentGraphicsMode, "Route Viewer", GameWindowFlags.Default);
 			currentGameWindow.Visible = true;

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -989,7 +989,7 @@ namespace OpenBve {
 							f.WorldPosition.X += dx * f.WorldSide.X + dy * f.WorldUp.X + dz * f.WorldDirection.X;
 							f.WorldPosition.Y += dx * f.WorldSide.Y + dy * f.WorldUp.Y + dz * f.WorldDirection.Y;
 							f.WorldPosition.Z += dx * f.WorldSide.Z + dy * f.WorldUp.Z + dz * f.WorldDirection.Z;
-							RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, t);
+							LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, t);
 						}
 					}
 				}
@@ -1008,7 +1008,7 @@ namespace OpenBve {
 						f.WorldPosition.X += dy * f.WorldUp.X;
 						f.WorldPosition.Y += dy * f.WorldUp.Y;
 						f.WorldPosition.Z += dy * f.WorldUp.Z;
-						RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, StopTexture);
+						LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, StopTexture);
 					}
 				}
 			}
@@ -1026,79 +1026,13 @@ namespace OpenBve {
 					f.WorldPosition.X += dy * f.WorldUp.X;
 					f.WorldPosition.Y += dy * f.WorldUp.Y;
 					f.WorldPosition.Z += dy * f.WorldUp.Z;
-					RenderCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, BufferTexture);
+					LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, BufferTexture);
 				}
 			}
-		}
-		private static void RenderCube(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double Size, Vector3 Camera, Texture TextureIndex)
-		{
-			
-			Vector3[] v = new Vector3[8];
-			v[0] = new Vector3(Size, Size, -Size);
-			v[1] = new Vector3(Size, -Size, -Size);
-			v[2] = new Vector3(-Size, -Size, -Size);
-			v[3] = new Vector3(-Size, Size, -Size);
-			v[4] = new Vector3(Size, Size, Size);
-			v[5] = new Vector3(Size, -Size, Size);
-			v[6] = new Vector3(-Size, -Size, Size);
-			v[7] = new Vector3(-Size, Size, Size);
-			for (int i = 0; i < 8; i++)
-			{
-				v[i].Rotate(Direction, Up, Side);
-				v[i] += Position - Camera;
-			}
-			int[][] Faces = new int[6][];
-			Faces[0] = new int[] { 0, 1, 2, 3 };
-			Faces[1] = new int[] { 0, 4, 5, 1 };
-			Faces[2] = new int[] { 0, 3, 7, 4 };
-			Faces[3] = new int[] { 6, 5, 4, 7 };
-			Faces[4] = new int[] { 6, 7, 3, 2 };
-			Faces[5] = new int[] { 6, 2, 1, 5 };
-			if (TextureIndex == null || !Textures.LoadTexture(TextureIndex, OpenGlTextureWrapMode.ClampClamp))
-			{
-				if (TexturingEnabled)
-				{
-					GL.Disable(EnableCap.Texture2D);
-					TexturingEnabled = false;
-				}
-				for (int i = 0; i < 6; i++)
-				{
-					GL.Begin(PrimitiveType.Quads);
-					GL.Color3(1.0, 1.0, 1.0);
-					for (int j = 0; j < 4; j++)
-					{
-						GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
-					}
-					GL.End();
-				}
-				return;
-			}
-			else
-			{
-				TexturingEnabled = true;
-				GL.Enable(EnableCap.Texture2D);
-			}
-			GL.BindTexture(TextureTarget.Texture2D, TextureIndex.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp].Name);
-			Vector2[][] t = new Vector2[6][];
-				t[0] = new Vector2[] { new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0) };
-				t[1] = new Vector2[] { new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0), new Vector2(0.0, 1.0) };
-				t[2] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
-				t[3] = new Vector2[] { new Vector2(1.0, 1.0), new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0) };
-				t[4] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
-				t[5] = new Vector2[] { new Vector2(0.0, 1.0), new Vector2(0.0, 0.0), new Vector2(1.0, 0.0), new Vector2(1.0, 1.0) };
-			for (int i = 0; i < 6; i++)
-			{
-				GL.Begin(PrimitiveType.Quads);
-				GL.Color3(1.0, 1.0, 1.0);
-				for (int j = 0; j < 4; j++)
-				{
-					GL.TexCoord2(t[i][j].X, t[i][j].Y);
-					GL.Vertex3(v[Faces[i][j]].X, v[Faces[i][j]].Y, v[Faces[i][j]].Z);
-				}
-				GL.End();
-			}
-		}
 
+			TexturingEnabled = true; //Set by the LibRender function
+		}
+		
 		// render overlays
 		private static void RenderOverlays(double TimeElapsed) {
 			// initialize
@@ -1454,6 +1388,7 @@ namespace OpenBve {
                                 Array.Resize(ref AlphaList, AlphaList.Length << 1);
                                 Array.Resize(ref AlphaListDistance, AlphaList.Length);
                             }
+							AlphaList[AlphaListCount] = new ObjectFace();
                             AlphaList[AlphaListCount].ObjectIndex = ObjectIndex;
                             AlphaList[AlphaListCount].FaceIndex = i;
                             AlphaList[AlphaListCount].ObjectListIndex = ObjectListCount;
@@ -1469,6 +1404,7 @@ namespace OpenBve {
                                 Array.Resize(ref TransparentColorList, TransparentColorList.Length << 1);
                                 Array.Resize(ref TransparentColorListDistance, TransparentColorList.Length);
                             }
+							TransparentColorList[TransparentColorListCount] = new ObjectFace();
                             TransparentColorList[TransparentColorListCount].ObjectIndex = ObjectIndex;
                             TransparentColorList[TransparentColorListCount].FaceIndex = i;
                             TransparentColorList[TransparentColorListCount].ObjectListIndex = ObjectListCount;
@@ -1483,6 +1419,7 @@ namespace OpenBve {
                             {
                                 Array.Resize(ref OpaqueList, OpaqueList.Length << 1);
                             }
+							OpaqueList[OpaqueListCount] = new ObjectFace();
                             OpaqueList[OpaqueListCount].ObjectIndex = ObjectIndex;
                             OpaqueList[OpaqueListCount].FaceIndex = i;
                             OpaqueList[OpaqueListCount].ObjectListIndex = ObjectListCount;

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -1068,19 +1068,19 @@ namespace OpenBve {
 			if (!Program.CurrentlyLoading) {
 				if (ObjectManager.ObjectsUsed == 0) {
 					string[][] Keys = { new string[] { "F7" }, new string[] { "F8" } };
-					RenderKeys(4, 4, 24, Keys);
+					LibRender.Renderer.RenderKeys(4, 4, 24, Fonts.SmallFont, Keys);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Open route", new Point(32,4), TextAlignment.TopLeft, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the options window", new Point(32, 24), TextAlignment.TopLeft, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "v" + System.Windows.Forms.Application.ProductVersion, new Point(ScreenWidth - 8, ScreenHeight - 8), TextAlignment.BottomRight, Color128.White);
 				} else if (OptionInterface) {
 					// keys
 					string[][] Keys = { new string[] { "F5" }, new string[] { "F7" }, new string[] { "F8" } };
-					RenderKeys(4, 4, 24, Keys);
+					LibRender.Renderer.RenderKeys(4, 4, 24, Fonts.SmallFont, Keys);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Reload route", new Point(32, 4), TextAlignment.TopLeft, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Open route", new Point(32, 24), TextAlignment.TopLeft, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the options window", new Point(32, 44), TextAlignment.TopLeft, Color128.White, true);
 					Keys = new string[][] { new string[] { "F" }, new string[] { "N" }, new string[] { "E" }, new string[] { "C" }, new string[] { "M" }, new string[] { "I" }};
-					RenderKeys(ScreenWidth - 20, 4, 16, Keys);
+					LibRender.Renderer.RenderKeys(ScreenWidth - 20, 4, 16, Fonts.SmallFont, Keys);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Wireframe:", new Point(ScreenWidth -32, 4), TextAlignment.TopRight, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Normals:", new Point(ScreenWidth - 32, 24), TextAlignment.TopRight, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Events:", new Point(ScreenWidth - 32, 44), TextAlignment.TopRight, Color128.White, true);
@@ -1089,15 +1089,15 @@ namespace OpenBve {
 					LibRender.Renderer.DrawString(Fonts.SmallFont, "Hide interface:", new Point(ScreenWidth - 32, 104), TextAlignment.TopRight, Color128.White, true);
 					LibRender.Renderer.DrawString(Fonts.SmallFont, (RenderStatsOverlay ? "Hide" : "Show") + " renderer statistics", new Point(ScreenWidth - 32, 124), TextAlignment.TopRight, Color128.White, true);
 					Keys = new string[][] { new string[] { "F10" } };
-					RenderKeys(ScreenWidth - 32, 124, 30, Keys);
+					LibRender.Renderer.RenderKeys(ScreenWidth - 32, 124, 30, Fonts.SmallFont, Keys);
 					Keys = new string[][] { new string[] { null, "W", null }, new string[] { "A", "S", "D" } };
-					RenderKeys(4, ScreenHeight - 40, 16, Keys);
+					LibRender.Renderer.RenderKeys(4, ScreenHeight - 40, 16, Fonts.SmallFont, Keys);
 					Keys = new string[][] { new string[] { null, "↑", null }, new string[] { "←", "↓", "→" } };
-					RenderKeys(0 * ScreenWidth - 48, ScreenHeight - 40, 16, Keys);
+					LibRender.Renderer.RenderKeys(0 * ScreenWidth - 48, ScreenHeight - 40, 16, Fonts.SmallFont, Keys);
 					Keys = new string[][] { new string[] { "P↑" }, new string[] { "P↓" } };
-					RenderKeys((int)(0.5 * ScreenWidth + 32), ScreenHeight - 40, 24, Keys);
+					LibRender.Renderer.RenderKeys((int)(0.5 * ScreenWidth + 32), ScreenHeight - 40, 24, Fonts.SmallFont, Keys);
 					Keys = new string[][] { new string[] { null, "/", "*" }, new string[] { "7", "8", "9" }, new string[] { "4", "5", "6" }, new string[] { "1", "2", "3" }, new string[] { null, "0", "." } };
-					RenderKeys(ScreenWidth - 60, ScreenHeight - 100, 16, Keys);
+					LibRender.Renderer.RenderKeys(ScreenWidth - 60, ScreenHeight - 100, 16, Fonts.SmallFont, Keys);
 					if (Program.JumpToPositionEnabled) {
 						LibRender.Renderer.DrawString(Fonts.SmallFont, "Jump to track position:", new Point(4, 80),TextAlignment.TopLeft, Color128.White, true);
 						double distance;
@@ -1159,7 +1159,7 @@ namespace OpenBve {
 					}
 					if (Interface.MessageCount == 1) {
 						Keys = new string[][] { new string[] { "F9" } };
-						RenderKeys(4, 72, 24, Keys);
+						LibRender.Renderer.RenderKeys(4, 72, 24, Fonts.SmallFont, Keys);
 						if (Interface.LogMessages[0].Type != MessageType.Information)
 						{
 							LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the 1 error message recently generated.", new Point(32, 72), TextAlignment.TopLeft, Color128.Red, true);
@@ -1170,8 +1170,7 @@ namespace OpenBve {
 							LibRender.Renderer.DrawString(Fonts.SmallFont, "Display the 1 message recently generated.", new Point(32, 72), TextAlignment.TopLeft, Color128.White, true);
 						}
 					} else if (Interface.MessageCount > 1) {
-						Keys = new string[][] { new string[] { "F9" } };
-						RenderKeys(4, 72, 24, Keys);
+						LibRender.Renderer.RenderKeys(4, 72, 24, Fonts.SmallFont, new string[][] { new string[] { "F9" } });
 						bool error = false;
 						for (int i = 0; i < Interface.MessageCount; i++)
 						{
@@ -1193,7 +1192,7 @@ namespace OpenBve {
 					}
 					if (RenderStatsOverlay)
 					{
-						RenderKeys(4, ScreenHeight - 126, 116, new string[][] { new string[] { "Renderer Statistics" } });
+						LibRender.Renderer.RenderKeys(4, ScreenHeight - 126, 116, Fonts.SmallFont, new string[][] { new string[] { "Renderer Statistics" } });
 						LibRender.Renderer.DrawString(Fonts.SmallFont, "Total static objects: " + ObjectManager.ObjectsUsed, new Point(4, ScreenHeight - 112), TextAlignment.TopLeft, Color128.White, true);
 						LibRender.Renderer.DrawString(Fonts.SmallFont, "Total animated objects: " + ObjectManager.AnimatedWorldObjectsUsed, new Point(4, ScreenHeight - 100), TextAlignment.TopLeft, Color128.White, true);
 						LibRender.Renderer.DrawString(Fonts.SmallFont, "Current framerate: " + Game.InfoFrameRate.ToString("0.0", Culture) + "fps", new Point(4, ScreenHeight - 88), TextAlignment.TopLeft, Color128.White, true);
@@ -1247,25 +1246,7 @@ namespace OpenBve {
 				return builder.ToString();
 			}
 		}
-
-		// render keys
-		private static void RenderKeys(int Left, int Top, int Width, string[][] Keys) {
-			int py = Top;
-			for (int y = 0; y < Keys.Length; y++) {
-				int px = Left;
-				for (int x = 0; x < Keys[y].Length; x++) {
-					if (Keys[y][x] != null) {
-						LibRender.Renderer.DrawRectangle(null, new Point(px -1, py -1), new Size(Width + 1, 17),  new Color128(0.25f,0.25f, 0.25f,0.5f));
-						LibRender.Renderer.DrawRectangle(null, new Point(px - 1, py - 1), new Size(Width - 1, 15), new Color128(0.75f, 0.75f, 0.75f, 0.5f));
-						LibRender.Renderer.DrawRectangle(null, new Point(px, py), new Size(Width, 16), new Color128(0.5f, 0.5f, 0.5f, 0.5f));
-						LibRender.Renderer.DrawString(Fonts.SmallFont, Keys[y][x], new Point(px -1 + Width /2, py + 7), TextAlignment.CenterMiddle, Color128.White);
-					}
-					px += Width + 4;
-				}
-				py += 20;
-			}
-		}
-
+		
 		// readd objects
 		private static void ReAddObjects() {
 			Object[] List = new Object[ObjectListCount];


### PR DESCRIPTION
Follows up to #351 .  #350 & #276 

This moves the following to the shared renderer:
* Cube drawing (Used for the Object Viewer co-ordinate display & event overlays in the main program / viewers)
* Key overlay drawing 