### PR TITLE
Fix: a crash in the motor sound simulation

### DIFF
--- a/source/TrainEditor2/App.config
+++ b/source/TrainEditor2/App.config
@@ -13,7 +13,7 @@
         <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
       </dependentAssembly>
-	  <probing privatePath="Data\Formats"/>
+	  <probing privatePath="Data\Formats" />
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/source/TrainEditor2/IO/Sounds/Xml/Parser.cs
+++ b/source/TrainEditor2/IO/Sounds/Xml/Parser.cs
@@ -329,7 +329,7 @@ namespace TrainEditor2.IO.Sounds.Xml
 				else
 				{
 					int idx;
-					XElement indexNode = childNode.Element("index");
+					XElement indexNode = childNode.Element("Index");
 
 					if (indexNode == null)
 					{

--- a/source/TrainEditor2/IO/Trains/TrainDat/Parser.cs
+++ b/source/TrainEditor2/IO/Trains/TrainDat/Parser.cs
@@ -1012,16 +1012,16 @@ namespace TrainEditor2.IO.Trains.TrainDat
 				car.CenterOfGravityHeight = centerOfGravityHeight;
 				car.ExposedFrontalArea = exposedFrontalArea;
 				car.UnexposedFrontalArea = unexposedFrontalArea;
-				car.Performance = performance;
-				car.Delay = delay;
-				car.Move = move;
-				car.Brake = brake;
-				car.Pressure = pressure;
+				car.Performance = (Performance)performance.Clone();
+				car.Delay = (Delay)delay.Clone();
+				car.Move = (Move)move.Clone();
+				car.Brake = (Brake)brake.Clone();
+				car.Pressure = (Pressure)pressure.Clone();
 
 				if (isMotorCar)
 				{
-					((MotorCar)car).Acceleration = acceleration;
-					((MotorCar)car).Motor = motor;
+					((MotorCar)car).Acceleration = (Acceleration)acceleration.Clone();
+					((MotorCar)car).Motor = (Motor)motor.Clone();
 				}
 
 				train.Cars.Add(car);

--- a/source/TrainEditor2/Models/App.cs
+++ b/source/TrainEditor2/Models/App.cs
@@ -521,7 +521,7 @@ namespace TrainEditor2.Models
 						Text = Utilities.GetInterfaceString("menu", "file", "wrongtype"),
 						IsOpen = true
 					};
-					
+
 				}
 				else
 				{
@@ -537,7 +537,7 @@ namespace TrainEditor2.Models
 						IsOpen = true
 					};
 				}
-				
+
 
 				SaveLocation = string.Empty;
 
@@ -613,129 +613,171 @@ namespace TrainEditor2.Models
 
 		internal void ImportFiles()
 		{
-			switch (CurrentTrainFileType)
+			try
 			{
-				case TrainFileType.OldFormat:
-					if (!string.IsNullOrEmpty(TrainDatImportLocation))
-					{
-						TrainDat.Parse(TrainDatImportLocation, out train);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Train)));
+				switch (CurrentTrainFileType)
+				{
+					case TrainFileType.OldFormat:
+						if (!string.IsNullOrEmpty(TrainDatImportLocation))
+						{
+							TrainDat.Parse(TrainDatImportLocation, out train);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Train)));
 
-						CreateItem();
-					}
+							CreateItem();
+						}
 
-					if (!string.IsNullOrEmpty(ExtensionsCfgImportLocation))
-					{
-						ExtensionsCfg.Parse(ExtensionsCfgImportLocation, Train);
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+						if (!string.IsNullOrEmpty(ExtensionsCfgImportLocation))
+						{
+							ExtensionsCfg.Parse(ExtensionsCfgImportLocation, Train);
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 
-			switch (CurrentPanelFileType)
+			try
 			{
-				case PanelFileType.Panel2Cfg:
-					if (!string.IsNullOrEmpty(Panel2CfgImportLocation))
-					{
-						PanelCfgBve4.Parse(Panel2CfgImportLocation, out panel);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Panel)));
-					}
-					break;
-				case PanelFileType.PanelXml:
-					if (!string.IsNullOrEmpty(PanelXmlImportLocation))
-					{
-						PanelCfgXml.Parse(PanelXmlImportLocation, out panel);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Panel)));
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+				switch (CurrentPanelFileType)
+				{
+					case PanelFileType.Panel2Cfg:
+						if (!string.IsNullOrEmpty(Panel2CfgImportLocation))
+						{
+							PanelCfgBve4.Parse(Panel2CfgImportLocation, out panel);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Panel)));
+						}
+						break;
+					case PanelFileType.PanelXml:
+						if (!string.IsNullOrEmpty(PanelXmlImportLocation))
+						{
+							PanelCfgXml.Parse(PanelXmlImportLocation, out panel);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Panel)));
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 
-			switch (CurrentSoundFileType)
+			try
 			{
-				case SoundFileType.NoSettingFile:
-					if (!string.IsNullOrEmpty(TrainFolderImportLocation))
-					{
-						SoundCfgBve2.Parse(TrainFolderImportLocation, out sound);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
-					}
-					break;
-				case SoundFileType.SoundCfg:
-					if (!string.IsNullOrEmpty(SoundCfgImportLocation))
-					{
-						SoundCfgBve4.Parse(SoundCfgImportLocation, out sound);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
-					}
-					break;
-				case SoundFileType.SoundXml:
-					if (!string.IsNullOrEmpty(SoundXmlImportLocation))
-					{
-						SoundCfgXml.Parse(SoundXmlImportLocation, out sound);
-						OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+				switch (CurrentSoundFileType)
+				{
+					case SoundFileType.NoSettingFile:
+						if (!string.IsNullOrEmpty(TrainFolderImportLocation))
+						{
+							SoundCfgBve2.Parse(TrainFolderImportLocation, out sound);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
+						}
+						break;
+					case SoundFileType.SoundCfg:
+						if (!string.IsNullOrEmpty(SoundCfgImportLocation))
+						{
+							SoundCfgBve4.Parse(SoundCfgImportLocation, out sound);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
+						}
+						break;
+					case SoundFileType.SoundXml:
+						if (!string.IsNullOrEmpty(SoundXmlImportLocation))
+						{
+							SoundCfgXml.Parse(SoundXmlImportLocation, out sound);
+							OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 		}
 
 		internal void ExportFiles()
 		{
-			switch (CurrentTrainFileType)
+			try
 			{
-				case TrainFileType.OldFormat:
-					if (!string.IsNullOrEmpty(TrainDatExportLocation))
-					{
-						TrainDat.Write(TrainDatExportLocation, Train);
-					}
+				switch (CurrentTrainFileType)
+				{
+					case TrainFileType.OldFormat:
+						if (!string.IsNullOrEmpty(TrainDatExportLocation))
+						{
+							TrainDat.Write(TrainDatExportLocation, Train);
+						}
 
-					if (!string.IsNullOrEmpty(ExtensionsCfgExportLocation))
-					{
-						ExtensionsCfg.Write(ExtensionsCfgExportLocation, Train);
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+						if (!string.IsNullOrEmpty(ExtensionsCfgExportLocation))
+						{
+							ExtensionsCfg.Write(ExtensionsCfgExportLocation, Train);
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 
-			switch (CurrentPanelFileType)
+			try
 			{
-				case PanelFileType.Panel2Cfg:
-					if (!string.IsNullOrEmpty(Panel2CfgExportLocation))
-					{
-						PanelCfgBve4.Write(Panel2CfgExportLocation, Panel);
-					}
-					break;
-				case PanelFileType.PanelXml:
-					if (!string.IsNullOrEmpty(PanelXmlExportLocation))
-					{
-						PanelCfgXml.Write(PanelXmlExportLocation, Panel);
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+				switch (CurrentPanelFileType)
+				{
+					case PanelFileType.Panel2Cfg:
+						if (!string.IsNullOrEmpty(Panel2CfgExportLocation))
+						{
+							PanelCfgBve4.Write(Panel2CfgExportLocation, Panel);
+						}
+						break;
+					case PanelFileType.PanelXml:
+						if (!string.IsNullOrEmpty(PanelXmlExportLocation))
+						{
+							PanelCfgXml.Write(PanelXmlExportLocation, Panel);
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 
-			switch (CurrentSoundFileType)
+			try
 			{
-				case SoundFileType.NoSettingFile:
-					break;
-				case SoundFileType.SoundCfg:
-					if (!string.IsNullOrEmpty(SoundCfgExportLocation))
-					{
-						SoundCfgBve4.Write(SoundCfgExportLocation, Sound);
-					}
-					break;
-				case SoundFileType.SoundXml:
-					if (!string.IsNullOrEmpty(SoundXmlExportLocation))
-					{
-						SoundCfgXml.Write(SoundXmlExportLocation, Sound);
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
+				switch (CurrentSoundFileType)
+				{
+					case SoundFileType.NoSettingFile:
+						break;
+					case SoundFileType.SoundCfg:
+						if (!string.IsNullOrEmpty(SoundCfgExportLocation))
+						{
+							SoundCfgBve4.Write(SoundCfgExportLocation, Sound);
+						}
+						break;
+					case SoundFileType.SoundXml:
+						if (!string.IsNullOrEmpty(SoundXmlExportLocation))
+						{
+							SoundCfgXml.Write(SoundXmlExportLocation, Sound);
+						}
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+			}
+			catch (Exception e)
+			{
+				Interface.AddMessage(MessageType.Error, false, e.Message);
 			}
 		}
 

--- a/source/TrainEditor2/Models/App.cs
+++ b/source/TrainEditor2/Models/App.cs
@@ -881,6 +881,7 @@ namespace TrainEditor2.Models
 			}
 
 			Item.Children[1].Children[carIndex].Tag = Train.Cars[carIndex];
+			OnPropertyChanged(new PropertyChangedEventArgs(nameof(SelectedItem)));
 		}
 
 		private string GetMessageTypeString(MessageType type)

--- a/source/TrainEditor2/Models/Trains/Motor.Functions.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.Functions.cs
@@ -1064,10 +1064,10 @@ namespace TrainEditor2.Models.Trains
 			GL.ClearColor(Color.Black);
 			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-			Matrix4d projPitch = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxPitch - MinPitch, double.Epsilon, 1.0);
-			Matrix4d projVolume = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxVolume - MinVolume, double.Epsilon, 1.0);
-			Matrix4d lookPitch = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, double.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, 0.0), Vector3d.UnitY);
-			Matrix4d lookVolume = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, double.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, 0.0), Vector3d.UnitY);
+			Matrix4d projPitch = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxPitch - MinPitch, float.Epsilon, 1.0);
+			Matrix4d projVolume = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxVolume - MinVolume, float.Epsilon, 1.0);
+			Matrix4d lookPitch = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, float.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, 0.0), Vector3d.UnitY);
+			Matrix4d lookVolume = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, float.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, 0.0), Vector3d.UnitY);
 
 			//Font font = new Font("MS UI Gothic", 7.0f);
 			//Pen grayPen = new Pen(Color.DimGray);

--- a/source/TrainEditor2/Models/Trains/Motor.Functions.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.Functions.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Text;
 using System.Linq;
 using System.Text;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
 using TrainEditor2.Extensions;
 using TrainEditor2.Models.Dialogs;
 using TrainEditor2.Models.Others;
