### PR TITLE
Shader improvements, Part 2

### DIFF
--- a/assets/Shaders/default.vert
+++ b/assets/Shaders/default.vert
@@ -40,8 +40,8 @@ out float oFogFactor;
 
 void main()
 {
-	vec4 viewPos = uCurrentModelViewMatrix * vec4(iPosition, 1.0);
-	vec4 viewNormal = uCurrentNormalMatrix * vec4(iNormal, 1.0);
+	vec4 viewPos = uCurrentModelViewMatrix * vec4(vec3(iPosition.x, iPosition.y, -iPosition.z), 1.0);
+	vec4 viewNormal = uCurrentNormalMatrix * vec4(vec3(iNormal.x, iNormal.y, -iNormal.z), 1.0);
 	gl_Position = uCurrentProjectionMatrix * viewPos;
 
 	// Lighting

--- a/source/LibRender2/Primitives/Cube.cs
+++ b/source/LibRender2/Primitives/Cube.cs
@@ -1,15 +1,14 @@
 ﻿using System.Linq;
 using OpenBveApi.Colors;
-using OpenBveApi.Graphics;
 using OpenBveApi.Math;
 using OpenBveApi.Textures;
 using OpenBveApi.World;
-using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using Vector2 = OpenBveApi.Math.Vector2;
 
 namespace LibRender2.Primitives
 {
+	/// <summary>A Cube of nomimal 1.0 size</summary>
 	public class Cube
 	{
 		private readonly BaseRenderer renderer;

--- a/source/LibRender2/Primitives/Cube.cs
+++ b/source/LibRender2/Primitives/Cube.cs
@@ -24,25 +24,25 @@ namespace LibRender2.Primitives
 				// back
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, 1.0f, -1.0f),
+					Position = new Vector3f(1.0f, 1.0f, 1.0f),
 					UV = Vector2.Null,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(-1.0f, 1.0f, -1.0f),
+					Position = new Vector3f(-1.0f, 1.0f, 1.0f),
 					UV = Vector2.Right,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(-1.0f, -1.0f, -1.0f),
+					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
 					UV = Vector2.One,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, -1.0f, -1.0f),
+					Position = new Vector3f(1.0f, -1.0f, 1.0f),
 					UV = Vector2.Down,
 					Color = Color128.White
 				},
@@ -50,25 +50,25 @@ namespace LibRender2.Primitives
 				// right
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, 1.0f, -1.0f),
+					Position = new Vector3f(1.0f, 1.0f, 1.0f),
 					UV = Vector2.Right,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, -1.0f, -1.0f),
+					Position = new Vector3f(1.0f, -1.0f, 1.0f),
 					UV = Vector2.One,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, -1.0f, 1.0f),
+					Position = new Vector3f(1.0f, -1.0f, -1.0f),
 					UV = Vector2.Down,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, 1.0f, 1.0f),
+					Position = new Vector3f(1.0f, 1.0f, -1.0f),
 					UV = Vector2.Null,
 					Color = Color128.White
 				},
@@ -76,33 +76,19 @@ namespace LibRender2.Primitives
 				// top
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, 1.0f, -1.0f),
+					Position = new Vector3f(1.0f, 1.0f, 1.0f),
 					UV = Vector2.Right,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(1.0f, 1.0f, 1.0f),
+					Position = new Vector3f(1.0f, 1.0f, -1.0f),
 					UV = Vector2.One,
-					Color = Color128.White
-				},
-				new LibRenderVertex
-				{
-					Position = new Vector3f(-1.0f, 1.0f, 1.0f),
-					UV = Vector2.Down,
 					Color = Color128.White
 				},
 				new LibRenderVertex
 				{
 					Position = new Vector3f(-1.0f, 1.0f, -1.0f),
-					UV = Vector2.Null,
-					Color = Color128.White
-				},
-
-				// front
-				new LibRenderVertex
-				{
-					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
 					UV = Vector2.Down,
 					Color = Color128.White
 				},
