### PR TITLE
Refactor TrackFollower to take an absolute or a relative position

### DIFF
--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -376,15 +376,15 @@ namespace OpenBve
 						// next station stop
 						int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
 						int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
-						for (int i = te; i < TrackManager.Tracks[currentTrack].Elements.Length; i++)
+						for (int i = te; i < CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
 						{
-							double stp = TrackManager.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+							double stp = CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
 							if (tp + lookahead <= stp) break;
-							for (int j = 0; j < TrackManager.Tracks[currentTrack].Elements[i].Events.Length; j++)
+							for (int j = 0; j < CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
 							{
-								if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+								if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
 								{
-									StationStartEvent e = (StationStartEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+									StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 									if (StopsAtStation(e.StationIndex, Train) & Train.LastStation != e.StationIndex)
 									{
 										int s = CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
@@ -405,16 +405,16 @@ namespace OpenBve
 						// events
 						int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
 						int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
-						for (int i = te; i < TrackManager.Tracks[currentTrack].Elements.Length; i++)
+						for (int i = te; i < CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
 						{
-							double stp = TrackManager.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+							double stp = CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
 							if (tp + lookahead <= stp) break;
-							for (int j = 0; j < TrackManager.Tracks[currentTrack].Elements[i].Events.Length; j++)
+							for (int j = 0; j < CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
 							{
-								if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is LimitChangeEvent)
+								if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is LimitChangeEvent)
 								{
 									// speed limit
-									LimitChangeEvent e = (LimitChangeEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+									LimitChangeEvent e = (LimitChangeEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 									if (e.NextSpeedLimit < spd)
 									{
 										double dist = stp + e.TrackPositionDelta - tp;
@@ -422,10 +422,10 @@ namespace OpenBve
 										if (edec > dec) dec = edec;
 									}
 								}
-								else if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is TrackManager.SectionChangeEvent)
+								else if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackManager.SectionChangeEvent)
 								{
 									// section
-									TrackManager.SectionChangeEvent e = (TrackManager.SectionChangeEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+									TrackManager.SectionChangeEvent e = (TrackManager.SectionChangeEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 									if (stp + e.TrackPositionDelta > tp)
 									{
 										if (!CurrentRoute.Sections[e.NextSectionIndex].Invisible & CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect >= 0)
@@ -484,12 +484,12 @@ namespace OpenBve
 										}
 									}
 								}
-								else if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+								else if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
 								{
 									// station start
 									if (Train.Station == -1)
 									{
-										StationStartEvent e = (StationStartEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+										StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 										if (StopsAtStation(e.StationIndex, Train) & Train.LastStation != e.StationIndex)
 										{
 											int s = CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
@@ -513,12 +513,12 @@ namespace OpenBve
 										}
 									}
 								}
-								else if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.Decelerate)
+								else if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.Decelerate)
 								{
 									// Brakes the train when passing through a request stop, which is not to be passed at linespeed
 									if (Train.Station == -1)
 									{
-										StationStartEvent e = (StationStartEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+										StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 										if (StopsAtStation(e.StationIndex, Train) & Train.LastStation != e.StationIndex)
 										{
 											int s = CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
@@ -546,12 +546,12 @@ namespace OpenBve
 										}
 									}
 								}
-								else if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is TrackManager.StationEndEvent && Train.NextStopSkipped == StopSkipMode.None)
+								else if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackManager.StationEndEvent && Train.NextStopSkipped == StopSkipMode.None)
 								{
 									// station end
 									if (Train.Station == -1)
 									{
-										TrackManager.StationEndEvent e = (TrackManager.StationEndEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+										TrackManager.StationEndEvent e = (TrackManager.StationEndEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 										if (StopsAtStation(e.StationIndex, Train) & Train.LastStation != e.StationIndex)
 										{
 											int s = CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
@@ -575,12 +575,12 @@ namespace OpenBve
 										}
 									}
 								}
-								else if (TrackManager.Tracks[currentTrack].Elements[i].Events[j] is TrackEndEvent)
+								else if (CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackEndEvent)
 								{
 									// track end
 									if (Train.IsPlayerTrain)
 									{
-										TrackEndEvent e = (TrackEndEvent)TrackManager.Tracks[currentTrack].Elements[i].Events[j];
+										TrackEndEvent e = (TrackEndEvent)CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
 										double dist = stp + e.TrackPositionDelta - tp;
 										double edec;
 										if (dist >= 15.0)

--- a/source/OpenBVE/Game/Game.cs
+++ b/source/OpenBVE/Game/Game.cs
@@ -46,9 +46,9 @@ namespace OpenBve {
         /// <param name="ResetLogs">Whether the logs should be reset</param>
 		internal static void Reset(bool ResetLogs) {
 			// track manager
-			for (int i = 0; i < TrackManager.Tracks.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks.Length; i++)
 			{
-				TrackManager.Tracks[i] = new Track();
+				CurrentRoute.Tracks[i] = new Track();
 			}
 			// train manager
 			TrainManager.Trains = new TrainManager.Train[] { };

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using LibRender;
+using OpenBve.RouteManager;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Trains;
@@ -123,8 +124,8 @@ namespace OpenBve
 				// apply position due to cant/toppling
 				{
 					double a = CurrentRollDueToTopplingAngle + CurrentRollDueToCantAngle;
-					double x = Math.Sign(a) * 0.5 * TrackManager.Tracks[FrontAxleFollower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
-					double y = Math.Abs(0.5 * TrackManager.Tracks[FrontAxleFollower.TrackIndex].RailGauge * Math.Sin(a));
+					double x = Math.Sign(a) * 0.5 * CurrentRoute.Tracks[FrontAxleFollower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
+					double y = Math.Abs(0.5 * CurrentRoute.Tracks[FrontAxleFollower.TrackIndex].RailGauge * Math.Sin(a));
 					Vector3 c = Side * x + Up * y;
 
 					FrontAxleFollower.WorldPosition += c;

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/TrackFollowingObject.cs
@@ -74,8 +74,8 @@ namespace OpenBve
 							//Calculate the distance travelled
 							double delta = UpdateTrackFollowerScript(false, train, train == null ? 0 : train.DriverCar, SectionIndex, TrackPosition, Position, true, timeDelta);
 							//Update the front and rear axle track followers
-							FrontAxleFollower.Update((TrackPosition + FrontAxlePosition) + delta, true, true);
-							RearAxleFollower.Update((TrackPosition + RearAxlePosition) + delta, true, true);
+							FrontAxleFollower.UpdateAbsolute((TrackPosition + FrontAxlePosition) + delta, true, true);
+							RearAxleFollower.UpdateAbsolute((TrackPosition + RearAxlePosition) + delta, true, true);
 							//Update the base object position
 							FrontAxleFollower.UpdateWorldCoordinates(false);
 							RearAxleFollower.UpdateWorldCoordinates(false);

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/WorldSound.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/WorldSound.cs
@@ -49,7 +49,7 @@ namespace OpenBve
 					Follower =  new TrackManager.TrackFollower(),
 					currentTrackPosition = trackPosition
 				};
-				snd.Follower.Update(trackPosition, true, true);
+				snd.Follower.UpdateAbsolute(trackPosition, true, true);
 				if (this.TrackFollowerFunction != null)
 				{
 					snd.TrackFollowerFunction = this.TrackFollowerFunction.Clone();
@@ -104,7 +104,7 @@ namespace OpenBve
 					{
 
 						double delta = this.TrackFollowerFunction.Perform(train, train == null ? 0 : train.DriverCar, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
-						this.Follower.Update(this.currentTrackPosition + delta, true, true);
+						this.Follower.UpdateAbsolute(this.currentTrackPosition + delta, true, true);
 						this.Follower.UpdateWorldCoordinates(false);
 					}
 					if (this.VolumeFunction != null)

--- a/source/OpenBVE/Game/PointsOfInterest.cs
+++ b/source/OpenBVE/Game/PointsOfInterest.cs
@@ -62,7 +62,7 @@ namespace OpenBve
 			}
 			// process poi
 			if (j < 0) return false;
-			World.CameraTrackFollower.Update(t, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(t, true, false);
 			Camera.CurrentAlignment.Position = CurrentRoute.PointsOfInterest[j].TrackOffset;
 			Camera.CurrentAlignment.Yaw = CurrentRoute.PointsOfInterest[j].TrackYaw;
 			Camera.CurrentAlignment.Pitch = CurrentRoute.PointsOfInterest[j].TrackPitch;

--- a/source/OpenBVE/Game/Timetable.cs
+++ b/source/OpenBVE/Game/Timetable.cs
@@ -66,11 +66,11 @@ namespace OpenBve {
 				double Limit = -1.0, LastLimit = 6.94444444444444;
 				int LastArrivalHours = -1, LastDepartureHours = -1;
 				double LastTime = -1.0;
-				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+				for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 				{
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 					{
-						StationStartEvent sse = TrackManager.Tracks[0].Elements[i].Events[j] as StationStartEvent;
+						StationStartEvent sse = CurrentRoute.Tracks[0].Elements[i].Events[j] as StationStartEvent;
 						if (sse != null && CurrentRoute.Stations[sse.StationIndex].Name != string.Empty)
 						{
 							if (Limit == -1.0) Limit = LastLimit;
@@ -200,7 +200,7 @@ namespace OpenBve {
 
 						if (n >= 1)
 						{
-							LimitChangeEvent lce = TrackManager.Tracks[0].Elements[i].Events[j] as LimitChangeEvent;
+							LimitChangeEvent lce = CurrentRoute.Tracks[0].Elements[i].Events[j] as LimitChangeEvent;
 							if (lce != null)
 							{
 								if (lce.NextSpeedLimit != double.PositiveInfinity & lce.NextSpeedLimit > Limit) Limit = lce.NextSpeedLimit;

--- a/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
+++ b/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OpenBve.RouteManager;
 using OpenBveApi.Math;
 using OpenBveApi.Routes;
 
@@ -46,22 +47,22 @@ namespace OpenBve
 			/// <param name="AddTrackInaccuracy">Whether to add track innacuracy</param>
 			internal void UpdateAbsolute(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccuracy)
 			{
-				if (TrackIndex >= Tracks.Length || Tracks[TrackIndex].Elements.Length == 0) return;
+				if (TrackIndex >= CurrentRoute.Tracks.Length || CurrentRoute.Tracks[TrackIndex].Elements.Length == 0) return;
 				int i = LastTrackElement;
-				while (i >= 0 && NewTrackPosition < Tracks[TrackIndex].Elements[i].StartingTrackPosition)
+				while (i >= 0 && NewTrackPosition < CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition)
 				{
-					double ta = TrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition;
+					double ta = TrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
 					double tb = -0.01;
 					CheckEvents(i, -1, ta, tb);
 					i--;
 				}
 				if (i >= 0)
 				{
-					while (i < Tracks[TrackIndex].Elements.Length - 1)
+					while (i < CurrentRoute.Tracks[TrackIndex].Elements.Length - 1)
 					{
-						if (NewTrackPosition < Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition) break;
-						double ta = TrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition;
-						double tb = Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition + 0.01;
+						if (NewTrackPosition < CurrentRoute.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition) break;
+						double ta = TrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
+						double tb = CurrentRoute.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition + 0.01;
 						CheckEvents(i, 1, ta, tb);
 						i++;
 					}
@@ -70,33 +71,33 @@ namespace OpenBve
 				{
 					i = 0;
 				}
-				double da = TrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition;
-				double db = NewTrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition;
+				double da = TrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
+				double db = NewTrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
 
 				// track
 				if (UpdateWorldCoordinates)
 				{
 					if (db != 0.0)
 					{
-						if (Tracks[TrackIndex].Elements[i].CurveRadius != 0.0)
+						if (CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius != 0.0)
 						{
 							// curve
-							double r = Tracks[TrackIndex].Elements[i].CurveRadius;
-							double p = Tracks[TrackIndex].Elements[i].WorldDirection.Y / Math.Sqrt(Tracks[TrackIndex].Elements[i].WorldDirection.X * Tracks[TrackIndex].Elements[i].WorldDirection.X + Tracks[TrackIndex].Elements[i].WorldDirection.Z * Tracks[TrackIndex].Elements[i].WorldDirection.Z);
+							double r = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius;
+							double p = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.Y / Math.Sqrt(CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.X * CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.X + CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.Z * CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.Z);
 							double s = db / Math.Sqrt(1.0 + p * p);
 							double h = s * p;
 							double b = s / Math.Abs(r);
 							double f = 2.0 * r * r * (1.0 - Math.Cos(b));
 							double c = (double)Math.Sign(db) * Math.Sqrt(f >= 0.0 ? f : 0.0);
 							double a = 0.5 * (double)Math.Sign(r) * b;
-							Vector3 D = new Vector3(Tracks[TrackIndex].Elements[i].WorldDirection.X, 0.0, Tracks[TrackIndex].Elements[i].WorldDirection.Z);
+							Vector3 D = new Vector3(CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.X, 0.0, CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection.Z);
 							D.Normalize();
 							double cosa = Math.Cos(a);
 							double sina = Math.Sin(a);
 							D.Rotate(Vector3.Down, cosa, sina);
-							WorldPosition.X = Tracks[TrackIndex].Elements[i].WorldPosition.X + c * D.X;
-							WorldPosition.Y = Tracks[TrackIndex].Elements[i].WorldPosition.Y + h;
-							WorldPosition.Z = Tracks[TrackIndex].Elements[i].WorldPosition.Z + c * D.Z;
+							WorldPosition.X = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldPosition.X + c * D.X;
+							WorldPosition.Y = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldPosition.Y + h;
+							WorldPosition.Z = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldPosition.Z + c * D.Z;
 							D.Rotate(Vector3.Down, cosa, sina);
 							WorldDirection.X = D.X;
 							WorldDirection.Y = p;
@@ -104,7 +105,7 @@ namespace OpenBve
 							WorldDirection.Normalize();
 							double cos2a = Math.Cos(2.0 * a);
 							double sin2a = Math.Sin(2.0 * a);
-							WorldSide = Tracks[TrackIndex].Elements[i].WorldSide;
+							WorldSide = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldSide;
 							WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
 							WorldUp = Vector3.Cross(WorldDirection, WorldSide);
 
@@ -112,17 +113,17 @@ namespace OpenBve
 						else
 						{
 							// straight
-							WorldPosition = Tracks[TrackIndex].Elements[i].WorldPosition + db * Tracks[TrackIndex].Elements[i].WorldDirection;
-							WorldDirection = Tracks[TrackIndex].Elements[i].WorldDirection;
-							WorldUp = Tracks[TrackIndex].Elements[i].WorldUp;
-							WorldSide = Tracks[TrackIndex].Elements[i].WorldSide;
+							WorldPosition = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldPosition + db * CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection;
+							WorldDirection = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection;
+							WorldUp = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldUp;
+							WorldSide = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldSide;
 							CurveRadius = 0.0;
 						}
 
 						// cant
-						if (i < Tracks[TrackIndex].Elements.Length - 1)
+						if (i < CurrentRoute.Tracks[TrackIndex].Elements.Length - 1)
 						{
-							double t = db / (Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition);
+							double t = db / (CurrentRoute.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition);
 							if (t < 0.0)
 							{
 								t = 0.0;
@@ -134,27 +135,27 @@ namespace OpenBve
 							double t2 = t * t;
 							double t3 = t2 * t;
 							CurveCant =
-								(2.0 * t3 - 3.0 * t2 + 1.0) * Tracks[TrackIndex].Elements[i].CurveCant +
-								(t3 - 2.0 * t2 + t) * Tracks[TrackIndex].Elements[i].CurveCantTangent +
-								(-2.0 * t3 + 3.0 * t2) * Tracks[TrackIndex].Elements[i + 1].CurveCant +
-								(t3 - t2) * Tracks[TrackIndex].Elements[i + 1].CurveCantTangent;
-							CurveRadius = Tracks[TrackIndex].Elements[i].CurveRadius;
+								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * CurrentRoute.Tracks[TrackIndex].Elements[i + 1].CurveCant +
+								(t3 - t2) * CurrentRoute.Tracks[TrackIndex].Elements[i + 1].CurveCantTangent;
+							CurveRadius = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius;
 						}
 						else
 						{
-							CurveCant = Tracks[TrackIndex].Elements[i].CurveCant;
+							CurveCant = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant;
 						}
 
 
 					}
 					else
 					{
-						WorldPosition = Tracks[TrackIndex].Elements[i].WorldPosition;
-						WorldDirection = Tracks[TrackIndex].Elements[i].WorldDirection;
-						WorldUp = Tracks[TrackIndex].Elements[i].WorldUp;
-						WorldSide = Tracks[TrackIndex].Elements[i].WorldSide;
-						CurveRadius = Tracks[TrackIndex].Elements[i].CurveRadius;
-						CurveCant = Tracks[TrackIndex].Elements[i].CurveCant;
+						WorldPosition = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldPosition;
+						WorldDirection = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldDirection;
+						WorldUp = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldUp;
+						WorldSide = CurrentRoute.Tracks[TrackIndex].Elements[i].WorldSide;
+						CurveRadius = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius;
+						CurveCant = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant;
 					}
 
 				}
@@ -162,17 +163,17 @@ namespace OpenBve
 				{
 					if (db != 0.0)
 					{
-						if (Tracks[TrackIndex].Elements[i].CurveRadius != 0.0)
+						if (CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius != 0.0)
 						{
-							CurveRadius = Tracks[TrackIndex].Elements[i].CurveRadius;
+							CurveRadius = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius;
 						}
 						else
 						{
 							CurveRadius = 0.0;
 						}
-						if (i < Tracks[TrackIndex].Elements.Length - 1)
+						if (i < CurrentRoute.Tracks[TrackIndex].Elements.Length - 1)
 						{
-							double t = db / (Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition);
+							double t = db / (CurrentRoute.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition);
 							if (t < 0.0)
 							{
 								t = 0.0;
@@ -184,34 +185,34 @@ namespace OpenBve
 							double t2 = t * t;
 							double t3 = t2 * t;
 							CurveCant =
-								(2.0 * t3 - 3.0 * t2 + 1.0) * Tracks[TrackIndex].Elements[i].CurveCant +
-								(t3 - 2.0 * t2 + t) * Tracks[TrackIndex].Elements[i].CurveCantTangent +
-								(-2.0 * t3 + 3.0 * t2) * Tracks[TrackIndex].Elements[i + 1].CurveCant +
-								(t3 - t2) * Tracks[TrackIndex].Elements[i + 1].CurveCantTangent;
+								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * CurrentRoute.Tracks[TrackIndex].Elements[i + 1].CurveCant +
+								(t3 - t2) * CurrentRoute.Tracks[TrackIndex].Elements[i + 1].CurveCantTangent;
 						}
 						else
 						{
-							CurveCant = Tracks[TrackIndex].Elements[i].CurveCant;
+							CurveCant = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant;
 						}
 					}
 					else
 					{
-						CurveRadius = Tracks[TrackIndex].Elements[i].CurveRadius;
-						CurveCant = Tracks[TrackIndex].Elements[i].CurveCant;
+						CurveRadius = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveRadius;
+						CurveCant = CurrentRoute.Tracks[TrackIndex].Elements[i].CurveCant;
 					}
 
 				}
-				AdhesionMultiplier = Tracks[TrackIndex].Elements[i].AdhesionMultiplier;
+				AdhesionMultiplier = CurrentRoute.Tracks[TrackIndex].Elements[i].AdhesionMultiplier;
 				//Pitch added for Plugin Data usage
 				//Mutliply this by 1000 to get the original value
-				Pitch = Tracks[TrackIndex].Elements[i].Pitch * 1000;
+				Pitch = CurrentRoute.Tracks[TrackIndex].Elements[i].Pitch * 1000;
 				// inaccuracy
 				if (AddTrackInaccuracy)
 				{
 					double x, y, c;
-					if (i < Tracks[TrackIndex].Elements.Length - 1)
+					if (i < CurrentRoute.Tracks[TrackIndex].Elements.Length - 1)
 					{
-						double t = db / (Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - Tracks[TrackIndex].Elements[i].StartingTrackPosition);
+						double t = db / (CurrentRoute.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[TrackIndex].Elements[i].StartingTrackPosition);
 						if (t < 0.0)
 						{
 							t = 0.0;
@@ -222,15 +223,15 @@ namespace OpenBve
 						}
 						double x1, y1, c1;
 						double x2, y2, c2;
-						Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, Tracks[TrackIndex].Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
-						Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, Tracks[TrackIndex].Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
+						CurrentRoute.Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, CurrentRoute.Tracks[TrackIndex].Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
+						CurrentRoute.Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, CurrentRoute.Tracks[TrackIndex].Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
 						x = (1.0 - t) * x1 + t * x2;
 						y = (1.0 - t) * y1 + t * y2;
 						c = (1.0 - t) * c1 + t * c2;
 					}
 					else
 					{
-						Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, Tracks[TrackIndex].Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
+						CurrentRoute.Tracks[TrackIndex].GetInaccuracies(NewTrackPosition, CurrentRoute.Tracks[TrackIndex].Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
 					}
 					WorldPosition += x * WorldSide + y * WorldUp;
 					CurveCant += c;
@@ -262,7 +263,7 @@ namespace OpenBve
 
 			private void CheckEvents(int ElementIndex, int Direction, double OldDelta, double NewDelta)
 			{
-				if (this.TriggerType == EventTriggerType.None || Tracks[TrackIndex].Elements[ElementIndex].Events.Length == 0)
+				if (this.TriggerType == EventTriggerType.None || CurrentRoute.Tracks[TrackIndex].Elements[ElementIndex].Events.Length == 0)
 				{
 					return;
 				}
@@ -270,10 +271,10 @@ namespace OpenBve
 				int Index = TrackIndex;
 				if (Direction < 0)
 				{
-					for (int j = Tracks[Index].Elements[ElementIndex].Events.Length - 1; j >= 0; j--)
+					for (int j = CurrentRoute.Tracks[Index].Elements[ElementIndex].Events.Length - 1; j >= 0; j--)
 					{
-						dynamic e = Tracks[Index].Elements[ElementIndex].Events[j];
-						if (Tracks[Index].Elements[ElementIndex].Events.Length == 0)
+						dynamic e = CurrentRoute.Tracks[Index].Elements[ElementIndex].Events[j];
+						if (CurrentRoute.Tracks[Index].Elements[ElementIndex].Events.Length == 0)
 						{
 							return;
 						}
@@ -285,9 +286,9 @@ namespace OpenBve
 				}
 				else if (Direction > 0)
 				{
-					for (int j = 0; j < Tracks[Index].Elements[ElementIndex].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[Index].Elements[ElementIndex].Events.Length; j++)
 					{
-						dynamic e = Tracks[Index].Elements[ElementIndex].Events[j];
+						dynamic e = CurrentRoute.Tracks[Index].Elements[ElementIndex].Events[j];
 						if (OldDelta < e.TrackPositionDelta & NewDelta >= e.TrackPositionDelta)
 						{
 							e.TryTrigger(1, this.TriggerType, this.Train, this.Train != null ? this.Train.Cars[CarIndex] : null);

--- a/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
+++ b/source/OpenBVE/Game/TrackManager/TrackManager.TrackFollower.cs
@@ -28,14 +28,23 @@ namespace OpenBve
 
 			internal void UpdateWorldCoordinates(bool AddTrackInaccuracy)
 			{
-				Update(this.TrackPosition, true, AddTrackInaccuracy);
+				UpdateAbsolute(this.TrackPosition, true, AddTrackInaccuracy);
 			}
 
-			/// <summary>Call this method to update a single track follower</summary>
-			/// <param name="NewTrackPosition">The new track position of the follower</param>
+			/// <summary>Call this method to update a single track follower on a relative basis</summary>
+			/// <param name="RelativeTrackPosition">The new absolute track position of the follower</param>
 			/// <param name="UpdateWorldCoordinates">Whether to update the world co-ordinates</param>
-			/// <param name="AddTrackInaccurary">Whether to add track innacuracy</param>
-			internal void Update(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccurary)
+			/// <param name="AddTrackInaccuracy">Whether to add track innacuracy</param>
+			internal void UpdateRelative(double RelativeTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccuracy)
+			{
+				UpdateAbsolute(TrackPosition + RelativeTrackPosition, UpdateWorldCoordinates, AddTrackInaccuracy);
+			}
+
+			/// <summary>Call this method to update a single track follower on an absolute basis</summary>
+			/// <param name="NewTrackPosition">The new absolute track position of the follower</param>
+			/// <param name="UpdateWorldCoordinates">Whether to update the world co-ordinates</param>
+			/// <param name="AddTrackInaccuracy">Whether to add track innacuracy</param>
+			internal void UpdateAbsolute(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccuracy)
 			{
 				if (TrackIndex >= Tracks.Length || Tracks[TrackIndex].Elements.Length == 0) return;
 				int i = LastTrackElement;
@@ -197,7 +206,7 @@ namespace OpenBve
 				//Mutliply this by 1000 to get the original value
 				Pitch = Tracks[TrackIndex].Elements[i].Pitch * 1000;
 				// inaccuracy
-				if (AddTrackInaccurary)
+				if (AddTrackInaccuracy)
 				{
 					double x, y, c;
 					if (i < Tracks[TrackIndex].Elements.Length - 1)

--- a/source/OpenBVE/Game/TrackManager/TrackManager.cs
+++ b/source/OpenBVE/Game/TrackManager/TrackManager.cs
@@ -6,10 +6,5 @@ namespace OpenBve
 	{
 		/// <summary>Whether sound events are currently suppressed</summary>
 		internal static bool SuppressSoundEvents = false;
-
-		/// <summary>The list of tracks available in the simulation.</summary>
-		internal static Track[] Tracks = new Track[] { new Track() };
-
-		
 	}
 }

--- a/source/OpenBVE/Graphics/Renderer/Events.cs
+++ b/source/OpenBVE/Graphics/Renderer/Events.cs
@@ -44,7 +44,7 @@ namespace OpenBve
 		/// <param name="Camera">The absolute camera position</param>
 		private static void RenderEvents(Vector3 Camera)
 		{
-			if (Interface.CurrentOptions.ShowEvents == false || TrackManager.Tracks[0].Elements == null)
+			if (Interface.CurrentOptions.ShowEvents == false || CurrentRoute.Tracks[0].Elements == null)
 			{
 				return;
 			}
@@ -71,15 +71,15 @@ namespace OpenBve
 			double db = LibRender.Camera.ForwardViewingDistance + LibRender.Camera.ExtraViewingDistance;
 			bool[] sta = new bool[CurrentRoute.Stations.Length];
 			// events
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 			{
-				double p = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+				double p = CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 				double d = p - World.CameraTrackFollower.TrackPosition;
 				if (d >= da & d <= db)
 				{
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 					{
-						dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
+						dynamic e = CurrentRoute.Tracks[0].Elements[i].Events[j];
 						double dy, dx = 0.0, dz = 0.0;
 						double s; Texture t;
 						if (e is BrightnessChangeEvent)

--- a/source/OpenBVE/Graphics/Renderer/Events.cs
+++ b/source/OpenBVE/Graphics/Renderer/Events.cs
@@ -156,7 +156,7 @@ namespace OpenBve
 							TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 							f.TriggerType = EventTriggerType.None;
 							f.TrackPosition = p;
-							f.Update(p + e.TrackPositionDelta, true, false);
+							f.UpdateAbsolute(p + e.TrackPositionDelta, true, false);
 							f.WorldPosition.X += dx * f.WorldSide.X + dy * f.WorldUp.X + dz * f.WorldDirection.X;
 							f.WorldPosition.Y += dx * f.WorldSide.Y + dy * f.WorldUp.Y + dz * f.WorldDirection.Y;
 							f.WorldPosition.Z += dx * f.WorldSide.Z + dy * f.WorldUp.Z + dz * f.WorldDirection.Z;
@@ -178,7 +178,7 @@ namespace OpenBve
 						TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 						f.TriggerType = EventTriggerType.None;
 						f.TrackPosition = p;
-						f.Update(p, true, false);
+						f.UpdateAbsolute(p, true, false);
 						f.WorldPosition.X += dy * f.WorldUp.X;
 						f.WorldPosition.Y += dy * f.WorldUp.Y;
 						f.WorldPosition.Z += dy * f.WorldUp.Z;
@@ -198,7 +198,7 @@ namespace OpenBve
 					TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 					f.TriggerType = EventTriggerType.None;
 					f.TrackPosition = p;
-					f.Update(p, true, false);
+					f.UpdateAbsolute(p, true, false);
 					f.WorldPosition.X += dy * f.WorldUp.X;
 					f.WorldPosition.Y += dy * f.WorldUp.Y;
 					f.WorldPosition.Z += dy * f.WorldUp.Z;

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -266,24 +266,21 @@ namespace OpenBve
 										int k = Trains[i].Cars.Length - 1;
 										if (Trains[i].Cars[k].CurrentSpeed < Trains[j].Cars[0].CurrentSpeed)
 										{
-											double v = Trains[j].Cars[0].CurrentSpeed -
-													   Trains[i].Cars[k].CurrentSpeed;
+											double v = Trains[j].Cars[0].CurrentSpeed - Trains[i].Cars[k].CurrentSpeed;
 											double s = (Trains[i].Cars[k].CurrentSpeed*Trains[i].Cars[k].Specs.MassCurrent +
 														Trains[j].Cars[0].CurrentSpeed*Trains[j].Cars[0].Specs.MassCurrent)/
 													   (Trains[i].Cars[k].Specs.MassCurrent + Trains[j].Cars[0].Specs.MassCurrent);
 											Trains[i].Cars[k].CurrentSpeed = s;
 											Trains[j].Cars[0].CurrentSpeed = s;
 											double e = 0.5*(c - b) + 0.0001;
-											Trains[i].Cars[k].FrontAxle.Follower.Update(Trains[i].Cars[k].FrontAxle.Follower.TrackPosition + e, false, false);
-											Trains[i].Cars[k].RearAxle.Follower.Update(Trains[i].Cars[k].RearAxle.Follower.TrackPosition + e, false, false);
-											Trains[j].Cars[0].FrontAxle.Follower.Update(Trains[j].Cars[0].FrontAxle.Follower.TrackPosition - e, false, false);
+											Trains[i].Cars[k].FrontAxle.Follower.UpdateRelative(e, false, false);
+											Trains[i].Cars[k].RearAxle.Follower.UpdateRelative(e, false, false);
+											Trains[j].Cars[0].FrontAxle.Follower.UpdateRelative(-e, false, false);
 
-											Trains[j].Cars[0].RearAxle.Follower.Update(Trains[j].Cars[0].RearAxle.Follower.TrackPosition - e, false, false);
+											Trains[j].Cars[0].RearAxle.Follower.UpdateRelative(-e, false, false);
 											if (Interface.CurrentOptions.Derailments)
 											{
-												double f = 2.0/
-														   (Trains[i].Cars[k].Specs.MassCurrent +
-															Trains[j].Cars[0].Specs.MassCurrent);
+												double f = 2.0/ (Trains[i].Cars[k].Specs.MassCurrent + Trains[j].Cars[0].Specs.MassCurrent);
 												double fi = Trains[j].Cars[0].Specs.MassCurrent*f;
 												double fj = Trains[i].Cars[k].Specs.MassCurrent*f;
 												double vi = v*fi;
@@ -304,13 +301,11 @@ namespace OpenBve
 												if (d < 0.0)
 												{
 													d -= 0.0001;
-													Trains[i].Cars[h].FrontAxle.Follower.Update(Trains[i].Cars[h].FrontAxle.Follower.TrackPosition - d, false, false);
-													Trains[i].Cars[h].RearAxle.Follower.Update(Trains[i].Cars[h].RearAxle.Follower.TrackPosition - d, false, false);
+													Trains[i].Cars[h].FrontAxle.Follower.UpdateRelative(-d, false, false);
+													Trains[i].Cars[h].RearAxle.Follower.UpdateRelative(-d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0/
-																   (Trains[i].Cars[h + 1].Specs.MassCurrent +
-																	Trains[i].Cars[h].Specs.MassCurrent);
+														double f = 2.0/ (Trains[i].Cars[h + 1].Specs.MassCurrent + Trains[i].Cars[h].Specs.MassCurrent);
 														double fi = Trains[i].Cars[h + 1].Specs.MassCurrent*f;
 														double fj = Trains[i].Cars[h].Specs.MassCurrent*f;
 														double vi = v*fi;
@@ -335,13 +330,11 @@ namespace OpenBve
 												if (d < 0.0)
 												{
 													d -= 0.0001;
-													Trains[j].Cars[h].FrontAxle.Follower.Update(Trains[j].Cars[h].FrontAxle.Follower.TrackPosition + d, false, false);
-													Trains[j].Cars[h].RearAxle.Follower.Update(Trains[j].Cars[h].RearAxle.Follower.TrackPosition + d, false, false);
+													Trains[j].Cars[h].FrontAxle.Follower.UpdateRelative(d, false, false);
+													Trains[j].Cars[h].RearAxle.Follower.UpdateRelative(d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0/
-																   (Trains[j].Cars[h - 1].Specs.MassCurrent +
-																	Trains[j].Cars[h].Specs.MassCurrent);
+														double f = 2.0/ (Trains[j].Cars[h - 1].Specs.MassCurrent + Trains[j].Cars[h].Specs.MassCurrent);
 														double fi = Trains[j].Cars[h - 1].Specs.MassCurrent*f;
 														double fj = Trains[j].Cars[h].Specs.MassCurrent*f;
 														double vi = v*fi;
@@ -371,15 +364,13 @@ namespace OpenBve
 											Trains[i].Cars[0].CurrentSpeed = s;
 											Trains[j].Cars[k].CurrentSpeed = s;
 											double e = 0.5*(a - d) + 0.0001;
-											Trains[i].Cars[0].FrontAxle.Follower.Update(Trains[i].Cars[0].FrontAxle.Follower.TrackPosition - e, false, false);
-											Trains[i].Cars[0].RearAxle.Follower.Update(Trains[i].Cars[0].RearAxle.Follower.TrackPosition - e, false, false);
-											Trains[j].Cars[k].FrontAxle.Follower.Update(Trains[j].Cars[k].FrontAxle.Follower.TrackPosition + e, false, false);
-											Trains[j].Cars[k].RearAxle.Follower.Update(Trains[j].Cars[k].RearAxle.Follower.TrackPosition + e, false, false);
+											Trains[i].Cars[0].FrontAxle.Follower.UpdateRelative(-e, false, false);
+											Trains[i].Cars[0].RearAxle.Follower.UpdateRelative(-e, false, false);
+											Trains[j].Cars[k].FrontAxle.Follower.UpdateRelative(e, false, false);
+											Trains[j].Cars[k].RearAxle.Follower.UpdateRelative(e, false, false);
 											if (Interface.CurrentOptions.Derailments)
 											{
-												double f = 2.0/
-														   (Trains[i].Cars[0].Specs.MassCurrent +
-															Trains[j].Cars[k].Specs.MassCurrent);
+												double f = 2.0/ (Trains[i].Cars[0].Specs.MassCurrent + Trains[j].Cars[k].Specs.MassCurrent);
 												double fi = Trains[j].Cars[k].Specs.MassCurrent*f;
 												double fj = Trains[i].Cars[0].Specs.MassCurrent*f;
 												double vi = v*fi;
@@ -400,13 +391,11 @@ namespace OpenBve
 												if (d < 0.0)
 												{
 													d -= 0.0001;
-													Trains[i].Cars[h].FrontAxle.Follower.Update(Trains[i].Cars[h].FrontAxle.Follower.TrackPosition + d, false, false);
-													Trains[i].Cars[h].RearAxle.Follower.Update(Trains[i].Cars[h].RearAxle.Follower.TrackPosition + d, false, false);
+													Trains[i].Cars[h].FrontAxle.Follower.UpdateRelative(d, false, false);
+													Trains[i].Cars[h].RearAxle.Follower.UpdateRelative(d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0/
-																   (Trains[i].Cars[h - 1].Specs.MassCurrent +
-																	Trains[i].Cars[h].Specs.MassCurrent);
+														double f = 2.0/ (Trains[i].Cars[h - 1].Specs.MassCurrent + Trains[i].Cars[h].Specs.MassCurrent);
 														double fi = Trains[i].Cars[h - 1].Specs.MassCurrent*f;
 														double fj = Trains[i].Cars[h].Specs.MassCurrent*f;
 														double vi = v*fi;
@@ -431,13 +420,11 @@ namespace OpenBve
 												if (d < 0.0)
 												{
 													d -= 0.0001;
-													Trains[j].Cars[h].FrontAxle.Follower.Update(Trains[j].Cars[h].FrontAxle.Follower.TrackPosition - d, false, false);
-													Trains[j].Cars[h].RearAxle.Follower.Update(Trains[j].Cars[h].RearAxle.Follower.TrackPosition - d, false, false);
+													Trains[j].Cars[h].FrontAxle.Follower.UpdateRelative(-d, false, false);
+													Trains[j].Cars[h].RearAxle.Follower.UpdateRelative(-d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0/
-																   (Trains[j].Cars[h + 1].Specs.MassCurrent +
-																	Trains[j].Cars[h].Specs.MassCurrent);
+														double f = 2.0/ (Trains[j].Cars[h + 1].Specs.MassCurrent + Trains[j].Cars[h].Specs.MassCurrent);
 														double fi = Trains[j].Cars[h + 1].Specs.MassCurrent*f;
 														double fj = Trains[j].Cars[h].Specs.MassCurrent*f;
 														double vi = v*fi;

--- a/source/OpenBVE/OldCode/World.cs
+++ b/source/OpenBVE/OldCode/World.cs
@@ -163,7 +163,7 @@ namespace OpenBve {
 				double tr = Camera.CurrentAlignment.TrackPosition;
 				AdjustAlignment(ref Camera.CurrentAlignment.TrackPosition, Camera.AlignmentDirection.TrackPosition, ref Camera.AlignmentSpeed.TrackPosition, TimeElapsed);
 				if (tr != Camera.CurrentAlignment.TrackPosition) {
-					World.CameraTrackFollower.Update(Camera.CurrentAlignment.TrackPosition, true, false);
+					World.CameraTrackFollower.UpdateAbsolute(Camera.CurrentAlignment.TrackPosition, true, false);
 					UpdateViewingDistances();
 				}
 				// position to focus on
@@ -272,7 +272,7 @@ namespace OpenBve {
 					double tr = Camera.CurrentAlignment.TrackPosition;
 					AdjustAlignment(ref Camera.CurrentAlignment.TrackPosition, Camera.AlignmentDirection.TrackPosition, ref Camera.AlignmentSpeed.TrackPosition, TimeElapsed);
 					if (tr != Camera.CurrentAlignment.TrackPosition) {
-						World.CameraTrackFollower.Update(Camera.CurrentAlignment.TrackPosition, true, false);
+						World.CameraTrackFollower.UpdateAbsolute(Camera.CurrentAlignment.TrackPosition, true, false);
 						q = true;
 					}
 					if (q) {
@@ -295,7 +295,7 @@ namespace OpenBve {
 					d -= TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].FrontAxle.Position;
 					TrackManager.TrackFollower f = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].FrontAxle.Follower;
 					f.TriggerType = EventTriggerType.None;
-					f.Update(f.TrackPosition + d, true, false);
+					f.UpdateRelative(d, true, false);
 					Vector3 r = new Vector3(f.WorldPosition - cF + World.CameraTrackFollower.WorldSide * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.X + World.CameraTrackFollower.WorldUp * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Y + World.CameraTrackFollower.WorldDirection * TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].Driver.Z);
 					r.Normalize();
 					double t = dF.Z * (sF.Y * uF.X - sF.X * uF.Y) + dF.Y * (-sF.Z * uF.X + sF.X * uF.Z) + dF.X * (sF.Z * uF.Y - sF.Y * uF.Z);

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -1878,8 +1878,8 @@ namespace OpenBve
 					TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 					double r = (double)m / (double)subdivisions;
 					double p = (1.0 - r) * TrackManager.Tracks[0].Elements[q].StartingTrackPosition + r * TrackManager.Tracks[0].Elements[q + 1].StartingTrackPosition;
-					follower.Update(-1.0, true, false);
-					follower.Update(p, true, false);
+					follower.UpdateAbsolute(-1.0, true, false);
+					follower.UpdateAbsolute(p, true, false);
 					midpointsTrackPositions[i] = p;
 					midpointsWorldPositions[i] = follower.WorldPosition;
 					midpointsWorldDirections[i] = follower.WorldDirection;
@@ -1921,7 +1921,7 @@ namespace OpenBve
 					if (m == 0)
 					{
 						double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
-						follower.Update(p, true, false);
+						follower.UpdateAbsolute(p, true, false);
 						Vector3 d1 = TrackManager.Tracks[0].Elements[i].WorldDirection;
 						Vector3 d2 = follower.WorldDirection;
 						Vector3 d = d1 - d2;
@@ -1998,8 +1998,8 @@ namespace OpenBve
 							TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 							TrackManager.Tracks[0].Elements[i - 1].CurveRadius = r;
 							double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
-							follower.Update(p - 1.0, true, false);
-							follower.Update(p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							TrackManager.Tracks[0].Elements[i].CurveRadius = r;
 							TrackManager.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
 							TrackManager.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
@@ -2007,8 +2007,8 @@ namespace OpenBve
 							TrackManager.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
 							// iterate to shorten track element length
 							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-							follower.Update(p - 1.0, true, false);
-							follower.Update(p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 							double bestT = d.NormSquared();
 							int bestJ = 0;
@@ -2016,7 +2016,7 @@ namespace OpenBve
 							double a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++)
 							{
-								follower.Update(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+								follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
 								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT)
@@ -2037,8 +2037,8 @@ namespace OpenBve
 							totalShortage += s;
 							// introduce turn to compensate for curve
 							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-							follower.Update(p - 1.0, true, false);
-							follower.Update(p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 AB = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 							Vector3 AC = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
 							Vector3 BC = follower.WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
@@ -2077,8 +2077,8 @@ namespace OpenBve
 									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
 									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 									p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-									follower.Update(p - 1.0, true, false);
-									follower.Update(p, true, false);
+									follower.UpdateAbsolute(p - 1.0, true, false);
+									follower.UpdateAbsolute(p, true, false);
 									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT)
@@ -2098,8 +2098,8 @@ namespace OpenBve
 								}
 								// iterate again to further shorten track element length
 								p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-								follower.Update(p - 1.0, true, false);
-								follower.Update(p, true, false);
+								follower.UpdateAbsolute(p - 1.0, true, false);
+								follower.UpdateAbsolute(p, true, false);
 								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								bestT = d.NormSquared();
 								bestJ = 0;
@@ -2107,7 +2107,7 @@ namespace OpenBve
 								a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++)
 								{
-									follower.Update(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+									follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
 									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT)
@@ -2129,8 +2129,8 @@ namespace OpenBve
 							}
 							// compensate for height difference
 							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-							follower.Update(p - 1.0, true, false);
-							follower.Update(p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 d1 = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
 							double a1 = Math.Atan(d1.Y / Math.Sqrt(d1.X * d1.X + d1.Z * d1.Z));
 							Vector3 d2 = follower.WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -154,20 +154,20 @@ namespace OpenBve
 			Fog CurrentFog = new Fog(CurrentRoute.NoFogStart, CurrentRoute.NoFogEnd, Color24.Grey, 0.0);
 			for (int i = Data.FirstUsedBlock; i < Data.Blocks.Length; i++)
 			{
-				if (Data.Blocks[i].Rails.Length > TrackManager.Tracks.Length)
+				if (Data.Blocks[i].Rails.Length > CurrentRoute.Tracks.Length)
 				{
-					Array.Resize(ref TrackManager.Tracks, Data.Blocks[i].Rails.Length);
+					Array.Resize(ref CurrentRoute.Tracks, Data.Blocks[i].Rails.Length);
 				}
 			}
-			for (int i = 0; i < TrackManager.Tracks.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks.Length; i++)
 			{
-				if (TrackManager.Tracks[i] == null)
+				if (CurrentRoute.Tracks[i] == null)
 				{
-					TrackManager.Tracks[i] = new Track();
+					CurrentRoute.Tracks[i] = new Track();
 				}
-				if (TrackManager.Tracks[i].Elements == null)
+				if (CurrentRoute.Tracks[i].Elements == null)
 				{
-					TrackManager.Tracks[i].Elements = new TrackElement[256];
+					CurrentRoute.Tracks[i].Elements = new TrackElement[256];
 				}
 			}
 			// process blocks
@@ -201,25 +201,25 @@ namespace OpenBve
 				}
 				TrackElement WorldTrackElement = Data.Blocks[i].CurrentTrackState;
 				int n = CurrentTrackLength;
-				for (int j = 0; j < TrackManager.Tracks.Length; j++)
+				for (int j = 0; j < CurrentRoute.Tracks.Length; j++)
 				{
-					if (n >= TrackManager.Tracks[j].Elements.Length)
+					if (n >= CurrentRoute.Tracks[j].Elements.Length)
 					{
-						Array.Resize(ref TrackManager.Tracks[j].Elements, TrackManager.Tracks[j].Elements.Length << 1);
+						Array.Resize(ref CurrentRoute.Tracks[j].Elements, CurrentRoute.Tracks[j].Elements.Length << 1);
 					}
 				}
 				CurrentTrackLength++;
-				TrackManager.Tracks[0].Elements[n] = WorldTrackElement;
-				TrackManager.Tracks[0].Elements[n].WorldPosition = Position;
-				TrackManager.Tracks[0].Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
-				TrackManager.Tracks[0].Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
-				TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
-				TrackManager.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
-				TrackManager.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
-				TrackManager.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
-				for (int j = 0; j < TrackManager.Tracks.Length; j++)
+				CurrentRoute.Tracks[0].Elements[n] = WorldTrackElement;
+				CurrentRoute.Tracks[0].Elements[n].WorldPosition = Position;
+				CurrentRoute.Tracks[0].Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
+				CurrentRoute.Tracks[0].Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
+				CurrentRoute.Tracks[0].Elements[n].WorldUp = Vector3.Cross(CurrentRoute.Tracks[0].Elements[n].WorldDirection, CurrentRoute.Tracks[0].Elements[n].WorldSide);
+				CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
+				CurrentRoute.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
+				CurrentRoute.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
+				for (int j = 0; j < CurrentRoute.Tracks.Length; j++)
 				{
-					TrackManager.Tracks[j].Elements[n].Events = new object[] { };
+					CurrentRoute.Tracks[j].Elements[n].Events = new object[] { };
 				}
 				// background
 				if (!PreviewOnly)
@@ -245,9 +245,9 @@ namespace OpenBve
 						}
 						if (typ >= 0 & Data.Backgrounds.ContainsKey(typ))
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
 						}
 					}
 				}
@@ -259,18 +259,18 @@ namespace OpenBve
 						/*
 						 * Legacy brightness: This applies equally to all tracks in a block
 						 */
-						for (int t = 0; t < TrackManager.Tracks.Length; t++)
+						for (int t = 0; t < CurrentRoute.Tracks.Length; t++)
 						{
-							int m = TrackManager.Tracks[t].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[t].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[t].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[t].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].BrightnessChanges[j].TrackPosition - StartingDistance;
-							TrackManager.Tracks[t].Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].BrightnessChanges[j].Value, CurrentBrightnessValue, Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition);
+							CurrentRoute.Tracks[t].Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].BrightnessChanges[j].Value, CurrentBrightnessValue, Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition);
 							
 							if (t == 0)
 							{
 								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
 								{
-									BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
+									BrightnessChangeEvent bce = (BrightnessChangeEvent)CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
 									bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
 									bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
 								}
@@ -281,11 +281,11 @@ namespace OpenBve
 							{
 								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
 								{
-									for (int e = 0; e < TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events.Length; e++)
+									for (int e = 0; e < CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events.Length; e++)
 									{
-										if (!(TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e] is BrightnessChangeEvent))
+										if (!(CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[e] is BrightnessChangeEvent))
 											continue;
-										BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e];
+										BrightnessChangeEvent bce = (BrightnessChangeEvent)CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[e];
 										bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
 										bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
 									}
@@ -310,12 +310,12 @@ namespace OpenBve
 								PreviousFog = Data.Blocks[i].Fog;
 							}
 							Data.Blocks[i].Fog.TrackPosition = StartingDistance;
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
 							if (PreviousFogElement >= 0 & PreviousFogEvent >= 0)
 							{
-								FogChangeEvent e = (FogChangeEvent)TrackManager.Tracks[0].Elements[PreviousFogElement].Events[PreviousFogEvent];
+								FogChangeEvent e = (FogChangeEvent)CurrentRoute.Tracks[0].Elements[PreviousFogElement].Events[PreviousFogEvent];
 								e.NextFog = Data.Blocks[i].Fog;
 							}
 							else
@@ -345,9 +345,9 @@ namespace OpenBve
 						else
 						{
 							Data.Blocks[i].Fog.TrackPosition = StartingDistance + Data.BlockInterval;
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
 							PreviousFog = CurrentFog;
 							CurrentFog = Data.Blocks[i].Fog;
 						}
@@ -359,9 +359,9 @@ namespace OpenBve
 					int j = Data.Blocks[i].RailType[0];
 					int r = j < Data.Structure.Run.Length ? Data.Structure.Run[j] : 0;
 					int f = j < Data.Structure.Flange.Length ? Data.Structure.Flange[j] : 0;
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-					TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
 					CurrentRunIndex = r;
 					CurrentFlangeIndex = f;
 				}
@@ -390,9 +390,9 @@ namespace OpenBve
 								}
 								if (q)
 								{
-									int m = TrackManager.Tracks[j].Elements[n].Events.Length;
-									Array.Resize(ref TrackManager.Tracks[j].Elements[n].Events, m + 1);
-									TrackManager.Tracks[j].Elements[n].Events[m] = new TrackManager.PointSoundEvent();
+									int m = CurrentRoute.Tracks[j].Elements[n].Events.Length;
+									Array.Resize(ref CurrentRoute.Tracks[j].Elements[n].Events, m + 1);
+									CurrentRoute.Tracks[j].Elements[n].Events[m] = new TrackManager.PointSoundEvent();
 								}
 							}
 						}
@@ -403,9 +403,9 @@ namespace OpenBve
 				{
 					// station
 					int s = Data.Blocks[i].Station;
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-					TrackManager.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
 					double dx, dy = 3.0;
 					if (CurrentRoute.Stations[s].OpenLeftDoors & !CurrentRoute.Stations[s].OpenRightDoors)
 					{
@@ -419,7 +419,7 @@ namespace OpenBve
 					{
 						dx = 0.0;
 					}
-					CurrentRoute.Stations[s].SoundOrigin = Position + dx * TrackManager.Tracks[0].Elements[n].WorldSide + dy * TrackManager.Tracks[0].Elements[n].WorldUp;
+					CurrentRoute.Stations[s].SoundOrigin = Position + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp;
 					// passalarm
 					if (!PreviewOnly)
 					{
@@ -431,9 +431,9 @@ namespace OpenBve
 								int j = b - Data.FirstUsedBlock;
 								if (j >= 0)
 								{
-									m = TrackManager.Tracks[0].Elements[j].Events.Length;
-									Array.Resize(ref TrackManager.Tracks[0].Elements[j].Events, m + 1);
-									TrackManager.Tracks[0].Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
+									m = CurrentRoute.Tracks[0].Elements[j].Events.Length;
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[j].Events, m + 1);
+									CurrentRoute.Tracks[0].Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
 								}
 							}
 						}
@@ -463,15 +463,15 @@ namespace OpenBve
 						dx = 0.0;
 					}
 
-					CurrentRoute.Stations[s].SoundOrigin = Position + dx * TrackManager.Tracks[0].Elements[n].WorldSide + dy * TrackManager.Tracks[0].Elements[n].WorldUp;
+					CurrentRoute.Stations[s].SoundOrigin = Position + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp;
 				}
 				// limit
 				for (int j = 0; j < Data.Blocks[i].Limits.Length; j++)
 				{
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 					double d = Data.Blocks[i].Limits[j].TrackPosition - StartingDistance;
-					TrackManager.Tracks[0].Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limits[j].Speed);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limits[j].Speed);
 					CurrentSpeedLimit = Data.Blocks[i].Limits[j].Speed;
 				}
 				// marker
@@ -481,22 +481,22 @@ namespace OpenBve
 					{
 						if (Data.Markers[j].StartingPosition >= StartingDistance & Data.Markers[j].StartingPosition < EndingDistance)
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].StartingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								CurrentRoute.Tracks[0].Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 						if (Data.Markers[j].EndingPosition >= StartingDistance & Data.Markers[j].EndingPosition < EndingDistance)
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].EndingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								CurrentRoute.Tracks[0].Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 					}
@@ -508,16 +508,16 @@ namespace OpenBve
 					{
 						if (Data.Blocks[i].SoundEvents[j].Type == SoundType.TrainStatic | Data.Blocks[i].SoundEvents[j].Type == SoundType.TrainDynamic)
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].SoundEvents[j].TrackPosition - StartingDistance;
 							switch (Data.Blocks[i].SoundEvents[j].Type)
 							{
 								case SoundType.TrainStatic:
-									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
+									CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
 									break;
 								case SoundType.TrainDynamic:
-									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].SoundEvents[j].Speed);
+									CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].SoundEvents[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].SoundEvents[j].Speed);
 									break;
 							}
 						}
@@ -530,18 +530,18 @@ namespace OpenBve
 					double cosag = Math.Cos(ag);
 					double sinag = Math.Sin(ag);
 					Direction.Rotate(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldDirection.RotatePlane(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldSide.RotatePlane(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
+					CurrentRoute.Tracks[0].Elements[n].WorldDirection.RotatePlane(cosag, sinag);
+					CurrentRoute.Tracks[0].Elements[n].WorldSide.RotatePlane(cosag, sinag);
+					CurrentRoute.Tracks[0].Elements[n].WorldUp = Vector3.Cross(CurrentRoute.Tracks[0].Elements[n].WorldDirection, CurrentRoute.Tracks[0].Elements[n].WorldSide);
 				}
 				//Pitch
 				if (Data.Blocks[i].Pitch != 0.0)
 				{
-					TrackManager.Tracks[0].Elements[n].Pitch = Data.Blocks[i].Pitch;
+					CurrentRoute.Tracks[0].Elements[n].Pitch = Data.Blocks[i].Pitch;
 				}
 				else
 				{
-					TrackManager.Tracks[0].Elements[n].Pitch = 0.0;
+					CurrentRoute.Tracks[0].Elements[n].Pitch = 0.0;
 				}
 				// curves
 				double a = 0.0;
@@ -711,13 +711,13 @@ namespace OpenBve
 								RailTransformation = new Transformation(TrackTransformation, 0.0, 0.0, 0.0);
 							}
 
-							TrackManager.Tracks[j].Elements[n].StartingTrackPosition = StartingDistance;
-							TrackManager.Tracks[j].Elements[n].WorldPosition = pos;
-							TrackManager.Tracks[j].Elements[n].WorldDirection = RailTransformation.Z;
-							TrackManager.Tracks[j].Elements[n].WorldSide = RailTransformation.X;
-							TrackManager.Tracks[j].Elements[n].WorldUp = RailTransformation.Y;
-							TrackManager.Tracks[j].Elements[n].CurveCant = Data.Blocks[i].Rails[j].CurveCant;
-							TrackManager.Tracks[j].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
+							CurrentRoute.Tracks[j].Elements[n].StartingTrackPosition = StartingDistance;
+							CurrentRoute.Tracks[j].Elements[n].WorldPosition = pos;
+							CurrentRoute.Tracks[j].Elements[n].WorldDirection = RailTransformation.Z;
+							CurrentRoute.Tracks[j].Elements[n].WorldSide = RailTransformation.X;
+							CurrentRoute.Tracks[j].Elements[n].WorldUp = RailTransformation.Y;
+							CurrentRoute.Tracks[j].Elements[n].CurveCant = Data.Blocks[i].Rails[j].CurveCant;
+							CurrentRoute.Tracks[j].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
 						}
 						if (Data.Structure.RailObjects.ContainsKey(Data.Blocks[i].RailType[j]))
 						{
@@ -1392,10 +1392,10 @@ namespace OpenBve
 									{
 										if (Data.Blocks[g].Transponders[l].Type != -1 & Data.Blocks[g].Transponders[l].SectionIndex == m)
 										{
-											int o = TrackManager.Tracks[0].Elements[n - i + g].Events.Length;
-											Array.Resize(ref TrackManager.Tracks[0].Elements[n - i + g].Events, o + 1);
+											int o = CurrentRoute.Tracks[0].Elements[n - i + g].Events.Length;
+											Array.Resize(ref CurrentRoute.Tracks[0].Elements[n - i + g].Events, o + 1);
 											double dt = Data.Blocks[g].Transponders[l].TrackPosition - StartingDistance + (double)(i - g) * Data.BlockInterval;
-											TrackManager.Tracks[0].Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponders[l].Type, Data.Blocks[g].Transponders[l].Data, m, Data.Blocks[g].Transponders[l].ClipToFirstRedSection);
+											CurrentRoute.Tracks[0].Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponders[l].Type, Data.Blocks[g].Transponders[l].Data, m, Data.Blocks[g].Transponders[l].ClipToFirstRedSection);
 											Data.Blocks[g].Transponders[l].Type = -1;
 										}
 									}
@@ -1432,9 +1432,9 @@ namespace OpenBve
 								CurrentRoute.Sections[m].Trains = new AbstractTrain[] { };
 								// create section change event
 								double d = Data.Blocks[i].Sections[k].TrackPosition - StartingDistance;
-								int p = TrackManager.Tracks[0].Elements[n].Events.Length;
-								Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, p + 1);
-								TrackManager.Tracks[0].Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
+								int p = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+								Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, p + 1);
+								CurrentRoute.Tracks[0].Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
 							}
 							// transponders introduced after corresponding sections
 							for (int l = 0; l < Data.Blocks[i].Transponders.Length; l++)
@@ -1444,10 +1444,10 @@ namespace OpenBve
 									int t = Data.Blocks[i].Transponders[l].SectionIndex;
 									if (t >= 0 & t < CurrentRoute.Sections.Length)
 									{
-										int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-										Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+										int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+										Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 										double dt = Data.Blocks[i].Transponders[l].TrackPosition - StartingDistance;
-										TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponders[l].Type, Data.Blocks[i].Transponders[l].Data, t, Data.Blocks[i].Transponders[l].ClipToFirstRedSection);
+										CurrentRoute.Tracks[0].Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponders[l].Type, Data.Blocks[i].Transponders[l].Data, t, Data.Blocks[i].Transponders[l].ClipToFirstRedSection);
 										Data.Blocks[i].Transponders[l].Type = -1;
 									}
 								}
@@ -1571,12 +1571,12 @@ namespace OpenBve
 						if (Data.Blocks[i].Transponders[j].Type != -1)
 						{
 							int n = i - Data.FirstUsedBlock;
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							double d = Data.Blocks[i].Transponders[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							double d = Data.Blocks[i].Transponders[j].TrackPosition - CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition;
 							int s = Data.Blocks[i].Transponders[j].SectionIndex;
 							if (s >= 0) s = -1;
-							TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponders[j].Type, Data.Blocks[i].Transponders[j].Data, s, Data.Blocks[i].Transponders[j].ClipToFirstRedSection);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponders[j].Type, Data.Blocks[i].Transponders[j].Data, s, Data.Blocks[i].Transponders[j].ClipToFirstRedSection);
 							Data.Blocks[i].Transponders[j].Type = -1;
 						}
 					}
@@ -1584,10 +1584,10 @@ namespace OpenBve
 					for (int j = 0; j < Data.Blocks[i].DestinationChanges.Length; j++)
 					{
 						int n = i - Data.FirstUsedBlock;
-						int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
-						TrackManager.Tracks[0].Elements[n].Events[m] = new RouteManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
+						int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition;
+						CurrentRoute.Tracks[0].Elements[n].Events[m] = new RouteManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
 					}
 				}
 			}
@@ -1602,9 +1602,9 @@ namespace OpenBve
 					if (k >= 0 & k < Data.Blocks.Length)
 					{
 						double d = p - (double)(k + Data.FirstUsedBlock) * (double)Data.BlockInterval;
-						int m = TrackManager.Tracks[0].Elements[k].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[k].Events, m + 1);
-						TrackManager.Tracks[0].Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
+						int m = CurrentRoute.Tracks[0].Elements[k].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[k].Events, m + 1);
+						CurrentRoute.Tracks[0].Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
 					}
 				}
 			}
@@ -1634,34 +1634,34 @@ namespace OpenBve
 				Array.Resize(ref CurrentRoute.PointsOfInterest, n);
 			}
 			// convert block-based cant into point-based cant
-			for (int i = 0; i < TrackManager.Tracks.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks.Length; i++)
 			{
 				for (int j = CurrentTrackLength - 1; j >= 1; j--)
 				{
-					if (TrackManager.Tracks[i].Elements[j].CurveCant == 0.0)
+					if (CurrentRoute.Tracks[i].Elements[j].CurveCant == 0.0)
 					{
-						TrackManager.Tracks[i].Elements[j].CurveCant = TrackManager.Tracks[i].Elements[j - 1].CurveCant;
+						CurrentRoute.Tracks[i].Elements[j].CurveCant = CurrentRoute.Tracks[i].Elements[j - 1].CurveCant;
 					}
-					else if (TrackManager.Tracks[i].Elements[j - 1].CurveCant != 0.0)
+					else if (CurrentRoute.Tracks[i].Elements[j - 1].CurveCant != 0.0)
 					{
-						if (Math.Sign(TrackManager.Tracks[i].Elements[j - 1].CurveCant) == Math.Sign(TrackManager.Tracks[i].Elements[j].CurveCant))
+						if (Math.Sign(CurrentRoute.Tracks[i].Elements[j - 1].CurveCant) == Math.Sign(CurrentRoute.Tracks[i].Elements[j].CurveCant))
 						{
-							if (Math.Abs(TrackManager.Tracks[i].Elements[j - 1].CurveCant) > Math.Abs(TrackManager.Tracks[i].Elements[j].CurveCant))
+							if (Math.Abs(CurrentRoute.Tracks[i].Elements[j - 1].CurveCant) > Math.Abs(CurrentRoute.Tracks[i].Elements[j].CurveCant))
 							{
-								TrackManager.Tracks[i].Elements[j].CurveCant = TrackManager.Tracks[i].Elements[j - 1].CurveCant;
+								CurrentRoute.Tracks[i].Elements[j].CurveCant = CurrentRoute.Tracks[i].Elements[j - 1].CurveCant;
 							}
 						}
 						else
 						{
-							TrackManager.Tracks[i].Elements[j].CurveCant = 0.5 * (TrackManager.Tracks[i].Elements[j].CurveCant + TrackManager.Tracks[i].Elements[j - 1].CurveCant);
+							CurrentRoute.Tracks[i].Elements[j].CurveCant = 0.5 * (CurrentRoute.Tracks[i].Elements[j].CurveCant + CurrentRoute.Tracks[i].Elements[j - 1].CurveCant);
 						}
 					}
 				}
 			}
 			// finalize
-			for (int i = 0; i < TrackManager.Tracks.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks.Length; i++)
 			{
-				Array.Resize(ref TrackManager.Tracks[i].Elements, CurrentTrackLength);
+				Array.Resize(ref CurrentRoute.Tracks[i].Elements, CurrentTrackLength);
 			}
 			for (int i = 0; i < CurrentRoute.Stations.Length; i++)
 			{
@@ -1691,70 +1691,70 @@ namespace OpenBve
 			{
 				CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Terminal;
 			}
-			if (TrackManager.Tracks[0].Elements.Length != 0)
+			if (CurrentRoute.Tracks[0].Elements.Length != 0)
 			{
-				int n = TrackManager.Tracks[0].Elements.Length - 1;
-				int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-				Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-				TrackManager.Tracks[0].Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
+				int n = CurrentRoute.Tracks[0].Elements.Length - 1;
+				int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+				Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+				CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
 			}
 			// insert compatibility beacons
 			if (!PreviewOnly)
 			{
 				List<TransponderEvent> transponders = new List<TransponderEvent>();
 				bool atc = false;
-				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+				for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 				{
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 					{
 						if (!atc)
 						{
-							if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+							if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 							{
-								StationStartEvent station = (StationStartEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+								StationStartEvent station = (StationStartEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 								if (CurrentRoute.Stations[station.StationIndex].SafetySystem == SafetySystem.Atc)
 								{
-									Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, TrackManager.Tracks[0].Elements[i].Events.Length + 2);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 0, 0, false);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 1, 0, false);
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, CurrentRoute.Tracks[0].Elements[i].Events.Length + 2);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 0, 0, false);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 1, 0, false);
 									atc = true;
 								}
 							}
 						}
 						else
 						{
-							if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+							if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 							{
-								StationStartEvent station = (StationStartEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+								StationStartEvent station = (StationStartEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 								if (CurrentRoute.Stations[station.StationIndex].SafetySystem == SafetySystem.Ats)
 								{
-									Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, TrackManager.Tracks[0].Elements[i].Events.Length + 2);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 2, 0, false);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 3, 0, false);
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, CurrentRoute.Tracks[0].Elements[i].Events.Length + 2);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 2, 0, false);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 3, 0, false);
 								}
 							}
-							else if (TrackManager.Tracks[0].Elements[i].Events[j] is TrackManager.StationEndEvent)
+							else if (CurrentRoute.Tracks[0].Elements[i].Events[j] is TrackManager.StationEndEvent)
 							{
-								TrackManager.StationEndEvent station = (TrackManager.StationEndEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+								TrackManager.StationEndEvent station = (TrackManager.StationEndEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 								if (CurrentRoute.Stations[station.StationIndex].SafetySystem == SafetySystem.Atc)
 								{
-									Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, TrackManager.Tracks[0].Elements[i].Events.Length + 2);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 1, 0, false);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 2, 0, false);
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, CurrentRoute.Tracks[0].Elements[i].Events.Length + 2);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 1, 0, false);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 2, 0, false);
 								}
 								else if (CurrentRoute.Stations[station.StationIndex].SafetySystem == SafetySystem.Ats)
 								{
-									Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, TrackManager.Tracks[0].Elements[i].Events.Length + 2);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 3, 0, false);
-									TrackManager.Tracks[0].Elements[i].Events[TrackManager.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 0, 0, false);
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, CurrentRoute.Tracks[0].Elements[i].Events.Length + 2);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 2] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 3, 0, false);
+									CurrentRoute.Tracks[0].Elements[i].Events[CurrentRoute.Tracks[0].Elements[i].Events.Length - 1] = new TransponderEvent(0.0, TransponderTypes.AtcTrackStatus, 0, 0, false);
 									atc = false;
 								}
 							}
-							else if (TrackManager.Tracks[0].Elements[i].Events[j] is LimitChangeEvent)
+							else if (CurrentRoute.Tracks[0].Elements[i].Events[j] is LimitChangeEvent)
 							{
-								LimitChangeEvent limit = (LimitChangeEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+								LimitChangeEvent limit = (LimitChangeEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 								int speed = (int)Math.Round(Math.Min(4095.0, 3.6 * limit.NextSpeedLimit));
-								int distance = Math.Min(1048575, (int)Math.Round(TrackManager.Tracks[0].Elements[i].StartingTrackPosition + limit.TrackPositionDelta));
+								int distance = Math.Min(1048575, (int)Math.Round(CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + limit.TrackPositionDelta));
 								unchecked
 								{
 									int value = (int)((uint)speed | ((uint)distance << 12));
@@ -1762,13 +1762,13 @@ namespace OpenBve
 								}
 							}
 						}
-						if (TrackManager.Tracks[0].Elements[i].Events[j] is TransponderEvent)
+						if (CurrentRoute.Tracks[0].Elements[i].Events[j] is TransponderEvent)
 						{
-							TransponderEvent transponder = TrackManager.Tracks[0].Elements[i].Events[j] as TransponderEvent;
+							TransponderEvent transponder = CurrentRoute.Tracks[0].Elements[i].Events[j] as TransponderEvent;
 							if (transponder.Type == (int)TransponderTypes.InternalAtsPTemporarySpeedLimit)
 							{
 								int speed = Math.Min(4095, transponder.Data);
-								int distance = Math.Min(1048575, (int)Math.Round(TrackManager.Tracks[0].Elements[i].StartingTrackPosition + transponder.TrackPositionDelta));
+								int distance = Math.Min(1048575, (int)Math.Round(CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + transponder.TrackPositionDelta));
 								unchecked
 								{
 									int value = (int)((uint)speed | ((uint)distance << 12));
@@ -1778,11 +1778,11 @@ namespace OpenBve
 						}
 					}
 				}
-				int n = TrackManager.Tracks[0].Elements[0].Events.Length;
-				Array.Resize(ref TrackManager.Tracks[0].Elements[0].Events, n + transponders.Count);
+				int n = CurrentRoute.Tracks[0].Elements[0].Events.Length;
+				Array.Resize(ref CurrentRoute.Tracks[0].Elements[0].Events, n + transponders.Count);
 				for (int i = 0; i < transponders.Count; i++)
 				{
-					TrackManager.Tracks[0].Elements[0].Events[n + i] = transponders[i];
+					CurrentRoute.Tracks[0].Elements[0].Events[n + i] = transponders[i];
 				}
 			}
 			// cant
@@ -1803,27 +1803,27 @@ namespace OpenBve
 		// compute cant tangents
 		private static void ComputeCantTangents()
 		{
-			for (int i = 0; i < TrackManager.Tracks.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks.Length; i++)
 			{
-				if (TrackManager.Tracks[i].Elements.Length == 1)
+				if (CurrentRoute.Tracks[i].Elements.Length == 1)
 				{
-					TrackManager.Tracks[i].Elements[0].CurveCantTangent = 0.0;
+					CurrentRoute.Tracks[i].Elements[0].CurveCantTangent = 0.0;
 				}
-				else if (TrackManager.Tracks[i].Elements.Length != 0)
+				else if (CurrentRoute.Tracks[i].Elements.Length != 0)
 				{
-					double[] deltas = new double[TrackManager.Tracks[i].Elements.Length - 1];
-					for (int j = 0; j < TrackManager.Tracks[i].Elements.Length - 1; j++)
+					double[] deltas = new double[CurrentRoute.Tracks[i].Elements.Length - 1];
+					for (int j = 0; j < CurrentRoute.Tracks[i].Elements.Length - 1; j++)
 					{
-						deltas[j] = TrackManager.Tracks[i].Elements[j + 1].CurveCant - TrackManager.Tracks[i].Elements[j].CurveCant;
+						deltas[j] = CurrentRoute.Tracks[i].Elements[j + 1].CurveCant - CurrentRoute.Tracks[i].Elements[j].CurveCant;
 					}
-					double[] tangents = new double[TrackManager.Tracks[i].Elements.Length];
+					double[] tangents = new double[CurrentRoute.Tracks[i].Elements.Length];
 					tangents[0] = deltas[0];
-					tangents[TrackManager.Tracks[i].Elements.Length - 1] = deltas[TrackManager.Tracks[i].Elements.Length - 2];
-					for (int j = 1; j < TrackManager.Tracks[i].Elements.Length - 1; j++)
+					tangents[CurrentRoute.Tracks[i].Elements.Length - 1] = deltas[CurrentRoute.Tracks[i].Elements.Length - 2];
+					for (int j = 1; j < CurrentRoute.Tracks[i].Elements.Length - 1; j++)
 					{
 						tangents[j] = 0.5 * (deltas[j - 1] + deltas[j]);
 					}
-					for (int j = 0; j < TrackManager.Tracks[i].Elements.Length - 1; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[i].Elements.Length - 1; j++)
 					{
 						if (deltas[j] == 0.0)
 						{
@@ -1842,9 +1842,9 @@ namespace OpenBve
 							}
 						}
 					}
-					for (int j = 0; j < TrackManager.Tracks[i].Elements.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[i].Elements.Length; j++)
 					{
-						TrackManager.Tracks[i].Elements[j].CurveCantTangent = tangents[j];
+						CurrentRoute.Tracks[i].Elements[j].CurveCantTangent = tangents[j];
 					}
 				}
 			}
@@ -1861,7 +1861,7 @@ namespace OpenBve
 				throw new InvalidOperationException();
 			}
 			// subdivide track
-			int length = TrackManager.Tracks[0].Elements.Length;
+			int length = CurrentRoute.Tracks[0].Elements.Length;
 			int newLength = (length - 1) * subdivisions + 1;
 			double[] midpointsTrackPositions = new double[newLength];
 			Vector3[] midpointsWorldPositions = new Vector3[newLength];
@@ -1877,7 +1877,7 @@ namespace OpenBve
 					int q = i / subdivisions;
 					TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 					double r = (double)m / (double)subdivisions;
-					double p = (1.0 - r) * TrackManager.Tracks[0].Elements[q].StartingTrackPosition + r * TrackManager.Tracks[0].Elements[q + 1].StartingTrackPosition;
+					double p = (1.0 - r) * CurrentRoute.Tracks[0].Elements[q].StartingTrackPosition + r * CurrentRoute.Tracks[0].Elements[q + 1].StartingTrackPosition;
 					follower.UpdateAbsolute(-1.0, true, false);
 					follower.UpdateAbsolute(p, true, false);
 					midpointsTrackPositions[i] = p;
@@ -1888,41 +1888,41 @@ namespace OpenBve
 					midpointsCant[i] = follower.CurveCant;
 				}
 			}
-			Array.Resize(ref TrackManager.Tracks[0].Elements, newLength);
+			Array.Resize(ref CurrentRoute.Tracks[0].Elements, newLength);
 			for (int i = length - 1; i >= 1; i--)
 			{
-				TrackManager.Tracks[0].Elements[subdivisions * i] = TrackManager.Tracks[0].Elements[i];
+				CurrentRoute.Tracks[0].Elements[subdivisions * i] = CurrentRoute.Tracks[0].Elements[i];
 			}
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 			{
 				int m = i % subdivisions;
 				if (m != 0)
 				{
 					int q = i / subdivisions;
 					int j = q * subdivisions;
-					TrackManager.Tracks[0].Elements[i] = TrackManager.Tracks[0].Elements[j];
-					TrackManager.Tracks[0].Elements[i].Events = new object[] { };
-					TrackManager.Tracks[0].Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
-					TrackManager.Tracks[0].Elements[i].WorldPosition = midpointsWorldPositions[i];
-					TrackManager.Tracks[0].Elements[i].WorldDirection = midpointsWorldDirections[i];
-					TrackManager.Tracks[0].Elements[i].WorldUp = midpointsWorldUps[i];
-					TrackManager.Tracks[0].Elements[i].WorldSide = midpointsWorldSides[i];
-					TrackManager.Tracks[0].Elements[i].CurveCant = midpointsCant[i];
-					TrackManager.Tracks[0].Elements[i].CurveCantTangent = 0.0;
+					CurrentRoute.Tracks[0].Elements[i] = CurrentRoute.Tracks[0].Elements[j];
+					CurrentRoute.Tracks[0].Elements[i].Events = new object[] { };
+					CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldPosition = midpointsWorldPositions[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldDirection = midpointsWorldDirections[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldUp = midpointsWorldUps[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldSide = midpointsWorldSides[i];
+					CurrentRoute.Tracks[0].Elements[i].CurveCant = midpointsCant[i];
+					CurrentRoute.Tracks[0].Elements[i].CurveCantTangent = 0.0;
 				}
 			}
 			// find turns
-			bool[] isTurn = new bool[TrackManager.Tracks[0].Elements.Length];
+			bool[] isTurn = new bool[CurrentRoute.Tracks[0].Elements.Length];
 			{
 				TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-				for (int i = 1; i < TrackManager.Tracks[0].Elements.Length - 1; i++)
+				for (int i = 1; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++)
 				{
 					int m = i % subdivisions;
 					if (m == 0)
 					{
-						double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+						double p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 						follower.UpdateAbsolute(p, true, false);
-						Vector3 d1 = TrackManager.Tracks[0].Elements[i].WorldDirection;
+						Vector3 d1 = CurrentRoute.Tracks[0].Elements[i].WorldDirection;
 						Vector3 d2 = follower.WorldDirection;
 						Vector3 d = d1 - d2;
 						double t = d.X * d.X + d.Z * d.Z;
@@ -1936,14 +1936,14 @@ namespace OpenBve
 			}
 			// replace turns by curves
 			double totalShortage = 0.0;
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 			{
 				if (isTurn[i])
 				{
 					// estimate radius
-					Vector3 AP = TrackManager.Tracks[0].Elements[i - 1].WorldPosition;
-					Vector3 BP = TrackManager.Tracks[0].Elements[i + 1].WorldPosition;
-					Vector3 S = TrackManager.Tracks[0].Elements[i - 1].WorldSide - TrackManager.Tracks[0].Elements[i + 1].WorldSide;
+					Vector3 AP = CurrentRoute.Tracks[0].Elements[i - 1].WorldPosition;
+					Vector3 BP = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition;
+					Vector3 S = CurrentRoute.Tracks[0].Elements[i - 1].WorldSide - CurrentRoute.Tracks[0].Elements[i + 1].WorldSide;
 					double rx;
 					if (S.X * S.X > 0.000001)
 					{
@@ -1996,28 +1996,28 @@ namespace OpenBve
 						{
 							// apply radius
 							TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-							TrackManager.Tracks[0].Elements[i - 1].CurveRadius = r;
-							double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+							CurrentRoute.Tracks[0].Elements[i - 1].CurveRadius = r;
+							double p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							TrackManager.Tracks[0].Elements[i].CurveRadius = r;
-							TrackManager.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
-							TrackManager.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
-							TrackManager.Tracks[0].Elements[i].WorldUp = follower.WorldUp;
-							TrackManager.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
+							CurrentRoute.Tracks[0].Elements[i].CurveRadius = r;
+							CurrentRoute.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
+							CurrentRoute.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
+							CurrentRoute.Tracks[0].Elements[i].WorldUp = follower.WorldUp;
+							CurrentRoute.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
 							// iterate to shorten track element length
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+							Vector3 d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 							double bestT = d.NormSquared();
 							int bestJ = 0;
 							int n = 1000;
-							double a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
+							double a = 1.0 / (double)n * (CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++)
 							{
-								follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+								follower.UpdateAbsolute(CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+								d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT)
 								{
@@ -2030,18 +2030,18 @@ namespace OpenBve
 								}
 							}
 							double s = (double)bestJ * a;
-							for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++)
+							for (int j = i + 1; j < CurrentRoute.Tracks[0].Elements.Length; j++)
 							{
-								TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
+								CurrentRoute.Tracks[0].Elements[j].StartingTrackPosition -= s;
 							}
 							totalShortage += s;
 							// introduce turn to compensate for curve
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 AB = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
-							Vector3 AC = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
-							Vector3 BC = follower.WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 AB = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+							Vector3 AC = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - CurrentRoute.Tracks[0].Elements[i].WorldPosition;
+							Vector3 BC = follower.WorldPosition - CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double sa = Math.Sqrt(BC.X * BC.X + BC.Z * BC.Z);
 							double sb = Math.Sqrt(AC.X * AC.X + AC.Z * AC.Z);
 							double sc = Math.Sqrt(AB.X * AB.X + AB.Z * AB.Z);
@@ -2064,7 +2064,7 @@ namespace OpenBve
 										originalAngle = Math.Acos(value);
 									}
 								}
-								TrackElement originalTrackElement = TrackManager.Tracks[0].Elements[i];
+								TrackElement originalTrackElement = CurrentRoute.Tracks[0].Elements[i];
 								bestT = double.MaxValue;
 								bestJ = 0;
 								for (int j = -1; j <= 1; j++)
@@ -2072,14 +2072,14 @@ namespace OpenBve
 									double g = (double)j * originalAngle;
 									double cosg = Math.Cos(g);
 									double sing = Math.Sin(g);
-									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
-									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
-									p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+									CurrentRoute.Tracks[0].Elements[i] = originalTrackElement;
+									CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 									follower.UpdateAbsolute(p - 1.0, true, false);
 									follower.UpdateAbsolute(p, true, false);
-									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+									d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT)
 									{
@@ -2091,24 +2091,24 @@ namespace OpenBve
 									double newAngle = (double)bestJ * originalAngle;
 									double cosg = Math.Cos(newAngle);
 									double sing = Math.Sin(newAngle);
-									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
-									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i] = originalTrackElement;
+									CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 								}
 								// iterate again to further shorten track element length
-								p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+								p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 								follower.UpdateAbsolute(p - 1.0, true, false);
 								follower.UpdateAbsolute(p, true, false);
-								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+								d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								bestT = d.NormSquared();
 								bestJ = 0;
 								n = 1000;
-								a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
+								a = 1.0 / (double)n * (CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++)
 								{
-									follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+									follower.UpdateAbsolute(CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+									d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT)
 									{
@@ -2121,54 +2121,54 @@ namespace OpenBve
 									}
 								}
 								s = (double)bestJ * a;
-								for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++)
+								for (int j = i + 1; j < CurrentRoute.Tracks[0].Elements.Length; j++)
 								{
-									TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
+									CurrentRoute.Tracks[0].Elements[j].StartingTrackPosition -= s;
 								}
 								totalShortage += s;
 							}
 							// compensate for height difference
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d1 = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 d1 = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double a1 = Math.Atan(d1.Y / Math.Sqrt(d1.X * d1.X + d1.Z * d1.Z));
-							Vector3 d2 = follower.WorldPosition - TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 d2 = follower.WorldPosition - CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double a2 = Math.Atan(d2.Y / Math.Sqrt(d2.X * d2.X + d2.Z * d2.Z));
 							double b = a2 - a1;
 							if (b * b > 0.00000001)
 							{
 								double cosa = Math.Cos(b);
 								double sina = Math.Sin(b);
-								TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
-								TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
+								CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(CurrentRoute.Tracks[0].Elements[i].WorldSide, cosa, sina);
+								CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(CurrentRoute.Tracks[0].Elements[i].WorldSide, cosa, sina);
 							}
 						}
 					}
 				}
 			}
 			// correct events
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++)
 			{
-				double startingTrackPosition = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
-				double endingTrackPosition = TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-				for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+				double startingTrackPosition = CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
+				double endingTrackPosition = CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
+				for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 				{
-					dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
+					dynamic e = CurrentRoute.Tracks[0].Elements[i].Events[j];
 					double p = startingTrackPosition + e.TrackPositionDelta;
 					if (p >= endingTrackPosition)
 					{
-						int len = TrackManager.Tracks[0].Elements[i + 1].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[i + 1].Events, len + 1);
-						TrackManager.Tracks[0].Elements[i + 1].Events[len] = TrackManager.Tracks[0].Elements[i].Events[j];
-						e = TrackManager.Tracks[0].Elements[i + 1].Events[len];
+						int len = CurrentRoute.Tracks[0].Elements[i + 1].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[i + 1].Events, len + 1);
+						CurrentRoute.Tracks[0].Elements[i + 1].Events[len] = CurrentRoute.Tracks[0].Elements[i].Events[j];
+						e = CurrentRoute.Tracks[0].Elements[i + 1].Events[len];
 						e.TrackPositionDelta += startingTrackPosition - endingTrackPosition;
-						for (int k = j; k < TrackManager.Tracks[0].Elements[i].Events.Length - 1; k++)
+						for (int k = j; k < CurrentRoute.Tracks[0].Elements[i].Events.Length - 1; k++)
 						{
-							TrackManager.Tracks[0].Elements[i].Events[k] = TrackManager.Tracks[0].Elements[i].Events[k + 1];
+							CurrentRoute.Tracks[0].Elements[i].Events[k] = CurrentRoute.Tracks[0].Elements[i].Events[k + 1];
 						}
-						len = TrackManager.Tracks[0].Elements[i].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, len - 1);
+						len = CurrentRoute.Tracks[0].Elements[i].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, len - 1);
 						j--;
 					}
 				}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -594,9 +594,9 @@ namespace OpenBve {
 										} else if (a <= 0.0) {
 											Interface.AddMessage(MessageType.Error, false, "ValueInMillimeters is expected to be positive in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 										} else {
-											for (int t = 0; t < TrackManager.Tracks.Length; t++)
+											for (int t = 0; t < CurrentRoute.Tracks.Length; t++)
 											{
-												TrackManager.Tracks[t].RailGauge = 0.001 * a;
+												CurrentRoute.Tracks[t].RailGauge = 0.001 * a;
 											}
 										}
 									} break;

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using LibRender;
+using OpenBve.RouteManager;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 
@@ -241,8 +242,8 @@ namespace OpenBve
 					{
 						double a = baseCar.Specs.CurrentRollDueToTopplingAngle +
 						           baseCar.Specs.CurrentRollDueToCantAngle;
-						double x = Math.Sign(a) * 0.5 * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
-						double y = Math.Abs(0.5 * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * Math.Sin(a));
+						double x = Math.Sign(a) * 0.5 * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
+						double y = Math.Abs(0.5 * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * Math.Sin(a));
 						Vector3 c = new Vector3(s.X * x + Up.X * y, s.Y * x + Up.Y * y, s.Z * x + Up.Z * y);
 						FrontAxle.Follower.WorldPosition += c;
 						RearAxle.Follower.WorldPosition += c;

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
@@ -759,7 +759,7 @@ namespace OpenBve
 				}
 				// roll due to cant (incorporates shaking)
 				{
-					double cantAngle = Math.Atan(c / TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge);
+					double cantAngle = Math.Atan(c / CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge);
 					Specs.CurrentRollDueToCantAngle = cantAngle + Specs.CurrentRollDueToShakingAngle;
 				}
 				// pitch due to acceleration