@@ -17,38 +17,38 @@ namespace TrainEditor2.Models.Trains
 	{
 		private double XtoVelocity(double x)
 		{
-			double factorVelocity = ImageWidth / (MaxVelocity - MinVelocity);
+			double factorVelocity = GlControlWidth / (MaxVelocity - MinVelocity);
 			return MinVelocity + x / factorVelocity;
 		}
 
 		private double YtoPitch(double y)
 		{
-			double factorPitch = -ImageHeight / (MaxPitch - MinPitch);
-			return MinPitch + (y - ImageHeight) / factorPitch;
+			double factorPitch = -GlControlHeight / (MaxPitch - MinPitch);
+			return MinPitch + (y - GlControlHeight) / factorPitch;
 		}
 
 		private double YtoVolume(double y)
 		{
-			double factorVolume = -ImageHeight / (MaxVolume - MinVolume);
-			return MinVolume + (y - ImageHeight) / factorVolume;
+			double factorVolume = -GlControlHeight / (MaxVolume - MinVolume);
+			return MinVolume + (y - GlControlHeight) / factorVolume;
 		}
 
 		private double VelocityToX(double v)
 		{
-			double factorVelocity = ImageWidth / (MaxVelocity - MinVelocity);
+			double factorVelocity = GlControlWidth / (MaxVelocity - MinVelocity);
 			return (v - MinVelocity) * factorVelocity;
 		}
 
 		private double PitchToY(double p)
 		{
-			double factorPitch = -ImageHeight / (MaxPitch - MinPitch);
-			return ImageHeight + (p - MinPitch) * factorPitch;
+			double factorPitch = -GlControlHeight / (MaxPitch - MinPitch);
+			return GlControlHeight + (p - MinPitch) * factorPitch;
 		}
 
 		private double VolumeToY(double v)
 		{
-			double factorVolume = -ImageHeight / (MaxVolume - MinVolume);
-			return ImageHeight + (v - MinVolume) * factorVolume;
+			double factorVolume = -GlControlHeight / (MaxVolume - MinVolume);
+			return GlControlHeight + (v - MinVolume) * factorVolume;
 		}
 
 		internal void ZoomIn()
@@ -184,7 +184,7 @@ namespace TrainEditor2.Models.Trains
 			SelectedTrack = (Track)prev.Track.Clone();
 			PrevTrackStates.Remove(prev);
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void Redo()
@@ -194,7 +194,7 @@ namespace TrainEditor2.Models.Trains
 			SelectedTrack = (Track)next.Track.Clone();
 			NextTrackStates.Remove(next);
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void TearingOff()
@@ -204,7 +204,7 @@ namespace TrainEditor2.Models.Trains
 			Copy();
 			SelectedTrack = new Track();
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void Copy()
@@ -218,7 +218,7 @@ namespace TrainEditor2.Models.Trains
 			NextTrackStates.RemoveAll(x => x.Info == SelectedTrackInfo);
 			SelectedTrack = (Track)CopyTrack.Clone();
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void Cleanup()
@@ -256,7 +256,7 @@ namespace TrainEditor2.Models.Trains
 				Tracks[(int)SelectedTrackInfo].VolumeVertices.Remove(targetID);
 			}
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		private void DeleteDotLine(VertexLibrary vertices, ObservableCollection<Line> lines)
@@ -298,7 +298,7 @@ namespace TrainEditor2.Models.Trains
 					break;
 			}
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void DirectDot(double x, double y)
@@ -433,9 +433,9 @@ namespace TrainEditor2.Models.Trains
 					double deltaX = e.X - lastMousePosX;
 					double deltaY = e.Y - lastMousePosY;
 
-					double factorVelocity = ImageWidth / (maxVelocity - minVelocity);
-					double factorPitch = -ImageHeight / (maxPitch - minPitch);
-					double factorVolume = -ImageHeight / (maxVolume - minVolume);
+					double factorVelocity = GlControlWidth / (maxVelocity - minVelocity);
+					double factorPitch = -GlControlHeight / (maxPitch - minPitch);
+					double factorVolume = -GlControlHeight / (maxVolume - minVolume);
 
 					double deltaVelocity = 0.2 * Math.Round(5.0 * deltaX / factorVelocity);
 					double deltaPitch = 0.01 * Math.Round(100.0 * deltaY / factorPitch);
@@ -467,7 +467,7 @@ namespace TrainEditor2.Models.Trains
 						lastMousePosY = e.Y;
 					}
 
-					DrawImage();
+					IsRefreshGlControl = true;
 				}
 			}
 		}
@@ -518,7 +518,7 @@ namespace TrainEditor2.Models.Trains
 				}
 				else
 				{
-					toolTipVertex.IsOpen=false;
+					toolTipVertex.IsOpen = false;
 				}
 
 				hoveredVertex = newHoveredVertex;
@@ -675,7 +675,7 @@ namespace TrainEditor2.Models.Trains
 				}
 			}
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		internal void DirectMove(double x, double y)
@@ -814,7 +814,7 @@ namespace TrainEditor2.Models.Trains
 				}
 			}
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		private void MoveDot(VertexLibrary vertices, double deltaX, double deltaY)
@@ -875,7 +875,7 @@ namespace TrainEditor2.Models.Trains
 					vertex.Y += deltaY;
 				}
 
-				DrawImage();
+				IsRefreshGlControl = true;
 			}
 		}
 
@@ -902,7 +902,7 @@ namespace TrainEditor2.Models.Trains
 			NextTrackStates.RemoveAll(s => s.Info == SelectedTrackInfo);
 			vertices.Add(new Vertex(x, y));
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		private bool IsDrawLine(VertexLibrary vertices, ObservableCollection<Line> lines, double x, double y)
@@ -992,63 +992,165 @@ namespace TrainEditor2.Models.Trains
 					selectVertex.Value.IsOrigin = true;
 				}
 
-				DrawImage();
+				IsRefreshGlControl = true;
 			}
 		}
 
-		internal void DrawImage()
+		private void DrawPolyLine(Matrix4d proj, Matrix4d look, Vector2d p1, Vector2d p2, double lineWidth, Color color)
 		{
-			Bitmap newImage = new Bitmap(ImageWidth, ImageHeight);
+			Matrix4d inv = Matrix4d.Invert(look) * Matrix4d.Invert(proj);
+			Vector2d line = new Vector2d((inv.M11 + inv.M12) * lineWidth / 2.0, (inv.M21 + inv.M22) * lineWidth / 2.0) / 100.0;
 
-			Graphics g = Graphics.FromImage(newImage);
+			double rad = Math.Atan2(p2.Y - p1.Y, p2.X - p1.X);
 
+			double p1x1 = p1.X + Math.Cos(rad + Math.PI / 2.0) * line.X;
+			double p1y1 = p1.Y + Math.Sin(rad + Math.PI / 2.0) * line.Y;
+
+			double p1x2 = p1.X + Math.Cos(rad - Math.PI / 2.0) * line.X;
+			double p1y2 = p1.Y + Math.Sin(rad - Math.PI / 2.0) * line.Y;
+
+			double p2x1 = p2.X + Math.Cos(rad + Math.PI / 2.0) * line.X;
+			double p2y1 = p2.Y + Math.Sin(rad + Math.PI / 2.0) * line.Y;
+
+			double p2x2 = p2.X + Math.Cos(rad - Math.PI / 2.0) * line.X;
+			double p2y2 = p2.Y + Math.Sin(rad - Math.PI / 2.0) * line.Y;
+
+			GL.Begin(PrimitiveType.TriangleStrip);
+			GL.Color4(color);
+			GL.Vertex2(p1x1, p1y1);
+			GL.Vertex2(p1x2, p1y2);
+			GL.Vertex2(p2x1, p2y1);
+			GL.Vertex2(p2x2, p2y2);
+			GL.End();
+		}
+
+		private void DrawPolyDashLine(Matrix4d proj, Matrix4d look, Box2d box, double lineWidth, double dashLength, Color color)
+		{
+			Matrix4d inv = Matrix4d.Invert(look) * Matrix4d.Invert(proj);
+			Vector2d dash = new Vector2d((inv.M11 + inv.M12) * dashLength, (inv.M21 + inv.M22) * dashLength) / 100.0;
+
+			for (double i = box.Left; i + dash.X < box.Right; i += dash.X * 2)
+			{
+				DrawPolyLine(proj, look, new Vector2d(i, box.Bottom), new Vector2d(i + dash.X, box.Bottom), lineWidth, color);
+			}
+
+			for (double i = box.Bottom; i + dash.Y < box.Top; i += dash.Y * 2)
+			{
+				DrawPolyLine(proj, look, new Vector2d(box.Right, i), new Vector2d(box.Right, i + dash.Y), lineWidth, color);
+			}
+
+			for (double i = box.Left; i + dash.X < box.Right; i += dash.X * 2)
+			{
+				DrawPolyLine(proj, look, new Vector2d(i, box.Top), new Vector2d(i + dash.X, box.Top), lineWidth, color);
+			}
+
+			for (double i = box.Bottom; i + dash.Y < box.Top; i += dash.Y * 2)
+			{
+				DrawPolyLine(proj, look, new Vector2d(box.Left, i), new Vector2d(box.Left, i + dash.Y), lineWidth, color);
+			}
+		}
+
+		internal void DrawGlControl()
+		{
 			// prepare
-			g.CompositingQuality = CompositingQuality.HighQuality;
-			g.InterpolationMode = InterpolationMode.High;
-			g.SmoothingMode = SmoothingMode.AntiAlias;
-			g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
-			g.Clear(Color.Black);
+			GL.Enable(EnableCap.PointSmooth);
+			GL.Enable(EnableCap.PolygonSmooth);
+			GL.Hint(HintTarget.PointSmoothHint, HintMode.Nicest);
+			GL.Hint(HintTarget.PolygonSmoothHint, HintMode.Nicest);
+			GL.Enable(EnableCap.Blend);
+			GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
 
-			Font font = new Font("MS UI Gothic", 7.0f);
-			Pen grayPen = new Pen(Color.DimGray);
-			Brush grayBrush = Brushes.DimGray;
+			GL.Viewport(0, 0, GlControlWidth, GlControlHeight);
+			GL.ClearColor(Color.Black);
+			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+
+			Matrix4d projPitch = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxPitch - MinPitch, double.Epsilon, 1.0);
+			Matrix4d projVolume = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxVolume - MinVolume, double.Epsilon, 1.0);
+			Matrix4d lookPitch = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, double.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, 0.0), Vector3d.UnitY);
+			Matrix4d lookVolume = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, double.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, 0.0), Vector3d.UnitY);
+
+			//Font font = new Font("MS UI Gothic", 7.0f);
+			//Pen grayPen = new Pen(Color.DimGray);
+			//Brush grayBrush = Brushes.DimGray;
 
 			// vertical grid