@@ -112,26 +98,8 @@ namespace LibRender2.Primitives
 					UV = Vector2.Null,
 					Color = Color128.White
 				},
-				new LibRenderVertex
-				{
-					Position = new Vector3f(1.0f, 1.0f, 1.0f),
-					UV = Vector2.Right,
-					Color = Color128.White
-				},
-				new LibRenderVertex
-				{
-					Position = new Vector3f(1.0f, -1.0f, 1.0f),
-					UV = Vector2.One,
-					Color = Color128.White
-				},
 
-				// left
-				new LibRenderVertex
-				{
-					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
-					UV = Vector2.One,
-					Color = Color128.White
-				},
+				// front
 				new LibRenderVertex
 				{
 					Position = new Vector3f(-1.0f, -1.0f, -1.0f),
@@ -146,21 +114,7 @@ namespace LibRender2.Primitives
 				},
 				new LibRenderVertex
 				{
-					Position = new Vector3f(-1.0f, 1.0f, 1.0f),
-					UV = Vector2.Right,
-					Color = Color128.White
-				},
-
-				// bottom
-				new LibRenderVertex
-				{
-					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
-					UV = Vector2.Null,
-					Color = Color128.White
-				},
-				new LibRenderVertex
-				{
-					Position = new Vector3f(1.0f, -1.0f, 1.0f),
+					Position = new Vector3f(1.0f, 1.0f, -1.0f),
 					UV = Vector2.Right,
 					Color = Color128.White
 				},
@@ -170,9 +124,55 @@ namespace LibRender2.Primitives
 					UV = Vector2.One,
 					Color = Color128.White
 				},
+
+				// left
 				new LibRenderVertex
 				{
 					Position = new Vector3f(-1.0f, -1.0f, -1.0f),
+					UV = Vector2.One,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
+					UV = Vector2.Down,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(-1.0f, 1.0f, 1.0f),
+					UV = Vector2.Null,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(-1.0f, 1.0f, -1.0f),
+					UV = Vector2.Right,
+					Color = Color128.White
+				},
+
+				// bottom
+				new LibRenderVertex
+				{
+					Position = new Vector3f(-1.0f, -1.0f, -1.0f),
+					UV = Vector2.Null,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(1.0f, -1.0f, -1.0f),
+					UV = Vector2.Right,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(1.0f, -1.0f, 1.0f),
+					UV = Vector2.One,
+					Color = Color128.White
+				},
+				new LibRenderVertex
+				{
+					Position = new Vector3f(-1.0f, -1.0f, 1.0f),
 					UV = Vector2.Down,
 					Color = Color128.White
 				}

--- a/source/LibRender2/Primitives/Cube.cs
+++ b/source/LibRender2/Primitives/Cube.cs
@@ -180,7 +180,7 @@ namespace LibRender2.Primitives
 			defaultVAO = new VertexArrayObject();
 			defaultVAO.Bind();
 			defaultVAO.SetVBO(new VertexBufferObject(vertexData, BufferUsageHint.StaticDraw));
-			defaultVAO.SetIBO(new IndexBufferObject(Enumerable.Range(0, vertexData.Length).ToArray(), BufferUsageHint.StaticDraw));
+			defaultVAO.SetIBO(new IndexBufferObject(Enumerable.Range(0, vertexData.Length).Select(x => (ushort) x).ToArray(), BufferUsageHint.StaticDraw));
 			defaultVAO.UnBind();
 		}
 

