### PR TITLE
Player Train: Access via method

### DIFF
--- a/source/ObjectViewer/FunctionScripts.cs
+++ b/source/ObjectViewer/FunctionScripts.cs
@@ -928,7 +928,7 @@ namespace OpenBve {
 						break;
 						// safety
 					case Instructions.SafetyPluginAvailable:
-						if (Train == TrainManager.PlayerTrain) {
+						if (Train.IsPlayerTrain()) {
 							Function.Stack[s] = TrainManager.PlayerTrain.Specs.Safety.Mode == TrainManager.SafetySystem.Plugin ? 1.0 : 0.0;
 						} else {
 							Function.Stack[s] = 0.0;

--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -171,7 +171,7 @@ namespace OpenBve
 				{
 					// door opened or boarding at station
 					this.PowerNotchAtWhichWheelSlipIsObserved = Train.Handles.Power.MaximumNotch + 1;
-					if (Train.Station >= 0 && Stations[Train.Station].Type != StationType.Normal && Stations[Train.Station].Type != StationType.RequestStop && Train == TrainManager.PlayerTrain)
+					if (Train.Station >= 0 && Stations[Train.Station].Type != StationType.Normal && Stations[Train.Station].Type != StationType.RequestStop && Train.IsPlayerTrain())
 					{
 						// player's terminal station
 						if (Train.Plugin == null || Train.Plugin.LastReverser == -2)
@@ -254,7 +254,7 @@ namespace OpenBve
 					}
 					CurrentInterval = 1.0;
 				}
-				else if (Train.Station >= 0 && stopIndex >= 0 && Stations[Train.Station].Type != StationType.Normal && Stations[Train.Station].Type != StationType.RequestStop && Train == TrainManager.PlayerTrain && Train.StationDistanceToStopPoint < Stations[Train.Station].Stops[stopIndex].BackwardTolerance && -Train.StationDistanceToStopPoint < Stations[Train.Station].Stops[stopIndex].ForwardTolerance && Math.Abs(Train.CurrentSpeed) < 0.25)
+				else if (Train.Station >= 0 && stopIndex >= 0 && Stations[Train.Station].Type != StationType.Normal && Stations[Train.Station].Type != StationType.RequestStop && Train.IsPlayerTrain() && Train.StationDistanceToStopPoint < Stations[Train.Station].Stops[stopIndex].BackwardTolerance && -Train.StationDistanceToStopPoint < Stations[Train.Station].Stops[stopIndex].ForwardTolerance && Math.Abs(Train.CurrentSpeed) < 0.25)
 				{
 					// player's terminal station (not boarding any longer)
 					if (Train.Plugin != null || Train.Plugin.LastReverser == -2)
@@ -576,7 +576,7 @@ namespace OpenBve
 								else if (TrackManager.Tracks[0].Elements[i].Events[j] is TrackManager.TrackEndEvent)
 								{
 									// track end
-									if (Train == TrainManager.PlayerTrain)
+									if (Train.IsPlayerTrain())
 									{
 										TrackManager.TrackEndEvent e = (TrackManager.TrackEndEvent)TrackManager.Tracks[0].Elements[i].Events[j];
 										double dist = stp + e.TrackPositionDelta - tp;
@@ -596,7 +596,7 @@ namespace OpenBve
 						}
 					}
 					// buffers ahead
-					if (Train == TrainManager.PlayerTrain)
+					if (Train.IsPlayerTrain())
 					{
 						for (int i = 0; i < BufferTrackPositions.Length; i++)
 						{

--- a/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/DestinationChange.cs
@@ -28,7 +28,7 @@ namespace OpenBve
 			}
 			public override void Trigger(int Direction, EventTriggerType TriggerType, AbstractTrain Train, int CarIndex)
 			{
-				if (this.Type == -1 && Train == TrainManager.PlayerTrain || this.Type == 1 && Train != TrainManager.PlayerTrain)
+				if (this.Type == -1 && Train.IsPlayerTrain() || this.Type == 1 && !Train.IsPlayerTrain())
 				{
 					return;
 				}

--- a/source/OpenBVE/Game/Events/EventTypes/Markers.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/Markers.cs
@@ -20,7 +20,7 @@ namespace OpenBve
 			}
 			public override void Trigger(int Direction, EventTriggerType TriggerType, AbstractTrain Train, int CarIndex)
 			{
-				if (Train == TrainManager.PlayerTrain & TriggerType == EventTriggerType.FrontCarFrontAxle)
+				if (Train.IsPlayerTrain() & TriggerType == EventTriggerType.FrontCarFrontAxle)
 				{
 					if (this.Message != null)
 					{
@@ -58,7 +58,7 @@ namespace OpenBve
 			}
 			public override void Trigger(int Direction, EventTriggerType TriggerType, AbstractTrain Train, int CarIndex)
 			{
-				if (Train == TrainManager.PlayerTrain & TriggerType == EventTriggerType.FrontCarFrontAxle)
+				if (Train.IsPlayerTrain() & TriggerType == EventTriggerType.FrontCarFrontAxle)
 				{
 					if (this.Message != null)
 					{

--- a/source/OpenBVE/Game/Events/EventTypes/RequestStop.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/RequestStop.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Colors;
+﻿using OpenBve.RouteManager;
+using OpenBveApi.Colors;
 using OpenBveApi.Routes;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
@@ -7,15 +8,6 @@ namespace OpenBve
 {
 	internal static partial class TrackManager
 	{
-		/// <summary>Defines a request stop which may be made by a train</summary>
-		internal class RequestStop
-		{
-			internal int Probability;
-			internal double Time = -1;
-			internal string StopMessage;
-			internal string PassMessage;
-		}
-
 		/// <summary>Called when a train passes over the trigger for a request stop</summary>
 		internal class RequestStopEvent : GeneralEvent<TrainManager.Train>
 		{

--- a/source/OpenBVE/Game/Events/EventTypes/RequestStop.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/RequestStop.cs
@@ -66,7 +66,7 @@ namespace OpenBve
 						if (Program.RandomNumberGenerator.Next(0, 100) <= stop.Probability)
 						{
 							//We have hit our probability roll
-							if (Game.Stations[StationIndex].StopMode == StationStopMode.AllRequestStop || (Train == TrainManager.PlayerTrain && Game.Stations[StationIndex].StopMode == StationStopMode.PlayerRequestStop))
+							if (Game.Stations[StationIndex].StopMode == StationStopMode.AllRequestStop || (Train.IsPlayerTrain() && Game.Stations[StationIndex].StopMode == StationStopMode.PlayerRequestStop))
 							{
 
 								//If our train can stop at this station, set it's index accordingly
@@ -90,7 +90,7 @@ namespace OpenBve
 								//Play sound
 								Program.Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Train.Cars[Train.DriverCar], false);
 								//If message is not empty, add it
-								if (!string.IsNullOrEmpty(stop.PassMessage) && Train == TrainManager.PlayerTrain)
+								if (!string.IsNullOrEmpty(stop.PassMessage) && Train.IsPlayerTrain())
 								{
 									Game.AddMessage(stop.PassMessage, MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.White, Game.SecondsSinceMidnight + 10.0, null);
 								}
@@ -99,7 +99,7 @@ namespace OpenBve
 							//Play sound
 							Program.Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[0], 1.0, 1.0, Train.Cars[Train.DriverCar], false);
 							//If message is not empty, add it
-							if (!string.IsNullOrEmpty(stop.StopMessage) && Train == TrainManager.PlayerTrain)
+							if (!string.IsNullOrEmpty(stop.StopMessage) && Train.IsPlayerTrain())
 							{
 								Game.AddMessage(stop.StopMessage, MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.White, Game.SecondsSinceMidnight + 10.0, null);
 							}
@@ -119,7 +119,7 @@ namespace OpenBve
 							//Play sound
 							Program.Sounds.PlayCarSound(Train.Cars[Train.DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Train.Cars[Train.DriverCar], false);
 							//If message is not empty, add it
-							if (!string.IsNullOrEmpty(stop.PassMessage) && Train == TrainManager.PlayerTrain)
+							if (!string.IsNullOrEmpty(stop.PassMessage) && Train.IsPlayerTrain())
 							{
 								Game.AddMessage(stop.PassMessage, MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.White, Game.SecondsSinceMidnight + 10.0, null);
 							}

--- a/source/OpenBVE/Game/Events/EventTypes/Sounds.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/Sounds.cs
@@ -53,7 +53,7 @@ namespace OpenBve
 				if (SuppressSoundEvents) return;
 				if (TriggerType == EventTriggerType.FrontCarFrontAxle | TriggerType == EventTriggerType.OtherCarFrontAxle | TriggerType == EventTriggerType.OtherCarRearAxle | TriggerType == EventTriggerType.RearCarRearAxle)
 				{
-					if (!PlayerTrainOnly | Train == TrainManager.PlayerTrain)
+					if (!PlayerTrainOnly | Train.IsPlayerTrain())
 					{
 						Vector3 p = this.Position;
 						double pitch = 1.0;

--- a/source/OpenBVE/Game/Events/EventTypes/Station.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/Station.cs
@@ -103,7 +103,7 @@ namespace OpenBve
 				{
 					if (Direction > 0)
 					{
-						if (Train == TrainManager.PlayerTrain)
+						if (Train.IsPlayerTrain())
 						{
 							Timetable.UpdateCustomTimetable(Game.Stations[this.StationIndex].TimetableDaytimeTexture, Game.Stations[this.StationIndex].TimetableNighttimeTexture);
 						}
@@ -124,7 +124,7 @@ namespace OpenBve
 					{
 						if (Train.Station == StationIndex)
 						{
-							if (Train == TrainManager.PlayerTrain)
+							if (Train.IsPlayerTrain())
 							{
 								if (Game.Stations[StationIndex].PlayerStops() & TrainManager.PlayerTrain.StationState == TrainStopState.Pending)
 								{

--- a/source/OpenBVE/Game/Events/EventTypes/TrackEnd.cs
+++ b/source/OpenBVE/Game/Events/EventTypes/TrackEnd.cs
@@ -16,11 +16,11 @@ namespace OpenBve
 			}
 			public override void Trigger(int Direction, EventTriggerType TriggerType, AbstractTrain Train, int CarIndex)
 			{
-				if (TriggerType == EventTriggerType.RearCarRearAxle & Train != TrainManager.PlayerTrain)
+				if (TriggerType == EventTriggerType.RearCarRearAxle & !Train.IsPlayerTrain())
 				{
 					Train.Dispose();
 				}
-				else if (Train == TrainManager.PlayerTrain)
+				else if (Train.IsPlayerTrain())
 				{
 					Train.Derail(CarIndex, 0.0);
 				}

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
@@ -1064,7 +1064,7 @@ namespace OpenBve {
 						break;
 						// safety
 					case Instructions.SafetyPluginAvailable:
-						if (Train == TrainManager.PlayerTrain && Train.Plugin != null) {
+						if (Train.IsPlayerTrain() && Train.Plugin != null) {
 							Function.Stack[s] = TrainManager.PlayerTrain.Plugin.IsDefault ? 0.0 : 1.0;
 						} else {
 							Function.Stack[s] = 0.0;

--- a/source/OpenBVE/Game/RouteInfoOverlay.cs
+++ b/source/OpenBVE/Game/RouteInfoOverlay.cs
@@ -94,7 +94,7 @@ namespace OpenBve
 					// draw a dot at current train position
 					LibRender.Renderer.DrawRectangle(null, new Point(xPos, zPos),
 							new Size(trainDotDiameter, trainDotDiameter),
-							TrainManager.Trains[i] == TrainManager.PlayerTrain ? playerTrainDotColour : trainDotColour);
+							TrainManager.Trains[i].IsPlayerTrain() ? playerTrainDotColour : trainDotColour);
 				}
 				break;
 			case state.gradient:

--- a/source/OpenBVE/Game/Signalling.cs
+++ b/source/OpenBVE/Game/Signalling.cs
@@ -115,7 +115,7 @@ namespace OpenBve
 					{
 						t = Stations[d].ArrivalTime;
 					}
-					if (train == TrainManager.PlayerTrain & Stations[d].Type != StationType.Normal & Stations[d].DepartureTime < 0.0)
+					if (train.IsPlayerTrain() & Stations[d].Type != StationType.Normal & Stations[d].DepartureTime < 0.0)
 					{
 						settored = true;
 					}

--- a/source/OpenBVE/Game/Station.cs
+++ b/source/OpenBVE/Game/Station.cs
@@ -15,7 +15,7 @@ namespace OpenBve
 		/// <summary>Indicates whether the specified train stops at a station.</summary>
 		internal static bool StopsAtStation(int StationIndex, TrainManager.Train Train)
 		{
-			if (Train == TrainManager.PlayerTrain)
+			if (Train.IsPlayerTrain())
 			{
 				return Stations[StationIndex].StopMode == StationStopMode.AllStop | Stations[StationIndex].StopMode == StationStopMode.PlayerStop | Stations[StationIndex].StopMode == StationStopMode.PlayerRequestStop | Stations[StationIndex].StopMode == StationStopMode.AllRequestStop;
 			}

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -458,7 +458,7 @@ namespace OpenBve
 						}
 					}
 					// with buffers
-					if (Trains[i] == PlayerTrain)
+					if (Trains[i].IsPlayerTrain())
 					{
 						double a = Trains[i].Cars[0].FrontAxle.Follower.TrackPosition - Trains[i].Cars[0].FrontAxle.Position +
 								   0.5*Trains[i].Cars[0].Length;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -123,9 +123,9 @@ namespace OpenBve
 			internal int StationIndex;
 			internal int MaxNumberOfCars;
 			internal double TrackPosition;
-			internal TrackManager.RequestStop Early;
-			internal TrackManager.RequestStop OnTime;
-			internal TrackManager.RequestStop Late;
+			internal RequestStop Early;
+			internal RequestStop OnTime;
+			internal RequestStop Late;
 			internal bool FullSpeed;
 		}
 		private enum SoundType { World, TrainStatic, TrainDynamic }

--- a/source/OpenBVE/Parsers/Script/StationXMLParser.cs
+++ b/source/OpenBVE/Parsers/Script/StationXMLParser.cs
@@ -19,9 +19,9 @@ namespace OpenBve
 			{
 				Stops = new StationStop[] { }
 			};
-			stopRequest.Early = new TrackManager.RequestStop();
-			stopRequest.OnTime = new TrackManager.RequestStop();
-			stopRequest.Late = new TrackManager.RequestStop();
+			stopRequest.Early = new RequestStop();
+			stopRequest.OnTime = new RequestStop();
+			stopRequest.Late = new RequestStop();
 			stopRequest.OnTime.Probability = 75;
 			//The current XML file to load
 			XmlDocument currentXML = new XmlDocument();
@@ -32,7 +32,7 @@ namespace OpenBve
 			if (currentXML.DocumentElement != null)
 			{
 				XmlNodeList DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Station");
-				//Check this file actually contains OpenBVE light definition nodes
+				//Check this file actually contains OpenBVE station nodes
 				if (DocumentNodes != null)
 				{
 					foreach (XmlNode n in DocumentNodes)

--- a/source/OpenBVE/Parsers/Train/TrainDatParser.cs
+++ b/source/OpenBVE/Parsers/Train/TrainDatParser.cs
@@ -1028,7 +1028,7 @@ namespace OpenBve {
 					}
 				}
 
-				if (Train.Cars[i].Specs.IsMotorCar || Train == TrainManager.PlayerTrain && i == Train.DriverCar || trainBrakeType == BrakeSystemType.ElectricCommandBrake)
+				if (Train.Cars[i].Specs.IsMotorCar || Train.IsPlayerTrain() && i == Train.DriverCar || trainBrakeType == BrakeSystemType.ElectricCommandBrake)
 				{
 					Train.Cars[i].CarBrake.brakeType = BrakeType.Main;
 				}
@@ -1262,7 +1262,7 @@ namespace OpenBve {
 			Train.Cars[Train.DriverCar].Driver.X = Driver.X;
 			Train.Cars[Train.DriverCar].Driver.Y = Driver.Y;
 			Train.Cars[Train.DriverCar].Driver.Z = 0.5 * CarLength + Driver.Z;
-			if (Train == TrainManager.PlayerTrain)
+			if (Train.IsPlayerTrain())
 			{
 				Train.Cars[DriverCar].HasInteriorView = true;
 			}

--- a/source/OpenBVE/Parsers/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/OpenBVE/Parsers/Train/XML/TrainXmlParser.CarNode.cs
@@ -258,7 +258,7 @@ namespace OpenBve.Parsers.Train
 						Train.Cars[Car].Driver.Z = 0.5 * Train.Cars[Car].Length + driverZ;
 						break;
 					case "interiorview":
-						if (Train != TrainManager.PlayerTrain)
+						if (!Train.IsPlayerTrain())
 						{
 							break;
 						}

--- a/source/OpenBVE/Simulation/TrainManager/Functions.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Functions.cs
@@ -31,7 +31,7 @@ namespace OpenBve
 		/// <param name="stationIndex">The zero-based index of the station</param>
 		internal static void JumpTrain(Train train, int stationIndex)
 		{
-			if (train == PlayerTrain)
+			if (train.IsPlayerTrain())
 			{
 				for (int i = 0; i < ObjectManager.AnimatedWorldObjects.Length; i++)
 				{
@@ -51,7 +51,7 @@ namespace OpenBve
 			int stopIndex = Game.Stations[stationIndex].GetStopIndex(train.Cars.Length);
 			if (stopIndex >= 0)
 			{
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					if (train.Plugin != null)
 					{
@@ -63,7 +63,7 @@ namespace OpenBve
 					train.Cars[h].CurrentSpeed = 0.0;
 				}
 				double d = Game.Stations[stationIndex].Stops[stopIndex].TrackPosition - train.Cars[0].FrontAxle.Follower.TrackPosition + train.Cars[0].FrontAxle.Position - 0.5 * train.Cars[0].Length;
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					TrackManager.SuppressSoundEvents = true;
 				}
@@ -91,7 +91,7 @@ namespace OpenBve
 						break;
 					}
 				}
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					TrainManager.UnderailTrains();
 					TrackManager.SuppressSoundEvents = false;
@@ -109,14 +109,14 @@ namespace OpenBve
 				{
 					Game.UpdateSection(CurrentRoute.Sections.Length - 1);
 				}
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					if (Game.CurrentScore.ArrivalStation <= stationIndex)
 					{
 						Game.CurrentScore.ArrivalStation = stationIndex + 1;
 					}
 				}
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					if (Game.Stations[stationIndex].ArrivalTime >= 0.0)
 					{
@@ -132,7 +132,7 @@ namespace OpenBve
 					train.Cars[i].Doors[0].AnticipatedOpen = Game.Stations[stationIndex].OpenLeftDoors;
 					train.Cars[i].Doors[1].AnticipatedOpen = Game.Stations[stationIndex].OpenRightDoors;
 				}
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					Game.CurrentScore.DepartureStation = stationIndex;
 					Game.CurrentInterface = Game.InterfaceType.Normal;
@@ -140,7 +140,7 @@ namespace OpenBve
 				}
 				ObjectManager.UpdateAnimatedWorldObjects(0.0, true);
 				TrainManager.UpdateTrainObjects(0.0, true);
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					if (train.Plugin != null)
 					{
@@ -148,7 +148,7 @@ namespace OpenBve
 					}
 				}
 				train.StationState = TrainStopState.Pending;
-				if (train == PlayerTrain)
+				if (train.IsPlayerTrain())
 				{
 					train.LastStation = stationIndex;
 				}

--- a/source/OpenBVE/Simulation/TrainManager/Station.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Station.cs
@@ -129,7 +129,7 @@ namespace OpenBve
 								}
 								Train.Passengers.PassengerRatio = Game.Stations[i].PassengerRatio;
 								UpdateTrainMassFromPassengerRatio(Train);
-								if (Train == PlayerTrain)
+								if (Train.IsPlayerTrain())
 								{
 									double early = 0.0;
 									if (Game.Stations[i].ArrivalTime >= 0.0)
@@ -217,7 +217,7 @@ namespace OpenBve
 										OpenBveApi.Math.Vector3 pos = Train.Cars[Train.DriverCar].Sounds.Adjust.Position;
 										Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Train.Cars[Train.DriverCar], false);
 									}
-									if (Train == TrainManager.PlayerTrain)
+									if (Train.IsPlayerTrain())
 									{
 										Game.AddMessage(Translations.GetInterfaceString("message_station_correct"), MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.Orange, Game.SecondsSinceMidnight + 5.0, null);
 									}
@@ -424,7 +424,7 @@ namespace OpenBve
 							if (Game.SecondsSinceMidnight > Train.StationDepartureTime && (Game.Stations[i].Type != StationType.Terminal || Train != PlayerTrain))
 							{
 								Train.StationState = TrainStopState.Completed;
-								if (Train == PlayerTrain & Game.Stations[i].Type == StationType.Normal)
+								if (Train.IsPlayerTrain() & Game.Stations[i].Type == StationType.Normal)
 								{
 									if (!Game.Stations[i].OpenLeftDoors & !Game.Stations[i].OpenRightDoors | Train.Specs.DoorCloseMode != DoorMode.Manual)
 									{
@@ -444,7 +444,7 @@ namespace OpenBve
 						else
 						{
 							Train.StationState = TrainStopState.Completed;
-							if (Train == PlayerTrain & Game.Stations[i].Type == StationType.Normal)
+							if (Train.IsPlayerTrain() & Game.Stations[i].Type == StationType.Normal)
 							{
 								Game.AddMessage(Translations.GetInterfaceString("message_station_depart"), MessageManager.MessageDependency.None, Interface.GameMode.Normal, MessageColor.White, Game.SecondsSinceMidnight + 5.0, null);
 							}

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -100,6 +100,11 @@ namespace OpenBve
 				}
 			}
 
+			public override bool IsPlayerTrain()
+			{
+				return this == PlayerTrain;
+			}
+
 			/// <summary>Call this method to update the train</summary>
 			/// <param name="TimeElapsed">The elapsed time this frame</param>
 			internal void Update(double TimeElapsed)
@@ -107,7 +112,7 @@ namespace OpenBve
 				if (State == TrainState.Pending)
 				{
 					// pending train
-					bool forceIntroduction = this == PlayerTrain && !Game.MinimalisticSimulation;
+					bool forceIntroduction = !IsPlayerTrain() && !Game.MinimalisticSimulation;
 					double time = 0.0;
 					if (!forceIntroduction)
 					{
@@ -149,7 +154,7 @@ namespace OpenBve
 							{
 								if (Cars[j].CarSections.Length != 0)
 								{
-									if (j == this.DriverCar && this == PlayerTrain)
+									if (j == this.DriverCar && IsPlayerTrain())
 									{
 										this.Cars[j].ChangeCarSection(CarSectionType.Interior);
 									}
@@ -163,7 +168,7 @@ namespace OpenBve
 										 * but we have no control over external factors....
 										 */
 										this.Cars[j].ChangeCarSection(CarSectionType.Exterior);
-										if (this == PlayerTrain)
+										if (IsPlayerTrain())
 										{
 											this.Cars[j].ChangeCarSection(CarSectionType.NotVisible);
 
@@ -171,8 +176,8 @@ namespace OpenBve
 									}
 
 								}
-								Cars[j].FrontBogie.ChangeSection(this != PlayerTrain ? 0 : -1);
-								Cars[j].RearBogie.ChangeSection(this != PlayerTrain ? 0 : -1);
+								Cars[j].FrontBogie.ChangeSection(!IsPlayerTrain() ? 0 : -1);
+								Cars[j].RearBogie.ChangeSection(!IsPlayerTrain() ? 0 : -1);
 								if (Cars[j].Specs.IsMotorCar)
 								{
 									if (Cars[j].Sounds.Loop.Buffer != null)
@@ -260,7 +265,7 @@ namespace OpenBve
 				}
 
 				// safety system
-				if (!Game.MinimalisticSimulation | this != PlayerTrain)
+				if (!Game.MinimalisticSimulation | !IsPlayerTrain())
 				{
 					UpdateSafetySystem();
 				}
@@ -306,7 +311,7 @@ namespace OpenBve
 					if (Handles.EmergencyBrake.Driver & CurrentSpeed > -0.03 & CurrentSpeed < 0.03)
 					{
 						CurrentSectionLimit = 6.94444444444444;
-						if (this == PlayerTrain)
+						if (IsPlayerTrain())
 						{
 							string s = Translations.GetInterfaceString("message_signal_proceed");
 							double a = (3.6 * CurrentSectionLimit) * Game.SpeedConversionFactor;
@@ -328,7 +333,7 @@ namespace OpenBve
 
 			private void UpdateSpeeds(double TimeElapsed)
 			{
-				if (Game.MinimalisticSimulation & this == PlayerTrain)
+				if (Game.MinimalisticSimulation & IsPlayerTrain())
 				{
 					// hold the position of the player's train during startup
 					for (int i = 0; i < Cars.Length; i++)

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -356,7 +356,7 @@ namespace OpenBve
 					{
 						if (Train.State != TrainState.Bogus)
 						{
-							if (Train == TrainManager.PlayerTrain)
+							if (Train.IsPlayerTrain())
 							{
 								InputDevicePlugin.AvailablePlugins[i].SetMaxNotch(Train.Handles.Power.MaximumDriverNotch, Train.Handles.Brake.MaximumDriverNotch);
 							}
@@ -619,7 +619,7 @@ namespace OpenBve
 			for (int i = 0; i < TrainManager.Trains.Length; i++)
 			{
 				TrainManager.Trains[i].Initialize();
-				int s = TrainManager.Trains[i] == TrainManager.PlayerTrain ? PlayerFirstStationIndex : OtherFirstStationIndex;
+				int s = TrainManager.Trains[i].IsPlayerTrain() ? PlayerFirstStationIndex : OtherFirstStationIndex;
 				if (s >= 0)
 				{
 					if (Game.Stations[s].OpenLeftDoors)
@@ -688,7 +688,7 @@ namespace OpenBve
 			for (int i = 0; i < TrainManager.Trains.Length; i++)
 			{
 				double p;
-				if (TrainManager.Trains[i] == TrainManager.PlayerTrain)
+				if (TrainManager.Trains[i].IsPlayerTrain())
 				{
 					p = PlayerFirstStationPosition;
 				}

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -255,7 +255,7 @@ namespace OpenBve {
 				} else {
 					TrainManager.Trains[k].TrainFolder = CurrentTrainFolder;
 					// real train
-					if (TrainManager.Trains[k] == TrainManager.PlayerTrain)
+					if (TrainManager.Trains[k].IsPlayerTrain())
 					{
 						Program.FileSystem.AppendToLogFile("Loading player train: " + TrainManager.Trains[k].TrainFolder);
 					}
@@ -327,7 +327,7 @@ namespace OpenBve {
 					}
 				}
 				// add panel section
-				if (TrainManager.Trains[k] == TrainManager.PlayerTrain) {	
+				if (TrainManager.Trains[k].IsPlayerTrain()) {	
 					TrainProgressCurrentWeight = 0.7 / TrainProgressMaximum;
 					TrainManager.ParsePanelConfig(TrainManager.Trains[k].TrainFolder, CurrentTrainEncoding, TrainManager.Trains[k]);
 					TrainProgressCurrentSum += TrainProgressCurrentWeight;
@@ -396,7 +396,7 @@ namespace OpenBve {
 				TrainManager.Trains[k].PlaceCars(0.0);
 				
 				// configure ai / timetable
-				if (TrainManager.Trains[k] == TrainManager.PlayerTrain) {
+				if (TrainManager.Trains[k].IsPlayerTrain()) {
 					TrainManager.Trains[k].TimetableDelta = 0.0;
 				} else if (TrainManager.Trains[k].State != TrainState.Bogus) {
 					TrainManager.Trains[k].AI = new Game.SimpleHumanDriverAI(TrainManager.Trains[k]);
@@ -417,7 +417,7 @@ namespace OpenBve {
 			// load plugin
 			for (int i = 0; i < TrainManager.Trains.Length; i++) {
 				if (TrainManager.Trains[i].State != TrainState.Bogus) {
-					if (TrainManager.Trains[i] == TrainManager.PlayerTrain) {
+					if (TrainManager.Trains[i].IsPlayerTrain()) {
 						if (!PluginManager.LoadCustomPlugin(TrainManager.Trains[i], TrainManager.Trains[i].TrainFolder, CurrentTrainEncoding)) {
 							PluginManager.LoadDefaultPlugin(TrainManager.Trains[i], TrainManager.Trains[i].TrainFolder);
 						}

--- a/source/OpenBVE/System/Scripting.cs
+++ b/source/OpenBVE/System/Scripting.cs
@@ -652,7 +652,7 @@ namespace OpenBve
             public static bool hasPlugin(TrainManager.Train Train)
             {
                 if (Train == null) return false;
-                if (Train == TrainManager.PlayerTrain && Train.Plugin != null)
+                if (Train.IsPlayerTrain() && Train.Plugin != null)
                 {
                     return TrainManager.PlayerTrain.Plugin.IsDefault;
                 }

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -31,6 +31,13 @@
 		/// <summary>Gets the track position of the rear car</summary>
 		public abstract double RearCarTrackPosition();
 
+		/// <summary>Returns true if this is the player driven train</summary>
+		public virtual bool IsPlayerTrain()
+		{
+			//An abstract train in and of itself cannot be the player train
+			return false;
+		}
+
 		/// <summary>Derails a car within the train</summary>
 		/// <param name="CarIndex">The index of the car to derail</param>
 		/// <param name="ElapsedTime">The frame time elapsed</param>

--- a/source/RouteManager/RouteManager.csproj
+++ b/source/RouteManager/RouteManager.csproj
@@ -54,6 +54,7 @@
     <Compile Include="SignalManager\SectionTypes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CurrentRoute.cs" />
+    <Compile Include="Stations\RequestStop.cs" />
     <Compile Include="Stations\RouteStation.cs" />
     <Compile Include="Stations\Station.Stop.cs" />
   </ItemGroup>

--- a/source/RouteManager/Stations/RequestStop.cs
+++ b/source/RouteManager/Stations/RequestStop.cs
@@ -1,0 +1,15 @@
+﻿namespace OpenBve.RouteManager
+{
+	/// <summary>Defines a request stop which may be made by a train</summary>
+	public class RequestStop
+	{
+		/// <summary>The probability that this stop may be called</summary>
+		public int Probability;
+		/// <summary>The time at which this stop may be called</summary>
+		public double Time = -1;
+		/// <summary>The message displayed when the train is to stop</summary>
+		public string StopMessage;
+		/// <summary>The message displayed when the train is to pass</summary>
+		public string PassMessage;
+	}
+}


### PR DESCRIPTION
This is another PR aimed at simplification and reducing interdependance.

At present, the PlayerTrain is checked and accessed via the TrainManager.PlayerTrain variable.
Often, we only need to know if a train *is* the player train in a function, and have no need for the rest of the TrainManager, normally because we're working with an abstract train in a separate assembly. 