-			for (double v = 0.0; v < MaxVelocity; v += 10.0)
 			{
-				float x = (float)VelocityToX(v);
-				g.DrawLine(grayPen, new PointF(x, 0.0f), new PointF(x, ImageHeight));
-				g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(x, 1.0f));
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projPitch);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookPitch);
+
+				GL.Begin(PrimitiveType.Lines);
+
+				for (double v = 0.0; v < MaxVelocity; v += 10.0)
+				{
+					GL.Color4(Color.DimGray);
+					GL.Vertex2(v, 0.0);
+					GL.Vertex2(v, float.MaxValue);
+					//g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(x, 1.0f));
+				}
+
+				GL.End();
 			}
 
 			// horizontal grid
 			switch (CurrentInputMode)
 			{
 				case InputMode.Pitch:
-					for (float p = 0.0f; p < MaxPitch; p += 100.0f)
+					GL.MatrixMode(MatrixMode.Projection);
+					GL.LoadMatrix(ref projPitch);
+
+					GL.MatrixMode(MatrixMode.Modelview);
+					GL.LoadMatrix(ref lookPitch);
+
+					GL.Begin(PrimitiveType.Lines);
+
+					for (double p = 0.0; p < MaxPitch; p += 100.0)
 					{
-						float y = (float)PitchToY(p);
-						g.DrawLine(grayPen, new PointF(0.0f, y), new PointF(ImageWidth, y));
-						g.DrawString(p.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
+						GL.Color4(Color.DimGray);
+						GL.Vertex2(MinVelocity, p);
+						GL.Vertex2(MaxVelocity, p);
+						//g.DrawString(p.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
 					}
+
+					GL.End();
 					break;
 				case InputMode.Volume:
-					for (float v = 0.0f; v < MaxVolume; v += 128.0f)
+					GL.MatrixMode(MatrixMode.Projection);
+					GL.LoadMatrix(ref projVolume);
+
+					GL.MatrixMode(MatrixMode.Modelview);
+					GL.LoadMatrix(ref lookVolume);
+
+					GL.Begin(PrimitiveType.Lines);
+
+					for (double v = 0.0; v < MaxVolume; v += 128.0)
 					{
-						float y = (float)VolumeToY(v);
-						g.DrawLine(grayPen, new PointF(0.0f, y), new PointF(ImageWidth, y));
-						g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
+						GL.Color4(Color.DimGray);
+						GL.Vertex2(MinVelocity, v);
+						GL.Vertex2(MaxVelocity, v);
+						//g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
 					}
+
+					GL.End();
 					break;
 			}
 
 			// dot
-			if (CurrentInputMode == InputMode.Pitch || CurrentInputMode == InputMode.SoundIndex)
+			if (CurrentInputMode != InputMode.Volume)
 			{
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projPitch);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookPitch);
+
+				GL.PointSize(11.0f);
+				GL.Begin(PrimitiveType.Points);
+
 				foreach (Vertex vertex in SelectedTrack.PitchVertices.Values)
 				{
-					float x = (float)VelocityToX(vertex.X);
-					float y = (float)PitchToY(vertex.Y);
 					Area area = SelectedTrack.SoundIndices.FirstOrDefault(a => a.LeftX <= vertex.X && vertex.X <= a.RightX);
 					Color c;
 
@@ -1070,16 +1172,26 @@ namespace TrainEditor2.Models.Trains
 						}
 					}
 
-					g.DrawRectangle(new Pen(c, 3.0f), x - 3.0f, y - 3.0f, 7.0f, 7.0f);
+					GL.Color4(c);
+					GL.Vertex2(vertex.X, vertex.Y);
 				}
+
+				GL.End();
 			}
 
-			if (CurrentInputMode == InputMode.Volume || CurrentInputMode == InputMode.SoundIndex)
+			if (CurrentInputMode != InputMode.Pitch)
 			{
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projVolume);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookVolume);
+
+				GL.PointSize(9.0f);
+				GL.Begin(PrimitiveType.Points);
+
 				foreach (Vertex vertex in SelectedTrack.VolumeVertices.Values)
 				{
-					float x = (float)VelocityToX(vertex.X);
-					float y = (float)VolumeToY(vertex.Y);
 					Area area = SelectedTrack.SoundIndices.FirstOrDefault(a => a.LeftX <= vertex.X && vertex.X <= a.RightX);
 					Color c;
 
@@ -1101,13 +1213,22 @@ namespace TrainEditor2.Models.Trains
 						}
 					}
 
-					g.DrawRectangle(new Pen(c, 2.0f), x - 2.0f, y - 2.0f, 5.0f, 5.0f);
+					GL.Color4(c);
+					GL.Vertex2(vertex.X, vertex.Y);
 				}
+
+				GL.End();
 			}
 
 			// line
-			if (CurrentInputMode == InputMode.Pitch || CurrentInputMode == InputMode.SoundIndex)
+			if (CurrentInputMode != InputMode.Volume)
 			{
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projPitch);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookPitch);
+
 				foreach (Line line in SelectedTrack.PitchLines)
 				{
 					Vertex left = SelectedTrack.PitchVertices[line.LeftID];
@@ -1116,12 +1237,6 @@ namespace TrainEditor2.Models.Trains
 					Func<double, double> f = x => left.Y + (right.Y - left.Y) / (right.X - left.X) * (x - left.X);
 
 					{
-						float leftX = (float)VelocityToX(left.X);
-						float leftY = (float)PitchToY(left.Y);
-
-						float rightX = (float)VelocityToX(right.X);
-						float rightY = (float)PitchToY(right.Y);
-
 						Color c;
 
 						if (line.Selected)
@@ -1133,7 +1248,7 @@ namespace TrainEditor2.Models.Trains
 							c = Color.FromArgb((int)Math.Round(Color.Silver.R * 0.6), (int)Math.Round(Color.Silver.G * 0.6), (int)Math.Round(Color.Silver.B * 0.6));
 						}
 
-						g.DrawLine(new Pen(c, 3.0f), leftX, leftY, rightX, rightY);
+						DrawPolyLine(projPitch, lookPitch, new Vector2d(left.X, left.Y), new Vector2d(right.X, right.Y), 1.5, c);
 					}
 
 					foreach (Area area in SelectedTrack.SoundIndices)
@@ -1143,33 +1258,25 @@ namespace TrainEditor2.Models.Trains
 							continue;
 						}
 
-						float leftX = (float)VelocityToX(left.X);
-						float leftY = (float)PitchToY(left.Y);
-
-						float rightX = (float)VelocityToX(right.X);
-						float rightY = (float)PitchToY(right.Y);
-
-						if (left.X < area.LeftX)
-						{
-							leftX = (float)VelocityToX(area.LeftX);
-							leftY = (float)PitchToY(f(area.LeftX));
-						}
-
-						if (right.X > area.RightX)
-						{
-							rightX = (float)VelocityToX(area.RightX);
-							rightY = (float)PitchToY(f(area.RightX));
-						}
-
 						double hue = Utilities.HueFactor * area.Index;
 						hue -= Math.Floor(hue);
-						g.DrawLine(new Pen(Utilities.GetColor(hue, line.Selected), 3.0f), leftX, leftY, rightX, rightY);
+
+						Vector2d p1 = new Vector2d(left.X < area.LeftX ? area.LeftX : left.X, left.X < area.LeftX ? f(area.LeftX) : left.Y);
+						Vector2d p2 = new Vector2d(right.X > area.RightX ? area.RightX : right.X, right.X > area.RightX ? f(area.RightX) : right.Y);
+
+						DrawPolyLine(projPitch, lookPitch, p1, p2, 1.5, Utilities.GetColor(hue, line.Selected));
 					}
 				}
 			}
 
-			if (CurrentInputMode == InputMode.Volume || CurrentInputMode == InputMode.SoundIndex)
+			if (CurrentInputMode != InputMode.Pitch)
 			{
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projVolume);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookVolume);
+
 				foreach (Line line in SelectedTrack.VolumeLines)
 				{
 					Vertex left = SelectedTrack.VolumeVertices[line.LeftID];
@@ -1178,12 +1285,6 @@ namespace TrainEditor2.Models.Trains
 					Func<double, double> f = x => left.Y + (right.Y - left.Y) / (right.X - left.X) * (x - left.X);
 
 					{
-						float leftX = (float)VelocityToX(left.X);
-						float leftY = (float)VolumeToY(left.Y);
-
-						float rightX = (float)VelocityToX(right.X);
-						float rightY = (float)VolumeToY(right.Y);
-
 						Color c;
 
 						if (line.Selected)
@@ -1195,7 +1296,7 @@ namespace TrainEditor2.Models.Trains
 							c = Color.FromArgb((int)Math.Round(Color.Silver.R * 0.6), (int)Math.Round(Color.Silver.G * 0.6), (int)Math.Round(Color.Silver.B * 0.6));
 						}
 
-						g.DrawLine(new Pen(c, 2.0f), leftX, leftY, rightX, rightY);
+						DrawPolyLine(projVolume, lookVolume, new Vector2d(left.X, left.Y), new Vector2d(right.X, right.Y), 1.0, c);
 					}
 
 					foreach (Area area in SelectedTrack.SoundIndices)
@@ -1205,27 +1306,13 @@ namespace TrainEditor2.Models.Trains
 							continue;
 						}
 
-						float leftX = (float)VelocityToX(left.X);
-						float leftY = (float)VolumeToY(left.Y);
-
-						float rightX = (float)VelocityToX(right.X);
-						float rightY = (float)VolumeToY(right.Y);
-
-						if (left.X < area.LeftX)
-						{
-							leftX = (float)VelocityToX(area.LeftX);
-							leftY = (float)VolumeToY(f(area.LeftX));
-						}
-
-						if (right.X > area.RightX)
-						{
-							rightX = (float)VelocityToX(area.RightX);
-							rightY = (float)VolumeToY(f(area.RightX));
-						}
-
 						double hue = Utilities.HueFactor * area.Index;
 						hue -= Math.Floor(hue);
-						g.DrawLine(new Pen(Utilities.GetColor(hue, line.Selected), 2.0f), leftX, leftY, rightX, rightY);
+
+						Vector2d p1 = new Vector2d(left.X < area.LeftX ? area.LeftX : left.X, left.X < area.LeftX ? f(area.LeftX) : left.Y);
+						Vector2d p2 = new Vector2d(right.X > area.RightX ? area.RightX : right.X, right.X > area.RightX ? f(area.RightX) : right.Y);
+
+						DrawPolyLine(projVolume, lookVolume, p1, p2, 1.0, Utilities.GetColor(hue, line.Selected));
 					}
 				}
 			}
@@ -1244,11 +1331,14 @@ namespace TrainEditor2.Models.Trains
 					areas = SelectedTrack.SoundIndices;
 				}
 
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projPitch);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookPitch);
+
 				foreach (Area area in areas)
 				{
-					float leftX = (float)VelocityToX(area.LeftX);
-					float rightX = (float)VelocityToX(area.RightX);
-
 					Color c;
 
 					if (area.Index >= 0)
@@ -1262,25 +1352,28 @@ namespace TrainEditor2.Models.Trains
 						c = Color.Silver;
 					}
 
-					g.FillRectangle(new SolidBrush(Color.FromArgb(32, c)), leftX, 0.0f, rightX - leftX, ImageHeight);
+					GL.Begin(PrimitiveType.TriangleStrip);
+
+					GL.Color4(Color.FromArgb(64, c));
+					GL.Vertex2(area.LeftX, 0.0);
+					GL.Vertex2(area.RightX, 0.0);
+					GL.Vertex2(area.LeftX, float.MaxValue);
+					GL.Vertex2(area.RightX, float.MaxValue);
+
+					GL.End();
 				}
 			}
 
 			// selected range
 			if (selectedRange != null)
 			{
-				Pen pen = new Pen(Color.DimGray, 3.0f)
-				{
-					DashStyle = DashStyle.Dash
-				};
-
 				switch (CurrentInputMode)
 				{
 					case InputMode.Pitch:
-						g.DrawRectangle(pen, (float)VelocityToX(selectedRange.Range.X), (float)PitchToY(selectedRange.Range.Y), (float)(VelocityToX(selectedRange.Range.Right) - VelocityToX(selectedRange.Range.Left)), (float)(PitchToY(selectedRange.Range.Top) - PitchToY(selectedRange.Range.Bottom)));
+						DrawPolyDashLine(projPitch, lookPitch, selectedRange.Range, 2.0, 4.0, Color.DimGray);
 						break;
 					case InputMode.Volume:
-						g.DrawRectangle(pen, (float)VelocityToX(selectedRange.Range.X), (float)VolumeToY(selectedRange.Range.Y), (float)(VelocityToX(selectedRange.Range.Right) - VelocityToX(selectedRange.Range.Left)), (float)(VolumeToY(selectedRange.Range.Top) - VolumeToY(selectedRange.Range.Bottom)));
+						DrawPolyDashLine(projVolume, lookVolume, selectedRange.Range, 2.0, 4.0, Color.DimGray);
 						break;
 				}
 			}
