### PR TITLE
Fix: Linux builds not uploading after Mono bump

### DIFF
--- a/UploadScript.sh
+++ b/UploadScript.sh
@@ -12,7 +12,7 @@ function wrap() {
   if [ "$TRAVIS_OS_NAME" = "linux" ] ;
     then
 	echo "Linux worker"
-	if [ "$mono_version" != "4.6.2" ] ;
+	if [ "$mono_version" != "5.20.1" ] ;
 		then
 		echo "Wrong Mono version- Not uploading this build"
 		exit


### PR DESCRIPTION
This PR fix an issue that Linux builds not uploading after Mono bump.