### PR TITLE
Change: Bump required Mono version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
 #Nightly builds for upload. Use lowest possible Mono version for compatibility purposes
     - os: linux
       dist: trusty
-      mono: 3.2.8
+      mono: 4.6.2
       script: make publish
     - os: osx
       mono: latest
@@ -24,7 +24,7 @@ matrix:
       script: make all-release
     - os: linux
       dist: trusty
-      mono: 3.2.8
+      mono: 4.6.2
       script: make all-release
 ##Use .sln file##
     - os: linux
@@ -41,7 +41,7 @@ matrix:
       solution: OpenBVE.sln
     - os: linux
       dist: trusty
-      mono: 3.2.8
+      mono: 4.6.2
       solution: OpenBVE.sln
  
 after_success:

--- a/DebianControl.sh
+++ b/DebianControl.sh
@@ -36,7 +36,7 @@ Maintainer: leezer3 <leezer3@gmail.com>
 Architecture: all
 Version: $Version
 Provides: bve-engine
-Depends: debhelper (>= 9), mono-runtime (>= 3.2.8), libmono-corlib4.5-cil (>= 3.2.8), libmono-system-drawing4.0-cil (>= 1.0), libmono-system-windows-forms4.0-cil (>= 1.0), libmono-system4.0-cil (>= 3.2.8), libmono-i18n4.0-all, libopenal1
+Depends: debhelper (>= 9), mono-runtime (>= 4.6.2), libmono-corlib4.5-cil (>= 4.6.2), libmono-system-drawing4.0-cil (>= 1.0), libmono-system-windows-forms4.0-cil (>= 1.0), libmono-system4.0-cil (>= 4.6.2), libmono-i18n4.0-all, libopenal1
 Recommends: bve-route, bve-train
 Homepage: http://openbve-project.net
 Description: realistic 3D train/railway simulator (main program)


### PR DESCRIPTION
Stretch is now Debian OldStable, and this gives us a much newer Mono version to play with!

This *should* be seamless hopefully.
Whilst we don't actually require anything newer than 3.2.8 at the minute, this should let us use a few newer features if we need.