@@ -1288,11 +1381,23 @@ namespace TrainEditor2.Models.Trains
 			// simulation speed
 			if (CurrentSimState == SimulationState.Started || CurrentSimState == SimulationState.Paused)
 			{
-				float x = (float)VelocityToX(nowSpeed);
-				g.DrawLine(new Pen(Color.White, 3.0f), new PointF(x, 0.0f), new PointF(x, ImageHeight));
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projPitch);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadMatrix(ref lookPitch);
+
+				GL.LineWidth(3.0f);
+				GL.Begin(PrimitiveType.Lines);
+
+				GL.Color4(Color.White);
+				GL.Vertex2(new Vector2((float)nowSpeed, 0.0f));
+				GL.Vertex2(new Vector2((float)nowSpeed, float.MaxValue));
+
+				GL.End();
 			}
 
-			Image = newImage;
+			IsRefreshGlControl = false;
 		}
 	}
 }

--- a/source/TrainEditor2/Models/Trains/Motor.Functions.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.Functions.cs
@@ -5,11 +5,15 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using LibRender;
+using OpenBveApi.Colors;
+using OpenBveApi.Graphics;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using TrainEditor2.Extensions;
 using TrainEditor2.Models.Dialogs;
 using TrainEditor2.Models.Others;
+using TrainEditor2.Systems;
 
 namespace TrainEditor2.Models.Trains
 {
@@ -1066,12 +1070,9 @@ namespace TrainEditor2.Models.Trains
 
 			Matrix4d projPitch = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxPitch - MinPitch, float.Epsilon, 1.0);
 			Matrix4d projVolume = Matrix4d.CreateOrthographic(MaxVelocity - MinVelocity, MaxVolume - MinVolume, float.Epsilon, 1.0);
+			Matrix4d projString = Matrix4d.CreateOrthographicOffCenter(0.0, GlControlWidth, GlControlHeight, 0.0, -1.0, 1.0);
 			Matrix4d lookPitch = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, float.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, 0.0), Vector3d.UnitY);
 			Matrix4d lookVolume = Matrix4d.LookAt(new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, float.Epsilon), new Vector3d((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, 0.0), Vector3d.UnitY);
-
-			//Font font = new Font("MS UI Gothic", 7.0f);
-			//Pen grayPen = new Pen(Color.DimGray);
-			//Brush grayBrush = Brushes.DimGray;
 
 			// vertical grid
 			{
@@ -1088,10 +1089,22 @@ namespace TrainEditor2.Models.Trains
 					GL.Color4(Color.DimGray);
 					GL.Vertex2(v, 0.0);
 					GL.Vertex2(v, float.MaxValue);
-					//g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(x, 1.0f));
 				}
 
 				GL.End();
+
+				GL.MatrixMode(MatrixMode.Projection);
+				GL.LoadMatrix(ref projString);
+
+				GL.MatrixMode(MatrixMode.Modelview);
+				GL.LoadIdentity();
+
+				for (double v = 0.0; v < MaxVelocity; v += 10.0)
+				{
+					Renderer.DrawString(Fonts.VerySmallFont, v.ToString("0", culture), new Point((int)VelocityToX(v) + 1, 1), TextAlignment.TopLeft, new Color128(Color24.Grey));
+				}
+
+				GL.Disable(EnableCap.Texture2D);
 			}
 
 			// horizontal grid
@@ -1111,10 +1124,22 @@ namespace TrainEditor2.Models.Trains
 						GL.Color4(Color.DimGray);
 						GL.Vertex2(MinVelocity, p);
 						GL.Vertex2(MaxVelocity, p);
-						//g.DrawString(p.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
 					}
 
 					GL.End();
+
+					GL.MatrixMode(MatrixMode.Projection);
+					GL.LoadMatrix(ref projString);
+
+					GL.MatrixMode(MatrixMode.Modelview);
+					GL.LoadIdentity();
+
+					for (double p = 0.0; p < MaxPitch; p += 100.0)
+					{
+						Renderer.DrawString(Fonts.VerySmallFont, p.ToString("0", culture), new Point(1, (int)PitchToY(p) + 1), TextAlignment.TopLeft, new Color128(Color24.Grey));
+					}
+
+					GL.Disable(EnableCap.Texture2D);
 					break;
 				case InputMode.Volume:
 					GL.MatrixMode(MatrixMode.Projection);
@@ -1130,10 +1155,22 @@ namespace TrainEditor2.Models.Trains
 						GL.Color4(Color.DimGray);
 						GL.Vertex2(MinVelocity, v);
 						GL.Vertex2(MaxVelocity, v);
-						//g.DrawString(v.ToString("0", culture), font, grayBrush, new PointF(1.0f, y));
 					}
 
 					GL.End();
+
+					GL.MatrixMode(MatrixMode.Projection);
+					GL.LoadMatrix(ref projString);
+
+					GL.MatrixMode(MatrixMode.Modelview);
+					GL.LoadIdentity();
+
+					for (double v = 0.0; v < MaxVolume; v += 128.0)
+					{
+						Renderer.DrawString(Fonts.VerySmallFont, v.ToString("0", culture), new Point(1, (int)VolumeToY(v) + 1), TextAlignment.TopLeft, new Color128(Color24.Grey));
+					}
+
+					GL.Disable(EnableCap.Texture2D);
 					break;
 			}
 

--- a/source/TrainEditor2/Models/Trains/Motor.Simulation.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.Simulation.cs
@@ -52,7 +52,7 @@ namespace TrainEditor2.Models.Trains
 			DisposeCar();
 			CurrentSimState = SimulationState.Stopped;
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		private void CreateCar()
@@ -126,6 +126,8 @@ namespace TrainEditor2.Models.Trains
 			Program.SoundApi.Update(deltaTime, SoundModels.Inverse);
 
 			oldElapsedTime = nowElapsedTime;
+
+			DrawSimulation();
 		}
 
 		internal void DrawSimulation()
@@ -147,6 +149,8 @@ namespace TrainEditor2.Models.Trains
 
 					OnPropertyChanged(new PropertyChangedEventArgs(nameof(MinVelocity)));
 					OnPropertyChanged(new PropertyChangedEventArgs(nameof(MaxVelocity)));
+
+					return;
 				}
 			}
 			else
@@ -164,10 +168,12 @@ namespace TrainEditor2.Models.Trains
 
 					OnPropertyChanged(new PropertyChangedEventArgs(nameof(MinVelocity)));
 					OnPropertyChanged(new PropertyChangedEventArgs(nameof(MaxVelocity)));
+
+					return;
 				}
 			}
 
-			DrawImage();
+			IsRefreshGlControl = true;
 		}
 
 		private void DisposeCar()

--- a/source/TrainEditor2/Models/Trains/Motor.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
+using OpenTK;
 using Prism.Mvvm;
 using TrainEditor2.Extensions;
 using TrainEditor2.Models.Dialogs;
@@ -501,7 +501,7 @@ namespace TrainEditor2.Models.Trains
 
 		internal class SelectedRange
 		{
-			internal RectangleF Range
+			internal Box2d Range
 			{
 				get;
 				private set;
@@ -519,7 +519,7 @@ namespace TrainEditor2.Models.Trains
 				private set;
 			}
 
-			private SelectedRange(RectangleF range, Vertex[] selectedVertices, Line[] selectedLines)
+			private SelectedRange(Box2d range, Vertex[] selectedVertices, Line[] selectedLines)
 			{
 				Range = range;
 				SelectedVertices = selectedVertices;
@@ -533,7 +533,7 @@ namespace TrainEditor2.Models.Trains
 				Vertex[] selectedVertices = vertices.Values.Where(v => conditionVertex(v)).ToArray();
 				Line[] selectedLines = lines.Where(l => selectedVertices.Any(v => v.X == vertices[l.LeftID].X) && selectedVertices.Any(v => v.X == vertices[l.RightID].X)).ToArray();
 
-				return new SelectedRange(new RectangleF((float)leftX, (float)topY, (float)(rightX - leftX), (float)(topY - bottomY)), selectedVertices, selectedLines);
+				return new SelectedRange(new Box2d(leftX, topY, rightX, bottomY), selectedVertices, selectedLines);
 			}
 		}
 
@@ -584,9 +584,9 @@ namespace TrainEditor2.Models.Trains
 		private double oldElapsedTime;
 		private double nowSpeed;
 
-		private int imageWidth;
-		private int imageHeight;
-		private Bitmap image;
+		private int glControlWidth;
+		private int glControlHeight;
+		private bool isRefreshGlControl;
 
 		internal ObservableCollection<Track> Tracks;
 		internal ObservableCollection<TrackState> PrevTrackStates;
@@ -940,39 +940,39 @@ namespace TrainEditor2.Models.Trains
 			}
 		}
 
-		internal int ImageWidth
+		internal int GlControlWidth
 		{
 			get
 			{
-				return imageWidth;
+				return glControlWidth;
 			}
 			set
 			{
-				SetProperty(ref imageWidth, value);
+				SetProperty(ref glControlWidth, value);
 			}
 		}
 
-		internal int ImageHeight
+		internal int GlControlHeight
 		{
 			get
 			{
-				return imageHeight;
+				return glControlHeight;
 			}
 			set
 			{
-				SetProperty(ref imageHeight, value);
+				SetProperty(ref glControlHeight, value);
 			}
 		}
 
-		internal Bitmap Image
+		internal bool IsRefreshGlControl
 		{
 			get
 			{
-				return image;
+				return isRefreshGlControl;
 			}
 			set
 			{
-				SetProperty(ref image, value);
+				SetProperty(ref isRefreshGlControl, value);
 			}
 		}
 
@@ -1014,9 +1014,8 @@ namespace TrainEditor2.Models.Trains
 			StartSpeed = 0.0;
 			EndSpeed = 160.0;
 
-			ImageWidth = 568;
-			ImageHeight = 593;
-			Image = new Bitmap(ImageWidth, ImageHeight);
+			GlControlWidth = 568;
+			GlControlHeight = 593;
 		}
 
 		public object Clone()
@@ -1030,7 +1029,6 @@ namespace TrainEditor2.Models.Trains
 			motor.Tracks = new ObservableCollection<Track>(Tracks.Select(x => (Track)x.Clone()));
 			motor.PrevTrackStates = new ObservableCollection<TrackState>(PrevTrackStates.Select(x => (TrackState)x.Clone()));
 			motor.NextTrackStates = new ObservableCollection<TrackState>(NextTrackStates.Select(x => (TrackState)x.Clone()));
-			motor.Image = (Bitmap)Image.Clone();
 			return motor;
 		}
 	}

--- a/source/TrainEditor2/Program.cs
+++ b/source/TrainEditor2/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive.Concurrency;
 using System.Windows.Forms;
+using LibRender;
 using OpenBveApi.FileSystem;
 using OpenBveApi.Interface;
 using Reactive.Bindings;