--- a/source/LibRender2/openGL/IndexBufferObject.cs
+++ b/source/LibRender2/openGL/IndexBufferObject.cs
@@ -8,8 +8,9 @@ namespace LibRender2
 	/// </summary>
 	public class IndexBufferObject : IDisposable
 	{
+		/// <summary>The openGL buffer name</summary>
 		private readonly int handle;
-		private readonly int[] indexData;
+		private readonly ushort[] indexData;
 		private readonly BufferUsageHint drawType;
 		private bool disposed;
 
@@ -18,7 +19,7 @@ namespace LibRender2
 		/// </summary>
 		/// <param name="IndexData">An int array of vertex indices that make the object</param>
 		/// <param name="DrawType">The hint representing how the object is to be used and therefore guides OpenGL's optimization of the object</param>
-		public IndexBufferObject(int[] IndexData, BufferUsageHint DrawType)
+		public IndexBufferObject(ushort[] IndexData, BufferUsageHint DrawType)
 		{
 			GL.GenBuffers(1, out handle);
 			indexData = IndexData;
@@ -37,7 +38,7 @@ namespace LibRender2
 		/// <remarks>Must be called before attempting to use the IBO/ EBO</remarks>
 		internal void BufferData()
 		{
-			GL.BufferData(BufferTarget.ElementArrayBuffer, indexData.Length * sizeof(int), indexData, drawType);
+			GL.BufferData(BufferTarget.ElementArrayBuffer, indexData.Length * sizeof(ushort), indexData, drawType);
 		}
 
 		/// <summary>
@@ -57,7 +58,7 @@ namespace LibRender2
 		/// <param name="Count">Number of vertex indices to use</param>
 		internal void Draw(PrimitiveType DrawMode, int Start, int Count)
 		{
-			GL.DrawElements(DrawMode, Count, DrawElementsType.UnsignedInt, Start * sizeof(int));
+			GL.DrawElements(DrawMode, Count, DrawElementsType.UnsignedShort, Start * sizeof(ushort));
 		}
 
 		/// <summary>

--- a/source/LibRender2/openGL/IndexBufferObject.cs
+++ b/source/LibRender2/openGL/IndexBufferObject.cs
@@ -33,9 +33,8 @@ namespace LibRender2
 			GL.BindBuffer(BufferTarget.ElementArrayBuffer, handle);
 		}
 
-		/// <summary>
-		/// Copies the Indices in to the IBO/EBO must be done before use
-		/// </summary>
+		/// <summary>Copies the Indices into the IBO/EBO</summary>
+		/// <remarks>Must be called before attempting to use the IBO/ EBO</remarks>
 		internal void BufferData()
 		{
 			GL.BufferData(BufferTarget.ElementArrayBuffer, indexData.Length * sizeof(int), indexData, drawType);

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -164,8 +164,8 @@ namespace LibRender2
 				{
 					var data = new LibRenderVertex
 					{
-						Position = new Vector3f((float)mesh.Vertices[vertex.Index].Coordinates.X, (float)mesh.Vertices[vertex.Index].Coordinates.Y, (float)mesh.Vertices[vertex.Index].Coordinates.Z),
-						Normal = new Vector3f((float)vertex.Normal.X, (float)vertex.Normal.Y, (float)vertex.Normal.Z),
+						Position = mesh.Vertices[vertex.Index].Coordinates,
+						Normal = vertex.Normal,
 						UV = mesh.Vertices[vertex.Index].TextureCoordinates
 					};
 

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenBveApi.Colors;
-using OpenBveApi.Graphics;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Routes;
-using OpenBveApi.Textures;
 using OpenTK.Graphics.OpenGL;
 
 namespace LibRender2
@@ -166,8 +164,8 @@ namespace LibRender2
 				{
 					var data = new LibRenderVertex
 					{
-						Position = new Vector3f((float)mesh.Vertices[vertex.Index].Coordinates.X, (float)mesh.Vertices[vertex.Index].Coordinates.Y, (float)-mesh.Vertices[vertex.Index].Coordinates.Z),
-						Normal = new Vector3f((float)vertex.Normal.X, (float)vertex.Normal.Y, (float)-vertex.Normal.Z),
+						Position = new Vector3f((float)mesh.Vertices[vertex.Index].Coordinates.X, (float)mesh.Vertices[vertex.Index].Coordinates.Y, (float)mesh.Vertices[vertex.Index].Coordinates.Z),
+						Normal = new Vector3f((float)vertex.Normal.X, (float)vertex.Normal.Y, (float)vertex.Normal.Z),
 						UV = mesh.Vertices[vertex.Index].TextureCoordinates
 					};
 
@@ -255,8 +253,8 @@ namespace LibRender2
 			{
 				float x = (float)(background.BackgroundImageDistance * System.Math.Cos(angleValue));
 				float z = (float)(background.BackgroundImageDistance * System.Math.Sin(angleValue));
-				bottom[i] = new Vector3f(x, y0, -z);
-				top[i] = new Vector3f(x, y1, -z);
+				bottom[i] = new Vector3f(x, y0, z);
+				top[i] = new Vector3f(x, y1, z);
 				angleValue += angleIncrement;
 			}
 

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -150,10 +150,10 @@ namespace LibRender2
 			var hint = isDynamic ? BufferUsageHint.DynamicDraw : BufferUsageHint.StaticDraw;
 
 			var vertexData = new List<LibRenderVertex>();
-			var indexData = new List<int>();
+			var indexData = new List<ushort>();
 
 			var normalsVertexData = new List<LibRenderVertex>();
-			var normalsIndexData = new List<int>();
+			var normalsIndexData = new List<ushort>();
 
 			for (int i = 0; i < mesh.Faces.Length; i++)
 			{
@@ -194,8 +194,8 @@ namespace LibRender2
 					normalsVertexData.AddRange(normalsData);
 				}
 
-				indexData.AddRange(Enumerable.Range(mesh.Faces[i].IboStartIndex, mesh.Faces[i].Vertices.Length));
-				normalsIndexData.AddRange(Enumerable.Range(mesh.Faces[i].NormalsIboStartIndex, mesh.Faces[i].Vertices.Length * 2));
+				indexData.AddRange(Enumerable.Range(mesh.Faces[i].IboStartIndex, mesh.Faces[i].Vertices.Length).Select(x => (ushort) x));
+				normalsIndexData.AddRange(Enumerable.Range(mesh.Faces[i].NormalsIboStartIndex, mesh.Faces[i].Vertices.Length * 2).Select(x => (ushort) x));
 			}
 
 			VertexArrayObject VAO = (VertexArrayObject) mesh.VAO;
@@ -263,7 +263,7 @@ namespace LibRender2
 			float textureX = textureStart;
 
 			List<LibRenderVertex> vertexData = new List<LibRenderVertex>();
-			List<int> indexData = new List<int>();
+			List<ushort> indexData = new List<ushort>();
 
 			for (int i = 0; i < n; i++)
 			{
@@ -299,7 +299,7 @@ namespace LibRender2
 					Color = Color128.White
 				});
 
-				indexData.AddRange(new[] { 0, 1, 2, 3 }.Select(x => x + indexOffset));
+				indexData.AddRange(new[] { 0, 1, 2, 3 }.Select(x => x + indexOffset).Select(x => (ushort) x));
 
 				// top cap
 				vertexData.Add(new LibRenderVertex
@@ -309,7 +309,7 @@ namespace LibRender2
 					Color = Color128.White
 				});
 
-				indexData.AddRange(new[] { 0, 3, 4 }.Select(x => x + indexOffset));
+				indexData.AddRange(new[] { 0, 3, 4 }.Select(x => x + indexOffset).Select(x => (ushort) x));
 
 				// bottom cap
 				vertexData.Add(new LibRenderVertex
@@ -319,7 +319,7 @@ namespace LibRender2
 					Color = Color128.White
 				});
 