@@ -842,7 +842,7 @@ namespace OpenBve
 					double ab = Specs.CurrentRollDueToTopplingAngle + Specs.CurrentRollDueToCantAngle;
 					double h = Specs.CenterOfGravityHeight;
 					double sr = Math.Abs(CurrentSpeed);
-					double rmax = 2.0 * h * sr * sr / (Atmosphere.AccelerationDueToGravity * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge);
+					double rmax = 2.0 * h * sr * sr / (Atmosphere.AccelerationDueToGravity * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge);
 					double ta;
 					Topples = false;
 					if (Derailed)
@@ -856,7 +856,7 @@ namespace OpenBve
 						{
 							if (r < rmax)
 							{
-								double s0 = Math.Sqrt(r * Atmosphere.AccelerationDueToGravity * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge / (2.0 * h));
+								double s0 = Math.Sqrt(r * Atmosphere.AccelerationDueToGravity * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge / (2.0 * h));
 								const double fac = 0.25; // arbitrary coefficient
 								ta = -fac * (sr - s0) * rs;
 								baseTrain.Topple(Index, TimeElapsed);
@@ -902,8 +902,8 @@ namespace OpenBve
 				// apply position due to cant/toppling
 				{
 					double a = Specs.CurrentRollDueToTopplingAngle + Specs.CurrentRollDueToCantAngle;
-					double x = Math.Sign(a) * 0.5 * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
-					double y = Math.Abs(0.5 * TrackManager.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * Math.Sin(a));
+					double x = Math.Sign(a) * 0.5 * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * (1.0 - Math.Cos(a));
+					double y = Math.Abs(0.5 * CurrentRoute.Tracks[FrontAxle.Follower.TrackIndex].RailGauge * Math.Sin(a));
 					Vector3 cc = new Vector3(s.X * x + Up.X * y, s.Y * x + Up.Y * y, s.Z * x + Up.Z * y);
 					FrontAxle.Follower.WorldPosition += cc;
 					RearAxle.Follower.WorldPosition += cc;

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
@@ -81,17 +81,17 @@ namespace OpenBve
 			{
 				if (baseTrain.State != TrainState.Disposed)
 				{
-					FrontAxle.Follower.Update(FrontAxle.Follower.TrackPosition + Delta, true, true);
-					FrontBogie.FrontAxle.Follower.Update(FrontBogie.FrontAxle.Follower.TrackPosition + Delta, true, true);
-					FrontBogie.RearAxle.Follower.Update(FrontBogie.RearAxle.Follower.TrackPosition + Delta, true, true);
+					FrontAxle.Follower.UpdateRelative(Delta, true, true);
+					FrontBogie.FrontAxle.Follower.UpdateRelative(Delta, true, true);
+					FrontBogie.RearAxle.Follower.UpdateRelative(Delta, true, true);
 					if (baseTrain.State != TrainState.Disposed)
 					{
-						RearAxle.Follower.Update(RearAxle.Follower.TrackPosition + Delta, true, true);
-						RearBogie.FrontAxle.Follower.Update(RearBogie.FrontAxle.Follower.TrackPosition + Delta, true, true);
-						RearBogie.RearAxle.Follower.Update(RearBogie.RearAxle.Follower.TrackPosition + Delta, true, true);
+						RearAxle.Follower.UpdateRelative(Delta, true, true);
+						RearBogie.FrontAxle.Follower.UpdateRelative(Delta, true, true);
+						RearBogie.RearAxle.Follower.UpdateRelative(Delta, true, true);
 						if (baseTrain.State != TrainState.Disposed)
 						{
-							BeaconReceiver.Update(BeaconReceiver.TrackPosition + Delta, true, true);
+							BeaconReceiver.UpdateRelative(Delta, true, true);
 						}
 					}
 				}
@@ -104,15 +104,15 @@ namespace OpenBve
 			internal void UpdateTrackFollowers(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccurary)
 			{
 				//Car axles
-				FrontAxle.Follower.Update(FrontAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
-				RearAxle.Follower.Update(RearAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				FrontAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				RearAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
 				//Front bogie axles
-				FrontBogie.FrontAxle.Follower.Update(FrontBogie.FrontAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
-				FrontBogie.RearAxle.Follower.Update(FrontBogie.RearAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				FrontBogie.FrontAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				FrontBogie.RearAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
 				//Rear bogie axles
 
-				RearBogie.FrontAxle.Follower.Update(RearBogie.FrontAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
-				RearBogie.RearAxle.Follower.Update(RearBogie.RearAxle.Follower.TrackPosition + NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				RearBogie.FrontAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
+				RearBogie.RearAxle.Follower.UpdateRelative(NewTrackPosition, UpdateWorldCoordinates, AddTrackInaccurary);
 			}
 
 			/// <summary>Initializes the car</summary>
@@ -139,10 +139,10 @@ namespace OpenBve
 			{
 				double s = 0.5 * (FrontAxle.Follower.TrackPosition + RearAxle.Follower.TrackPosition);
 				double d = 0.5 * (FrontAxle.Follower.TrackPosition - RearAxle.Follower.TrackPosition);
-				FrontAxle.Follower.Update(s + d, false, false);
-				RearAxle.Follower.Update(s - d, false, false);
+				FrontAxle.Follower.UpdateAbsolute(s + d, false, false);
+				RearAxle.Follower.UpdateAbsolute(s - d, false, false);
 				double b = FrontAxle.Follower.TrackPosition - FrontAxle.Position + BeaconReceiverPosition;
-				BeaconReceiver.Update(b, false, false);
+				BeaconReceiver.UpdateAbsolute(b, false, false);
 			}
 
 			public override void CreateWorldCoordinates(Vector3 Car, out Vector3 Position, out Vector3 Direction)
@@ -1078,7 +1078,7 @@ namespace OpenBve
 				World.CameraTrackFollower.WorldSide = new Vector3(sx, sy, sz);
 				double f = (Driver.Z - RearAxle.Position) / (FrontAxle.Position - RearAxle.Position);
 				double tp = (1.0 - f) * RearAxle.Follower.TrackPosition + f * FrontAxle.Follower.TrackPosition;
-				World.CameraTrackFollower.Update(tp, false, false);
+				World.CameraTrackFollower.UpdateAbsolute(tp, false, false);
 			}
 		}
 	}

--- a/source/OpenBVE/System/Functions/Illustrations.cs
+++ b/source/OpenBVE/System/Functions/Illustrations.cs
@@ -98,8 +98,8 @@ namespace OpenBve {
 			double x1 = double.NegativeInfinity, z1 = double.NegativeInfinity;
 			for (int i = n0; i <= n1; i++)
 			{
-				double x = TrackManager.Tracks[0].Elements[i].WorldPosition.X;
-				double z = TrackManager.Tracks[0].Elements[i].WorldPosition.Z;
+				double x = CurrentRoute.Tracks[0].Elements[i].WorldPosition.X;
+				double z = CurrentRoute.Tracks[0].Elements[i].WorldPosition.Z;
 				if (x < x0) x0 = x;
 				if (x > x1) x1 = x;
 				if (z < z0) z0 = z;
@@ -157,19 +157,19 @@ namespace OpenBve {
 				PointF[] p = new PointF[n];
 				for (int i = 0; i < n; i++)
 				{
-					double x = TrackManager.Tracks[0].Elements[i+n0].WorldPosition.X;
-					double z = TrackManager.Tracks[0].Elements[i+n0].WorldPosition.Z;
+					double x = CurrentRoute.Tracks[0].Elements[i+n0].WorldPosition.X;
+					double z = CurrentRoute.Tracks[0].Elements[i+n0].WorldPosition.Z;
 					x = ox + (x - x0) * xd;
 					z = oy + (z0 - z) * zd + h;
 					p[i] = new PointF((float)x, (float)z);
 					// ATS / ATC
 					// for each track element, look for a StationStartEvent
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i+n0].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i+n0].Events.Length; j++)
 					{
-						if (TrackManager.Tracks[0].Elements[i+n0].Events[j] is StationStartEvent)
+						if (CurrentRoute.Tracks[0].Elements[i+n0].Events[j] is StationStartEvent)
 						{
 							StationStartEvent e =
-								(StationStartEvent)TrackManager.Tracks[0].Elements[i+n0].Events[j];
+								(StationStartEvent)CurrentRoute.Tracks[0].Elements[i+n0].Events[j];
 							// if StationStartEvent found, look for a change in ATS/ATC control;
 							// if there is a change, draw all previous track elements
 							// with colour for the previous control state
@@ -203,15 +203,15 @@ namespace OpenBve {
 			// STATION ICONS
 			for (int i = n0; i <= n1; i++)
 			{
-				for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+				for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 				{
-					if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+					if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 					{
-						StationStartEvent e = (StationStartEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+						StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 						if (CurrentRoute.Stations[e.StationIndex].Name != string.Empty)
 						{
-							double x = TrackManager.Tracks[0].Elements[i].WorldPosition.X;
-							double y = TrackManager.Tracks[0].Elements[i].WorldPosition.Z;
+							double x = CurrentRoute.Tracks[0].Elements[i].WorldPosition.X;
+							double y = CurrentRoute.Tracks[0].Elements[i].WorldPosition.Z;
 							x = ox + (x - x0) * xd;
 							y = oy + (z0 - y) * zd + h;
 							// station circle
@@ -240,22 +240,22 @@ namespace OpenBve {
 				Font f = new Font(FontFamily.GenericSansSerif, wh < 65536.0 ? 9.0f : 10.0f, GraphicsUnit.Pixel);
 				for (int i = n0; i <= n1; i++)
 				{
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 					{
-						if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+						if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 						{
-							StationStartEvent e = (StationStartEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+							StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 							if (CurrentRoute.Stations[e.StationIndex].Name != string.Empty)
 							{
-								double x = TrackManager.Tracks[0].Elements[i].WorldPosition.X;
-								double y = TrackManager.Tracks[0].Elements[i].WorldPosition.Z;
+								double x = CurrentRoute.Tracks[0].Elements[i].WorldPosition.X;
+								double y = CurrentRoute.Tracks[0].Elements[i].WorldPosition.Z;
 								x = ox + (x - x0) * xd;
 								y = oy + (z0 - y) * zd + h;
 								bool stop = CurrentRoute.Stations[e.StationIndex].PlayerStops();
 								string t = CurrentRoute.Stations[e.StationIndex].Name;
 								SizeF m = g.MeasureString(t, f, Width, StringFormat.GenericDefault);
-								double sx = TrackManager.Tracks[0].Elements[i].WorldSide.X;
-								double sz = TrackManager.Tracks[0].Elements[i].WorldSide.Z;
+								double sx = CurrentRoute.Tracks[0].Elements[i].WorldSide.X;
+								double sz = CurrentRoute.Tracks[0].Elements[i].WorldSide.Z;
 								double xt, yt;
 								if (Math.Sign(sx) == Math.Sign(sz))
 								{
@@ -361,7 +361,7 @@ namespace OpenBve {
 		/// <param name="inGame"><c>true</c> = bitmap for in-game overlay | <c>false</c> = for standard window.</param>
 		internal static Bitmap CreateRouteGradientProfile(int Width, int Height, bool inGame)
 		{
-			if (TrackManager.Tracks[0].Elements.Length > 36 && CurrentRoute.Stations.Length == 0)
+			if (CurrentRoute.Tracks[0].Elements.Length > 36 && CurrentRoute.Stations.Length == 0)
 			{
 				// If we have track elements, but no stations, show a specific error message, rather
 				// than the more generic one thrown later
@@ -379,7 +379,7 @@ namespace OpenBve {
 			double y0 = double.PositiveInfinity, y1 = double.NegativeInfinity;
 			for (int i = n0; i <= n1; i++)
 			{
-				double y = TrackManager.Tracks[0].Elements[i].WorldPosition.Y;
+				double y = CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y;
 				if (y < y0) y0 = y;
 				if (y > y1) y1 = y;
 			}
@@ -396,8 +396,8 @@ namespace OpenBve {
 			// set total bitmap track position range; used by in-game profile to place
 			// the current position of the trains; as the train positions are known as track positions,
 			// actual track positions are needed here, rather than indices into the track element array.
-			double minX = TrackManager.Tracks[0].Elements[n0].StartingTrackPosition;
-			double maxX = TrackManager.Tracks[0].Elements[n1].StartingTrackPosition;
+			double minX = CurrentRoute.Tracks[0].Elements[n0].StartingTrackPosition;
+			double maxX = CurrentRoute.Tracks[0].Elements[n1].StartingTrackPosition;
 			double offX = ox * (maxX - minX) / w;
 			lastGradientMinTrack = (int)(minX - offX);
 			lastGradientMaxTrack = (int)(maxX + offX);
@@ -429,7 +429,7 @@ namespace OpenBve {
 				{
 					double x = ox + (double)(i - n0) * nd;
 					double y = oy + (h - 0.5 *
-						(double)(TrackManager.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
+						(double)(CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
 					p[i -n0 + 1] = new PointF((float)x, (float)y);
 				}
 				p[n + 1] = new PointF((float)(ox + (double)(n - 1) * nd), (float)(oy + h));
@@ -444,11 +444,11 @@ namespace OpenBve {
 				StringFormat m = new StringFormat();
 				for (int i = n0; i <= n1; i++)
 				{
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 					{
-						if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+						if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 						{
-							StationStartEvent e = (StationStartEvent)TrackManager.Tracks[0].Elements[i].Events[j];
+							StationStartEvent e = (StationStartEvent)CurrentRoute.Tracks[0].Elements[i].Events[j];
 							if (CurrentRoute.Stations[e.StationIndex].Name != string.Empty)
 							{
 								bool stop = CurrentRoute.Stations[e.StationIndex].PlayerStops();
@@ -458,7 +458,7 @@ namespace OpenBve {
 									m.LineAlignment = StringAlignment.Near;
 									double x = ox + (double)(i - n0) * nd;
 									double y = oy + (h - 0.5 *
-										(double)(TrackManager.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
+										(double)(CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
 									string t = CurrentRoute.Stations[e.StationIndex].Name;
 									float tx = 0.0f, ty = (float)oy;
 									for (int k = 0; k < t.Length; k++)
@@ -482,7 +482,7 @@ namespace OpenBve {
 									m.LineAlignment = StringAlignment.Near;
 									double x = ox + (double)(i - n0) * nd;
 									double y = oy + (h - 0.5 *
-										(double)(TrackManager.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
+										(double)(CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd);
 									g.RotateTransform(-90.0f);
 									g.TranslateTransform((float)x, (float)oy, System.Drawing.Drawing2D.MatrixOrder.Append);
 									g.DrawString(CurrentRoute.Stations[e.StationIndex].Name, f,
@@ -527,17 +527,17 @@ namespace OpenBve {
 				for (int i = n0; i <= n1; i += k)
 				{
 					double x = ox + (double)(i - n0) * nd;
-					double y = (double)(TrackManager.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd;
+					double y = (double)(CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y - y0) * yd;
 					// track offset label
 					if (x < w)
 					{
-						string t = ((int)Math.Round(TrackManager.Tracks[0].Elements[i].StartingTrackPosition)).ToString(Culture);
+						string t = ((int)Math.Round(CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition)).ToString(Culture);
 						g.DrawString(t + "m", f, mapColors[mode].actNameText, (float)x, (float)(oy + h + TrackOffY));
 					}
 					// route height at track offset (with measure and vertical line)
 					{
 						y = oy + (h - 0.5 * y) + 2.0f;
-						string t = ((int)Math.Round(CurrentRoute.InitialElevation + TrackManager.Tracks[0].Elements[i].WorldPosition.Y)).ToString(Culture);
+						string t = ((int)Math.Round(CurrentRoute.InitialElevation + CurrentRoute.Tracks[0].Elements[i].WorldPosition.Y)).ToString(Culture);
 						SizeF s = g.MeasureString(t, fs);
 						if (y < oy + h - (double)s.Width - 10.0)
 						{
@@ -577,14 +577,14 @@ namespace OpenBve {
 		private static void RouteRange(out int n, out int n0, out int n1)
 		{
 			// find first and last track element actually used by stations
-			n	= TrackManager.Tracks[0].Elements.Length;
+			n	= CurrentRoute.Tracks[0].Elements.Length;
 			n0	= n - 1;
 			n1	= 0;
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++)
 			{
-				for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+				for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 				{
-					if (TrackManager.Tracks[0].Elements[i].Events[j] is StationStartEvent)
+					if (CurrentRoute.Tracks[0].Elements[i].Events[j] is StationStartEvent)
 					{
 						if (i < n0) n0 = i;
 						if (i > n1) n1 = i;
@@ -597,8 +597,8 @@ namespace OpenBve {
 			n1 += 8;
 			// But not outside of actual track element array!
 			if (n0 < 0) n0 = 0;
-			if (n1 >= TrackManager.Tracks[0].Elements.Length)
-				n1 = TrackManager.Tracks[0].Elements.Length - 1;
+			if (n1 >= CurrentRoute.Tracks[0].Elements.Length)
+				n1 = CurrentRoute.Tracks[0].Elements.Length - 1;
 			if (n1 <= n0)		// neither a 0-length or 'negative' track!
 				n1 = n0 + 1;
 		}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -471,9 +471,9 @@ namespace OpenBve
 			// camera
 			ObjectManager.InitializeVisibility();
 			TrainManager.PlayerTrain.DriverBody = new DriverBody(TrainManager.PlayerTrain);
-			World.CameraTrackFollower.Update(0.0, true, false);
-			World.CameraTrackFollower.Update(-0.1, true, false);
-			World.CameraTrackFollower.Update(0.1, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(0.0, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(-0.1, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(0.1, true, false);
 			World.CameraTrackFollower.TriggerType = EventTriggerType.Camera;
 			// starting time and track position
 			Game.SecondsSinceMidnight = 0.0;
@@ -720,7 +720,7 @@ namespace OpenBve
 			}
 			//Place the initial camera in the driver car
 			TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].UpdateCamera();
-			World.CameraTrackFollower.Update(-1.0, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
 			ObjectManager.UpdateVisibility(World.CameraTrackFollower.TrackPosition + Camera.CurrentAlignment.Position.Z);
 			World.CameraSavedExterior = new CameraAlignment(new OpenBveApi.Math.Vector3(-2.5, 1.5, -15.0), 0.3, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
 			World.CameraSavedTrack = new CameraAlignment(new OpenBveApi.Math.Vector3(-3.0, 2.5, 0.0), 0.3, 0.0, 0.0, TrainManager.PlayerTrain.Cars[0].TrackPosition - 10.0, 1.0);

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -912,7 +912,7 @@ namespace OpenBve
 												TrainManager.PlayerTrain.Cars[j].FrontBogie.ChangeSection(0);
 												TrainManager.PlayerTrain.Cars[j].RearBogie.ChangeSection(0);
 											}
-											World.CameraTrackFollower.Update(World.CameraTrackFollower.TrackPosition + z, true, false);
+											World.CameraTrackFollower.UpdateRelative(z, true, false);
 											Camera.CurrentAlignment.TrackPosition = World.CameraTrackFollower.TrackPosition;
 											Camera.VerticalViewingAngle = Camera.OriginalVerticalViewingAngle;
 											Renderer.UpdateViewport(ViewPortChangeMode.NoChange);
@@ -960,7 +960,7 @@ namespace OpenBve
 												TrainManager.PlayerTrain.Cars[j].FrontBogie.ChangeSection(0);
 												TrainManager.PlayerTrain.Cars[j].RearBogie.ChangeSection(0);
 											}
-											World.CameraTrackFollower.Update(World.CameraTrackFollower.TrackPosition + z, true, false);
+											World.CameraTrackFollower.UpdateRelative(z, true, false);
 											Camera.CurrentAlignment.TrackPosition =
 												World.CameraTrackFollower.TrackPosition;
 											Camera.VerticalViewingAngle = Camera.OriginalVerticalViewingAngle;
@@ -982,7 +982,7 @@ namespace OpenBve
 										Camera.CurrentAlignment.Roll = 0.0;
 										if (Camera.CurrentMode == CameraViewMode.Track)
 										{
-											World.CameraTrackFollower.Update(
+											World.CameraTrackFollower.UpdateAbsolute(
 												TrainManager.PlayerTrain.Cars[0].TrackPosition, true,
 												false);
 										}
@@ -993,7 +993,7 @@ namespace OpenBve
 											{
 												double d = 30.0 +
 														   4.0*TrainManager.PlayerTrain.CurrentSpeed;
-												World.CameraTrackFollower.Update(
+												World.CameraTrackFollower.UpdateAbsolute(
 													TrainManager.PlayerTrain.Cars[0].FrontAxle.Follower
 														.TrackPosition + d, true, false);
 											}
@@ -1001,7 +1001,7 @@ namespace OpenBve
 											{
 												double d = 30.0 -
 														   4.0*TrainManager.PlayerTrain.CurrentSpeed;
-												World.CameraTrackFollower.Update(
+												World.CameraTrackFollower.UpdateAbsolute(
 													TrainManager.PlayerTrain.Cars[
 														TrainManager.PlayerTrain.Cars.Length - 1].RearAxle.Follower
 														.TrackPosition - d, true, false);

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -447,7 +447,7 @@ namespace OpenBve
 				case CameraViewMode.FlyBy:
 				case CameraViewMode.FlyByZooming:
 					Camera.CurrentAlignment = World.CameraSavedTrack;
-					World.CameraTrackFollower.Update(World.CameraSavedTrack.TrackPosition, true, false);
+					World.CameraTrackFollower.UpdateAbsolute(World.CameraSavedTrack.TrackPosition, true, false);
 					Camera.CurrentAlignment.TrackPosition = World.CameraTrackFollower.TrackPosition;
 					break;
 			}

--- a/source/RouteManager/CurrentRoute.cs
+++ b/source/RouteManager/CurrentRoute.cs
@@ -10,6 +10,8 @@ namespace OpenBve.RouteManager
 	/// <summary>The current route</summary>
 	public static class CurrentRoute
 	{
+		/// <summary>The list of tracks available in the simulation.</summary>
+		public static Track[] Tracks = new Track[] { new Track() };
 		/// <summary>Holds all signal sections within the current route</summary>
 		public static Section[] Sections = { };
 		/// <summary>Holds all stations within the current route</summary>

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -231,7 +231,7 @@ namespace OpenBve {
 			}
 			// process poi
 			if (j >= 0) {
-				TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, t, true, false);
+				World.CameraTrackFollower.UpdateAbsolute(t, true, false);
 				Camera.CurrentAlignment.Position = CurrentRoute.PointsOfInterest[j].TrackOffset;
 				Camera.CurrentAlignment.Yaw = CurrentRoute.PointsOfInterest[j].TrackYaw;
 				Camera.CurrentAlignment.Pitch = CurrentRoute.PointsOfInterest[j].TrackPitch;

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -52,7 +52,7 @@ namespace OpenBve {
 
 		internal static void Reset() {
 			// track manager
-			TrackManager.CurrentTrack = new Track();
+			TrackManager.Tracks = new Track[] { new Track() };
 			// train manager
 			TrainManager.Trains = new TrainManager.Train[] { };
 			// game

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -52,7 +52,7 @@ namespace OpenBve {
 
 		internal static void Reset() {
 			// track manager
-			TrackManager.Tracks = new Track[] { new Track() };
+			CurrentRoute.Tracks = new Track[] { new Track() };
 			// train manager
 			TrainManager.Trains = new TrainManager.Train[] { };
 			// game

--- a/source/RouteViewer/LoadingR.cs
+++ b/source/RouteViewer/LoadingR.cs
@@ -137,9 +137,9 @@ namespace OpenBve {
 			RouteProgress = 1.0;
 			// camera
 			ObjectManager.InitializeVisibility();
-			TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, 0.0, true, false);
-			TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, 0.1, true, false);
-			TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, -0.1, true, false);
+			World.CameraTrackFollower.UpdateAbsolute( 0.0, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(0.1, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(-0.1, true, false);
 			World.CameraTrackFollower.TriggerType = EventTriggerType.Camera;
 			// default starting time
 			Game.SecondsSinceMidnight = 0.0;
@@ -174,8 +174,8 @@ namespace OpenBve {
 				}
 			}
 			// initialize camera
-			TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, -1.0, true, false);
-			TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, FirstStationPosition, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
+			World.CameraTrackFollower.UpdateAbsolute(FirstStationPosition, true, false);
 			Camera.CurrentAlignment = new CameraAlignment(new Vector3(0.0, 2.5, 0.0), 0.0, 0.0, 0.0, FirstStationPosition, 1.0);
 			World.UpdateAbsoluteCamera(0.0);
 			ObjectManager.UpdateVisibility(World.CameraTrackFollower.TrackPosition + Camera.CurrentAlignment.Position.Z);

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -1847,7 +1847,7 @@ namespace OpenBve {
 										} else if (a <= 0.0) {
 											Interface.AddMessage(MessageType.Error, false, "ValueInMillimeters is expected to be positive in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 										} else {
-											TrackManager.Tracks[0].RailGauge = 0.001 * a;
+											CurrentRoute.Tracks[0].RailGauge = 0.001 * a;
 										}
 									} break;
 								case "route.signal":
@@ -5488,13 +5488,13 @@ namespace OpenBve {
 			// create objects and track
 			Vector3 Position = Vector3.Zero;
 			Vector2 Direction = new Vector2(0.0, 1.0);
-			TrackManager.Tracks[0] = new Track();
-			TrackManager.Tracks[0].Elements = new TrackElement[] { };
+			CurrentRoute.Tracks[0] = new Track();
+			CurrentRoute.Tracks[0].Elements = new TrackElement[] { };
 			double CurrentSpeedLimit = double.PositiveInfinity;
 			int CurrentRunIndex = 0;
 			int CurrentFlangeIndex = 0;
 			if (Data.FirstUsedBlock < 0) Data.FirstUsedBlock = 0;
-			TrackManager.Tracks[0].Elements = new TrackElement[256];
+			CurrentRoute.Tracks[0].Elements = new TrackElement[256];
 			int CurrentTrackLength = 0;
 			int PreviousFogElement = -1;
 			int PreviousFogEvent = -1;
@@ -5524,19 +5524,19 @@ namespace OpenBve {
 				}
 				TrackElement WorldTrackElement = Data.Blocks[i].CurrentTrackState;
 				int n = CurrentTrackLength;
-				if (n >= TrackManager.Tracks[0].Elements.Length) {
-					Array.Resize(ref TrackManager.Tracks[0].Elements, TrackManager.Tracks[0].Elements.Length << 1);
+				if (n >= CurrentRoute.Tracks[0].Elements.Length) {
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements, CurrentRoute.Tracks[0].Elements.Length << 1);
 				}
 				CurrentTrackLength++;
-				TrackManager.Tracks[0].Elements[n] = WorldTrackElement;
-				TrackManager.Tracks[0].Elements[n].WorldPosition = Position;
-				TrackManager.Tracks[0].Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
-				TrackManager.Tracks[0].Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
-				TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
-				TrackManager.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
-				TrackManager.Tracks[0].Elements[n].Events = new object[] { };
-				TrackManager.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
-				TrackManager.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
+				CurrentRoute.Tracks[0].Elements[n] = WorldTrackElement;
+				CurrentRoute.Tracks[0].Elements[n].WorldPosition = Position;
+				CurrentRoute.Tracks[0].Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
+				CurrentRoute.Tracks[0].Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
+				CurrentRoute.Tracks[0].Elements[n].WorldUp = Vector3.Cross(CurrentRoute.Tracks[0].Elements[n].WorldDirection, CurrentRoute.Tracks[0].Elements[n].WorldSide);
+				CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
+				CurrentRoute.Tracks[0].Elements[n].Events = new object[] { };
+				CurrentRoute.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
+				CurrentRoute.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
 				// background
 				if (!PreviewOnly) {
 					if (Data.Blocks[i].Background >= 0) {
@@ -5553,9 +5553,9 @@ namespace OpenBve {
 							}
 						}
 						if (typ >= 0 & Data.Backgrounds.ContainsKey(typ)) {
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
 						}
 					}
 				}
@@ -5567,18 +5567,18 @@ namespace OpenBve {
 						/*
 						 * Legacy brightness: This applies equally to all tracks in a block
 						 */
-						for (int t = 0; t < TrackManager.Tracks.Length; t++)
+						for (int t = 0; t < CurrentRoute.Tracks.Length; t++)
 						{
-							int m = TrackManager.Tracks[t].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[t].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[t].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[t].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].BrightnessChanges[j].TrackPosition - StartingDistance;
-							TrackManager.Tracks[t].Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].BrightnessChanges[j].Value, CurrentBrightnessValue, Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition);
+							CurrentRoute.Tracks[t].Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].BrightnessChanges[j].Value, CurrentBrightnessValue, Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition);
 							
 							if (t == 0)
 							{
 								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
 								{
-									BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
+									BrightnessChangeEvent bce = (BrightnessChangeEvent)CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
 									bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
 									bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
 								}
@@ -5589,11 +5589,11 @@ namespace OpenBve {
 							{
 								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
 								{
-									for (int e = 0; e < TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events.Length; e++)
+									for (int e = 0; e < CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events.Length; e++)
 									{
-										if (!(TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e] is BrightnessChangeEvent))
+										if (!(CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[e] is BrightnessChangeEvent))
 											continue;
-										BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e];
+										BrightnessChangeEvent bce = (BrightnessChangeEvent)CurrentRoute.Tracks[t].Elements[CurrentBrightnessElement].Events[e];
 										bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
 										bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
 									}
@@ -5610,11 +5610,11 @@ namespace OpenBve {
 					if (Data.FogTransitionMode) {
 						if (Data.Blocks[i].FogDefined) {
 							Data.Blocks[i].Fog.TrackPosition = StartingDistance;
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
 							if (PreviousFogElement >= 0 & PreviousFogEvent >= 0) {
-								FogChangeEvent e = (FogChangeEvent)TrackManager.Tracks[0].Elements[PreviousFogElement].Events[PreviousFogEvent];
+								FogChangeEvent e = (FogChangeEvent)CurrentRoute.Tracks[0].Elements[PreviousFogElement].Events[PreviousFogEvent];
 								e.NextFog = Data.Blocks[i].Fog;
 							} else {
 								CurrentRoute.PreviousFog = PreviousFog;
@@ -5627,9 +5627,9 @@ namespace OpenBve {
 						}
 					} else {
 						Data.Blocks[i].Fog.TrackPosition = StartingDistance + Data.BlockInterval;
-						int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-						TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
+						int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+						CurrentRoute.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
 						PreviousFog = CurrentFog;
 						CurrentFog = Data.Blocks[i].Fog;
 					}
@@ -5639,9 +5639,9 @@ namespace OpenBve {
 					int j = Data.Blocks[i].RailType[0];
 					int r = j < Data.Structure.Run.Length ? Data.Structure.Run[j] : 0;
 					int f = j < Data.Structure.Flange.Length ? Data.Structure.Flange[j] : 0;
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-					TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
 					CurrentRunIndex = r;
 					CurrentFlangeIndex = f;
 				}
@@ -5660,9 +5660,9 @@ namespace OpenBve {
 							}
 						}
 						if (q) {
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, Vector3.Zero, 12.5);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, Vector3.Zero, 12.5);
 						}
 					}
 				}
@@ -5670,9 +5670,9 @@ namespace OpenBve {
 				if (Data.Blocks[i].Station >= 0) {
 					// station
 					int s = Data.Blocks[i].Station;
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-					TrackManager.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
 					double dx, dy = 3.0;
 					if (CurrentRoute.Stations[s].OpenLeftDoors & !CurrentRoute.Stations[s].OpenRightDoors) {
 						dx = -5.0;
@@ -5681,9 +5681,9 @@ namespace OpenBve {
 					} else {
 						dx = 0.0;
 					}
-					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.Tracks[0].Elements[n].WorldSide.X + dy * TrackManager.Tracks[0].Elements[n].WorldUp.X;
-					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Y + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Y;
-					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Z + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Z;
+					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.X + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.X;
+					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.Y + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.Y;
+					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.Z + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.Z;
 					// passalarm
 					if (!PreviewOnly) {
 						if (Data.Blocks[i].StationPassAlarm) {
@@ -5691,9 +5691,9 @@ namespace OpenBve {
 							if (b >= 0) {
 								int j = b - Data.FirstUsedBlock;
 								if (j >= 0) {
-									m = TrackManager.Tracks[0].Elements[j].Events.Length;
-									Array.Resize(ref TrackManager.Tracks[0].Elements[j].Events, m + 1);
-									TrackManager.Tracks[0].Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
+									m = CurrentRoute.Tracks[0].Elements[j].Events.Length;
+									Array.Resize(ref CurrentRoute.Tracks[0].Elements[j].Events, m + 1);
+									CurrentRoute.Tracks[0].Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
 								}
 							}
 						}
@@ -5716,16 +5716,16 @@ namespace OpenBve {
 					} else {
 						dx = 0.0;
 					}
-					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.Tracks[0].Elements[n].WorldSide.X + dy * TrackManager.Tracks[0].Elements[n].WorldUp.X;
-					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Y + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Y;
-					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Z + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Z;
+					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.X + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.X;
+					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.Y + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.Y;
+					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * CurrentRoute.Tracks[0].Elements[n].WorldSide.Z + dy * CurrentRoute.Tracks[0].Elements[n].WorldUp.Z;
 				}
 				// limit
 				for (int j = 0; j < Data.Blocks[i].Limit.Length; j++) {
-					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 					double d = Data.Blocks[i].Limit[j].TrackPosition - StartingDistance;
-					TrackManager.Tracks[0].Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limit[j].Speed);
+					CurrentRoute.Tracks[0].Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limit[j].Speed);
 					CurrentSpeedLimit = Data.Blocks[i].Limit[j].Speed;
 				}
 				// marker
@@ -5735,22 +5735,22 @@ namespace OpenBve {
 					{
 						if (Data.Markers[j].StartingPosition >= StartingDistance & Data.Markers[j].StartingPosition < EndingDistance)
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].StartingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								CurrentRoute.Tracks[0].Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 						if (Data.Markers[j].EndingPosition >= StartingDistance & Data.Markers[j].EndingPosition < EndingDistance)
 						{
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].EndingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								CurrentRoute.Tracks[0].Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 					}
@@ -5759,15 +5759,15 @@ namespace OpenBve {
 				if (!PreviewOnly) {
 					for (int j = 0; j < Data.Blocks[i].Sound.Length; j++) {
 						if (Data.Blocks[i].Sound[j].Type == SoundType.TrainStatic | Data.Blocks[i].Sound[j].Type == SoundType.TrainDynamic) {
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].Sound[j].TrackPosition - StartingDistance;
 							switch (Data.Blocks[i].Sound[j].Type) {
 								case SoundType.TrainStatic:
-									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
+									CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
 									break;
 								case SoundType.TrainDynamic:
-									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].Sound[j].Speed);
+									CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].Sound[j].Speed);
 									break;
 							}
 						}
@@ -5779,17 +5779,17 @@ namespace OpenBve {
 					double cosag = Math.Cos(ag);
 					double sinag = Math.Sin(ag);
 					Direction.Rotate(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldDirection.RotatePlane(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldSide.RotatePlane(cosag, sinag);
-					TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
+					CurrentRoute.Tracks[0].Elements[n].WorldDirection.RotatePlane(cosag, sinag);
+					CurrentRoute.Tracks[0].Elements[n].WorldSide.RotatePlane(cosag, sinag);
+					CurrentRoute.Tracks[0].Elements[n].WorldUp = Vector3.Cross(CurrentRoute.Tracks[0].Elements[n].WorldDirection, CurrentRoute.Tracks[0].Elements[n].WorldSide);
 				}
 				if (Data.Blocks[i].Pitch != 0.0)
 				{
-					TrackManager.Tracks[0].Elements[n].Pitch = Data.Blocks[i].Pitch;
+					CurrentRoute.Tracks[0].Elements[n].Pitch = Data.Blocks[i].Pitch;
 				}
 				else
 				{
-					TrackManager.Tracks[0].Elements[n].Pitch = 0.0;
+					CurrentRoute.Tracks[0].Elements[n].Pitch = 0.0;
 				}
 				// curves
 				double a = 0.0;
@@ -6423,10 +6423,10 @@ namespace OpenBve {
 									{
 										if (Data.Blocks[g].Transponders[l].Type != -1 & Data.Blocks[g].Transponders[l].SectionIndex == m)
 										{
-											int o = TrackManager.Tracks[0].Elements[n - i + g].Events.Length;
-											Array.Resize(ref TrackManager.Tracks[0].Elements[n - i + g].Events, o + 1);
+											int o = CurrentRoute.Tracks[0].Elements[n - i + g].Events.Length;
+											Array.Resize(ref CurrentRoute.Tracks[0].Elements[n - i + g].Events, o + 1);
 											double dt = Data.Blocks[g].Transponders[l].TrackPosition - StartingDistance + (double)(i - g) * Data.BlockInterval;
-											TrackManager.Tracks[0].Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponders[l].Type, Data.Blocks[g].Transponders[l].Data, m, Data.Blocks[g].Transponders[l].ClipToFirstRedSection);
+											CurrentRoute.Tracks[0].Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponders[l].Type, Data.Blocks[g].Transponders[l].Data, m, Data.Blocks[g].Transponders[l].ClipToFirstRedSection);
 											Data.Blocks[g].Transponders[l].Type = -1;
 										}
 									}
@@ -6456,9 +6456,9 @@ namespace OpenBve {
 								CurrentRoute.Sections[m].Trains = new TrainManager.Train[] { };
 								// create section change event
 								double d = Data.Blocks[i].Section[k].TrackPosition - StartingDistance;
-								int p = TrackManager.Tracks[0].Elements[n].Events.Length;
-								Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, p + 1);
-								TrackManager.Tracks[0].Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
+								int p = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+								Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, p + 1);
+								CurrentRoute.Tracks[0].Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
 							}
 							// transponders introduced after corresponding sections
 							for (int l = 0; l < Data.Blocks[i].Transponders.Length; l++)
@@ -6468,10 +6468,10 @@ namespace OpenBve {
 									int t = Data.Blocks[i].Transponders[l].SectionIndex;
 									if (t >= 0 & t < CurrentRoute.Sections.Length)
 									{
-										int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-										Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+										int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+										Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
 										double dt = Data.Blocks[i].Transponders[l].TrackPosition - StartingDistance;
-										TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponders[l].Type, Data.Blocks[i].Transponders[l].Data, t, Data.Blocks[i].Transponders[l].ClipToFirstRedSection);
+										CurrentRoute.Tracks[0].Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponders[l].Type, Data.Blocks[i].Transponders[l].Data, t, Data.Blocks[i].Transponders[l].ClipToFirstRedSection);
 										Data.Blocks[i].Transponders[l].Type = -1;
 									}
 								}
@@ -6572,12 +6572,12 @@ namespace OpenBve {
 						if (Data.Blocks[i].Transponders[j].Type != -1)
 						{
 							int n = i - Data.FirstUsedBlock;
-							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-							double d = Data.Blocks[i].Transponders[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
+							int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+							double d = Data.Blocks[i].Transponders[j].TrackPosition - CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition;
 							int s = Data.Blocks[i].Transponders[j].SectionIndex;
 							if (s >= 0) s = -1;
-							TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponders[j].Type, Data.Blocks[i].Transponders[j].Data, s, Data.Blocks[i].Transponders[j].ClipToFirstRedSection);
+							CurrentRoute.Tracks[0].Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponders[j].Type, Data.Blocks[i].Transponders[j].Data, s, Data.Blocks[i].Transponders[j].ClipToFirstRedSection);
 							Data.Blocks[i].Transponders[j].Type = -1;
 						}
 					}
@@ -6585,9 +6585,9 @@ namespace OpenBve {
 					for (int j = 0; j < Data.Blocks[i].DestinationChanges.Length; j++)
 					{
 						int n = i - Data.FirstUsedBlock;
-						int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
+						int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition;
 						//Destination events not supported in Route Viewer.....
 						//TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
 					}
@@ -6601,9 +6601,9 @@ namespace OpenBve {
 					int k = (int)Math.Floor(p / (double)Data.BlockInterval) - Data.FirstUsedBlock;
 					if (k >= 0 & k < Data.Blocks.Length) {
 						double d = p - (double)(k + Data.FirstUsedBlock) * (double)Data.BlockInterval;
-						int m = TrackManager.Tracks[0].Elements[k].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[k].Events, m + 1);
-						TrackManager.Tracks[0].Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
+						int m = CurrentRoute.Tracks[0].Elements[k].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[k].Events, m + 1);
+						CurrentRoute.Tracks[0].Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
 					}
 				}
 			}
@@ -6628,20 +6628,20 @@ namespace OpenBve {
 			}
 			// convert block-based cant into point-based cant
 			for (int i = CurrentTrackLength - 1; i >= 1; i--) {
-				if (TrackManager.Tracks[0].Elements[i].CurveCant == 0.0) {
-					TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i - 1].CurveCant;
-				} else if (TrackManager.Tracks[0].Elements[i - 1].CurveCant != 0.0) {
-					if (Math.Sign(TrackManager.Tracks[0].Elements[i - 1].CurveCant) == Math.Sign(TrackManager.Tracks[0].Elements[i].CurveCant)) {
-						if (Math.Abs(TrackManager.Tracks[0].Elements[i - 1].CurveCant) > Math.Abs(TrackManager.Tracks[0].Elements[i].CurveCant)) {
-							TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i - 1].CurveCant;
+				if (CurrentRoute.Tracks[0].Elements[i].CurveCant == 0.0) {
+					CurrentRoute.Tracks[0].Elements[i].CurveCant = CurrentRoute.Tracks[0].Elements[i - 1].CurveCant;
+				} else if (CurrentRoute.Tracks[0].Elements[i - 1].CurveCant != 0.0) {
+					if (Math.Sign(CurrentRoute.Tracks[0].Elements[i - 1].CurveCant) == Math.Sign(CurrentRoute.Tracks[0].Elements[i].CurveCant)) {
+						if (Math.Abs(CurrentRoute.Tracks[0].Elements[i - 1].CurveCant) > Math.Abs(CurrentRoute.Tracks[0].Elements[i].CurveCant)) {
+							CurrentRoute.Tracks[0].Elements[i].CurveCant = CurrentRoute.Tracks[0].Elements[i - 1].CurveCant;
 						}
 					} else {
-						TrackManager.Tracks[0].Elements[i].CurveCant = 0.5 * (TrackManager.Tracks[0].Elements[i].CurveCant + TrackManager.Tracks[0].Elements[i - 1].CurveCant);
+						CurrentRoute.Tracks[0].Elements[i].CurveCant = 0.5 * (CurrentRoute.Tracks[0].Elements[i].CurveCant + CurrentRoute.Tracks[0].Elements[i - 1].CurveCant);
 					}
 				}
 			}
 			// finalize
-			Array.Resize(ref TrackManager.Tracks[0].Elements, CurrentTrackLength);
+			Array.Resize(ref CurrentRoute.Tracks[0].Elements, CurrentTrackLength);
 			for (int i = 0; i < CurrentRoute.Stations.Length; i++) {
 				if (CurrentRoute.Stations[i].Stops.Length == 0 & CurrentRoute.Stations[i].StopMode != StationStopMode.AllPass) {
 					Interface.AddMessage(MessageType.Warning, false, "Station " + CurrentRoute.Stations[i].Name + " expects trains to stop but does not define stop points at track position " + CurrentRoute.Stations[i].DefaultTrackPosition.ToString(Culture) + " in file " + FileName);
@@ -6662,11 +6662,11 @@ namespace OpenBve {
 			if (CurrentRoute.Stations.Length != 0) {
 				CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Terminal;
 			}
-			if (TrackManager.Tracks[0].Elements.Length != 0) {
-				int n = TrackManager.Tracks[0].Elements.Length - 1;
-				int m = TrackManager.Tracks[0].Elements[n].Events.Length;
-				Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
-				TrackManager.Tracks[0].Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
+			if (CurrentRoute.Tracks[0].Elements.Length != 0) {
+				int n = CurrentRoute.Tracks[0].Elements.Length - 1;
+				int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
+				Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
+				CurrentRoute.Tracks[0].Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
 			}
 			if (!PreviewOnly) {
 				ComputeCantTangents();
@@ -6682,20 +6682,20 @@ namespace OpenBve {
 
 		// compute cant tangents
 		private static void ComputeCantTangents() {
-			if (TrackManager.Tracks[0].Elements.Length == 1) {
-				TrackManager.Tracks[0].Elements[0].CurveCantTangent = 0.0;
-			} else if (TrackManager.Tracks[0].Elements.Length != 0) {
-				double[] deltas = new double[TrackManager.Tracks[0].Elements.Length - 1];
-				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
-					deltas[i] = TrackManager.Tracks[0].Elements[i + 1].CurveCant - TrackManager.Tracks[0].Elements[i].CurveCant;
+			if (CurrentRoute.Tracks[0].Elements.Length == 1) {
+				CurrentRoute.Tracks[0].Elements[0].CurveCantTangent = 0.0;
+			} else if (CurrentRoute.Tracks[0].Elements.Length != 0) {
+				double[] deltas = new double[CurrentRoute.Tracks[0].Elements.Length - 1];
+				for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++) {
+					deltas[i] = CurrentRoute.Tracks[0].Elements[i + 1].CurveCant - CurrentRoute.Tracks[0].Elements[i].CurveCant;
 				}
-				double[] tangents = new double[TrackManager.Tracks[0].Elements.Length];
+				double[] tangents = new double[CurrentRoute.Tracks[0].Elements.Length];
 				tangents[0] = deltas[0];
-				tangents[TrackManager.Tracks[0].Elements.Length - 1] = deltas[TrackManager.Tracks[0].Elements.Length - 2];
-				for (int i = 1; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
+				tangents[CurrentRoute.Tracks[0].Elements.Length - 1] = deltas[CurrentRoute.Tracks[0].Elements.Length - 2];
+				for (int i = 1; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++) {
 					tangents[i] = 0.5 * (deltas[i - 1] + deltas[i]);
 				}
-				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
+				for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++) {
 					if (deltas[i] == 0.0) {
 						tangents[i] = 0.0;
 						tangents[i + 1] = 0.0;
@@ -6709,8 +6709,8 @@ namespace OpenBve {
 						}
 					}
 				}
-				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
-					TrackManager.Tracks[0].Elements[i].CurveCantTangent = tangents[i];
+				for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++) {
+					CurrentRoute.Tracks[0].Elements[i].CurveCantTangent = tangents[i];
 				}
 			}
 		}
@@ -6724,7 +6724,7 @@ namespace OpenBve {
 				throw new InvalidOperationException();
 			}
 			// subdivide track
-			int length = TrackManager.Tracks[0].Elements.Length;
+			int length = CurrentRoute.Tracks[0].Elements.Length;
 			int newLength = (length - 1) * subdivisions + 1;
 			double[] midpointsTrackPositions = new double[newLength];
 			Vector3[] midpointsWorldPositions = new Vector3[newLength];
@@ -6738,7 +6738,7 @@ namespace OpenBve {
 					int q = i / subdivisions;
 					TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 					double r = (double)m / (double)subdivisions;
-					double p = (1.0 - r) * TrackManager.Tracks[0].Elements[q].StartingTrackPosition + r * TrackManager.Tracks[0].Elements[q + 1].StartingTrackPosition;
+					double p = (1.0 - r) * CurrentRoute.Tracks[0].Elements[q].StartingTrackPosition + r * CurrentRoute.Tracks[0].Elements[q + 1].StartingTrackPosition;
 					follower.UpdateAbsolute(-1.0, true, false);
 					follower.UpdateAbsolute(p, true, false);
 					midpointsTrackPositions[i] = p;
@@ -6749,36 +6749,36 @@ namespace OpenBve {
 					midpointsCant[i] = follower.CurveCant;
 				}
 			}
-			Array.Resize(ref TrackManager.Tracks[0].Elements, newLength);
+			Array.Resize(ref CurrentRoute.Tracks[0].Elements, newLength);
 			for (int i = length - 1; i >= 1; i--) {
-				TrackManager.Tracks[0].Elements[subdivisions * i] = TrackManager.Tracks[0].Elements[i];
+				CurrentRoute.Tracks[0].Elements[subdivisions * i] = CurrentRoute.Tracks[0].Elements[i];
 			}
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++) {
 				int m = i % subdivisions;
 				if (m != 0) {
 					int q = i / subdivisions;
 					int j = q * subdivisions;
-					TrackManager.Tracks[0].Elements[i] = TrackManager.Tracks[0].Elements[j];
-					TrackManager.Tracks[0].Elements[i].Events = new object[] { };
-					TrackManager.Tracks[0].Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
-					TrackManager.Tracks[0].Elements[i].WorldPosition = midpointsWorldPositions[i];
-					TrackManager.Tracks[0].Elements[i].WorldDirection = midpointsWorldDirections[i];
-					TrackManager.Tracks[0].Elements[i].WorldUp = midpointsWorldUps[i];
-					TrackManager.Tracks[0].Elements[i].WorldSide = midpointsWorldSides[i];
-					TrackManager.Tracks[0].Elements[i].CurveCant = midpointsCant[i];
-					TrackManager.Tracks[0].Elements[i].CurveCantTangent = 0.0;
+					CurrentRoute.Tracks[0].Elements[i] = CurrentRoute.Tracks[0].Elements[j];
+					CurrentRoute.Tracks[0].Elements[i].Events = new object[] { };
+					CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldPosition = midpointsWorldPositions[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldDirection = midpointsWorldDirections[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldUp = midpointsWorldUps[i];
+					CurrentRoute.Tracks[0].Elements[i].WorldSide = midpointsWorldSides[i];
+					CurrentRoute.Tracks[0].Elements[i].CurveCant = midpointsCant[i];
+					CurrentRoute.Tracks[0].Elements[i].CurveCantTangent = 0.0;
 				}
 			}
 			// find turns
-			bool[] isTurn = new bool[TrackManager.Tracks[0].Elements.Length];
+			bool[] isTurn = new bool[CurrentRoute.Tracks[0].Elements.Length];
 			{
 				TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-				for (int i = 1; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
+				for (int i = 1; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++) {
 					int m = i % subdivisions;
 					if (m == 0) {
-						double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+						double p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 						follower.UpdateAbsolute(p, true, false);
-						Vector3 d1 = TrackManager.Tracks[0].Elements[i].WorldDirection;
+						Vector3 d1 = CurrentRoute.Tracks[0].Elements[i].WorldDirection;
 						Vector3 d2 = follower.WorldDirection;
 						Vector3 d = d1 - d2;
 						double t = d.X * d.X + d.Z * d.Z;
@@ -6791,13 +6791,13 @@ namespace OpenBve {
 			}
 			// replace turns by curves
 			double totalShortage = 0.0;
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++) {
 				if (isTurn[i]) {
 					// estimate radius
-					Vector3 AP = TrackManager.Tracks[0].Elements[i - 1].WorldPosition;
-					Vector3 AS = TrackManager.Tracks[0].Elements[i - 1].WorldSide;
-					Vector3 BP = TrackManager.Tracks[0].Elements[i + 1].WorldPosition;
-					Vector3 BS = TrackManager.Tracks[0].Elements[i + 1].WorldSide;
+					Vector3 AP = CurrentRoute.Tracks[0].Elements[i - 1].WorldPosition;
+					Vector3 AS = CurrentRoute.Tracks[0].Elements[i - 1].WorldSide;
+					Vector3 BP = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition;
+					Vector3 BS = CurrentRoute.Tracks[0].Elements[i + 1].WorldSide;
 					Vector3 S = AS - BS;
 					double rx;
 					if (S.X * S.X > 0.000001) {
@@ -6832,29 +6832,29 @@ namespace OpenBve {
 						if (r * r > 1.0) {
 							// apply radius
 							TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-							TrackManager.Tracks[0].Elements[i - 1].CurveRadius = r;
-							double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+							CurrentRoute.Tracks[0].Elements[i - 1].CurveRadius = r;
+							double p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							TrackManager.Tracks[0].Elements[i].CurveRadius = r;
+							CurrentRoute.Tracks[0].Elements[i].CurveRadius = r;
 							//TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i].CurveCant;
 							//TrackManager.Tracks[0].Elements[i].CurveCantInterpolation = TrackManager.Tracks[0].Elements[i].CurveCantInterpolation;
-							TrackManager.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
-							TrackManager.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
-							TrackManager.Tracks[0].Elements[i].WorldUp = follower.WorldUp;
-							TrackManager.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
+							CurrentRoute.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
+							CurrentRoute.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
+							CurrentRoute.Tracks[0].Elements[i].WorldUp = follower.WorldUp;
+							CurrentRoute.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
 							// iterate to shorten track element length
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+							Vector3 d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 							double bestT = d.NormSquared();
 							int bestJ = 0;
 							int n = 1000;
-							double a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
+							double a = 1.0 / (double)n * (CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++) {
-								follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
+								follower.UpdateAbsolute(CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+								d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT) {
 									bestT = t;
@@ -6864,17 +6864,17 @@ namespace OpenBve {
 								}
 							}
 							double s = (double)bestJ * a;
-							for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++) {
-								TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
+							for (int j = i + 1; j < CurrentRoute.Tracks[0].Elements.Length; j++) {
+								CurrentRoute.Tracks[0].Elements[j].StartingTrackPosition -= s;
 							}
 							totalShortage += s;
 							// introduce turn to compensate for curve
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 AB = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
-							Vector3 AC = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
-							Vector3 BC = follower.WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 AB = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+							Vector3 AC = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- CurrentRoute.Tracks[0].Elements[i].WorldPosition;
+							Vector3 BC = follower.WorldPosition- CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double sa = Math.Sqrt(BC.X * BC.X + BC.Z * BC.Z);
 							double sb = Math.Sqrt(AC.X * AC.X + AC.Z * AC.Z);
 							double sc = Math.Sqrt(AB.X * AB.X + AB.Z * AB.Z);
@@ -6891,21 +6891,21 @@ namespace OpenBve {
 										originalAngle = Math.Acos(value);
 									}
 								}
-								TrackElement originalTrackElement = TrackManager.Tracks[0].Elements[i];
+								TrackElement originalTrackElement = CurrentRoute.Tracks[0].Elements[i];
 								bestT = double.MaxValue;
 								bestJ = 0;
 								for (int j = -1; j <= 1; j++) {
 									double g = (double)j * originalAngle;
 									double cosg = Math.Cos(g);
 									double sing = Math.Sin(g);
-									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
-									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
-									p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+									CurrentRoute.Tracks[0].Elements[i] = originalTrackElement;
+									CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 									follower.UpdateAbsolute(p - 1.0, true, false);
 									follower.UpdateAbsolute(p, true, false);
-									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+									d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
 										bestT = t;
@@ -6916,23 +6916,23 @@ namespace OpenBve {
 									double newAngle = (double)bestJ * originalAngle;
 									double cosg = Math.Cos(newAngle);
 									double sing = Math.Sin(newAngle);
-									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
-									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i] = originalTrackElement;
+									CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									CurrentRoute.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 								}
 								// iterate again to further shorten track element length
-								p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+								p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 								follower.UpdateAbsolute(p - 1.0, true, false);
 								follower.UpdateAbsolute(p, true, false);
-								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+								d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 								bestT = d.NormSquared();
 								bestJ = 0;
 								n = 1000;
-								a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
+								a = 1.0 / (double)n * (CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++) {
-									follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+									follower.UpdateAbsolute(CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+									d = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
 										bestT = t;
@@ -6942,49 +6942,49 @@ namespace OpenBve {
 									}
 								}
 								s = (double)bestJ * a;
-								for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++) {
-									TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
+								for (int j = i + 1; j < CurrentRoute.Tracks[0].Elements.Length; j++) {
+									CurrentRoute.Tracks[0].Elements[j].StartingTrackPosition -= s;
 								}
 								totalShortage += s;
 							}
 							// compensate for height difference
-							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d1 = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 d1 = CurrentRoute.Tracks[0].Elements[i + 1].WorldPosition- CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double a1 = Math.Atan(d1.Y / Math.Sqrt(d1.X * d1.X + d1.Z * d1.Z));
-							Vector3 d2 = follower.WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 d2 = follower.WorldPosition- CurrentRoute.Tracks[0].Elements[i].WorldPosition;
 							double a2 = Math.Atan(d2.Y / Math.Sqrt(d2.X * d2.X + d2.Z * d2.Z));
 							double b = a2 - a1;
 							if (b * b > 0.00000001) {
 								double cosa = Math.Cos(b);
 								double sina = Math.Sin(b);
-								TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
-								TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
+								CurrentRoute.Tracks[0].Elements[i].WorldDirection.Rotate(CurrentRoute.Tracks[0].Elements[i].WorldSide, cosa, sina);
+								CurrentRoute.Tracks[0].Elements[i].WorldUp.Rotate(CurrentRoute.Tracks[0].Elements[i].WorldSide, cosa, sina);
 							}
 						}
 					}
 				}
 			}
 			// correct events
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
-				double startingTrackPosition = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
-				double endingTrackPosition = TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
-				for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length - 1; i++) {
+				double startingTrackPosition = CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
+				double endingTrackPosition = CurrentRoute.Tracks[0].Elements[i + 1].StartingTrackPosition;
+				for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++)
 				{
-					dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
+					dynamic e = CurrentRoute.Tracks[0].Elements[i].Events[j];
 					double p = startingTrackPosition + e.TrackPositionDelta;
 					if (p >= endingTrackPosition) {
-						int len = TrackManager.Tracks[0].Elements[i + 1].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[i + 1].Events, len + 1);
-						TrackManager.Tracks[0].Elements[i + 1].Events[len] = TrackManager.Tracks[0].Elements[i].Events[j];
-						e = TrackManager.Tracks[0].Elements[i + 1].Events[len];
+						int len = CurrentRoute.Tracks[0].Elements[i + 1].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[i + 1].Events, len + 1);
+						CurrentRoute.Tracks[0].Elements[i + 1].Events[len] = CurrentRoute.Tracks[0].Elements[i].Events[j];
+						e = CurrentRoute.Tracks[0].Elements[i + 1].Events[len];
 						e.TrackPositionDelta += startingTrackPosition - endingTrackPosition;
-						for (int k = j; k < TrackManager.Tracks[0].Elements[i].Events.Length - 1; k++) {
-							TrackManager.Tracks[0].Elements[i].Events[k] = TrackManager.Tracks[0].Elements[i].Events[k + 1];
+						for (int k = j; k < CurrentRoute.Tracks[0].Elements[i].Events.Length - 1; k++) {
+							CurrentRoute.Tracks[0].Elements[i].Events[k] = CurrentRoute.Tracks[0].Elements[i].Events[k + 1];
 						}
-						len = TrackManager.Tracks[0].Elements[i].Events.Length;
-						Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, len - 1);
+						len = CurrentRoute.Tracks[0].Elements[i].Events.Length;
+						Array.Resize(ref CurrentRoute.Tracks[0].Elements[i].Events, len - 1);
 						j--;
 					}
 				}

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -4914,6 +4914,7 @@ namespace OpenBve {
 											}
 											if (typ < 0 | !Data.Backgrounds.ContainsKey(typ)) {
 												Interface.AddMessage(MessageType.Error, false, "BackgroundTextureIndex " + typ + " references a texture not loaded in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+												continue;
 											}
 											StaticBackground b = Data.Backgrounds[typ] as StaticBackground;
 											if (b.Texture == null)
@@ -6709,8 +6710,8 @@ namespace OpenBve {
 					TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 					double r = (double)m / (double)subdivisions;
 					double p = (1.0 - r) * TrackManager.CurrentTrack.Elements[q].StartingTrackPosition + r * TrackManager.CurrentTrack.Elements[q + 1].StartingTrackPosition;
-					TrackManager.UpdateTrackFollower(ref follower, -1.0, true, false);
-					TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+					follower.UpdateAbsolute(-1.0, true, false);
+					follower.UpdateAbsolute(p, true, false);
 					midpointsTrackPositions[i] = p;
 					midpointsWorldPositions[i] = follower.WorldPosition;
 					midpointsWorldDirections[i] = follower.WorldDirection;
@@ -6747,7 +6748,7 @@ namespace OpenBve {
 					int m = i % subdivisions;
 					if (m == 0) {
 						double p = 0.00000001 * TrackManager.CurrentTrack.Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
-						TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+						follower.UpdateAbsolute(p, true, false);
 						Vector3 d1 = TrackManager.CurrentTrack.Elements[i].WorldDirection;
 						Vector3 d2 = follower.WorldDirection;
 						Vector3 d = d1 - d2;
@@ -6804,8 +6805,8 @@ namespace OpenBve {
 							TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 							TrackManager.CurrentTrack.Elements[i - 1].CurveRadius = r;
 							double p = 0.00000001 * TrackManager.CurrentTrack.Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
-							TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-							TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							TrackManager.CurrentTrack.Elements[i].CurveRadius = r;
 							//TrackManager.CurrentTrack.Elements[i].CurveCant = TrackManager.CurrentTrack.Elements[i].CurveCant;
 							//TrackManager.CurrentTrack.Elements[i].CurveCantInterpolation = TrackManager.CurrentTrack.Elements[i].CurveCantInterpolation;
@@ -6815,15 +6816,15 @@ namespace OpenBve {
 							TrackManager.CurrentTrack.Elements[i].WorldSide = follower.WorldSide;
 							// iterate to shorten track element length
 							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-							TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-							TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
 							double bestT = d.NormSquared();
 							int bestJ = 0;
 							int n = 1000;
 							double a = 1.0 / (double)n * (TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - TrackManager.CurrentTrack.Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++) {
-								TrackManager.UpdateTrackFollower(ref follower, TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+								follower.UpdateAbsolute(TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
 								d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT) {
@@ -6840,8 +6841,8 @@ namespace OpenBve {
 							totalShortage += s;
 							// introduce turn to compensate for curve
 							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-							TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-							TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 AB = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
 							Vector3 AC = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
 							Vector3 BC = follower.WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
@@ -6873,8 +6874,8 @@ namespace OpenBve {
 									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
 									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 									p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-									TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-									TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+									follower.UpdateAbsolute(p - 1.0, true, false);
+									follower.UpdateAbsolute(p, true, false);
 									d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
@@ -6893,15 +6894,15 @@ namespace OpenBve {
 								}
 								// iterate again to further shorten track element length
 								p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-								TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-								TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+								follower.UpdateAbsolute(p - 1.0, true, false);
+								follower.UpdateAbsolute(p, true, false);
 								d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
 								bestT = d.NormSquared();
 								bestJ = 0;
 								n = 1000;
 								a = 1.0 / (double)n * (TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - TrackManager.CurrentTrack.Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++) {
-									TrackManager.UpdateTrackFollower(ref follower, TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+									follower.UpdateAbsolute(TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
 									d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
@@ -6919,8 +6920,8 @@ namespace OpenBve {
 							}
 							// compensate for height difference
 							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-							TrackManager.UpdateTrackFollower(ref follower, p - 1.0, true, false);
-							TrackManager.UpdateTrackFollower(ref follower, p, true, false);
+							follower.UpdateAbsolute(p - 1.0, true, false);
+							follower.UpdateAbsolute(p, true, false);
 							Vector3 d1 = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
 							double a1 = Math.Atan(d1.Y / Math.Sqrt(d1.X * d1.X + d1.Z * d1.Z));
 							Vector3 d2 = follower.WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -290,7 +290,7 @@ namespace OpenBve {
         }
         private class Block {
 			internal int Background;
-			internal Brightness[] Brightness;
+			internal Brightness[] BrightnessChanges;
 			internal Fog Fog;
 			internal bool FogDefined;
 			internal int[] Cycle;
@@ -310,7 +310,7 @@ namespace OpenBve {
 			internal Limit[] Limit;
 			internal Stop[] Stop;
 			internal Sound[] Sound;
-			internal Transponder[] Transponder;
+			internal Transponder[] Transponders;
 	        internal DestinationEvent[] DestinationChanges;
 			internal PointOfInterest[] PointsOfInterest;
 			internal TrackElement CurrentTrackState;
@@ -406,7 +406,7 @@ namespace OpenBve {
 			Data.Blocks[0].CurrentTrackState = new TrackElement(0.0);
             if (!PreviewOnly) {
                 Data.Blocks[0].Background = 0;
-                Data.Blocks[0].Brightness = new Brightness[] { };
+                Data.Blocks[0].BrightnessChanges = new Brightness[] { };
                 Data.Blocks[0].Fog.Start = CurrentRoute.NoFogStart;
                 Data.Blocks[0].Fog.End = CurrentRoute.NoFogEnd;
                 Data.Blocks[0].Fog.Color = Color24.Grey;
@@ -424,7 +424,7 @@ namespace OpenBve {
 				Data.Blocks[0].Signal = new Signal[] { };
 				Data.Blocks[0].Section = new Section[] { };
 				Data.Blocks[0].Sound = new Sound[] { };
-				Data.Blocks[0].Transponder = new Transponder[] { };
+				Data.Blocks[0].Transponders = new Transponder[] { };
 	            Data.Blocks[0].DestinationChanges = new DestinationEvent[] { };
 				Data.Blocks[0].PointsOfInterest = new PointOfInterest[] { };
 				Data.Markers = new Marker[] { };
@@ -1847,7 +1847,7 @@ namespace OpenBve {
 										} else if (a <= 0.0) {
 											Interface.AddMessage(MessageType.Error, false, "ValueInMillimeters is expected to be positive in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 										} else {
-											TrackManager.CurrentTrack.RailGauge = 0.001 * a;
+											TrackManager.Tracks[0].RailGauge = 0.001 * a;
 										}
 									} break;
 								case "route.signal":
@@ -3366,10 +3366,10 @@ namespace OpenBve {
 											value /= 255.0f;
 											if (value < 0.0f) value = 0.0f;
 											if (value > 1.0f) value = 1.0f;
-											int n = Data.Blocks[BlockIndex].Brightness.Length;
-											Array.Resize<Brightness>(ref Data.Blocks[BlockIndex].Brightness, n + 1);
-											Data.Blocks[BlockIndex].Brightness[n].TrackPosition = Data.TrackPosition;
-											Data.Blocks[BlockIndex].Brightness[n].Value = value;
+											int n = Data.Blocks[BlockIndex].BrightnessChanges.Length;
+											Array.Resize<Brightness>(ref Data.Blocks[BlockIndex].BrightnessChanges, n + 1);
+											Data.Blocks[BlockIndex].BrightnessChanges[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].BrightnessChanges[n].Value = value;
 										}
 									} break;
 								case "track.fog":
@@ -3788,19 +3788,19 @@ namespace OpenBve {
 													Interface.AddMessage(MessageType.Error, false, "Roll is invalid in Track.Beacon at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													roll = 0.0;
 												}
-												int n = Data.Blocks[BlockIndex].Transponder.Length;
-												Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-												Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
-												Data.Blocks[BlockIndex].Transponder[n].Type = type;
-												Data.Blocks[BlockIndex].Transponder[n].Data = optional;
-												Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = structure;
-												Data.Blocks[BlockIndex].Transponder[n].SectionIndex = section;
-												Data.Blocks[BlockIndex].Transponder[n].ShowDefaultObject = false;
-												Data.Blocks[BlockIndex].Transponder[n].Position.X = x;
-												Data.Blocks[BlockIndex].Transponder[n].Position.Y = y;
-												Data.Blocks[BlockIndex].Transponder[n].Yaw = yaw.ToRadians();
-												Data.Blocks[BlockIndex].Transponder[n].Pitch = pitch.ToRadians();
-												Data.Blocks[BlockIndex].Transponder[n].Roll = roll.ToRadians();
+												int n = Data.Blocks[BlockIndex].Transponders.Length;
+												Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+												Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
+												Data.Blocks[BlockIndex].Transponders[n].Type = type;
+												Data.Blocks[BlockIndex].Transponders[n].Data = optional;
+												Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = structure;
+												Data.Blocks[BlockIndex].Transponders[n].SectionIndex = section;
+												Data.Blocks[BlockIndex].Transponders[n].ShowDefaultObject = false;
+												Data.Blocks[BlockIndex].Transponders[n].Position.X = x;
+												Data.Blocks[BlockIndex].Transponders[n].Position.Y = y;
+												Data.Blocks[BlockIndex].Transponders[n].Yaw = yaw.ToRadians();
+												Data.Blocks[BlockIndex].Transponders[n].Pitch = pitch.ToRadians();
+												Data.Blocks[BlockIndex].Transponders[n].Roll = roll.ToRadians();
 											}
 										}
 									} break;
@@ -3847,48 +3847,48 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "Roll is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												roll = 0.0;
 											}
-											int n = Data.Blocks[BlockIndex].Transponder.Length;
-											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-											Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
-											Data.Blocks[BlockIndex].Transponder[n].Type = type;
-											Data.Blocks[BlockIndex].Transponder[n].Data = work;
-											Data.Blocks[BlockIndex].Transponder[n].ShowDefaultObject = true;
-											Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = -1;
-											Data.Blocks[BlockIndex].Transponder[n].Position.X = x;
-											Data.Blocks[BlockIndex].Transponder[n].Position.Y = y;
-											Data.Blocks[BlockIndex].Transponder[n].Yaw = yaw.ToRadians();
-											Data.Blocks[BlockIndex].Transponder[n].Pitch = pitch.ToRadians();
-											Data.Blocks[BlockIndex].Transponder[n].Roll = roll.ToRadians();
-											Data.Blocks[BlockIndex].Transponder[n].SectionIndex = CurrentSection + oversig + 1;
-											Data.Blocks[BlockIndex].Transponder[n].ClipToFirstRedSection = true;
+											int n = Data.Blocks[BlockIndex].Transponders.Length;
+											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+											Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].Transponders[n].Type = type;
+											Data.Blocks[BlockIndex].Transponders[n].Data = work;
+											Data.Blocks[BlockIndex].Transponders[n].ShowDefaultObject = true;
+											Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].Position.X = x;
+											Data.Blocks[BlockIndex].Transponders[n].Position.Y = y;
+											Data.Blocks[BlockIndex].Transponders[n].Yaw = yaw.ToRadians();
+											Data.Blocks[BlockIndex].Transponders[n].Pitch = pitch.ToRadians();
+											Data.Blocks[BlockIndex].Transponders[n].Roll = roll.ToRadians();
+											Data.Blocks[BlockIndex].Transponders[n].SectionIndex = CurrentSection + oversig + 1;
+											Data.Blocks[BlockIndex].Transponders[n].ClipToFirstRedSection = true;
 										}
 									} break;
 								case "track.atssn":
 									{
 										if (!PreviewOnly) {
-											int n = Data.Blocks[BlockIndex].Transponder.Length;
-											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-											Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
-											Data.Blocks[BlockIndex].Transponder[n].Type = 0;
-											Data.Blocks[BlockIndex].Transponder[n].Data = 0;
-											Data.Blocks[BlockIndex].Transponder[n].ShowDefaultObject = true;
-											Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = -1;
-											Data.Blocks[BlockIndex].Transponder[n].SectionIndex = CurrentSection + 1;
-											Data.Blocks[BlockIndex].Transponder[n].ClipToFirstRedSection = true;
+											int n = Data.Blocks[BlockIndex].Transponders.Length;
+											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+											Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].Transponders[n].Type = 0;
+											Data.Blocks[BlockIndex].Transponders[n].Data = 0;
+											Data.Blocks[BlockIndex].Transponders[n].ShowDefaultObject = true;
+											Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].SectionIndex = CurrentSection + 1;
+											Data.Blocks[BlockIndex].Transponders[n].ClipToFirstRedSection = true;
 										}
 									} break;
 								case "track.atsp":
 									{
 										if (!PreviewOnly) {
-											int n = Data.Blocks[BlockIndex].Transponder.Length;
-											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-											Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
-											Data.Blocks[BlockIndex].Transponder[n].Type = 3;
-											Data.Blocks[BlockIndex].Transponder[n].Data = 0;
-											Data.Blocks[BlockIndex].Transponder[n].ShowDefaultObject = true;
-											Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = -1;
-											Data.Blocks[BlockIndex].Transponder[n].SectionIndex = CurrentSection + 1;
-											Data.Blocks[BlockIndex].Transponder[n].ClipToFirstRedSection = true;
+											int n = Data.Blocks[BlockIndex].Transponders.Length;
+											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+											Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].Transponders[n].Type = 3;
+											Data.Blocks[BlockIndex].Transponders[n].Data = 0;
+											Data.Blocks[BlockIndex].Transponders[n].ShowDefaultObject = true;
+											Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].SectionIndex = CurrentSection + 1;
+											Data.Blocks[BlockIndex].Transponders[n].ClipToFirstRedSection = true;
 										}
 									} break;
 								case "track.pattern":
@@ -3904,18 +3904,18 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "Speed is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												speed = 0.0;
 											}
-											int n = Data.Blocks[BlockIndex].Transponder.Length;
-											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-											Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
+											int n = Data.Blocks[BlockIndex].Transponders.Length;
+											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+											Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
 											if (type == 0) {
-												Data.Blocks[BlockIndex].Transponder[n].Type = (int)TransponderTypes.InternalAtsPTemporarySpeedLimit;
-												Data.Blocks[BlockIndex].Transponder[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
+												Data.Blocks[BlockIndex].Transponders[n].Type = (int)TransponderTypes.InternalAtsPTemporarySpeedLimit;
+												Data.Blocks[BlockIndex].Transponders[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
 											} else {
-												Data.Blocks[BlockIndex].Transponder[n].Type = (int)TransponderTypes.AtsPPermanentSpeedLimit;
-												Data.Blocks[BlockIndex].Transponder[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
+												Data.Blocks[BlockIndex].Transponders[n].Type = (int)TransponderTypes.AtsPPermanentSpeedLimit;
+												Data.Blocks[BlockIndex].Transponders[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
 											}
-											Data.Blocks[BlockIndex].Transponder[n].SectionIndex = -1;
-											Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].SectionIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = -1;
 										}
 									} break;
 								case "track.plimit":
@@ -3926,13 +3926,13 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "Speed is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												speed = 0.0;
 											}
-											int n = Data.Blocks[BlockIndex].Transponder.Length;
-											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponder, n + 1);
-											Data.Blocks[BlockIndex].Transponder[n].TrackPosition = Data.TrackPosition;
-											Data.Blocks[BlockIndex].Transponder[n].Type = (int)TransponderTypes.AtsPPermanentSpeedLimit;
-											Data.Blocks[BlockIndex].Transponder[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
-											Data.Blocks[BlockIndex].Transponder[n].SectionIndex = -1;
-											Data.Blocks[BlockIndex].Transponder[n].BeaconStructureIndex = -1;
+											int n = Data.Blocks[BlockIndex].Transponders.Length;
+											Array.Resize<Transponder>(ref Data.Blocks[BlockIndex].Transponders, n + 1);
+											Data.Blocks[BlockIndex].Transponders[n].TrackPosition = Data.TrackPosition;
+											Data.Blocks[BlockIndex].Transponders[n].Type = (int)TransponderTypes.AtsPPermanentSpeedLimit;
+											Data.Blocks[BlockIndex].Transponders[n].Data = speed == 0.0 ? int.MaxValue : (int)Math.Round(speed * Data.UnitOfSpeed * 3.6);
+											Data.Blocks[BlockIndex].Transponders[n].SectionIndex = -1;
+											Data.Blocks[BlockIndex].Transponders[n].BeaconStructureIndex = -1;
 										}
 									} break;
 								case "track.limit":
@@ -5107,7 +5107,7 @@ namespace OpenBve {
 					Data.Blocks[i] = new Block();
 					if (!PreviewOnly) {
 						Data.Blocks[i].Background = -1;
-						Data.Blocks[i].Brightness = new Brightness[] { };
+						Data.Blocks[i].BrightnessChanges = new Brightness[] { };
 						Data.Blocks[i].Fog = Data.Blocks[i - 1].Fog;
 						Data.Blocks[i].FogDefined = false;
 						Data.Blocks[i].Cycle = Data.Blocks[i - 1].Cycle;
@@ -5168,7 +5168,7 @@ namespace OpenBve {
 						Data.Blocks[i].Signal = new Signal[] { };
 						Data.Blocks[i].Section = new Section[] { };
 						Data.Blocks[i].Sound = new Sound[] { };
-						Data.Blocks[i].Transponder = new Transponder[] { };
+						Data.Blocks[i].Transponders = new Transponder[] { };
 						Data.Blocks[i].DestinationChanges = new DestinationEvent[] { };
 						Data.Blocks[i].RailFreeObj = new FreeObj[][] { };
 						Data.Blocks[i].GroundFreeObj = new FreeObj[] { };
@@ -5356,18 +5356,18 @@ namespace OpenBve {
 			double tmax = double.NegativeInfinity;
 			double bmin = 1.0, bmax = 1.0;
 			for (int i = 0; i < Data.Blocks.Length; i++) {
-				for (int j = 0; j < Data.Blocks[i].Brightness.Length; j++) {
-					if (Data.Blocks[i].Brightness[j].TrackPosition <= TrackPosition) {
-						tmin = Data.Blocks[i].Brightness[j].TrackPosition;
-						bmin = (double)Data.Blocks[i].Brightness[j].Value;
+				for (int j = 0; j < Data.Blocks[i].BrightnessChanges.Length; j++) {
+					if (Data.Blocks[i].BrightnessChanges[j].TrackPosition <= TrackPosition) {
+						tmin = Data.Blocks[i].BrightnessChanges[j].TrackPosition;
+						bmin = (double)Data.Blocks[i].BrightnessChanges[j].Value;
 					}
 				}
 			}
 			for (int i = Data.Blocks.Length - 1; i >= 0; i--) {
-				for (int j = Data.Blocks[i].Brightness.Length - 1; j >= 0; j--) {
-					if (Data.Blocks[i].Brightness[j].TrackPosition >= TrackPosition) {
-						tmax = Data.Blocks[i].Brightness[j].TrackPosition;
-						bmax = (double)Data.Blocks[i].Brightness[j].Value;
+				for (int j = Data.Blocks[i].BrightnessChanges.Length - 1; j >= 0; j--) {
+					if (Data.Blocks[i].BrightnessChanges[j].TrackPosition >= TrackPosition) {
+						tmax = Data.Blocks[i].BrightnessChanges[j].TrackPosition;
+						bmax = (double)Data.Blocks[i].BrightnessChanges[j].Value;
 					}
 				}
 			}
@@ -5478,9 +5478,9 @@ namespace OpenBve {
 			double CurrentBrightnessTrackPosition = (double)Data.FirstUsedBlock * Data.BlockInterval;
 			if (!PreviewOnly) {
 				for (int i = Data.FirstUsedBlock; i < Data.Blocks.Length; i++) {
-					if (Data.Blocks[i].Brightness != null && Data.Blocks[i].Brightness.Length != 0) {
-						CurrentBrightnessValue = Data.Blocks[i].Brightness[0].Value;
-						CurrentBrightnessTrackPosition = Data.Blocks[i].Brightness[0].Value;
+					if (Data.Blocks[i].BrightnessChanges != null && Data.Blocks[i].BrightnessChanges.Length != 0) {
+						CurrentBrightnessValue = Data.Blocks[i].BrightnessChanges[0].Value;
+						CurrentBrightnessTrackPosition = Data.Blocks[i].BrightnessChanges[0].Value;
 						break;
 					}
 				}
@@ -5488,13 +5488,13 @@ namespace OpenBve {
 			// create objects and track
 			Vector3 Position = Vector3.Zero;
 			Vector2 Direction = new Vector2(0.0, 1.0);
-			TrackManager.CurrentTrack = new Track();
-			TrackManager.CurrentTrack.Elements = new TrackElement[] { };
+			TrackManager.Tracks[0] = new Track();
+			TrackManager.Tracks[0].Elements = new TrackElement[] { };
 			double CurrentSpeedLimit = double.PositiveInfinity;
 			int CurrentRunIndex = 0;
 			int CurrentFlangeIndex = 0;
 			if (Data.FirstUsedBlock < 0) Data.FirstUsedBlock = 0;
-			TrackManager.CurrentTrack.Elements = new TrackElement[256];
+			TrackManager.Tracks[0].Elements = new TrackElement[256];
 			int CurrentTrackLength = 0;
 			int PreviousFogElement = -1;
 			int PreviousFogEvent = -1;
@@ -5524,19 +5524,19 @@ namespace OpenBve {
 				}
 				TrackElement WorldTrackElement = Data.Blocks[i].CurrentTrackState;
 				int n = CurrentTrackLength;
-				if (n >= TrackManager.CurrentTrack.Elements.Length) {
-					Array.Resize(ref TrackManager.CurrentTrack.Elements, TrackManager.CurrentTrack.Elements.Length << 1);
+				if (n >= TrackManager.Tracks[0].Elements.Length) {
+					Array.Resize(ref TrackManager.Tracks[0].Elements, TrackManager.Tracks[0].Elements.Length << 1);
 				}
 				CurrentTrackLength++;
-				TrackManager.CurrentTrack.Elements[n] = WorldTrackElement;
-				TrackManager.CurrentTrack.Elements[n].WorldPosition = Position;
-				TrackManager.CurrentTrack.Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
-				TrackManager.CurrentTrack.Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
-				TrackManager.CurrentTrack.Elements[n].WorldUp = Vector3.Cross(TrackManager.CurrentTrack.Elements[n].WorldDirection, TrackManager.CurrentTrack.Elements[n].WorldSide);
-				TrackManager.CurrentTrack.Elements[n].StartingTrackPosition = StartingDistance;
-				TrackManager.CurrentTrack.Elements[n].Events = new object[] { };
-				TrackManager.CurrentTrack.Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
-				TrackManager.CurrentTrack.Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
+				TrackManager.Tracks[0].Elements[n] = WorldTrackElement;
+				TrackManager.Tracks[0].Elements[n].WorldPosition = Position;
+				TrackManager.Tracks[0].Elements[n].WorldDirection = Vector3.GetVector3(Direction, Data.Blocks[i].Pitch);
+				TrackManager.Tracks[0].Elements[n].WorldSide = new Vector3(Direction.Y, 0.0, -Direction.X);
+				TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
+				TrackManager.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
+				TrackManager.Tracks[0].Elements[n].Events = new object[] { };
+				TrackManager.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
+				TrackManager.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
 				// background
 				if (!PreviewOnly) {
 					if (Data.Blocks[i].Background >= 0) {
@@ -5553,28 +5553,56 @@ namespace OpenBve {
 							}
 						}
 						if (typ >= 0 & Data.Backgrounds.ContainsKey(typ)) {
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							TrackManager.Tracks[0].Elements[n].Events[m] = new BackgroundChangeEvent(0.0, Data.Backgrounds[typ], Data.Backgrounds[Data.Blocks[i].Background]);
 						}
 					}
 				}
 				// brightness
-				if (!PreviewOnly) {
-					for (int j = 0; j < Data.Blocks[i].Brightness.Length; j++) {
-						int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-						double d = Data.Blocks[i].Brightness[j].TrackPosition - StartingDistance;
-						TrackManager.CurrentTrack.Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].Brightness[j].Value, CurrentBrightnessValue, Data.Blocks[i].Brightness[j].TrackPosition - CurrentBrightnessTrackPosition);
-						if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0) {
-							BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.CurrentTrack.Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
-							bce.NextBrightness = Data.Blocks[i].Brightness[j].Value;
-							bce.NextDistance = Data.Blocks[i].Brightness[j].TrackPosition - CurrentBrightnessTrackPosition;
+				if (!PreviewOnly)
+				{
+					for (int j = 0; j < Data.Blocks[i].BrightnessChanges.Length; j++)
+					{
+						/*
+						 * Legacy brightness: This applies equally to all tracks in a block
+						 */
+						for (int t = 0; t < TrackManager.Tracks.Length; t++)
+						{
+							int m = TrackManager.Tracks[t].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[t].Elements[n].Events, m + 1);
+							double d = Data.Blocks[i].BrightnessChanges[j].TrackPosition - StartingDistance;
+							TrackManager.Tracks[t].Elements[n].Events[m] = new BrightnessChangeEvent(d, Data.Blocks[i].BrightnessChanges[j].Value, CurrentBrightnessValue, Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition);
+							
+							if (t == 0)
+							{
+								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
+								{
+									BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[CurrentBrightnessEvent];
+									bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
+									bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
+								}
+								CurrentBrightnessEvent = m;
+								
+							}
+							else
+							{
+								if (CurrentBrightnessElement >= 0 & CurrentBrightnessEvent >= 0)
+								{
+									for (int e = 0; e < TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events.Length; e++)
+									{
+										if (!(TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e] is BrightnessChangeEvent))
+											continue;
+										BrightnessChangeEvent bce = (BrightnessChangeEvent)TrackManager.Tracks[t].Elements[CurrentBrightnessElement].Events[e];
+										bce.NextBrightness = Data.Blocks[i].BrightnessChanges[j].Value;
+										bce.NextDistance = Data.Blocks[i].BrightnessChanges[j].TrackPosition - CurrentBrightnessTrackPosition;
+									}
+								}
+							}
 						}
 						CurrentBrightnessElement = n;
-						CurrentBrightnessEvent = m;
-						CurrentBrightnessValue = Data.Blocks[i].Brightness[j].Value;
-						CurrentBrightnessTrackPosition = Data.Blocks[i].Brightness[j].TrackPosition;
+						CurrentBrightnessTrackPosition = Data.Blocks[i].BrightnessChanges[j].TrackPosition;
+						CurrentBrightnessValue = Data.Blocks[i].BrightnessChanges[j].Value;
 					}
 				}
 				// fog
@@ -5582,11 +5610,11 @@ namespace OpenBve {
 					if (Data.FogTransitionMode) {
 						if (Data.Blocks[i].FogDefined) {
 							Data.Blocks[i].Fog.TrackPosition = StartingDistance;
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, Data.Blocks[i].Fog, Data.Blocks[i].Fog);
 							if (PreviousFogElement >= 0 & PreviousFogEvent >= 0) {
-								FogChangeEvent e = (FogChangeEvent)TrackManager.CurrentTrack.Elements[PreviousFogElement].Events[PreviousFogEvent];
+								FogChangeEvent e = (FogChangeEvent)TrackManager.Tracks[0].Elements[PreviousFogElement].Events[PreviousFogEvent];
 								e.NextFog = Data.Blocks[i].Fog;
 							} else {
 								CurrentRoute.PreviousFog = PreviousFog;
@@ -5599,9 +5627,9 @@ namespace OpenBve {
 						}
 					} else {
 						Data.Blocks[i].Fog.TrackPosition = StartingDistance + Data.BlockInterval;
-						int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-						TrackManager.CurrentTrack.Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
+						int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+						Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+						TrackManager.Tracks[0].Elements[n].Events[m] = new FogChangeEvent(0.0, PreviousFog, CurrentFog, Data.Blocks[i].Fog);
 						PreviousFog = CurrentFog;
 						CurrentFog = Data.Blocks[i].Fog;
 					}
@@ -5611,9 +5639,9 @@ namespace OpenBve {
 					int j = Data.Blocks[i].RailType[0];
 					int r = j < Data.Structure.Run.Length ? Data.Structure.Run[j] : 0;
 					int f = j < Data.Structure.Flange.Length ? Data.Structure.Flange[j] : 0;
-					int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-					TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
+					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+					TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.RailSoundsChangeEvent(0.0, CurrentRunIndex, CurrentFlangeIndex, r, f);
 					CurrentRunIndex = r;
 					CurrentFlangeIndex = f;
 				}
@@ -5632,9 +5660,9 @@ namespace OpenBve {
 							}
 						}
 						if (q) {
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, Vector3.Zero, 12.5);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(0.0, null, false, false, true, Vector3.Zero, 12.5);
 						}
 					}
 				}
@@ -5642,9 +5670,9 @@ namespace OpenBve {
 				if (Data.Blocks[i].Station >= 0) {
 					// station
 					int s = Data.Blocks[i].Station;
-					int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-					TrackManager.CurrentTrack.Elements[n].Events[m] = new StationStartEvent(0.0, s);
+					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+					TrackManager.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
 					double dx, dy = 3.0;
 					if (CurrentRoute.Stations[s].OpenLeftDoors & !CurrentRoute.Stations[s].OpenRightDoors) {
 						dx = -5.0;
@@ -5653,9 +5681,9 @@ namespace OpenBve {
 					} else {
 						dx = 0.0;
 					}
-					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.X + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.X;
-					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.Y + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.Y;
-					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.Z + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.Z;
+					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.Tracks[0].Elements[n].WorldSide.X + dy * TrackManager.Tracks[0].Elements[n].WorldUp.X;
+					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Y + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Y;
+					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Z + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Z;
 					// passalarm
 					if (!PreviewOnly) {
 						if (Data.Blocks[i].StationPassAlarm) {
@@ -5663,9 +5691,9 @@ namespace OpenBve {
 							if (b >= 0) {
 								int j = b - Data.FirstUsedBlock;
 								if (j >= 0) {
-									m = TrackManager.CurrentTrack.Elements[j].Events.Length;
-									Array.Resize(ref TrackManager.CurrentTrack.Elements[j].Events, m + 1);
-									TrackManager.CurrentTrack.Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
+									m = TrackManager.Tracks[0].Elements[j].Events.Length;
+									Array.Resize(ref TrackManager.Tracks[0].Elements[j].Events, m + 1);
+									TrackManager.Tracks[0].Elements[j].Events[m] = new TrackManager.StationPassAlarmEvent(0.0);
 								}
 							}
 						}
@@ -5688,16 +5716,16 @@ namespace OpenBve {
 					} else {
 						dx = 0.0;
 					}
-					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.X + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.X;
-					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.Y + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.Y;
-					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.CurrentTrack.Elements[n].WorldSide.Z + dy * TrackManager.CurrentTrack.Elements[n].WorldUp.Z;
+					CurrentRoute.Stations[s].SoundOrigin.X = Position.X + dx * TrackManager.Tracks[0].Elements[n].WorldSide.X + dy * TrackManager.Tracks[0].Elements[n].WorldUp.X;
+					CurrentRoute.Stations[s].SoundOrigin.Y = Position.Y + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Y + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Y;
+					CurrentRoute.Stations[s].SoundOrigin.Z = Position.Z + dx * TrackManager.Tracks[0].Elements[n].WorldSide.Z + dy * TrackManager.Tracks[0].Elements[n].WorldUp.Z;
 				}
 				// limit
 				for (int j = 0; j < Data.Blocks[i].Limit.Length; j++) {
-					int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-					Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
+					int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+					Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
 					double d = Data.Blocks[i].Limit[j].TrackPosition - StartingDistance;
-					TrackManager.CurrentTrack.Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limit[j].Speed);
+					TrackManager.Tracks[0].Elements[n].Events[m] = new LimitChangeEvent(d, CurrentSpeedLimit, Data.Blocks[i].Limit[j].Speed);
 					CurrentSpeedLimit = Data.Blocks[i].Limit[j].Speed;
 				}
 				// marker
@@ -5707,22 +5735,22 @@ namespace OpenBve {
 					{
 						if (Data.Markers[j].StartingPosition >= StartingDistance & Data.Markers[j].StartingPosition < EndingDistance)
 						{
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].StartingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.CurrentTrack.Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerStartEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 						if (Data.Markers[j].EndingPosition >= StartingDistance & Data.Markers[j].EndingPosition < EndingDistance)
 						{
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Markers[j].EndingPosition - StartingDistance;
 							if (Data.Markers[j].Message != null)
 							{
-								TrackManager.CurrentTrack.Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
+								TrackManager.Tracks[0].Elements[n].Events[m] = new MarkerEndEvent(d, Data.Markers[j].Message, Program.CurrentHost);
 							}
 						}
 					}
@@ -5731,15 +5759,15 @@ namespace OpenBve {
 				if (!PreviewOnly) {
 					for (int j = 0; j < Data.Blocks[i].Sound.Length; j++) {
 						if (Data.Blocks[i].Sound[j].Type == SoundType.TrainStatic | Data.Blocks[i].Sound[j].Type == SoundType.TrainDynamic) {
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].Sound[j].TrackPosition - StartingDistance;
 							switch (Data.Blocks[i].Sound[j].Type) {
 								case SoundType.TrainStatic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
+									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, true, true, false, Vector3.Zero, 0.0);
 									break;
 								case SoundType.TrainDynamic:
-									TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].Sound[j].Speed);
+									TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.SoundEvent(d, Data.Blocks[i].Sound[j].SoundBuffer, false, false, true, Vector3.Zero, Data.Blocks[i].Sound[j].Speed);
 									break;
 							}
 						}
@@ -5751,17 +5779,17 @@ namespace OpenBve {
 					double cosag = Math.Cos(ag);
 					double sinag = Math.Sin(ag);
 					Direction.Rotate(cosag, sinag);
-					TrackManager.CurrentTrack.Elements[n].WorldDirection.RotatePlane(cosag, sinag);
-					TrackManager.CurrentTrack.Elements[n].WorldSide.RotatePlane(cosag, sinag);
-					TrackManager.CurrentTrack.Elements[n].WorldUp = Vector3.Cross(TrackManager.CurrentTrack.Elements[n].WorldDirection, TrackManager.CurrentTrack.Elements[n].WorldSide);
+					TrackManager.Tracks[0].Elements[n].WorldDirection.RotatePlane(cosag, sinag);
+					TrackManager.Tracks[0].Elements[n].WorldSide.RotatePlane(cosag, sinag);
+					TrackManager.Tracks[0].Elements[n].WorldUp = Vector3.Cross(TrackManager.Tracks[0].Elements[n].WorldDirection, TrackManager.Tracks[0].Elements[n].WorldSide);
 				}
 				if (Data.Blocks[i].Pitch != 0.0)
 				{
-					TrackManager.CurrentTrack.Elements[n].Pitch = Data.Blocks[i].Pitch;
+					TrackManager.Tracks[0].Elements[n].Pitch = Data.Blocks[i].Pitch;
 				}
 				else
 				{
-					TrackManager.CurrentTrack.Elements[n].Pitch = 0.0;
+					TrackManager.Tracks[0].Elements[n].Pitch = 0.0;
 				}
 				// curves
 				double a = 0.0;
@@ -6214,12 +6242,12 @@ namespace OpenBve {
 						// transponder objects
 						if (j == 0)
 						{
-							for (int k = 0; k < Data.Blocks[i].Transponder.Length; k++)
+							for (int k = 0; k < Data.Blocks[i].Transponders.Length; k++)
 							{
 								UnifiedObject obj = null;
-								if (Data.Blocks[i].Transponder[k].ShowDefaultObject)
+								if (Data.Blocks[i].Transponders[k].ShowDefaultObject)
 								{
-									switch (Data.Blocks[i].Transponder[k].Type)
+									switch (Data.Blocks[i].Transponders[k].Type)
 									{
 										case 0: obj = TransponderS; break;
 										case 1: obj = TransponderSN; break;
@@ -6230,7 +6258,7 @@ namespace OpenBve {
 								}
 								else
 								{
-									int b = Data.Blocks[i].Transponder[k].BeaconStructureIndex;
+									int b = Data.Blocks[i].Transponders[k].BeaconStructureIndex;
 									if (b >= 0 & Data.Structure.Beacon.ContainsKey(b))
 									{
 										obj = Data.Structure.Beacon[b];
@@ -6238,20 +6266,20 @@ namespace OpenBve {
 								}
 								if (obj != null)
 								{
-									double dx = Data.Blocks[i].Transponder[k].Position.X;
-									double dy = Data.Blocks[i].Transponder[k].Position.Y;
-									double dz = Data.Blocks[i].Transponder[k].TrackPosition - StartingDistance;
+									double dx = Data.Blocks[i].Transponders[k].Position.X;
+									double dy = Data.Blocks[i].Transponders[k].Position.Y;
+									double dz = Data.Blocks[i].Transponders[k].TrackPosition - StartingDistance;
 									Vector3 wpos = pos;
 									wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
-									double tpos = Data.Blocks[i].Transponder[k].TrackPosition;
-									if (Data.Blocks[i].Transponder[k].ShowDefaultObject)
+									double tpos = Data.Blocks[i].Transponders[k].TrackPosition;
+									if (Data.Blocks[i].Transponders[k].ShowDefaultObject)
 									{
 										double b = 0.25 + 0.75 * GetBrightness(ref Data, tpos);
-										obj.CreateObject(wpos, RailTransformation, new Transformation(Data.Blocks[i].Transponder[k].Yaw, Data.Blocks[i].Transponder[k].Pitch, Data.Blocks[i].Transponder[k].Roll), -1, Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, tpos, b, false);
+										obj.CreateObject(wpos, RailTransformation, new Transformation(Data.Blocks[i].Transponders[k].Yaw, Data.Blocks[i].Transponders[k].Pitch, Data.Blocks[i].Transponders[k].Roll), -1, Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, tpos, b, false);
 									}
 									else
 									{
-										obj.CreateObject(wpos, RailTransformation, new Transformation(Data.Blocks[i].Transponder[k].Yaw, Data.Blocks[i].Transponder[k].Pitch, Data.Blocks[i].Transponder[k].Roll), Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, tpos);
+										obj.CreateObject(wpos, RailTransformation, new Transformation(Data.Blocks[i].Transponders[k].Yaw, Data.Blocks[i].Transponders[k].Pitch, Data.Blocks[i].Transponders[k].Roll), Data.AccurateObjectDisposal, StartingDistance, EndingDistance, Data.BlockInterval, tpos);
 									}
 								}
 							}
@@ -6391,15 +6419,15 @@ namespace OpenBve {
 								// create associated transponders
 								for (int g = 0; g <= i; g++)
 								{
-									for (int l = 0; l < Data.Blocks[g].Transponder.Length; l++)
+									for (int l = 0; l < Data.Blocks[g].Transponders.Length; l++)
 									{
-										if (Data.Blocks[g].Transponder[l].Type != -1 & Data.Blocks[g].Transponder[l].SectionIndex == m)
+										if (Data.Blocks[g].Transponders[l].Type != -1 & Data.Blocks[g].Transponders[l].SectionIndex == m)
 										{
-											int o = TrackManager.CurrentTrack.Elements[n - i + g].Events.Length;
-											Array.Resize(ref TrackManager.CurrentTrack.Elements[n - i + g].Events, o + 1);
-											double dt = Data.Blocks[g].Transponder[l].TrackPosition - StartingDistance + (double)(i - g) * Data.BlockInterval;
-											TrackManager.CurrentTrack.Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponder[l].Type, Data.Blocks[g].Transponder[l].Data, m, Data.Blocks[g].Transponder[l].ClipToFirstRedSection);
-											Data.Blocks[g].Transponder[l].Type = -1;
+											int o = TrackManager.Tracks[0].Elements[n - i + g].Events.Length;
+											Array.Resize(ref TrackManager.Tracks[0].Elements[n - i + g].Events, o + 1);
+											double dt = Data.Blocks[g].Transponders[l].TrackPosition - StartingDistance + (double)(i - g) * Data.BlockInterval;
+											TrackManager.Tracks[0].Elements[n - i + g].Events[o] = new TransponderEvent(dt, Data.Blocks[g].Transponders[l].Type, Data.Blocks[g].Transponders[l].Data, m, Data.Blocks[g].Transponders[l].ClipToFirstRedSection);
+											Data.Blocks[g].Transponders[l].Type = -1;
 										}
 									}
 								}
@@ -6428,23 +6456,23 @@ namespace OpenBve {
 								CurrentRoute.Sections[m].Trains = new TrainManager.Train[] { };
 								// create section change event
 								double d = Data.Blocks[i].Section[k].TrackPosition - StartingDistance;
-								int p = TrackManager.CurrentTrack.Elements[n].Events.Length;
-								Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, p + 1);
-								TrackManager.CurrentTrack.Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
+								int p = TrackManager.Tracks[0].Elements[n].Events.Length;
+								Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, p + 1);
+								TrackManager.Tracks[0].Elements[n].Events[p] = new TrackManager.SectionChangeEvent(d, m - 1, m);
 							}
 							// transponders introduced after corresponding sections
-							for (int l = 0; l < Data.Blocks[i].Transponder.Length; l++)
+							for (int l = 0; l < Data.Blocks[i].Transponders.Length; l++)
 							{
-								if (Data.Blocks[i].Transponder[l].Type != -1)
+								if (Data.Blocks[i].Transponders[l].Type != -1)
 								{
-									int t = Data.Blocks[i].Transponder[l].SectionIndex;
+									int t = Data.Blocks[i].Transponders[l].SectionIndex;
 									if (t >= 0 & t < CurrentRoute.Sections.Length)
 									{
-										int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-										Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-										double dt = Data.Blocks[i].Transponder[l].TrackPosition - StartingDistance;
-										TrackManager.CurrentTrack.Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponder[l].Type, Data.Blocks[i].Transponder[l].Data, t, Data.Blocks[i].Transponder[l].ClipToFirstRedSection);
-										Data.Blocks[i].Transponder[l].Type = -1;
+										int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+										Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+										double dt = Data.Blocks[i].Transponders[l].TrackPosition - StartingDistance;
+										TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(dt, Data.Blocks[i].Transponders[l].Type, Data.Blocks[i].Transponders[l].Data, t, Data.Blocks[i].Transponders[l].ClipToFirstRedSection);
+										Data.Blocks[i].Transponders[l].Type = -1;
 									}
 								}
 							}
@@ -6539,28 +6567,29 @@ namespace OpenBve {
 			{
 				for (int i = Data.FirstUsedBlock; i < Data.Blocks.Length; i++)
 				{
-					for (int j = 0; j < Data.Blocks[i].Transponder.Length; j++)
+					for (int j = 0; j < Data.Blocks[i].Transponders.Length; j++)
 					{
-						if (Data.Blocks[i].Transponder[j].Type != -1)
+						if (Data.Blocks[i].Transponders[j].Type != -1)
 						{
 							int n = i - Data.FirstUsedBlock;
-							int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-							Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-							double d = Data.Blocks[i].Transponder[j].TrackPosition - TrackManager.CurrentTrack.Elements[n].StartingTrackPosition;
-							int s = Data.Blocks[i].Transponder[j].SectionIndex;
+							int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+							Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+							double d = Data.Blocks[i].Transponders[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
+							int s = Data.Blocks[i].Transponders[j].SectionIndex;
 							if (s >= 0) s = -1;
-							TrackManager.CurrentTrack.Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponder[j].Type, Data.Blocks[i].Transponder[j].Data, s, Data.Blocks[i].Transponder[j].ClipToFirstRedSection);
-							Data.Blocks[i].Transponder[j].Type = -1;
+							TrackManager.Tracks[0].Elements[n].Events[m] = new TransponderEvent(d, Data.Blocks[i].Transponders[j].Type, Data.Blocks[i].Transponders[j].Data, s, Data.Blocks[i].Transponders[j].ClipToFirstRedSection);
+							Data.Blocks[i].Transponders[j].Type = -1;
 						}
 					}
 					// Destination Change Events
 					for (int j = 0; j < Data.Blocks[i].DestinationChanges.Length; j++)
 					{
 						int n = i - Data.FirstUsedBlock;
-						int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - TrackManager.CurrentTrack.Elements[n].StartingTrackPosition;
-						TrackManager.CurrentTrack.Elements[n].Events[m] = new RouteManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
+						int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+						Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+						double d = Data.Blocks[i].DestinationChanges[j].TrackPosition - TrackManager.Tracks[0].Elements[n].StartingTrackPosition;
+						//Destination events not supported in Route Viewer.....
+						//TrackManager.Tracks[0].Elements[n].Events[m] = new TrackManager.DestinationEvent(d, Data.Blocks[i].DestinationChanges[j].Type, Data.Blocks[i].DestinationChanges[j].NextDestination, Data.Blocks[i].DestinationChanges[j].PreviousDestination, Data.Blocks[i].DestinationChanges[j].TriggerOnce);
 					}
 				}
 			}
@@ -6572,9 +6601,9 @@ namespace OpenBve {
 					int k = (int)Math.Floor(p / (double)Data.BlockInterval) - Data.FirstUsedBlock;
 					if (k >= 0 & k < Data.Blocks.Length) {
 						double d = p - (double)(k + Data.FirstUsedBlock) * (double)Data.BlockInterval;
-						int m = TrackManager.CurrentTrack.Elements[k].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[k].Events, m + 1);
-						TrackManager.CurrentTrack.Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
+						int m = TrackManager.Tracks[0].Elements[k].Events.Length;
+						Array.Resize(ref TrackManager.Tracks[0].Elements[k].Events, m + 1);
+						TrackManager.Tracks[0].Elements[k].Events[m] = new TrackManager.StationEndEvent(d, i);
 					}
 				}
 			}
@@ -6599,20 +6628,20 @@ namespace OpenBve {
 			}
 			// convert block-based cant into point-based cant
 			for (int i = CurrentTrackLength - 1; i >= 1; i--) {
-				if (TrackManager.CurrentTrack.Elements[i].CurveCant == 0.0) {
-					TrackManager.CurrentTrack.Elements[i].CurveCant = TrackManager.CurrentTrack.Elements[i - 1].CurveCant;
-				} else if (TrackManager.CurrentTrack.Elements[i - 1].CurveCant != 0.0) {
-					if (Math.Sign(TrackManager.CurrentTrack.Elements[i - 1].CurveCant) == Math.Sign(TrackManager.CurrentTrack.Elements[i].CurveCant)) {
-						if (Math.Abs(TrackManager.CurrentTrack.Elements[i - 1].CurveCant) > Math.Abs(TrackManager.CurrentTrack.Elements[i].CurveCant)) {
-							TrackManager.CurrentTrack.Elements[i].CurveCant = TrackManager.CurrentTrack.Elements[i - 1].CurveCant;
+				if (TrackManager.Tracks[0].Elements[i].CurveCant == 0.0) {
+					TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i - 1].CurveCant;
+				} else if (TrackManager.Tracks[0].Elements[i - 1].CurveCant != 0.0) {
+					if (Math.Sign(TrackManager.Tracks[0].Elements[i - 1].CurveCant) == Math.Sign(TrackManager.Tracks[0].Elements[i].CurveCant)) {
+						if (Math.Abs(TrackManager.Tracks[0].Elements[i - 1].CurveCant) > Math.Abs(TrackManager.Tracks[0].Elements[i].CurveCant)) {
+							TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i - 1].CurveCant;
 						}
 					} else {
-						TrackManager.CurrentTrack.Elements[i].CurveCant = 0.5 * (TrackManager.CurrentTrack.Elements[i].CurveCant + TrackManager.CurrentTrack.Elements[i - 1].CurveCant);
+						TrackManager.Tracks[0].Elements[i].CurveCant = 0.5 * (TrackManager.Tracks[0].Elements[i].CurveCant + TrackManager.Tracks[0].Elements[i - 1].CurveCant);
 					}
 				}
 			}
 			// finalize
-			Array.Resize(ref TrackManager.CurrentTrack.Elements, CurrentTrackLength);
+			Array.Resize(ref TrackManager.Tracks[0].Elements, CurrentTrackLength);
 			for (int i = 0; i < CurrentRoute.Stations.Length; i++) {
 				if (CurrentRoute.Stations[i].Stops.Length == 0 & CurrentRoute.Stations[i].StopMode != StationStopMode.AllPass) {
 					Interface.AddMessage(MessageType.Warning, false, "Station " + CurrentRoute.Stations[i].Name + " expects trains to stop but does not define stop points at track position " + CurrentRoute.Stations[i].DefaultTrackPosition.ToString(Culture) + " in file " + FileName);
@@ -6633,11 +6662,11 @@ namespace OpenBve {
 			if (CurrentRoute.Stations.Length != 0) {
 				CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Terminal;
 			}
-			if (TrackManager.CurrentTrack.Elements.Length != 0) {
-				int n = TrackManager.CurrentTrack.Elements.Length - 1;
-				int m = TrackManager.CurrentTrack.Elements[n].Events.Length;
-				Array.Resize(ref TrackManager.CurrentTrack.Elements[n].Events, m + 1);
-				TrackManager.CurrentTrack.Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
+			if (TrackManager.Tracks[0].Elements.Length != 0) {
+				int n = TrackManager.Tracks[0].Elements.Length - 1;
+				int m = TrackManager.Tracks[0].Elements[n].Events.Length;
+				Array.Resize(ref TrackManager.Tracks[0].Elements[n].Events, m + 1);
+				TrackManager.Tracks[0].Elements[n].Events[m] = new TrackEndEvent(Data.BlockInterval);
 			}
 			if (!PreviewOnly) {
 				ComputeCantTangents();
@@ -6653,20 +6682,20 @@ namespace OpenBve {
 
 		// compute cant tangents
 		private static void ComputeCantTangents() {
-			if (TrackManager.CurrentTrack.Elements.Length == 1) {
-				TrackManager.CurrentTrack.Elements[0].CurveCantTangent = 0.0;
-			} else if (TrackManager.CurrentTrack.Elements.Length != 0) {
-				double[] deltas = new double[TrackManager.CurrentTrack.Elements.Length - 1];
-				for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length - 1; i++) {
-					deltas[i] = TrackManager.CurrentTrack.Elements[i + 1].CurveCant - TrackManager.CurrentTrack.Elements[i].CurveCant;
+			if (TrackManager.Tracks[0].Elements.Length == 1) {
+				TrackManager.Tracks[0].Elements[0].CurveCantTangent = 0.0;
+			} else if (TrackManager.Tracks[0].Elements.Length != 0) {
+				double[] deltas = new double[TrackManager.Tracks[0].Elements.Length - 1];
+				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
+					deltas[i] = TrackManager.Tracks[0].Elements[i + 1].CurveCant - TrackManager.Tracks[0].Elements[i].CurveCant;
 				}
-				double[] tangents = new double[TrackManager.CurrentTrack.Elements.Length];
+				double[] tangents = new double[TrackManager.Tracks[0].Elements.Length];
 				tangents[0] = deltas[0];
-				tangents[TrackManager.CurrentTrack.Elements.Length - 1] = deltas[TrackManager.CurrentTrack.Elements.Length - 2];
-				for (int i = 1; i < TrackManager.CurrentTrack.Elements.Length - 1; i++) {
+				tangents[TrackManager.Tracks[0].Elements.Length - 1] = deltas[TrackManager.Tracks[0].Elements.Length - 2];
+				for (int i = 1; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
 					tangents[i] = 0.5 * (deltas[i - 1] + deltas[i]);
 				}
-				for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length - 1; i++) {
+				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
 					if (deltas[i] == 0.0) {
 						tangents[i] = 0.0;
 						tangents[i + 1] = 0.0;
@@ -6680,8 +6709,8 @@ namespace OpenBve {
 						}
 					}
 				}
-				for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++) {
-					TrackManager.CurrentTrack.Elements[i].CurveCantTangent = tangents[i];
+				for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
+					TrackManager.Tracks[0].Elements[i].CurveCantTangent = tangents[i];
 				}
 			}
 		}
@@ -6695,7 +6724,7 @@ namespace OpenBve {
 				throw new InvalidOperationException();
 			}
 			// subdivide track
-			int length = TrackManager.CurrentTrack.Elements.Length;
+			int length = TrackManager.Tracks[0].Elements.Length;
 			int newLength = (length - 1) * subdivisions + 1;
 			double[] midpointsTrackPositions = new double[newLength];
 			Vector3[] midpointsWorldPositions = new Vector3[newLength];
@@ -6709,7 +6738,7 @@ namespace OpenBve {
 					int q = i / subdivisions;
 					TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
 					double r = (double)m / (double)subdivisions;
-					double p = (1.0 - r) * TrackManager.CurrentTrack.Elements[q].StartingTrackPosition + r * TrackManager.CurrentTrack.Elements[q + 1].StartingTrackPosition;
+					double p = (1.0 - r) * TrackManager.Tracks[0].Elements[q].StartingTrackPosition + r * TrackManager.Tracks[0].Elements[q + 1].StartingTrackPosition;
 					follower.UpdateAbsolute(-1.0, true, false);
 					follower.UpdateAbsolute(p, true, false);
 					midpointsTrackPositions[i] = p;
@@ -6720,36 +6749,36 @@ namespace OpenBve {
 					midpointsCant[i] = follower.CurveCant;
 				}
 			}
-			Array.Resize(ref TrackManager.CurrentTrack.Elements, newLength);
+			Array.Resize(ref TrackManager.Tracks[0].Elements, newLength);
 			for (int i = length - 1; i >= 1; i--) {
-				TrackManager.CurrentTrack.Elements[subdivisions * i] = TrackManager.CurrentTrack.Elements[i];
+				TrackManager.Tracks[0].Elements[subdivisions * i] = TrackManager.Tracks[0].Elements[i];
 			}
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++) {
+			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
 				int m = i % subdivisions;
 				if (m != 0) {
 					int q = i / subdivisions;
 					int j = q * subdivisions;
-					TrackManager.CurrentTrack.Elements[i] = TrackManager.CurrentTrack.Elements[j];
-					TrackManager.CurrentTrack.Elements[i].Events = new object[] { };
-					TrackManager.CurrentTrack.Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
-					TrackManager.CurrentTrack.Elements[i].WorldPosition = midpointsWorldPositions[i];
-					TrackManager.CurrentTrack.Elements[i].WorldDirection = midpointsWorldDirections[i];
-					TrackManager.CurrentTrack.Elements[i].WorldUp = midpointsWorldUps[i];
-					TrackManager.CurrentTrack.Elements[i].WorldSide = midpointsWorldSides[i];
-					TrackManager.CurrentTrack.Elements[i].CurveCant = midpointsCant[i];
-					TrackManager.CurrentTrack.Elements[i].CurveCantTangent = 0.0;
+					TrackManager.Tracks[0].Elements[i] = TrackManager.Tracks[0].Elements[j];
+					TrackManager.Tracks[0].Elements[i].Events = new object[] { };
+					TrackManager.Tracks[0].Elements[i].StartingTrackPosition = midpointsTrackPositions[i];
+					TrackManager.Tracks[0].Elements[i].WorldPosition = midpointsWorldPositions[i];
+					TrackManager.Tracks[0].Elements[i].WorldDirection = midpointsWorldDirections[i];
+					TrackManager.Tracks[0].Elements[i].WorldUp = midpointsWorldUps[i];
+					TrackManager.Tracks[0].Elements[i].WorldSide = midpointsWorldSides[i];
+					TrackManager.Tracks[0].Elements[i].CurveCant = midpointsCant[i];
+					TrackManager.Tracks[0].Elements[i].CurveCantTangent = 0.0;
 				}
 			}
 			// find turns
-			bool[] isTurn = new bool[TrackManager.CurrentTrack.Elements.Length];
+			bool[] isTurn = new bool[TrackManager.Tracks[0].Elements.Length];
 			{
 				TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-				for (int i = 1; i < TrackManager.CurrentTrack.Elements.Length - 1; i++) {
+				for (int i = 1; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
 					int m = i % subdivisions;
 					if (m == 0) {
-						double p = 0.00000001 * TrackManager.CurrentTrack.Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
+						double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
 						follower.UpdateAbsolute(p, true, false);
-						Vector3 d1 = TrackManager.CurrentTrack.Elements[i].WorldDirection;
+						Vector3 d1 = TrackManager.Tracks[0].Elements[i].WorldDirection;
 						Vector3 d2 = follower.WorldDirection;
 						Vector3 d = d1 - d2;
 						double t = d.X * d.X + d.Z * d.Z;
@@ -6762,13 +6791,13 @@ namespace OpenBve {
 			}
 			// replace turns by curves
 			double totalShortage = 0.0;
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++) {
+			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
 				if (isTurn[i]) {
 					// estimate radius
-					Vector3 AP = TrackManager.CurrentTrack.Elements[i - 1].WorldPosition;
-					Vector3 AS = TrackManager.CurrentTrack.Elements[i - 1].WorldSide;
-					Vector3 BP = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition;
-					Vector3 BS = TrackManager.CurrentTrack.Elements[i + 1].WorldSide;
+					Vector3 AP = TrackManager.Tracks[0].Elements[i - 1].WorldPosition;
+					Vector3 AS = TrackManager.Tracks[0].Elements[i - 1].WorldSide;
+					Vector3 BP = TrackManager.Tracks[0].Elements[i + 1].WorldPosition;
+					Vector3 BS = TrackManager.Tracks[0].Elements[i + 1].WorldSide;
 					Vector3 S = AS - BS;
 					double rx;
 					if (S.X * S.X > 0.000001) {
@@ -6803,29 +6832,29 @@ namespace OpenBve {
 						if (r * r > 1.0) {
 							// apply radius
 							TrackManager.TrackFollower follower = new TrackManager.TrackFollower();
-							TrackManager.CurrentTrack.Elements[i - 1].CurveRadius = r;
-							double p = 0.00000001 * TrackManager.CurrentTrack.Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
+							TrackManager.Tracks[0].Elements[i - 1].CurveRadius = r;
+							double p = 0.00000001 * TrackManager.Tracks[0].Elements[i - 1].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							TrackManager.CurrentTrack.Elements[i].CurveRadius = r;
-							//TrackManager.CurrentTrack.Elements[i].CurveCant = TrackManager.CurrentTrack.Elements[i].CurveCant;
-							//TrackManager.CurrentTrack.Elements[i].CurveCantInterpolation = TrackManager.CurrentTrack.Elements[i].CurveCantInterpolation;
-							TrackManager.CurrentTrack.Elements[i].WorldPosition = follower.WorldPosition;
-							TrackManager.CurrentTrack.Elements[i].WorldDirection = follower.WorldDirection;
-							TrackManager.CurrentTrack.Elements[i].WorldUp = follower.WorldUp;
-							TrackManager.CurrentTrack.Elements[i].WorldSide = follower.WorldSide;
+							TrackManager.Tracks[0].Elements[i].CurveRadius = r;
+							//TrackManager.Tracks[0].Elements[i].CurveCant = TrackManager.Tracks[0].Elements[i].CurveCant;
+							//TrackManager.Tracks[0].Elements[i].CurveCantInterpolation = TrackManager.Tracks[0].Elements[i].CurveCantInterpolation;
+							TrackManager.Tracks[0].Elements[i].WorldPosition = follower.WorldPosition;
+							TrackManager.Tracks[0].Elements[i].WorldDirection = follower.WorldDirection;
+							TrackManager.Tracks[0].Elements[i].WorldUp = follower.WorldUp;
+							TrackManager.Tracks[0].Elements[i].WorldSide = follower.WorldSide;
 							// iterate to shorten track element length
-							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
+							Vector3 d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 							double bestT = d.NormSquared();
 							int bestJ = 0;
 							int n = 1000;
-							double a = 1.0 / (double)n * (TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - TrackManager.CurrentTrack.Elements[i].StartingTrackPosition);
+							double a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++) {
-								follower.UpdateAbsolute(TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-								d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition - follower.WorldPosition;
+								follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT) {
 									bestT = t;
@@ -6835,17 +6864,17 @@ namespace OpenBve {
 								}
 							}
 							double s = (double)bestJ * a;
-							for (int j = i + 1; j < TrackManager.CurrentTrack.Elements.Length; j++) {
-								TrackManager.CurrentTrack.Elements[j].StartingTrackPosition -= s;
+							for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++) {
+								TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
 							}
 							totalShortage += s;
 							// introduce turn to compensate for curve
-							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 AB = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
-							Vector3 AC = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
-							Vector3 BC = follower.WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
+							Vector3 AB = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
+							Vector3 AC = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
+							Vector3 BC = follower.WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
 							double sa = Math.Sqrt(BC.X * BC.X + BC.Z * BC.Z);
 							double sb = Math.Sqrt(AC.X * AC.X + AC.Z * AC.Z);
 							double sc = Math.Sqrt(AB.X * AB.X + AB.Z * AB.Z);
@@ -6862,21 +6891,21 @@ namespace OpenBve {
 										originalAngle = Math.Acos(value);
 									}
 								}
-								TrackElement originalTrackElement = TrackManager.CurrentTrack.Elements[i];
+								TrackElement originalTrackElement = TrackManager.Tracks[0].Elements[i];
 								bestT = double.MaxValue;
 								bestJ = 0;
 								for (int j = -1; j <= 1; j++) {
 									double g = (double)j * originalAngle;
 									double cosg = Math.Cos(g);
 									double sing = Math.Sin(g);
-									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
-									p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
+									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
+									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
 									follower.UpdateAbsolute(p - 1.0, true, false);
 									follower.UpdateAbsolute(p, true, false);
-									d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
+									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
 										bestT = t;
@@ -6887,23 +6916,23 @@ namespace OpenBve {
 									double newAngle = (double)bestJ * originalAngle;
 									double cosg = Math.Cos(newAngle);
 									double sing = Math.Sin(newAngle);
-									TrackManager.CurrentTrack.Elements[i] = originalTrackElement;
-									TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
-									TrackManager.CurrentTrack.Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.Tracks[0].Elements[i] = originalTrackElement;
+									TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(Vector3.Down, cosg, sing);
+									TrackManager.Tracks[0].Elements[i].WorldSide.Rotate(Vector3.Down, cosg, sing);
 								}
 								// iterate again to further shorten track element length
-								p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
+								p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
 								follower.UpdateAbsolute(p - 1.0, true, false);
 								follower.UpdateAbsolute(p, true, false);
-								d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
+								d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 								bestT = d.NormSquared();
 								bestJ = 0;
 								n = 1000;
-								a = 1.0 / (double)n * (TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - TrackManager.CurrentTrack.Elements[i].StartingTrackPosition);
+								a = 1.0 / (double)n * (TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - TrackManager.Tracks[0].Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++) {
-									follower.UpdateAbsolute(TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
-									d = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- follower.WorldPosition;
+									follower.UpdateAbsolute(TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition - (double)j * a, true, false);
+									d = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT) {
 										bestT = t;
@@ -6913,49 +6942,49 @@ namespace OpenBve {
 									}
 								}
 								s = (double)bestJ * a;
-								for (int j = i + 1; j < TrackManager.CurrentTrack.Elements.Length; j++) {
-									TrackManager.CurrentTrack.Elements[j].StartingTrackPosition -= s;
+								for (int j = i + 1; j < TrackManager.Tracks[0].Elements.Length; j++) {
+									TrackManager.Tracks[0].Elements[j].StartingTrackPosition -= s;
 								}
 								totalShortage += s;
 							}
 							// compensate for height difference
-							p = 0.00000001 * TrackManager.CurrentTrack.Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
+							p = 0.00000001 * TrackManager.Tracks[0].Elements[i].StartingTrackPosition + 0.99999999 * TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
 							follower.UpdateAbsolute(p - 1.0, true, false);
 							follower.UpdateAbsolute(p, true, false);
-							Vector3 d1 = TrackManager.CurrentTrack.Elements[i + 1].WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
+							Vector3 d1 = TrackManager.Tracks[0].Elements[i + 1].WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
 							double a1 = Math.Atan(d1.Y / Math.Sqrt(d1.X * d1.X + d1.Z * d1.Z));
-							Vector3 d2 = follower.WorldPosition- TrackManager.CurrentTrack.Elements[i].WorldPosition;
+							Vector3 d2 = follower.WorldPosition- TrackManager.Tracks[0].Elements[i].WorldPosition;
 							double a2 = Math.Atan(d2.Y / Math.Sqrt(d2.X * d2.X + d2.Z * d2.Z));
 							double b = a2 - a1;
 							if (b * b > 0.00000001) {
 								double cosa = Math.Cos(b);
 								double sina = Math.Sin(b);
-								TrackManager.CurrentTrack.Elements[i].WorldDirection.Rotate(TrackManager.CurrentTrack.Elements[i].WorldSide, cosa, sina);
-								TrackManager.CurrentTrack.Elements[i].WorldUp.Rotate(TrackManager.CurrentTrack.Elements[i].WorldSide, cosa, sina);
+								TrackManager.Tracks[0].Elements[i].WorldDirection.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
+								TrackManager.Tracks[0].Elements[i].WorldUp.Rotate(TrackManager.Tracks[0].Elements[i].WorldSide, cosa, sina);
 							}
 						}
 					}
 				}
 			}
 			// correct events
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length - 1; i++) {
-				double startingTrackPosition = TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
-				double endingTrackPosition = TrackManager.CurrentTrack.Elements[i + 1].StartingTrackPosition;
-				for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++)
+			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length - 1; i++) {
+				double startingTrackPosition = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+				double endingTrackPosition = TrackManager.Tracks[0].Elements[i + 1].StartingTrackPosition;
+				for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++)
 				{
-					dynamic e = TrackManager.CurrentTrack.Elements[i].Events[j];
+					dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
 					double p = startingTrackPosition + e.TrackPositionDelta;
 					if (p >= endingTrackPosition) {
-						int len = TrackManager.CurrentTrack.Elements[i + 1].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[i + 1].Events, len + 1);
-						TrackManager.CurrentTrack.Elements[i + 1].Events[len] = TrackManager.CurrentTrack.Elements[i].Events[j];
-						e = TrackManager.CurrentTrack.Elements[i + 1].Events[len];
+						int len = TrackManager.Tracks[0].Elements[i + 1].Events.Length;
+						Array.Resize(ref TrackManager.Tracks[0].Elements[i + 1].Events, len + 1);
+						TrackManager.Tracks[0].Elements[i + 1].Events[len] = TrackManager.Tracks[0].Elements[i].Events[j];
+						e = TrackManager.Tracks[0].Elements[i + 1].Events[len];
 						e.TrackPositionDelta += startingTrackPosition - endingTrackPosition;
-						for (int k = j; k < TrackManager.CurrentTrack.Elements[i].Events.Length - 1; k++) {
-							TrackManager.CurrentTrack.Elements[i].Events[k] = TrackManager.CurrentTrack.Elements[i].Events[k + 1];
+						for (int k = j; k < TrackManager.Tracks[0].Elements[i].Events.Length - 1; k++) {
+							TrackManager.Tracks[0].Elements[i].Events[k] = TrackManager.Tracks[0].Elements[i].Events[k + 1];
 						}
-						len = TrackManager.CurrentTrack.Elements[i].Events.Length;
-						Array.Resize(ref TrackManager.CurrentTrack.Elements[i].Events, len - 1);
+						len = TrackManager.Tracks[0].Elements[i].Events.Length;
+						Array.Resize(ref TrackManager.Tracks[0].Elements[i].Events, len - 1);
 						j--;
 					}
 				}

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -180,7 +180,7 @@ namespace OpenBve {
 					if (RouteManager.CurrentRoute.Stations[i].Stops.Length != 0) {
 						double p = RouteManager.CurrentRoute.Stations[i].Stops[RouteManager.CurrentRoute.Stations[i].Stops.Length - 1].TrackPosition;
 						if (p < World.CameraTrackFollower.TrackPosition - 0.1) {
-							TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, p, true, false);
+							World.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Camera.CurrentAlignment.TrackPosition = p;
 							CurrentStation = i;
 							break;
@@ -192,7 +192,7 @@ namespace OpenBve {
 					if (RouteManager.CurrentRoute.Stations[i].Stops.Length != 0) {
 						double p = RouteManager.CurrentRoute.Stations[i].Stops[RouteManager.CurrentRoute.Stations[i].Stops.Length - 1].TrackPosition;
 						if (p > World.CameraTrackFollower.TrackPosition + 0.1) {
-							TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, p, true, false);
+							World.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Camera.CurrentAlignment.TrackPosition = p;
 							CurrentStation = i;
 							break;
@@ -214,8 +214,8 @@ namespace OpenBve {
 				if (Program.LoadRoute())
 				{
 					Camera.CurrentAlignment = a;
-					TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, -1.0, true, false);
-					TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, a.TrackPosition, true, false);
+					World.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
+					World.CameraTrackFollower.UpdateAbsolute(a.TrackPosition, true, false);
 					Camera.AlignmentDirection = new CameraAlignment();
 					Camera.AlignmentSpeed = new CameraAlignment();
 					ObjectManager.UpdateVisibility(a.TrackPosition, true);
@@ -327,8 +327,8 @@ namespace OpenBve {
 						if (LoadRoute())
 						{
 							Camera.CurrentAlignment = a;
-							TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, -1.0, true, false);
-							TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, a.TrackPosition, true, false);
+							World.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
+							World.CameraTrackFollower.UpdateAbsolute(a.TrackPosition, true, false);
 							Camera.AlignmentDirection = new CameraAlignment();
 							Camera.AlignmentSpeed = new CameraAlignment();
 							ObjectManager.UpdateVisibility(a.TrackPosition, true);
@@ -592,7 +592,7 @@ namespace OpenBve {
 								{
 									value = World.CameraTrackFollower.TrackPosition + (double) direction*value;
 								}
-								TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, value, true, false);
+								World.CameraTrackFollower.UpdateAbsolute(value, true, false);
 								Camera.CurrentAlignment.TrackPosition = value;
 								World.UpdateAbsoluteCamera(0.0);
 								World.UpdateViewingDistances();

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -586,7 +586,7 @@ namespace OpenBve {
 							double value;
 							if (double.TryParse(JumpToPositionValue, NumberStyles.Float, CultureInfo.InvariantCulture,
 								out value))
-								if (value < TrackManager.Tracks[0].Elements[TrackManager.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100 && value > MinimumJumpToPositionValue - 100)
+								if (value < RouteManager.CurrentRoute.Tracks[0].Elements[RouteManager.CurrentRoute.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100 && value > MinimumJumpToPositionValue - 100)
 							{
 								if (direction != 0)
 								{

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -586,7 +586,7 @@ namespace OpenBve {
 							double value;
 							if (double.TryParse(JumpToPositionValue, NumberStyles.Float, CultureInfo.InvariantCulture,
 								out value))
-								if (value < TrackManager.CurrentTrack.Elements[TrackManager.CurrentTrack.Elements.Length - 1].StartingTrackPosition + 100 && value > MinimumJumpToPositionValue - 100)
+								if (value < TrackManager.Tracks[0].Elements[TrackManager.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100 && value > MinimumJumpToPositionValue - 100)
 							{
 								if (direction != 0)
 								{

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -447,7 +447,7 @@ namespace OpenBve {
 							TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 							f.TriggerType = EventTriggerType.None;
 							f.TrackPosition = p;
-							TrackManager.UpdateTrackFollower(ref f, p + e.TrackPositionDelta, true, false);
+							f.UpdateAbsolute(p + e.TrackPositionDelta, true, false);
 							f.WorldPosition += dx * f.WorldSide + dy * f.WorldUp + dz * f.WorldDirection;
 							LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, t);
 						}
@@ -464,7 +464,7 @@ namespace OpenBve {
 						TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 						f.TriggerType = EventTriggerType.None;
 						f.TrackPosition = p;
-						TrackManager.UpdateTrackFollower(ref f, p, true, false);
+						f.UpdateAbsolute(p, true, false);
 						f.WorldPosition += dy * f.WorldUp;
 						LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, StopTexture);
 					}
@@ -480,7 +480,7 @@ namespace OpenBve {
 					TrackManager.TrackFollower f = new TrackManager.TrackFollower();
 					f.TriggerType = EventTriggerType.None;
 					f.TrackPosition = p;
-					TrackManager.UpdateTrackFollower(ref f, p, true, false);
+					f.UpdateAbsolute(p, true, false);
 					f.WorldPosition += dy * f.WorldUp;
 					LibRender.Renderer.DrawCube(f.WorldPosition, f.WorldDirection, f.WorldUp, f.WorldSide, s, Camera, BufferTexture);
 				}

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -375,7 +375,7 @@ namespace OpenBve {
 		
 		// render events
 		private static void RenderEvents(Vector3 Camera) {
-			if (TrackManager.Tracks[0].Elements == null) {
+			if (CurrentRoute.Tracks[0].Elements == null) {
 				return;
 			}
 			LibRender.Renderer.LastBoundTexture = null;
@@ -391,12 +391,12 @@ namespace OpenBve {
 			double db = LibRender.Camera.ForwardViewingDistance + LibRender.Camera.ExtraViewingDistance;
 			bool[] sta = new bool[CurrentRoute.Stations.Length];
 			// events
-			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
-				double p = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
+			for (int i = 0; i < CurrentRoute.Tracks[0].Elements.Length; i++) {
+				double p = CurrentRoute.Tracks[0].Elements[i].StartingTrackPosition;
 				double d = p - World.CameraTrackFollower.TrackPosition;
 				if (d >= da & d <= db) {
-					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++) {
-						dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
+					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Length; j++) {
+						dynamic e = CurrentRoute.Tracks[0].Elements[i].Events[j];
 						double dy, dx = 0.0, dz = 0.0;
 						double s; Texture t;
 						if (e is BrightnessChangeEvent) {
@@ -565,7 +565,7 @@ namespace OpenBve {
 							}
 							else
 							{
-								LibRender.Renderer.DrawString(Fonts.SmallFont, (Environment.TickCount % 1000 <= 500 ? Program.JumpToPositionValue + "_" : Program.JumpToPositionValue), new Point(4, 100), TextAlignment.TopLeft, distance > TrackManager.Tracks[0].Elements[TrackManager.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100
+								LibRender.Renderer.DrawString(Fonts.SmallFont, (Environment.TickCount % 1000 <= 500 ? Program.JumpToPositionValue + "_" : Program.JumpToPositionValue), new Point(4, 100), TextAlignment.TopLeft, distance > CurrentRoute.Tracks[0].Elements[CurrentRoute.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100
 								? Color128.Red : Color128.Yellow, true);
 							}
 							

--- a/source/RouteViewer/RendererR.cs
+++ b/source/RouteViewer/RendererR.cs
@@ -375,7 +375,7 @@ namespace OpenBve {
 		
 		// render events
 		private static void RenderEvents(Vector3 Camera) {
-			if (TrackManager.CurrentTrack.Elements == null) {
+			if (TrackManager.Tracks[0].Elements == null) {
 				return;
 			}
 			LibRender.Renderer.LastBoundTexture = null;
@@ -391,12 +391,12 @@ namespace OpenBve {
 			double db = LibRender.Camera.ForwardViewingDistance + LibRender.Camera.ExtraViewingDistance;
 			bool[] sta = new bool[CurrentRoute.Stations.Length];
 			// events
-			for (int i = 0; i < TrackManager.CurrentTrack.Elements.Length; i++) {
-				double p = TrackManager.CurrentTrack.Elements[i].StartingTrackPosition;
+			for (int i = 0; i < TrackManager.Tracks[0].Elements.Length; i++) {
+				double p = TrackManager.Tracks[0].Elements[i].StartingTrackPosition;
 				double d = p - World.CameraTrackFollower.TrackPosition;
 				if (d >= da & d <= db) {
-					for (int j = 0; j < TrackManager.CurrentTrack.Elements[i].Events.Length; j++) {
-						dynamic e = TrackManager.CurrentTrack.Elements[i].Events[j];
+					for (int j = 0; j < TrackManager.Tracks[0].Elements[i].Events.Length; j++) {
+						dynamic e = TrackManager.Tracks[0].Elements[i].Events[j];
 						double dy, dx = 0.0, dz = 0.0;
 						double s; Texture t;
 						if (e is BrightnessChangeEvent) {
@@ -565,7 +565,7 @@ namespace OpenBve {
 							}
 							else
 							{
-								LibRender.Renderer.DrawString(Fonts.SmallFont, (Environment.TickCount % 1000 <= 500 ? Program.JumpToPositionValue + "_" : Program.JumpToPositionValue), new Point(4, 100), TextAlignment.TopLeft, distance > TrackManager.CurrentTrack.Elements[TrackManager.CurrentTrack.Elements.Length - 1].StartingTrackPosition + 100
+								LibRender.Renderer.DrawString(Fonts.SmallFont, (Environment.TickCount % 1000 <= 500 ? Program.JumpToPositionValue + "_" : Program.JumpToPositionValue), new Point(4, 100), TextAlignment.TopLeft, distance > TrackManager.Tracks[0].Elements[TrackManager.Tracks[0].Elements.Length - 1].StartingTrackPosition + 100
 								? Color128.Red : Color128.Yellow, true);
 							}
 							

--- a/source/RouteViewer/TrackManagerR.cs
+++ b/source/RouteViewer/TrackManagerR.cs
@@ -113,72 +113,131 @@ namespace OpenBve {
 			internal EventTriggerType TriggerType;
 			internal TrainManager.Train Train;
 			internal int CarIndex;
-		}
-		internal static void UpdateTrackFollower(ref TrackFollower Follower, double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccurary) {
-			if (CurrentTrack.Elements == null || CurrentTrack.Elements.Length == 0) return;
-			int i = Follower.LastTrackElement;
-			while (i >= 0 && NewTrackPosition < CurrentTrack.Elements[i].StartingTrackPosition) {
-				double ta = Follower.TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-				double tb = -0.01;
-				CheckEvents(ref Follower, i, -1, ta, tb);
-				i--;
-			}
-			if (i >= 0) {
-				while (i < CurrentTrack.Elements.Length - 1) {
-					if (NewTrackPosition < CurrentTrack.Elements[i + 1].StartingTrackPosition) break;
-					double ta = Follower.TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-					double tb = CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition + 0.01;
-					CheckEvents(ref Follower, i, 1, ta, tb);
-					i++;
+
+			internal void UpdateAbsolute(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccurary) {
+				if (CurrentTrack.Elements == null || CurrentTrack.Elements.Length == 0) return;
+				int i = LastTrackElement;
+				while (i >= 0 && NewTrackPosition < CurrentTrack.Elements[i].StartingTrackPosition) {
+					double ta = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+					double tb = -0.01;
+					CheckEvents(i, -1, ta, tb);
+					i--;
 				}
-			} else {
-				i = 0;
-			}
-			double da = Follower.TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-			double db = NewTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-			// track
-			if (UpdateWorldCoordinates) {
-				if (db != 0.0) {
-					if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
-						// curve
-						double r = CurrentTrack.Elements[i].CurveRadius;
-						double p = CurrentTrack.Elements[i].WorldDirection.Y / Math.Sqrt(CurrentTrack.Elements[i].WorldDirection.X * CurrentTrack.Elements[i].WorldDirection.X + CurrentTrack.Elements[i].WorldDirection.Z * CurrentTrack.Elements[i].WorldDirection.Z);
-						double s = db / Math.Sqrt(1.0 + p * p);
-						double h = s * p;
-						double b = s / Math.Abs(r);
-						double f = 2.0 * r * r * (1.0 - Math.Cos(b));
-						double c = (double)Math.Sign(db) * Math.Sqrt(f >= 0.0 ? f : 0.0);
-						double a = 0.5 * (double)Math.Sign(r) * b;
-						Vector3 D = new Vector3(CurrentTrack.Elements[i].WorldDirection.X, 0.0, CurrentTrack.Elements[i].WorldDirection.Z);
-						D.Normalize();
-						double cosa = Math.Cos(a);
-						double sina = Math.Sin(a);
-						D.Rotate(Vector3.Down, cosa, sina);
-						Follower.WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + c * D.X;
-						Follower.WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + h;
-						Follower.WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + c * D.Z;
-						D.Rotate(Vector3.Down, cosa, sina);
-						Follower.WorldDirection.X = D.X;
-						Follower.WorldDirection.Y = p;
-						Follower.WorldDirection.Z = D.Z;
-						Follower.WorldDirection.Normalize();
-						double cos2a = Math.Cos(2.0 * a);
-						double sin2a = Math.Sin(2.0 * a);
-						Follower.WorldSide = CurrentTrack.Elements[i].WorldSide;
-						Follower.WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
-						Follower.WorldUp = Vector3.Cross(Follower.WorldDirection, Follower.WorldSide);
-						Follower.CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-					} else {
-						// straight
-						Follower.WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + db * CurrentTrack.Elements[i].WorldDirection.X;
-						Follower.WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + db * CurrentTrack.Elements[i].WorldDirection.Y;
-						Follower.WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + db * CurrentTrack.Elements[i].WorldDirection.Z;
-						Follower.WorldDirection = CurrentTrack.Elements[i].WorldDirection;
-						Follower.WorldUp = CurrentTrack.Elements[i].WorldUp;
-						Follower.WorldSide = CurrentTrack.Elements[i].WorldSide;
-						Follower.CurveRadius = 0.0;
+				if (i >= 0) {
+					while (i < CurrentTrack.Elements.Length - 1) {
+						if (NewTrackPosition < CurrentTrack.Elements[i + 1].StartingTrackPosition) break;
+						double ta = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+						double tb = CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition + 0.01;
+						CheckEvents(i, 1, ta, tb);
+						i++;
 					}
-					// cant
+				} else {
+					i = 0;
+				}
+				double da = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+				double db = NewTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+				// track
+				if (UpdateWorldCoordinates) {
+					if (db != 0.0) {
+						if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
+							// curve
+							double r = CurrentTrack.Elements[i].CurveRadius;
+							double p = CurrentTrack.Elements[i].WorldDirection.Y / Math.Sqrt(CurrentTrack.Elements[i].WorldDirection.X * CurrentTrack.Elements[i].WorldDirection.X + CurrentTrack.Elements[i].WorldDirection.Z * CurrentTrack.Elements[i].WorldDirection.Z);
+							double s = db / Math.Sqrt(1.0 + p * p);
+							double h = s * p;
+							double b = s / Math.Abs(r);
+							double f = 2.0 * r * r * (1.0 - Math.Cos(b));
+							double c = (double)Math.Sign(db) * Math.Sqrt(f >= 0.0 ? f : 0.0);
+							double a = 0.5 * (double)Math.Sign(r) * b;
+							Vector3 D = new Vector3(CurrentTrack.Elements[i].WorldDirection.X, 0.0, CurrentTrack.Elements[i].WorldDirection.Z);
+							D.Normalize();
+							double cosa = Math.Cos(a);
+							double sina = Math.Sin(a);
+							D.Rotate(Vector3.Down, cosa, sina);
+							WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + c * D.X;
+							WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + h;
+							WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + c * D.Z;
+							D.Rotate(Vector3.Down, cosa, sina);
+							WorldDirection.X = D.X;
+							WorldDirection.Y = p;
+							WorldDirection.Z = D.Z;
+							WorldDirection.Normalize();
+							double cos2a = Math.Cos(2.0 * a);
+							double sin2a = Math.Sin(2.0 * a);
+							WorldSide = CurrentTrack.Elements[i].WorldSide;
+							WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
+							WorldUp = Vector3.Cross(WorldDirection, WorldSide);
+							CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+						} else {
+							// straight
+							WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + db * CurrentTrack.Elements[i].WorldDirection.X;
+							WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + db * CurrentTrack.Elements[i].WorldDirection.Y;
+							WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + db * CurrentTrack.Elements[i].WorldDirection.Z;
+							WorldDirection = CurrentTrack.Elements[i].WorldDirection;
+							WorldUp = CurrentTrack.Elements[i].WorldUp;
+							WorldSide = CurrentTrack.Elements[i].WorldSide;
+							CurveRadius = 0.0;
+						}
+						// cant
+						if (i < CurrentTrack.Elements.Length - 1) {
+							double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
+							if (t < 0.0) {
+								t = 0.0;
+							} else if (t > 1.0) {
+								t = 1.0;
+							}
+							double t2 = t * t;
+							double t3 = t2 * t;
+							CurveCant =
+								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
+								(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
+						} else {
+							CurveCant = CurrentTrack.Elements[i].CurveCant;
+						}
+					} else {
+						WorldPosition = CurrentTrack.Elements[i].WorldPosition;
+						WorldDirection = CurrentTrack.Elements[i].WorldDirection;
+						WorldUp = CurrentTrack.Elements[i].WorldUp;
+						WorldSide = CurrentTrack.Elements[i].WorldSide;
+						CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+						CurveCant = CurrentTrack.Elements[i].CurveCant;
+					}
+				} else {
+					if (db != 0.0) {
+						if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
+							CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+						} else {
+							CurveRadius = 0.0;
+						}
+						if (i < CurrentTrack.Elements.Length - 1) {
+							double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
+							if (t < 0.0) {
+								t = 0.0;
+							} else if (t > 1.0) {
+								t = 1.0;
+							}
+							double t2 = t * t;
+							double t3 = t2 * t;
+							CurveCant =
+								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
+								(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
+						} else {
+							CurveCant = CurrentTrack.Elements[i].CurveCant;
+						}
+					} else {
+						CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+						CurveCant = CurrentTrack.Elements[i].CurveCant;
+					}
+				}
+				AdhesionMultiplier = CurrentTrack.Elements[i].AdhesionMultiplier;
+				Pitch = CurrentTrack.Elements[i].Pitch * 1000;
+				// inaccuracy
+				if (AddTrackInaccurary) {
+					double x, y, c;
 					if (i < CurrentTrack.Elements.Length - 1) {
 						double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
 						if (t < 0.0) {
@@ -186,110 +245,53 @@ namespace OpenBve {
 						} else if (t > 1.0) {
 							t = 1.0;
 						}
-						double t2 = t * t;
-						double t3 = t2 * t;
-						Follower.CurveCant =
-							(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
-							(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
-							(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
-							(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
+						double x1, y1, c1;
+						double x2, y2, c2;
+						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
+						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
+						x = (1.0 - t) * x1 + t * x2;
+						y = (1.0 - t) * y1 + t * y2;
+						c = (1.0 - t) * c1 + t * c2;
 					} else {
-						Follower.CurveCant = CurrentTrack.Elements[i].CurveCant;
+						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
 					}
+					WorldPosition.X += x * WorldSide.X + y * WorldUp.X;
+					WorldPosition.Y += x * WorldSide.Y + y * WorldUp.Y;
+					WorldPosition.Z += x * WorldSide.Z + y * WorldUp.Z;
+					CurveCant += c;
+					CantDueToInaccuracy = c;
 				} else {
-					Follower.WorldPosition = CurrentTrack.Elements[i].WorldPosition;
-					Follower.WorldDirection = CurrentTrack.Elements[i].WorldDirection;
-					Follower.WorldUp = CurrentTrack.Elements[i].WorldUp;
-					Follower.WorldSide = CurrentTrack.Elements[i].WorldSide;
-					Follower.CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-					Follower.CurveCant = CurrentTrack.Elements[i].CurveCant;
+					CantDueToInaccuracy = 0.0;
 				}
-			} else {
-				if (db != 0.0) {
-					if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
-						Follower.CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-					} else {
-						Follower.CurveRadius = 0.0;
-					}
-					if (i < CurrentTrack.Elements.Length - 1) {
-						double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
-						if (t < 0.0) {
-							t = 0.0;
-						} else if (t > 1.0) {
-							t = 1.0;
+				// events
+				CheckEvents(i, Math.Sign(db - da), da, db);
+				// finish
+				TrackPosition = NewTrackPosition;
+				LastTrackElement = i;
+			}
+			private void CheckEvents(int ElementIndex, int Direction, double OldDelta, double NewDelta) {
+				if (Direction < 0) {
+					for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
+					{
+						dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
+						if (OldDelta > e.TrackPositionDelta & NewDelta <= e.TrackPositionDelta) {
+							e.TryTrigger(-1, TriggerType, Train, CarIndex);
 						}
-						double t2 = t * t;
-						double t3 = t2 * t;
-						Follower.CurveCant =
-							(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
-							(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
-							(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
-							(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
-					} else {
-						Follower.CurveCant = CurrentTrack.Elements[i].CurveCant;
 					}
-				} else {
-					Follower.CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-					Follower.CurveCant = CurrentTrack.Elements[i].CurveCant;
+				} else if (Direction > 0) {
+					for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
+					{
+						dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
+						if (OldDelta < e.TrackPositionDelta & NewDelta >= e.TrackPositionDelta) {
+							e.TryTrigger(1, TriggerType, Train, CarIndex);
+						}
+					}
 				}
 			}
-			Follower.AdhesionMultiplier = CurrentTrack.Elements[i].AdhesionMultiplier;
-			Follower.Pitch = CurrentTrack.Elements[i].Pitch * 1000;
-			// inaccuracy
-			if (AddTrackInaccurary) {
-				double x, y, c;
-				if (i < CurrentTrack.Elements.Length - 1) {
-					double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
-					if (t < 0.0) {
-						t = 0.0;
-					} else if (t > 1.0) {
-						t = 1.0;
-					}
-					double x1, y1, c1;
-					double x2, y2, c2;
-					CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
-					CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
-					x = (1.0 - t) * x1 + t * x2;
-					y = (1.0 - t) * y1 + t * y2;
-					c = (1.0 - t) * c1 + t * c2;
-				} else {
-					CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
-				}
-				Follower.WorldPosition.X += x * Follower.WorldSide.X + y * Follower.WorldUp.X;
-				Follower.WorldPosition.Y += x * Follower.WorldSide.Y + y * Follower.WorldUp.Y;
-				Follower.WorldPosition.Z += x * Follower.WorldSide.Z + y * Follower.WorldUp.Z;
-				Follower.CurveCant += c;
-				Follower.CantDueToInaccuracy = c;
-			} else {
-				Follower.CantDueToInaccuracy = 0.0;
-			}
-			// events
-			CheckEvents(ref Follower, i, Math.Sign(db - da), da, db);
-			// finish
-			Follower.TrackPosition = NewTrackPosition;
-			Follower.LastTrackElement = i;
 		}
 		
+		
 		// check events
-        private static void CheckEvents(ref TrackFollower Follower, int ElementIndex, int Direction, double OldDelta, double NewDelta) {
-            if (Direction < 0) {
-                for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
-                {
-	                dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
-                    if (OldDelta > e.TrackPositionDelta & NewDelta <= e.TrackPositionDelta) {
-                        e.TryTrigger(-1, Follower.TriggerType, Follower.Train, Follower.Train != null ? Follower.Train.Cars[Follower.CarIndex] : null);
-                    }
-                }
-            } else if (Direction > 0) {
-                for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
-                {
-	                dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
-                    if (OldDelta < e.TrackPositionDelta & NewDelta >= e.TrackPositionDelta) {
-                        e.TryTrigger(1, Follower.TriggerType, Follower.Train, Follower.Train != null ? Follower.Train.Cars[Follower.CarIndex] : null);
-                    }
-                }
-            }
-        }
-
+        
     }
 }

--- a/source/RouteViewer/TrackManagerR.cs
+++ b/source/RouteViewer/TrackManagerR.cs
@@ -94,8 +94,8 @@ namespace OpenBve {
             public override void Trigger(int Direction, EventTriggerType TriggerType, TrainManager.Train Train, AbstractCar Car) { }
         }
         // ================================
-		
-        internal static Track CurrentTrack;
+
+        internal static Track[] Tracks;
 
 		// track follower
 		internal struct TrackFollower {
@@ -115,48 +115,48 @@ namespace OpenBve {
 			internal int CarIndex;
 
 			internal void UpdateAbsolute(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccurary) {
-				if (CurrentTrack.Elements == null || CurrentTrack.Elements.Length == 0) return;
+				if (Tracks[0].Elements == null || Tracks[0].Elements.Length == 0) return;
 				int i = LastTrackElement;
-				while (i >= 0 && NewTrackPosition < CurrentTrack.Elements[i].StartingTrackPosition) {
-					double ta = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+				while (i >= 0 && NewTrackPosition < Tracks[0].Elements[i].StartingTrackPosition) {
+					double ta = TrackPosition - Tracks[0].Elements[i].StartingTrackPosition;
 					double tb = -0.01;
 					CheckEvents(i, -1, ta, tb);
 					i--;
 				}
 				if (i >= 0) {
-					while (i < CurrentTrack.Elements.Length - 1) {
-						if (NewTrackPosition < CurrentTrack.Elements[i + 1].StartingTrackPosition) break;
-						double ta = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-						double tb = CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition + 0.01;
+					while (i < Tracks[0].Elements.Length - 1) {
+						if (NewTrackPosition < Tracks[0].Elements[i + 1].StartingTrackPosition) break;
+						double ta = TrackPosition - Tracks[0].Elements[i].StartingTrackPosition;
+						double tb = Tracks[0].Elements[i + 1].StartingTrackPosition - Tracks[0].Elements[i].StartingTrackPosition + 0.01;
 						CheckEvents(i, 1, ta, tb);
 						i++;
 					}
 				} else {
 					i = 0;
 				}
-				double da = TrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
-				double db = NewTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition;
+				double da = TrackPosition - Tracks[0].Elements[i].StartingTrackPosition;
+				double db = NewTrackPosition - Tracks[0].Elements[i].StartingTrackPosition;
 				// track
 				if (UpdateWorldCoordinates) {
 					if (db != 0.0) {
-						if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
+						if (Tracks[0].Elements[i].CurveRadius != 0.0) {
 							// curve
-							double r = CurrentTrack.Elements[i].CurveRadius;
-							double p = CurrentTrack.Elements[i].WorldDirection.Y / Math.Sqrt(CurrentTrack.Elements[i].WorldDirection.X * CurrentTrack.Elements[i].WorldDirection.X + CurrentTrack.Elements[i].WorldDirection.Z * CurrentTrack.Elements[i].WorldDirection.Z);
+							double r = Tracks[0].Elements[i].CurveRadius;
+							double p = Tracks[0].Elements[i].WorldDirection.Y / Math.Sqrt(Tracks[0].Elements[i].WorldDirection.X * Tracks[0].Elements[i].WorldDirection.X + Tracks[0].Elements[i].WorldDirection.Z * Tracks[0].Elements[i].WorldDirection.Z);
 							double s = db / Math.Sqrt(1.0 + p * p);
 							double h = s * p;
 							double b = s / Math.Abs(r);
 							double f = 2.0 * r * r * (1.0 - Math.Cos(b));
 							double c = (double)Math.Sign(db) * Math.Sqrt(f >= 0.0 ? f : 0.0);
 							double a = 0.5 * (double)Math.Sign(r) * b;
-							Vector3 D = new Vector3(CurrentTrack.Elements[i].WorldDirection.X, 0.0, CurrentTrack.Elements[i].WorldDirection.Z);
+							Vector3 D = new Vector3(Tracks[0].Elements[i].WorldDirection.X, 0.0, Tracks[0].Elements[i].WorldDirection.Z);
 							D.Normalize();
 							double cosa = Math.Cos(a);
 							double sina = Math.Sin(a);
 							D.Rotate(Vector3.Down, cosa, sina);
-							WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + c * D.X;
-							WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + h;
-							WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + c * D.Z;
+							WorldPosition.X = Tracks[0].Elements[i].WorldPosition.X + c * D.X;
+							WorldPosition.Y = Tracks[0].Elements[i].WorldPosition.Y + h;
+							WorldPosition.Z = Tracks[0].Elements[i].WorldPosition.Z + c * D.Z;
 							D.Rotate(Vector3.Down, cosa, sina);
 							WorldDirection.X = D.X;
 							WorldDirection.Y = p;
@@ -164,23 +164,23 @@ namespace OpenBve {
 							WorldDirection.Normalize();
 							double cos2a = Math.Cos(2.0 * a);
 							double sin2a = Math.Sin(2.0 * a);
-							WorldSide = CurrentTrack.Elements[i].WorldSide;
+							WorldSide = Tracks[0].Elements[i].WorldSide;
 							WorldSide.Rotate(Vector3.Down, cos2a, sin2a);
 							WorldUp = Vector3.Cross(WorldDirection, WorldSide);
-							CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+							CurveRadius = Tracks[0].Elements[i].CurveRadius;
 						} else {
 							// straight
-							WorldPosition.X = CurrentTrack.Elements[i].WorldPosition.X + db * CurrentTrack.Elements[i].WorldDirection.X;
-							WorldPosition.Y = CurrentTrack.Elements[i].WorldPosition.Y + db * CurrentTrack.Elements[i].WorldDirection.Y;
-							WorldPosition.Z = CurrentTrack.Elements[i].WorldPosition.Z + db * CurrentTrack.Elements[i].WorldDirection.Z;
-							WorldDirection = CurrentTrack.Elements[i].WorldDirection;
-							WorldUp = CurrentTrack.Elements[i].WorldUp;
-							WorldSide = CurrentTrack.Elements[i].WorldSide;
+							WorldPosition.X = Tracks[0].Elements[i].WorldPosition.X + db * Tracks[0].Elements[i].WorldDirection.X;
+							WorldPosition.Y = Tracks[0].Elements[i].WorldPosition.Y + db * Tracks[0].Elements[i].WorldDirection.Y;
+							WorldPosition.Z = Tracks[0].Elements[i].WorldPosition.Z + db * Tracks[0].Elements[i].WorldDirection.Z;
+							WorldDirection = Tracks[0].Elements[i].WorldDirection;
+							WorldUp = Tracks[0].Elements[i].WorldUp;
+							WorldSide = Tracks[0].Elements[i].WorldSide;
 							CurveRadius = 0.0;
 						}
 						// cant
-						if (i < CurrentTrack.Elements.Length - 1) {
-							double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
+						if (i < Tracks[0].Elements.Length - 1) {
+							double t = db / (Tracks[0].Elements[i + 1].StartingTrackPosition - Tracks[0].Elements[i].StartingTrackPosition);
 							if (t < 0.0) {
 								t = 0.0;
 							} else if (t > 1.0) {
@@ -189,30 +189,30 @@ namespace OpenBve {
 							double t2 = t * t;
 							double t3 = t2 * t;
 							CurveCant =
-								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
-								(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
-								(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
-								(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
+								(2.0 * t3 - 3.0 * t2 + 1.0) * Tracks[0].Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * Tracks[0].Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * Tracks[0].Elements[i + 1].CurveCant +
+								(t3 - t2) * Tracks[0].Elements[i + 1].CurveCantTangent;
 						} else {
-							CurveCant = CurrentTrack.Elements[i].CurveCant;
+							CurveCant = Tracks[0].Elements[i].CurveCant;
 						}
 					} else {
-						WorldPosition = CurrentTrack.Elements[i].WorldPosition;
-						WorldDirection = CurrentTrack.Elements[i].WorldDirection;
-						WorldUp = CurrentTrack.Elements[i].WorldUp;
-						WorldSide = CurrentTrack.Elements[i].WorldSide;
-						CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-						CurveCant = CurrentTrack.Elements[i].CurveCant;
+						WorldPosition = Tracks[0].Elements[i].WorldPosition;
+						WorldDirection = Tracks[0].Elements[i].WorldDirection;
+						WorldUp = Tracks[0].Elements[i].WorldUp;
+						WorldSide = Tracks[0].Elements[i].WorldSide;
+						CurveRadius = Tracks[0].Elements[i].CurveRadius;
+						CurveCant = Tracks[0].Elements[i].CurveCant;
 					}
 				} else {
 					if (db != 0.0) {
-						if (CurrentTrack.Elements[i].CurveRadius != 0.0) {
-							CurveRadius = CurrentTrack.Elements[i].CurveRadius;
+						if (Tracks[0].Elements[i].CurveRadius != 0.0) {
+							CurveRadius = Tracks[0].Elements[i].CurveRadius;
 						} else {
 							CurveRadius = 0.0;
 						}
-						if (i < CurrentTrack.Elements.Length - 1) {
-							double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
+						if (i < Tracks[0].Elements.Length - 1) {
+							double t = db / (Tracks[0].Elements[i + 1].StartingTrackPosition - Tracks[0].Elements[i].StartingTrackPosition);
 							if (t < 0.0) {
 								t = 0.0;
 							} else if (t > 1.0) {
@@ -221,25 +221,25 @@ namespace OpenBve {
 							double t2 = t * t;
 							double t3 = t2 * t;
 							CurveCant =
-								(2.0 * t3 - 3.0 * t2 + 1.0) * CurrentTrack.Elements[i].CurveCant +
-								(t3 - 2.0 * t2 + t) * CurrentTrack.Elements[i].CurveCantTangent +
-								(-2.0 * t3 + 3.0 * t2) * CurrentTrack.Elements[i + 1].CurveCant +
-								(t3 - t2) * CurrentTrack.Elements[i + 1].CurveCantTangent;
+								(2.0 * t3 - 3.0 * t2 + 1.0) * Tracks[0].Elements[i].CurveCant +
+								(t3 - 2.0 * t2 + t) * Tracks[0].Elements[i].CurveCantTangent +
+								(-2.0 * t3 + 3.0 * t2) * Tracks[0].Elements[i + 1].CurveCant +
+								(t3 - t2) * Tracks[0].Elements[i + 1].CurveCantTangent;
 						} else {
-							CurveCant = CurrentTrack.Elements[i].CurveCant;
+							CurveCant = Tracks[0].Elements[i].CurveCant;
 						}
 					} else {
-						CurveRadius = CurrentTrack.Elements[i].CurveRadius;
-						CurveCant = CurrentTrack.Elements[i].CurveCant;
+						CurveRadius = Tracks[0].Elements[i].CurveRadius;
+						CurveCant = Tracks[0].Elements[i].CurveCant;
 					}
 				}
-				AdhesionMultiplier = CurrentTrack.Elements[i].AdhesionMultiplier;
-				Pitch = CurrentTrack.Elements[i].Pitch * 1000;
+				AdhesionMultiplier = Tracks[0].Elements[i].AdhesionMultiplier;
+				Pitch = Tracks[0].Elements[i].Pitch * 1000;
 				// inaccuracy
 				if (AddTrackInaccurary) {
 					double x, y, c;
-					if (i < CurrentTrack.Elements.Length - 1) {
-						double t = db / (CurrentTrack.Elements[i + 1].StartingTrackPosition - CurrentTrack.Elements[i].StartingTrackPosition);
+					if (i < Tracks[0].Elements.Length - 1) {
+						double t = db / (Tracks[0].Elements[i + 1].StartingTrackPosition - Tracks[0].Elements[i].StartingTrackPosition);
 						if (t < 0.0) {
 							t = 0.0;
 						} else if (t > 1.0) {
@@ -247,13 +247,13 @@ namespace OpenBve {
 						}
 						double x1, y1, c1;
 						double x2, y2, c2;
-						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
-						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
+						Tracks[0].GetInaccuracies(NewTrackPosition, Tracks[0].Elements[i].CsvRwAccuracyLevel, out x1, out y1, out c1);
+						Tracks[0].GetInaccuracies(NewTrackPosition, Tracks[0].Elements[i + 1].CsvRwAccuracyLevel, out x2, out y2, out c2);
 						x = (1.0 - t) * x1 + t * x2;
 						y = (1.0 - t) * y1 + t * y2;
 						c = (1.0 - t) * c1 + t * c2;
 					} else {
-						CurrentTrack.GetInaccuracies(NewTrackPosition, CurrentTrack.Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
+						Tracks[0].GetInaccuracies(NewTrackPosition, Tracks[0].Elements[i].CsvRwAccuracyLevel, out x, out y, out c);
 					}
 					WorldPosition.X += x * WorldSide.X + y * WorldUp.X;
 					WorldPosition.Y += x * WorldSide.Y + y * WorldUp.Y;
@@ -271,19 +271,19 @@ namespace OpenBve {
 			}
 			private void CheckEvents(int ElementIndex, int Direction, double OldDelta, double NewDelta) {
 				if (Direction < 0) {
-					for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
+					for (int j = 0; j < Tracks[0].Elements[ElementIndex].Events.Length; j++)
 					{
-						dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
+						dynamic e = Tracks[0].Elements[ElementIndex].Events[j];
 						if (OldDelta > e.TrackPositionDelta & NewDelta <= e.TrackPositionDelta) {
-							e.TryTrigger(-1, TriggerType, Train, CarIndex);
+							e.TryTrigger(-1, this.TriggerType, this.Train, this.Train != null ? this.Train.Cars[CarIndex] : null);
 						}
 					}
 				} else if (Direction > 0) {
-					for (int j = 0; j < CurrentTrack.Elements[ElementIndex].Events.Length; j++)
+					for (int j = 0; j < Tracks[0].Elements[ElementIndex].Events.Length; j++)
 					{
-						dynamic e = CurrentTrack.Elements[ElementIndex].Events[j];
+						dynamic e = Tracks[0].Elements[ElementIndex].Events[j];
 						if (OldDelta < e.TrackPositionDelta & NewDelta >= e.TrackPositionDelta) {
-							e.TryTrigger(1, TriggerType, Train, CarIndex);
+							e.TryTrigger(1, this.TriggerType, this.Train, this.Train != null ? this.Train.Cars[CarIndex] : null);
 						}
 					}
 				}

--- a/source/RouteViewer/WorldR.cs
+++ b/source/RouteViewer/WorldR.cs
@@ -37,7 +37,7 @@ namespace OpenBve {
 			double tr = Camera.CurrentAlignment.TrackPosition;
 			AdjustAlignment(ref Camera.CurrentAlignment.TrackPosition, Camera.AlignmentDirection.TrackPosition, ref Camera.AlignmentSpeed.TrackPosition, TimeElapsed);
 			if (tr != Camera.CurrentAlignment.TrackPosition) {
-				TrackManager.UpdateTrackFollower(ref World.CameraTrackFollower, Camera.CurrentAlignment.TrackPosition, true, false);
+				World.CameraTrackFollower.UpdateAbsolute(Camera.CurrentAlignment.TrackPosition, true, false);
 				q = true;
 			}
 			if (q) {


### PR DESCRIPTION
Marginal bit of refactoring work in the TrackFollower class.

This makes it so that it will take either an absolute track position (Moves the follower to said position, was the previous behaviour), or a relative position. 

### Benefits:
* A lot less passing around of relative positions.
* Moves the static methods used to update the track follower in Route Viewer into methods pertaining to the follower as per the main program.

### Drawbacks:
* Only relative in the main program.
* A bunch of stuff probably should use this (e.g. some of the camera based stuff), but doesn't for legacy reasons.

### TODO:
* Test and check that nothing has gone awry.
* Make RouteViewer use the multiple track logic from https://github.com/leezer3/OpenBVE/pull/326