@@ -44,6 +45,8 @@ namespace TrainEditor2
 			}
 
 			Interface.LoadOptions();
+
+			Renderer.currentHost = CurrentHost;
 
 			SoundApi = new SoundApi();
 			SoundApi.Initialize(CurrentHost, SoundRange.Medium);

--- a/source/TrainEditor2/Systems/Fonts.cs
+++ b/source/TrainEditor2/Systems/Fonts.cs
@@ -1,0 +1,14 @@
+﻿using System.Drawing;
+using LibRender;
+
+namespace TrainEditor2.Systems
+{
+	/// <summary>Provides font support.</summary>
+	internal static class Fonts
+	{
+		// --- read-only fields ---
+
+		/// <summary>Represents a very small sans serif font.</summary>
+		internal static readonly OpenGlFont VerySmallFont = new OpenGlFont(FontFamily.GenericSansSerif, 9.0f);
+	}
+}

--- a/source/TrainEditor2/Systems/Host.cs
+++ b/source/TrainEditor2/Systems/Host.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO;
+using LibRender;
+using OpenBveApi.Graphics;
 using OpenBveApi.Hosts;
 using OpenBveApi.Sounds;
+using OpenBveApi.Textures;
 using TrainEditor2.Systems.Functions;
 
 namespace TrainEditor2.Systems
@@ -10,6 +13,13 @@ namespace TrainEditor2.Systems
 	internal class Host : HostInterface
 	{
 		public Host() : base(HostApplication.TrainEditor) { }
+
+		// --- texture ---
+
+		public override bool LoadTexture(Texture Texture, OpenGlTextureWrapMode wrapMode)
+		{
+			return TextureManager.LoadTexture(Texture, wrapMode, Environment.TickCount, InterpolationMode.BilinearMipmapped, 16);
+		}
 
 		// --- sound ---
 

--- a/source/TrainEditor2/TrainEditor2.csproj
+++ b/source/TrainEditor2/TrainEditor2.csproj
@@ -45,6 +45,9 @@
     <Reference Include="OpenTK, Version=3.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\..\packages\OpenTK.3.1.0\lib\net20\OpenTK.dll</HintPath>
     </Reference>
+    <Reference Include="OpenTK.GLControl, Version=3.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Prism, Version=7.2.0.1367, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">

--- a/source/TrainEditor2/TrainEditor2.csproj
+++ b/source/TrainEditor2/TrainEditor2.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Simulation\TrainManager\Motor\MotorSounds.cs" />
     <Compile Include="Simulation\TrainManager\TrainManager.cs" />
     <Compile Include="Simulation\TrainManager\Train\Train.cs" />
+    <Compile Include="Systems\Fonts.cs" />
     <Compile Include="Systems\Functions\Plugins.cs" />
     <Compile Include="Systems\Host.cs" />
     <Compile Include="Systems\Interface.cs" />
@@ -364,6 +365,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\LibRender\LibRender.csproj">
+      <Project>{2072ecd1-c7ff-427c-84dc-063f7c19792e}</Project>
+      <Name>LibRender</Name>
+    </ProjectReference>
     <ProjectReference Include="..\OpenBveApi\OpenBveApi.csproj">
       <Project>{27134980-4415-4375-a564-40a9014dfa5f}</Project>
       <Name>OpenBveApi</Name>

--- a/source/TrainEditor2/Views/FormDelay.cs
+++ b/source/TrainEditor2/Views/FormDelay.cs
@@ -47,14 +47,14 @@ namespace TrainEditor2.Views
 				)
 				.AddTo(disposable);
 
-			CompositeDisposable entryDisposable = null;
+			CompositeDisposable entryDisposable = new CompositeDisposable().AddTo(disposable);
 
 			SelectedEntry
 				.Where(x => x != null)
 				.Subscribe(x =>
 				{
-					entryDisposable?.Dispose();
-					entryDisposable = new CompositeDisposable();
+					entryDisposable.Dispose();
+					entryDisposable = new CompositeDisposable().AddTo(disposable);
 
 					x.Up.BindTo(
 							textBoxUp,

--- a/source/TrainEditor2/Views/FormEditor.Acceleration.cs
+++ b/source/TrainEditor2/Views/FormEditor.Acceleration.cs
@@ -13,7 +13,7 @@ namespace TrainEditor2.Views
 		private IDisposable BindToAcceleration(AccelerationViewModel z)
 		{
 			CompositeDisposable accelerationDisposable = new CompositeDisposable();
-			CompositeDisposable entryDisposable = new CompositeDisposable();
+			CompositeDisposable entryDisposable = new CompositeDisposable().AddTo(accelerationDisposable);
 
 			z.SelectedEntryIndex
 				.BindTo(
@@ -39,7 +39,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					entryDisposable.Dispose();
-					entryDisposable = new CompositeDisposable();
+					entryDisposable = new CompositeDisposable().AddTo(accelerationDisposable);
 
 					x.A0.BindTo(
 							textBoxAccelA0,
@@ -290,8 +290,6 @@ namespace TrainEditor2.Views
 			z.ZoomIn.BindToButton(buttonAccelZoomIn).AddTo(accelerationDisposable);
 			z.ZoomOut.BindToButton(buttonAccelZoomOut).AddTo(accelerationDisposable);
 			z.Reset.BindToButton(buttonAccelReset).AddTo(accelerationDisposable);
-
-			entryDisposable.AddTo(accelerationDisposable);
 
 			return accelerationDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.Car.cs
+++ b/source/TrainEditor2/Views/FormEditor.Car.cs
@@ -14,12 +14,12 @@ namespace TrainEditor2.Views
 		{
 			CompositeDisposable carDisposable = new CompositeDisposable();
 
-			CompositeDisposable performanceDisposable = new CompositeDisposable();
-			CompositeDisposable moveDisposable = new CompositeDisposable();
-			CompositeDisposable brakeDisposable = new CompositeDisposable();
-			CompositeDisposable pressureDisposable = new CompositeDisposable();
-			CompositeDisposable accelerationDisposable = new CompositeDisposable();
-			CompositeDisposable motorDisposable = new CompositeDisposable();
+			CompositeDisposable performanceDisposable = new CompositeDisposable().AddTo(carDisposable);
+			CompositeDisposable moveDisposable = new CompositeDisposable().AddTo(carDisposable);
+			CompositeDisposable brakeDisposable = new CompositeDisposable().AddTo(carDisposable);
+			CompositeDisposable pressureDisposable = new CompositeDisposable().AddTo(carDisposable);
+			CompositeDisposable accelerationDisposable = new CompositeDisposable().AddTo(carDisposable);
+			CompositeDisposable motorDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 			y.Mass
 				.BindTo(
@@ -228,7 +228,7 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					performanceDisposable.Dispose();
-					performanceDisposable = new CompositeDisposable();
+					performanceDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToPerformance(z).AddTo(performanceDisposable);
 				})
@@ -238,7 +238,7 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					moveDisposable.Dispose();
-					moveDisposable = new CompositeDisposable();
+					moveDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToMove(z).AddTo(moveDisposable);
 				})
@@ -248,7 +248,7 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					brakeDisposable.Dispose();
-					brakeDisposable = new CompositeDisposable();
+					brakeDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToBrake(z).AddTo(brakeDisposable);
 				})
@@ -258,7 +258,7 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					pressureDisposable.Dispose();
-					pressureDisposable = new CompositeDisposable();
+					pressureDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToPressure(z).AddTo(pressureDisposable);
 				})
@@ -318,7 +318,7 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					accelerationDisposable.Dispose();
-					accelerationDisposable = new CompositeDisposable();
+					accelerationDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToAcceleration(z).AddTo(accelerationDisposable);
 				})
@@ -328,18 +328,11 @@ namespace TrainEditor2.Views
 				.Subscribe(z =>
 				{
 					motorDisposable.Dispose();
-					motorDisposable = new CompositeDisposable();
+					motorDisposable = new CompositeDisposable().AddTo(carDisposable);
 
 					BindToMotor(z).AddTo(motorDisposable);
 				})
 				.AddTo(carDisposable);
-
-			performanceDisposable.AddTo(carDisposable);
-			moveDisposable.AddTo(carDisposable);
-			brakeDisposable.AddTo(carDisposable);
-			pressureDisposable.AddTo(carDisposable);
-			accelerationDisposable.AddTo(carDisposable);
-			motorDisposable.AddTo(carDisposable);
 
 			return carDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.Designer.cs
+++ b/source/TrainEditor2/Views/FormEditor.Designer.cs
@@ -242,7 +242,6 @@ namespace TrainEditor2.Views
 			this.tabPageMotor = new System.Windows.Forms.TabPage();
 			this.panelMotorSound = new System.Windows.Forms.Panel();
 			this.toolStripContainerDrawArea = new System.Windows.Forms.ToolStripContainer();
-			this.pictureBoxDrawArea = new System.Windows.Forms.PictureBox();
 			this.toolStripToolBar = new System.Windows.Forms.ToolStrip();
 			this.toolStripButtonUndo = new System.Windows.Forms.ToolStripButton();
 			this.toolStripButtonRedo = new System.Windows.Forms.ToolStripButton();
@@ -633,6 +632,7 @@ namespace TrainEditor2.Views
 			this.toolStripComboBoxLanguage = new System.Windows.Forms.ToolStripComboBox();
 			this.toolStripStatusLabelLanguage = new System.Windows.Forms.ToolStripStatusLabel();
 			this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
+			this.glControlMotor = new OpenTK.GLControl();
 			this.tabControlEditor.SuspendLayout();
 			this.tabPageTrain.SuspendLayout();
 			this.groupBoxDevice.SuspendLayout();
@@ -663,7 +663,6 @@ namespace TrainEditor2.Views
 			this.toolStripContainerDrawArea.ContentPanel.SuspendLayout();
 			this.toolStripContainerDrawArea.TopToolStripPanel.SuspendLayout();
 			this.toolStripContainerDrawArea.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBoxDrawArea)).BeginInit();
 			this.toolStripToolBar.SuspendLayout();
 			this.panelMotorSetting.SuspendLayout();
 			this.groupBoxDirect.SuspendLayout();
@@ -2788,7 +2787,7 @@ namespace TrainEditor2.Views
 			// 
 			// toolStripContainerDrawArea.ContentPanel
 			// 
-			this.toolStripContainerDrawArea.ContentPanel.Controls.Add(this.pictureBoxDrawArea);
+			this.toolStripContainerDrawArea.ContentPanel.Controls.Add(this.glControlMotor);
 			this.toolStripContainerDrawArea.ContentPanel.Size = new System.Drawing.Size(568, 593);
 			this.toolStripContainerDrawArea.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.toolStripContainerDrawArea.Location = new System.Drawing.Point(0, 24);
@@ -2800,19 +2799,6 @@ namespace TrainEditor2.Views
 			// toolStripContainerDrawArea.TopToolStripPanel
 			// 
 			this.toolStripContainerDrawArea.TopToolStripPanel.Controls.Add(this.toolStripToolBar);