-				indexData.AddRange(new[] { 5, 2, 1 }.Select(x => x + indexOffset));
+				indexData.AddRange(new[] { 5, 2, 1 }.Select(x => x + indexOffset).Select(x => (ushort) x));
 
 				// finish
 				textureX += textureIncrement;

--- a/source/LibRender2/openGL/VertexBufferObject.cs
+++ b/source/LibRender2/openGL/VertexBufferObject.cs
@@ -35,25 +35,20 @@ namespace LibRender2
 			GL.BindBuffer(BufferTarget.ArrayBuffer, handle);
 		}
 
-		/// <summary>
-		/// Copies the VertexData into the the VBO must be done before using the VBO
-		/// </summary>
+		/// <summary>Copies the VertexData into the the VBO</summary>
+		/// <remarks>This method must be called before attempting to use the VBO</remarks>
 		internal void BufferData()
 		{
 			GL.BufferData(BufferTarget.ArrayBuffer, new IntPtr(vertexData.Length * LibRenderVertex.SizeInBytes), vertexData, drawType);
 		}
 
-		/// <summary>
-		/// Update the VertexData into the the VBO
-		/// </summary>
+		/// <summary>Updates the VertexData contained within the VBO</summary>
 		internal void BufferSubData(LibRenderVertex[] VertexData, int Offset = 0)
 		{
 			GL.BufferSubData(BufferTarget.ArrayBuffer, new IntPtr(Offset * LibRenderVertex.SizeInBytes), new IntPtr(VertexData.Length * LibRenderVertex.SizeInBytes), VertexData);
 		}
 