-			// 
-			// pictureBoxDrawArea
-			// 
-			this.pictureBoxDrawArea.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.pictureBoxDrawArea.Location = new System.Drawing.Point(0, 0);
-			this.pictureBoxDrawArea.Name = "pictureBoxDrawArea";
-			this.pictureBoxDrawArea.Size = new System.Drawing.Size(568, 593);
-			this.pictureBoxDrawArea.TabIndex = 2;
-			this.pictureBoxDrawArea.TabStop = false;
-			this.pictureBoxDrawArea.MouseDown += new System.Windows.Forms.MouseEventHandler(this.PictureBoxDrawArea_MouseDown);
-			this.pictureBoxDrawArea.MouseEnter += new System.EventHandler(this.PictureBoxDrawArea_MouseEnter);
-			this.pictureBoxDrawArea.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PictureBoxDrawArea_MouseMove);
-			this.pictureBoxDrawArea.MouseUp += new System.Windows.Forms.MouseEventHandler(this.PictureBoxDrawArea_MouseUp);
 			// 
 			// toolStripToolBar
 			// 
@@ -6481,6 +6467,23 @@ namespace TrainEditor2.Views
 			// 
 			this.errorProvider.ContainerControl = this;
 			// 
+			// glControlMotor
+			// 
+			this.glControlMotor.BackColor = System.Drawing.Color.Black;
+			this.glControlMotor.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.glControlMotor.Location = new System.Drawing.Point(0, 0);
+			this.glControlMotor.Name = "glControlMotor";
+			this.glControlMotor.Size = new System.Drawing.Size(568, 593);
+			this.glControlMotor.TabIndex = 0;
+			this.glControlMotor.VSync = false;
+			this.glControlMotor.Paint += new System.Windows.Forms.PaintEventHandler(this.GlControlMotor_Paint);
+			this.glControlMotor.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GlControlMotor_KeyDown);
+			this.glControlMotor.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseDown);
+			this.glControlMotor.MouseEnter += new System.EventHandler(this.GlControlMotor_MouseEnter);
+			this.glControlMotor.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseMove);
+			this.glControlMotor.MouseUp += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseUp);
+			this.glControlMotor.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.GlControlMotor_PreviewKeyDown);
+			// 
 			// FormEditor
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
@@ -6540,7 +6543,6 @@ namespace TrainEditor2.Views
 			this.toolStripContainerDrawArea.TopToolStripPanel.PerformLayout();
 			this.toolStripContainerDrawArea.ResumeLayout(false);
 			this.toolStripContainerDrawArea.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBoxDrawArea)).EndInit();
 			this.toolStripToolBar.ResumeLayout(false);
 			this.toolStripToolBar.PerformLayout();
 			this.panelMotorSetting.ResumeLayout(false);
@@ -6858,7 +6860,6 @@ namespace TrainEditor2.Views
 		private System.Windows.Forms.TabPage tabPageMotor;
 		private System.Windows.Forms.Panel panelMotorSound;
 		private System.Windows.Forms.ToolStripContainer toolStripContainerDrawArea;
-		private System.Windows.Forms.PictureBox pictureBoxDrawArea;
 		private System.Windows.Forms.ToolStrip toolStripToolBar;
 		private System.Windows.Forms.ToolStripButton toolStripButtonUndo;
 		private System.Windows.Forms.ToolStripButton toolStripButtonRedo;
@@ -7253,5 +7254,6 @@ namespace TrainEditor2.Views
 		private System.Windows.Forms.ErrorProvider errorProvider;
 		private SplitContainer splitContainerSound;
 		private TreeView treeViewSound;
+		private OpenTK.GLControl glControlMotor;
 	}
 }

--- a/source/TrainEditor2/Views/FormEditor.Functions.cs
+++ b/source/TrainEditor2/Views/FormEditor.Functions.cs
@@ -119,7 +119,7 @@ namespace TrainEditor2.Views
 		{
 			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
 
-			if (pictureBoxDrawArea.Focused)
+			if (glControlMotor.Focused)
 			{
 				if (car != null)
 				{

--- a/source/TrainEditor2/Views/FormEditor.Motor.cs
+++ b/source/TrainEditor2/Views/FormEditor.Motor.cs
@@ -15,9 +15,9 @@ namespace TrainEditor2.Views
 		private IDisposable BindToMotor(MotorViewModel z)
 		{
 			CompositeDisposable motorDisposable = new CompositeDisposable();
-			CompositeDisposable messageDisposable = new CompositeDisposable();
-			CompositeDisposable toolTipVertexPitchDisposable = new CompositeDisposable();
-			CompositeDisposable toolTipVertexVolumeDisposable = new CompositeDisposable();
+			CompositeDisposable messageDisposable = new CompositeDisposable().AddTo(motorDisposable);
+			CompositeDisposable toolTipVertexPitchDisposable = new CompositeDisposable().AddTo(motorDisposable);
+			CompositeDisposable toolTipVertexVolumeDisposable = new CompositeDisposable().AddTo(motorDisposable);
 
 			CultureInfo culture = CultureInfo.InvariantCulture;
 
@@ -25,7 +25,7 @@ namespace TrainEditor2.Views
 				.Subscribe(w =>
 				{
 					messageDisposable.Dispose();
-					messageDisposable = new CompositeDisposable();
+					messageDisposable = new CompositeDisposable().AddTo(motorDisposable);
 
 					BindToMessageBox(w).AddTo(messageDisposable);
 				})
@@ -35,7 +35,7 @@ namespace TrainEditor2.Views
 				.Subscribe(w =>
 				{
 					toolTipVertexPitchDisposable.Dispose();
-					toolTipVertexPitchDisposable = new CompositeDisposable();
+					toolTipVertexPitchDisposable = new CompositeDisposable().AddTo(motorDisposable);
 
 					BindToToolTip(w, glControlMotor).AddTo(toolTipVertexPitchDisposable);
 				})
@@ -45,7 +45,7 @@ namespace TrainEditor2.Views
 				.Subscribe(w =>
 				{
 					toolTipVertexVolumeDisposable.Dispose();
-					toolTipVertexVolumeDisposable = new CompositeDisposable();
+					toolTipVertexVolumeDisposable = new CompositeDisposable().AddTo(motorDisposable);
 
 					BindToToolTip(w, glControlMotor).AddTo(toolTipVertexVolumeDisposable);
 				})
@@ -820,10 +820,6 @@ namespace TrainEditor2.Views
 			z.StartSimulation.BindToButton(buttonPlay).AddTo(motorDisposable);
 			z.PauseSimulation.BindToButton(buttonPause).AddTo(motorDisposable);
 			z.StopSimulation.BindToButton(buttonStop).AddTo(motorDisposable);
-
-			messageDisposable.AddTo(motorDisposable);
-			toolTipVertexPitchDisposable.AddTo(motorDisposable);
-			toolTipVertexVolumeDisposable.AddTo(motorDisposable);
 
 			return motorDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.Motor.cs
+++ b/source/TrainEditor2/Views/FormEditor.Motor.cs
@@ -19,7 +19,7 @@ namespace TrainEditor2.Views
 			CompositeDisposable toolTipVertexPitchDisposable = new CompositeDisposable();
 			CompositeDisposable toolTipVertexVolumeDisposable = new CompositeDisposable();
 
-			var culture = CultureInfo.InvariantCulture;
+			CultureInfo culture = CultureInfo.InvariantCulture;
 
 			z.MessageBox
 				.Subscribe(w =>
@@ -37,7 +37,7 @@ namespace TrainEditor2.Views
 					toolTipVertexPitchDisposable.Dispose();
 					toolTipVertexPitchDisposable = new CompositeDisposable();
 
-					BindToToolTip(w, pictureBoxDrawArea).AddTo(toolTipVertexPitchDisposable);
+					BindToToolTip(w, glControlMotor).AddTo(toolTipVertexPitchDisposable);
 				})
 				.AddTo(motorDisposable);
 
@@ -47,13 +47,13 @@ namespace TrainEditor2.Views
 					toolTipVertexVolumeDisposable.Dispose();
 					toolTipVertexVolumeDisposable = new CompositeDisposable();
 
-					BindToToolTip(w, pictureBoxDrawArea).AddTo(toolTipVertexVolumeDisposable);
+					BindToToolTip(w, glControlMotor).AddTo(toolTipVertexVolumeDisposable);
 				})
 				.AddTo(motorDisposable);
 
 			z.CurrentCursorType
 				.BindTo(
-					pictureBoxDrawArea,
+					glControlMotor,
 					w => w.Cursor,
 					CursorTypeToCursor
 				)
@@ -362,7 +362,7 @@ namespace TrainEditor2.Views
 					w => w != Motor.InputMode.SoundIndex
 				)
 				.AddTo(motorDisposable);
-			
+
 			z.SelectedSoundIndex
 				.BindTo(
 					toolStripComboBoxIndex,
@@ -733,9 +733,9 @@ namespace TrainEditor2.Views
 				.BindToErrorProvider(errorProvider, textBoxDirectY)
 				.AddTo(motorDisposable);
 
-			z.ImageWidth
+			z.GlControlWidth
 				.BindTo(
-					pictureBoxDrawArea,
+					glControlMotor,
 					w => w.Width,
 					BindingMode.OneWayToSource,
 					null,
@@ -749,11 +749,11 @@ namespace TrainEditor2.Views
 				)
 				.AddTo(motorDisposable);
 
-			z.ImageWidth.Value = pictureBoxDrawArea.Width;
+			z.GlControlWidth.Value = glControlMotor.Width;
 
-			z.ImageHeight
+			z.GlControlHeight
 				.BindTo(
-					pictureBoxDrawArea,
+					glControlMotor,
 					w => w.Height,
 					BindingMode.OneWayToSource,
 					null,
@@ -767,22 +767,11 @@ namespace TrainEditor2.Views
 				)
 				.AddTo(motorDisposable);
 
-			z.ImageHeight.Value = pictureBoxDrawArea.Height;
+			z.GlControlHeight.Value = glControlMotor.Height;
 
-			z.Image
-				.Subscribe(x =>
-				{
-					pictureBoxDrawArea.Image = x;
-
-					if (InvokeRequired)
-					{
-						Invoke(new Action(pictureBoxDrawArea.Refresh));
-					}
-					else
-					{
-						pictureBoxDrawArea.Refresh();
-					}
-				})
+			z.IsRefreshGlControl
+				.Where(x => x)
+				.Subscribe(_ => glControlMotor.Invalidate())
 				.AddTo(motorDisposable);
 
 			z.Undo.BindToButton(toolStripMenuItemUndo).AddTo(motorDisposable);

--- a/source/TrainEditor2/Views/FormEditor.Panel.cs
+++ b/source/TrainEditor2/Views/FormEditor.Panel.cs
@@ -16,16 +16,16 @@ namespace TrainEditor2.Views
 		private IDisposable BindToPanel(PanelViewModel x)
 		{
 			CompositeDisposable panelDisposable = new CompositeDisposable();
-			CompositeDisposable listItemDisposable = new CompositeDisposable();
-			CompositeDisposable thisDisposable = new CompositeDisposable();
-			CompositeDisposable screenDisposable = new CompositeDisposable();
-			CompositeDisposable pilotLampDisposable = new CompositeDisposable();
-			CompositeDisposable needleDisposable = new CompositeDisposable();
-			CompositeDisposable digitalNumberDisposable = new CompositeDisposable();
-			CompositeDisposable digitalGaugeDisposable = new CompositeDisposable();
-			CompositeDisposable linearGaugeDisposable = new CompositeDisposable();
-			CompositeDisposable timetableDisposable = new CompositeDisposable();
-			CompositeDisposable touchDisposable = new CompositeDisposable();
+			CompositeDisposable listItemDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable thisDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable screenDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable pilotLampDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable needleDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable digitalNumberDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable digitalGaugeDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable linearGaugeDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable timetableDisposable = new CompositeDisposable().AddTo(panelDisposable);
+			CompositeDisposable touchDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 			listViewPanel.Items.Clear();
 
@@ -148,7 +148,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					listItemDisposable.Dispose();
-					listItemDisposable = new CompositeDisposable();
+					listItemDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					y.Texts
 						.ObserveReplaceChanged()
@@ -165,7 +165,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					thisDisposable.Dispose();
-					thisDisposable = new CompositeDisposable();
+					thisDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToThis(y).AddTo(thisDisposable);
 				})
@@ -192,7 +192,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					screenDisposable.Dispose();
-					screenDisposable = new CompositeDisposable();
+					screenDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToScreen(y).AddTo(screenDisposable);
 				})
@@ -219,7 +219,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					pilotLampDisposable.Dispose();
-					pilotLampDisposable = new CompositeDisposable();
+					pilotLampDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToPilotLamp(y).AddTo(pilotLampDisposable);
 				})
@@ -246,7 +246,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					needleDisposable.Dispose();
-					needleDisposable = new CompositeDisposable();
+					needleDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToNeedle(y).AddTo(needleDisposable);
 				})
@@ -273,7 +273,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					digitalNumberDisposable.Dispose();
-					digitalNumberDisposable = new CompositeDisposable();
+					digitalNumberDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToDigitalNumber(y).AddTo(digitalNumberDisposable);
 				})
@@ -300,7 +300,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					digitalGaugeDisposable.Dispose();
-					digitalGaugeDisposable = new CompositeDisposable();
+					digitalGaugeDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToDigitalGauge(y).AddTo(digitalGaugeDisposable);
 				})
@@ -327,7 +327,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					linearGaugeDisposable.Dispose();
-					linearGaugeDisposable = new CompositeDisposable();
+					linearGaugeDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToLinearGauge(y).AddTo(linearGaugeDisposable);
 				})
@@ -354,7 +354,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					timetableDisposable.Dispose();
-					timetableDisposable = new CompositeDisposable();
+					timetableDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToTimetable(y).AddTo(timetableDisposable);
 				})
@@ -381,7 +381,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					touchDisposable.Dispose();
-					touchDisposable = new CompositeDisposable();
+					touchDisposable = new CompositeDisposable().AddTo(panelDisposable);
 
 					BindToTouch(y).AddTo(touchDisposable);
 				})
@@ -398,17 +398,6 @@ namespace TrainEditor2.Views
 			new[] { x.RemoveScreen, x.RemovePilotLamp, x.RemoveNeedle, x.RemoveDigitalNumber, x.RemoveDigitalGauge, x.RemoveLinearGauge, x.RemoveTimetable, x.RemoveTouch }
 				.BindToButton(buttonPanelRemove)
 				.AddTo(panelDisposable);
-
-			listItemDisposable.AddTo(panelDisposable);
-			thisDisposable.AddTo(panelDisposable);
-			screenDisposable.AddTo(panelDisposable);
-			pilotLampDisposable.AddTo(panelDisposable);
-			needleDisposable.AddTo(panelDisposable);
-			digitalNumberDisposable.AddTo(panelDisposable);
-			digitalGaugeDisposable.AddTo(panelDisposable);
-			linearGaugeDisposable.AddTo(panelDisposable);
-			timetableDisposable.AddTo(panelDisposable);
-			touchDisposable.AddTo(panelDisposable);
 
 			return panelDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.Sound.cs
+++ b/source/TrainEditor2/Views/FormEditor.Sound.cs
@@ -17,8 +17,8 @@ namespace TrainEditor2.Views
 		private IDisposable BindToSound(SoundViewModel x)
 		{
 			CompositeDisposable soundDisposable = new CompositeDisposable();
-			CompositeDisposable listItemDisposable = new CompositeDisposable();
-			CompositeDisposable elementDisposable = new CompositeDisposable();
+			CompositeDisposable listItemDisposable = new CompositeDisposable().AddTo(soundDisposable);
+			CompositeDisposable elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 			listViewSound.Items.Clear();
 
@@ -121,7 +121,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					listItemDisposable.Dispose();
-					listItemDisposable = new CompositeDisposable();
+					listItemDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					y.Texts
 						.ObserveReplaceChanged()
@@ -157,7 +157,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -168,7 +168,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -179,7 +179,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -190,7 +190,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -201,7 +201,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -212,7 +212,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<BrakeElementViewModel, BrakeKey>(y).AddTo(elementDisposable);
 				})
@@ -223,7 +223,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<CompressorElementViewModel, CompressorKey>(y).AddTo(elementDisposable);
 				})
@@ -234,7 +234,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<SuspensionElementViewModel, SuspensionKey>(y).AddTo(elementDisposable);
 				})
@@ -245,7 +245,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<PrimaryHornElementViewModel, HornKey>(y).AddTo(elementDisposable);
 				})
@@ -256,7 +256,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<SecondaryHornElementViewModel, HornKey>(y).AddTo(elementDisposable);
 				})
@@ -267,7 +267,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<MusicHornElementViewModel, HornKey>(y).AddTo(elementDisposable);
 				})
@@ -278,7 +278,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<DoorElementViewModel, DoorKey>(y).AddTo(elementDisposable);
 				})
@@ -289,7 +289,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -300,7 +300,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<BuzzerElementViewModel, BuzzerKey>(y).AddTo(elementDisposable);
 				})
@@ -311,7 +311,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<PilotLampElementViewModel, PilotLampKey>(y).AddTo(elementDisposable);
 				})
@@ -322,7 +322,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<BrakeHandleElementViewModel, BrakeHandleKey>(y).AddTo(elementDisposable);
 				})
@@ -333,7 +333,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<MasterControllerElementViewModel, MasterControllerKey>(y).AddTo(elementDisposable);
 				})
@@ -344,7 +344,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<ReverserElementViewModel, ReverserKey>(y).AddTo(elementDisposable);
 				})
@@ -355,7 +355,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<BreakerElementViewModel, BreakerKey>(y).AddTo(elementDisposable);
 				})
@@ -366,7 +366,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<RequestStopElementViewModel, RequestStopKey>(y).AddTo(elementDisposable);
 				})
@@ -377,7 +377,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement(y).AddTo(elementDisposable);
 				})
@@ -388,7 +388,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					elementDisposable.Dispose();
-					elementDisposable = new CompositeDisposable();
+					elementDisposable = new CompositeDisposable().AddTo(soundDisposable);
 
 					BindToSoundElement<OthersElementViewModel, OthersKey>(y).AddTo(elementDisposable);
 				})
@@ -415,8 +415,6 @@ namespace TrainEditor2.Views
 				}
 				.BindToButton(buttonSoundRemove)
 				.AddTo(soundDisposable);
-
-			listItemDisposable.AddTo(soundDisposable);
 
 			return soundDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.Train.cs
+++ b/source/TrainEditor2/Views/FormEditor.Train.cs
@@ -14,11 +14,11 @@ namespace TrainEditor2.Views
 		{
 			CompositeDisposable trainDisposable = new CompositeDisposable();
 
-			CompositeDisposable handleDisposable = new CompositeDisposable();
-			CompositeDisposable deviceDisposable = new CompositeDisposable();
-			CompositeDisposable cabDisposable = new CompositeDisposable();
-			CompositeDisposable carDisposable = new CompositeDisposable();
-			CompositeDisposable couplerDisposable = new CompositeDisposable();
+			CompositeDisposable handleDisposable = new CompositeDisposable().AddTo(trainDisposable);
+			CompositeDisposable deviceDisposable = new CompositeDisposable().AddTo(trainDisposable);
+			CompositeDisposable cabDisposable = new CompositeDisposable().AddTo(trainDisposable);
+			CompositeDisposable carDisposable = new CompositeDisposable().AddTo(trainDisposable);
+			CompositeDisposable couplerDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 			x.Cars
 				.CollectionChangedAsObservable()
@@ -45,7 +45,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					handleDisposable.Dispose();
-					handleDisposable = new CompositeDisposable();
+					handleDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 					BindToHandle(y).AddTo(handleDisposable);
 				})
@@ -55,7 +55,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					deviceDisposable.Dispose();
-					deviceDisposable = new CompositeDisposable();
+					deviceDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 					BindToDevice(y).AddTo(deviceDisposable);
 				})
@@ -65,7 +65,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					cabDisposable.Dispose();
-					cabDisposable = new CompositeDisposable();
+					cabDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 					BindToCab(y).AddTo(cabDisposable);
 				})
@@ -75,7 +75,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					carDisposable.Dispose();
-					carDisposable = new CompositeDisposable();
+					carDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 					if (y != null)
 					{
@@ -88,7 +88,6 @@ namespace TrainEditor2.Views
 				.BindTo(
 					checkBoxIsMotorCar,
 					y => y.Checked,
-					BindingMode.OneWay,
 					y => y is MotorCarViewModel
 				)
 				.AddTo(trainDisposable);
@@ -97,7 +96,7 @@ namespace TrainEditor2.Views
 				.Subscribe(y =>
 				{
 					couplerDisposable.Dispose();
-					couplerDisposable = new CompositeDisposable();
+					couplerDisposable = new CompositeDisposable().AddTo(trainDisposable);
 
 					if (y != null)
 					{
@@ -105,12 +104,6 @@ namespace TrainEditor2.Views
 					}
 				})
 				.AddTo(trainDisposable);
-
-			handleDisposable.AddTo(trainDisposable);
-			deviceDisposable.AddTo(trainDisposable);
-			cabDisposable.AddTo(trainDisposable);
-			carDisposable.AddTo(trainDisposable);
-			couplerDisposable.AddTo(trainDisposable);
 
 			return trainDisposable;
 		}

--- a/source/TrainEditor2/Views/FormEditor.cs
+++ b/source/TrainEditor2/Views/FormEditor.cs
@@ -8,6 +8,7 @@ using System.Reactive.Linq;
 using System.Security.Permissions;
 using System.Windows.Forms;
 using OpenBveApi.Interface;
+using OpenTK.Graphics.OpenGL;
 using Reactive.Bindings;
 using Reactive.Bindings.Binding;
 using Reactive.Bindings.Extensions;
@@ -155,6 +156,8 @@ namespace TrainEditor2.Views
 
 		public FormEditor()
 		{
+			UIDispatcherScheduler.Initialize();
+
 			disposable = new CompositeDisposable();
 
 			CompositeDisposable messageDisposable = new CompositeDisposable();
@@ -555,12 +558,6 @@ namespace TrainEditor2.Views
 					car?.Acceleration.Value.MoveLeft.Execute();
 					ret = true;
 				}
-
-				if (pictureBoxDrawArea.Focused)
-				{
-					car?.Motor.Value.MoveLeft.Execute();
-					ret = true;
-				}
 			}
 
 			if (keyData == Keys.Right)
@@ -568,12 +565,6 @@ namespace TrainEditor2.Views
 				if (pictureBoxAccel.Focused)
 				{
 					car?.Acceleration.Value.MoveRight.Execute();
-					ret = true;
-				}
-
-				if (pictureBoxDrawArea.Focused)
-				{
-					car?.Motor.Value.MoveRight.Execute();
 					ret = true;
 				}
 			}
@@ -585,12 +576,6 @@ namespace TrainEditor2.Views
 					car?.Acceleration.Value.MoveBottom.Execute();
 					ret = true;
 				}
-
-				if (pictureBoxDrawArea.Focused)
-				{
-					car?.Motor.Value.MoveBottom.Execute();
-					ret = true;
-				}
 			}
 
 			if (keyData == Keys.Up)