-		/// <summary>
-		/// Enables the attribute
-		/// </summary>
+		/// <summary>Enables a specific vertex attribute array</summary>
 		internal void EnableAttribute(VertexLayout VertexLayout)
 		{
 			if (VertexLayout.Position >= 0)

--- a/source/ObjectViewer/NewRendererS.cs
+++ b/source/ObjectViewer/NewRendererS.cs
@@ -11,7 +11,6 @@ using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.World;
-using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using Vector3 = OpenBveApi.Math.Vector3;
 

--- a/source/ObjectViewer/NewRendererS.cs
+++ b/source/ObjectViewer/NewRendererS.cs
@@ -132,7 +132,7 @@ namespace OpenBve
 				vertexData[i].Color = Color;
 			}
 
-			int[] indexData =
+			ushort[] indexData =
 			{
 				0, 1, 2, 3,
 				0, 4, 5, 1,

--- a/source/ObjectViewer/NewRendererS.cs
+++ b/source/ObjectViewer/NewRendererS.cs
@@ -119,14 +119,14 @@ namespace OpenBve
 		private VertexArrayObject RegisterBox(Color128 Color)
 		{
 			LibRenderVertex[] vertexData = new LibRenderVertex[8];
-			vertexData[0].Position = new OpenBveApi.Math.Vector3f(1.0f, 1.0f, -1.0f);
-			vertexData[1].Position = new OpenBveApi.Math.Vector3f(1.0f, -1.0f, -1.0f);
-			vertexData[2].Position = new OpenBveApi.Math.Vector3f(-1.0f, -1.0f, -1.0f);
-			vertexData[3].Position = new OpenBveApi.Math.Vector3f(-1.0f, 1.0f, -1.0f);
-			vertexData[4].Position = new OpenBveApi.Math.Vector3f(1.0f, 1.0f, 1.0f);
-			vertexData[5].Position = new OpenBveApi.Math.Vector3f(1.0f, -1.0f, 1.0f);
-			vertexData[6].Position = new OpenBveApi.Math.Vector3f(-1.0f, -1.0f, 1.0f);
-			vertexData[7].Position = new OpenBveApi.Math.Vector3f(-1.0f, 1.0f, 1.0f);
+			vertexData[0].Position = new OpenBveApi.Math.Vector3f(1.0f, 1.0f, 1.0f);
+			vertexData[1].Position = new OpenBveApi.Math.Vector3f(1.0f, -1.0f, 1.0f);
+			vertexData[2].Position = new OpenBveApi.Math.Vector3f(-1.0f, -1.0f, 1.0f);
+			vertexData[3].Position = new OpenBveApi.Math.Vector3f(-1.0f, 1.0f, 1.0f);
+			vertexData[4].Position = new OpenBveApi.Math.Vector3f(1.0f, 1.0f, -1.0f);
+			vertexData[5].Position = new OpenBveApi.Math.Vector3f(1.0f, -1.0f, -1.0f);
+			vertexData[6].Position = new OpenBveApi.Math.Vector3f(-1.0f, -1.0f, -1.0f);
+			vertexData[7].Position = new OpenBveApi.Math.Vector3f(-1.0f, 1.0f, -1.0f);
 
 			for (int i = 0; i < vertexData.Length; i++)
 			{

--- a/source/OpenBveApi/Math/Matrix4.cs
+++ b/source/OpenBveApi/Math/Matrix4.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿/*
+Some Matrix math code derived from OpenTK-
+
+Copyright (c) 2006 - 2008 The Open Toolkit library.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 

--- a/source/OpenBveApi/Math/Quaternion.cs
+++ b/source/OpenBveApi/Math/Quaternion.cs
@@ -1,4 +1,25 @@
-﻿using System.Runtime.InteropServices;
+﻿/*
+Some Matrix math code derived from OpenTK-
+
+Copyright (c) 2006 - 2008 The Open Toolkit library.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
 
 namespace OpenBveApi.Math
 {

--- a/source/OpenBveApi/Math/Vectors/Vector3.cs
+++ b/source/OpenBveApi/Math/Vectors/Vector3.cs
@@ -103,6 +103,12 @@ namespace OpenBveApi.Math {
 			return new Vector3(Vector1.X + ((Vector2.X - Vector1.X) * mu), Vector1.Y + ((Vector2.Y - Vector1.Y) * mu), Vector1.Z + ((Vector2.Z - Vector1.Z) * mu));
 		}
 		
+		/// <summary>Converts a Vector3 to a Vector3f</summary>
+		///	<remarks>This discards the double precision</remarks>
+		public static implicit operator Vector3f(Vector3 v)
+		{
+			return new Vector3f(v.X, v.Y, v.Z);
+		}
 		
 		// --- arithmetic operators ---
 		

--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -14,8 +14,6 @@ namespace OpenBveApi.Objects
 		public float StartingDistance;
 		/// <summary>The ending track position, for static objects only.</summary>
 		public float EndingDistance;
-		/// <summary>The block mod group, for static objects only.</summary>
-		public short GroupIndex;
 		/// <summary>Whether the object is dynamic, i.e. not static.</summary>
 		public bool Dynamic;
 		/// <summary> Stores the author for this object.</summary>
@@ -480,14 +478,6 @@ namespace OpenBveApi.Objects
 			{
 				StartingDistance = (float) startingDistance;
 				EndingDistance = (float) endingDistance;
-			}
-
-			if (BlockLength != 0.0)
-			{
-				checked
-				{
-					GroupIndex = (short) NumberFormats.Mod(System.Math.Floor(StartingDistance / BlockLength), System.Math.Ceiling(ViewingDistance / BlockLength));
-				}
 			}
 		}
 


### PR DESCRIPTION
Some more shader improvements. (The last got merged due to the missing animated object part bug being critical)

* openTK notice added to matrix & quaternion code (Missed this from the last one....)
* The Z-axis flip is now performed inside the shader- This allows an implicit operator when passing the vertex co-ordinates, which is much neater (and makes it so much simpler to debug...)
* The vertex indices are stored as ushort as opposed to int. This does limit us to 65,535 verts per VBO, but frankly something else will fall over long before we hit this limit. On the flip side, it saves us 2 bytes per vertex. This is likely to be of use on systems with lower memory bandwidth, which are also most likely to benefit from the VBO changes.

Work in progress again.
I suspect the VBO creation can probably be optimised a bit, need to think about that.....