@@ -598,12 +583,6 @@ namespace TrainEditor2.Views
 				if (pictureBoxAccel.Focused)
 				{
 					car?.Acceleration.Value.MoveTop.Execute();
-					ret = true;
-				}
-
-				if (pictureBoxDrawArea.Focused)
-				{
-					car?.Motor.Value.MoveTop.Execute();
 					ret = true;
 				}
 			}
@@ -760,32 +739,6 @@ namespace TrainEditor2.Views
 			e.Graphics.DrawString(toolStripComboBoxIndex.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), e.Bounds.X + e.Bounds.Height + 10, e.Bounds.Y);
 		}
 
-		private void PictureBoxDrawArea_MouseEnter(object sender, EventArgs e)
-		{
-			pictureBoxDrawArea.Focus();
-		}
-
-		private void PictureBoxDrawArea_MouseDown(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseDown.Execute(MouseEventArgsToModel(e));
-		}
-
-		private void PictureBoxDrawArea_MouseMove(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseMove.Execute(MouseEventArgsToModel(e));
-		}
-
-		private void PictureBoxDrawArea_MouseUp(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseUp.Execute();
-		}
-
 		private void ButtonThisDaytimeImageOpen_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog(textBoxThisDaytimeImage);
@@ -919,6 +872,85 @@ namespace TrainEditor2.Views
 		private void ButtonSoundFileNameOpen_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog(textBoxSoundFileName);
+		}
+
+		private void GlControlMotor_MouseEnter(object sender, EventArgs e)
+		{
+			glControlMotor.Focus();
+		}
+
+		private void GlControlMotor_MouseDown(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseDown.Execute(MouseEventArgsToModel(e));
+		}
+
+		private void GlControlMotor_MouseMove(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseMove.Execute(MouseEventArgsToModel(e));
+		}
+
+		private void GlControlMotor_MouseUp(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseUp.Execute();
+		}
+
+		private void GlControlMotor_Paint(object sender, PaintEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			glControlMotor.MakeCurrent();
+
+			if (car != null)
+			{
+				car.Motor.Value.DrawGlControl.Execute();
+			}
+			else
+			{
+				GL.ClearColor(Color.Black);
+				GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+			}
+
+			glControlMotor.SwapBuffers();
+		}
+
+		private void GlControlMotor_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+		{
+			switch (e.KeyCode)
+			{
+				case Keys.Up:
+				case Keys.Left:
+				case Keys.Right:
+				case Keys.Down:
+					e.IsInputKey = true;
+					break;
+			}
+		}
+
+		private void GlControlMotor_KeyDown(object sender, KeyEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			switch (e.KeyCode)
+			{
+				case Keys.Left:
+					car?.Motor.Value.MoveLeft.Execute();
+					break;
+				case Keys.Right:
+					car?.Motor.Value.MoveRight.Execute();
+					break;
+				case Keys.Down:
+					car?.Motor.Value.MoveBottom.Execute();
+					break;
+				case Keys.Up:
+					car?.Motor.Value.MoveTop.Execute();
+					break;
+			}
 		}
 	}
 }

--- a/source/TrainEditor2/Views/FormEditor.cs
+++ b/source/TrainEditor2/Views/FormEditor.cs
@@ -160,12 +160,12 @@ namespace TrainEditor2.Views
 
 			disposable = new CompositeDisposable();
 
-			CompositeDisposable messageDisposable = new CompositeDisposable();
-			CompositeDisposable openFileDialogDisposable = new CompositeDisposable();
-			CompositeDisposable saveFileDialogDisposable = new CompositeDisposable();
-			CompositeDisposable trainDisposable = new CompositeDisposable();
-			CompositeDisposable panelDisposable = new CompositeDisposable();
-			CompositeDisposable soundDisposable = new CompositeDisposable();
+			CompositeDisposable messageDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable openFileDialogDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable saveFileDialogDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable trainDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable panelDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable soundDisposable = new CompositeDisposable().AddTo(disposable);
 
 			app = new AppViewModel();
 
@@ -183,7 +183,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					messageDisposable.Dispose();
-					messageDisposable = new CompositeDisposable();
+					messageDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToMessageBox(x).AddTo(messageDisposable);
 				})
@@ -193,7 +193,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					openFileDialogDisposable.Dispose();
-					openFileDialogDisposable = new CompositeDisposable();
+					openFileDialogDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToOpenFileDialog(x).AddTo(openFileDialogDisposable);
 				})
@@ -203,7 +203,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					saveFileDialogDisposable.Dispose();
-					saveFileDialogDisposable = new CompositeDisposable();
+					saveFileDialogDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToSaveFileDialog(x).AddTo(saveFileDialogDisposable);
 				})
@@ -213,7 +213,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					trainDisposable.Dispose();
-					trainDisposable = new CompositeDisposable();
+					trainDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToTrain(x).AddTo(trainDisposable);
 				})
@@ -223,7 +223,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					panelDisposable.Dispose();
-					panelDisposable = new CompositeDisposable();
+					panelDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToPanel(x).AddTo(panelDisposable);
 				})
@@ -233,7 +233,7 @@ namespace TrainEditor2.Views
 				.Subscribe(x =>
 				{
 					soundDisposable.Dispose();
-					soundDisposable = new CompositeDisposable();
+					soundDisposable = new CompositeDisposable().AddTo(disposable);
 
 					BindToSound(x).AddTo(soundDisposable);
 				})
@@ -452,13 +452,6 @@ namespace TrainEditor2.Views
 			app.ChangeVisibleLogMessages.BindToButton(MessageType.Error, toolStripMenuItemError).AddTo(disposable);
 			app.ChangeVisibleLogMessages.BindToButton(MessageType.Critical, toolStripMenuItemError).AddTo(disposable);
 			app.ClearLogMessages.BindToButton(toolStripMenuItemClear).AddTo(disposable);
-
-			messageDisposable.AddTo(disposable);
-			openFileDialogDisposable.AddTo(disposable);
-			saveFileDialogDisposable.AddTo(disposable);
-			trainDisposable.AddTo(disposable);
-			panelDisposable.AddTo(disposable);
-			soundDisposable.AddTo(disposable);
 		}
 
 		private void FormEditor_Load(object sender, EventArgs e)
@@ -739,6 +732,85 @@ namespace TrainEditor2.Views
 			e.Graphics.DrawString(toolStripComboBoxIndex.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), e.Bounds.X + e.Bounds.Height + 10, e.Bounds.Y);
 		}
 
+		private void GlControlMotor_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+		{
+			switch (e.KeyCode)
+			{
+				case Keys.Up:
+				case Keys.Left:
+				case Keys.Right:
+				case Keys.Down:
+					e.IsInputKey = true;
+					break;
+			}
+		}
+
+		private void GlControlMotor_KeyDown(object sender, KeyEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			switch (e.KeyCode)
+			{
+				case Keys.Left:
+					car?.Motor.Value.MoveLeft.Execute();
+					break;
+				case Keys.Right:
+					car?.Motor.Value.MoveRight.Execute();
+					break;
+				case Keys.Down:
+					car?.Motor.Value.MoveBottom.Execute();
+					break;
+				case Keys.Up:
+					car?.Motor.Value.MoveTop.Execute();
+					break;
+			}
+		}
+
+		private void GlControlMotor_MouseEnter(object sender, EventArgs e)
+		{
+			glControlMotor.Focus();
+		}
+
+		private void GlControlMotor_MouseDown(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseDown.Execute(MouseEventArgsToModel(e));
+		}
+
+		private void GlControlMotor_MouseMove(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseMove.Execute(MouseEventArgsToModel(e));
+		}
+
+		private void GlControlMotor_MouseUp(object sender, MouseEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			car?.Motor.Value.MouseUp.Execute();
+		}
+
+		private void GlControlMotor_Paint(object sender, PaintEventArgs e)
+		{
+			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
+
+			glControlMotor.MakeCurrent();
+
+			if (car != null)
+			{
+				car.Motor.Value.DrawGlControl.Execute();
+			}
+			else
+			{
+				GL.ClearColor(Color.Black);
+				GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+			}
+
+			glControlMotor.SwapBuffers();
+		}
+
 		private void ButtonThisDaytimeImageOpen_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog(textBoxThisDaytimeImage);
@@ -872,85 +944,6 @@ namespace TrainEditor2.Views
 		private void ButtonSoundFileNameOpen_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog(textBoxSoundFileName);
-		}
-
-		private void GlControlMotor_MouseEnter(object sender, EventArgs e)
-		{
-			glControlMotor.Focus();
-		}
-
-		private void GlControlMotor_MouseDown(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseDown.Execute(MouseEventArgsToModel(e));
-		}
-
-		private void GlControlMotor_MouseMove(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseMove.Execute(MouseEventArgsToModel(e));
-		}
-
-		private void GlControlMotor_MouseUp(object sender, MouseEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			car?.Motor.Value.MouseUp.Execute();
-		}
-
-		private void GlControlMotor_Paint(object sender, PaintEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			glControlMotor.MakeCurrent();
-
-			if (car != null)
-			{
-				car.Motor.Value.DrawGlControl.Execute();
-			}
-			else
-			{
-				GL.ClearColor(Color.Black);
-				GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-			}
-
-			glControlMotor.SwapBuffers();
-		}
-
-		private void GlControlMotor_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
-		{
-			switch (e.KeyCode)
-			{
-				case Keys.Up:
-				case Keys.Left:
-				case Keys.Right:
-				case Keys.Down:
-					e.IsInputKey = true;
-					break;
-			}
-		}
-
-		private void GlControlMotor_KeyDown(object sender, KeyEventArgs e)
-		{
-			MotorCarViewModel car = app.Train.Value.SelectedCar.Value as MotorCarViewModel;
-
-			switch (e.KeyCode)
-			{
-				case Keys.Left:
-					car?.Motor.Value.MoveLeft.Execute();
-					break;
-				case Keys.Right:
-					car?.Motor.Value.MoveRight.Execute();
-					break;
-				case Keys.Down:
-					car?.Motor.Value.MoveBottom.Execute();
-					break;
-				case Keys.Up:
-					car?.Motor.Value.MoveTop.Execute();
-					break;
-			}
 		}
 	}
 }

--- a/source/TrainEditor2/Views/FormEditor.resx
+++ b/source/TrainEditor2/Views/FormEditor.resx
@@ -117,15 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>431, 17</value>
-  </metadata>
-  <metadata name="statusStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>154, 17</value>
-  </metadata>
-  <metadata name="menuStripMotor.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>297, 17</value>
-  </metadata>
   <metadata name="toolStripToolBar.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
@@ -134,6 +125,9 @@
   </metadata>
   <metadata name="menuStripMotor.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>297, 17</value>
+  </metadata>
+  <metadata name="menuStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>431, 17</value>
   </metadata>
   <metadata name="menuStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>431, 17</value>

--- a/source/TrainEditor2/packages.config
+++ b/source/TrainEditor2/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.0.1" targetFramework="net472" />
   <package id="OpenTK" version="3.1.0" targetFramework="net472" />
+  <package id="OpenTK.GLControl" version="3.1.0" targetFramework="net472" />
   <package id="Prism.Core" version="7.2.0.1367" targetFramework="net472" />
   <package id="ReactiveProperty" version="6.1.2" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net472" />


### PR DESCRIPTION
This PR fix a crash in the motor sound simulation.

However, the numerical value of the scale of the Motor sound settings graph is no longer displayed.

This is because I decided to use OpenGL.

Can I use the main program or viewer text display mechanism?

I am worried about this.

What do you think?

Related to #388 .