### PR TITLE
Add: multiple sounds and commands to one touch element on the panel

### DIFF
--- a/source/OpenBVE/Graphics/Renderers/Touch.cs
+++ b/source/OpenBVE/Graphics/Renderers/Touch.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using LibRender2;
 using LibRender2.Objects;
 using LibRender2.Shaders;
@@ -200,25 +201,23 @@ namespace OpenBve.Graphics.Renderers
 
 			ObjectState pickedObject = ParseFBO(Point, 5, 5);
 
-			foreach (TrainManager.TouchElement TouchElement in TouchElements)
+			foreach (TrainManager.TouchElement TouchElement in TouchElements.Where(x => x.Element.internalObject == pickedObject))
 			{
-				if (TouchElement.Element.internalObject != pickedObject)
+				foreach (int index in TouchElement.ControlIndices)
 				{
-					continue;
-				}
-
-				switch (TouchElement.Command)
-				{
-					case Translations.Command.PowerIncrease:
-					case Translations.Command.BrakeIncrease:
-					case Translations.Command.ReverserForward:
-						Status = Cursor.Status.Plus;
-						break;
-					case Translations.Command.PowerDecrease:
-					case Translations.Command.BrakeDecrease:
-					case Translations.Command.ReverserBackward:
-						Status = Cursor.Status.Minus;
-						break;
+					switch (Interface.CurrentControls[index].Command)
+					{
+						case Translations.Command.PowerIncrease:
+						case Translations.Command.BrakeIncrease:
+						case Translations.Command.ReverserForward:
+							Status = Cursor.Status.Plus;
+							break;
+						case Translations.Command.PowerDecrease:
+						case Translations.Command.BrakeDecrease:
+						case Translations.Command.ReverserBackward:
+							Status = Cursor.Status.Minus;
+							break;
+					}
 				}
 			}
 
@@ -254,42 +253,13 @@ namespace OpenBve.Graphics.Renderers
 
 			ObjectState pickedObject = ParseFBO(Point, 5, 5);
 
-			foreach (TrainManager.TouchElement TouchElement in TouchElements)
+			foreach (TrainManager.TouchElement TouchElement in TouchElements.Where(x => x.Element.internalObject == pickedObject))
 			{
-				if (TouchElement.Element.internalObject != pickedObject)
+				foreach (int index in TouchElement.ControlIndices)
 				{
-					continue;
-				}
-
-				for (int i = 0; i < Interface.CurrentControls.Length; i++)
-				{
-					if (Interface.CurrentControls[i].Method != Interface.ControlMethod.Touch)
-					{
-						continue;
-					}
-
-					bool EnableOption = false;
-
-					for (int j = 0; j < Translations.CommandInfos.Length; j++)
-					{
-						if (Interface.CurrentControls[i].Command == Translations.CommandInfos[j].Command)
-						{
-							EnableOption = Translations.CommandInfos[j].EnableOption;
-							break;
-						}
-					}
-
-					if (TouchElement.Command == Interface.CurrentControls[i].Command)
-					{
-						if (EnableOption && TouchElement.CommandOption != Interface.CurrentControls[i].Option)
-						{
-							continue;
-						}
-
-						Interface.CurrentControls[i].AnalogState = 1.0;
-						Interface.CurrentControls[i].DigitalState = Interface.DigitalControlState.Pressed;
-						MainLoop.AddControlRepeat(i);
-					}
+					Interface.CurrentControls[index].AnalogState = 1.0;
+					Interface.CurrentControls[index].DigitalState = Interface.DigitalControlState.Pressed;
+					MainLoop.AddControlRepeat(index);
 				}
 			}
 
@@ -331,10 +301,10 @@ namespace OpenBve.Graphics.Renderers
 					Car.CarSections[0].CurrentAdditionalGroup = TouchElement.JumpScreenIndex;
 					Car.ChangeCarSection(TrainManager.CarSectionType.Interior);
 
-					if (TouchElement.SoundIndex >= 0 && TouchElement.SoundIndex < Car.Sounds.Touch.Length)
+					foreach (var index in TouchElement.SoundIndices.Where(x => x >= 0 && x < Car.Sounds.Touch.Length))
 					{
-						SoundBuffer Buffer = Car.Sounds.Touch[TouchElement.SoundIndex].Buffer;
-						OpenBveApi.Math.Vector3 Position = Car.Sounds.Touch[TouchElement.SoundIndex].Position;
+						SoundBuffer Buffer = Car.Sounds.Touch[index].Buffer;
+						OpenBveApi.Math.Vector3 Position = Car.Sounds.Touch[index].Position;
 						Program.Sounds.PlaySound(Buffer, 1.0, 1.0, Position, TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar], false);
 					}
 				}
@@ -342,35 +312,11 @@ namespace OpenBve.Graphics.Renderers
 				// HACK: Normally terminate the command issued once.
 				if (TouchElement.Element.internalObject == pickedObject || (pickedObject != prePickedObject && TouchElement.Element.internalObject == prePickedObject))
 				{
-					for (int i = 0; i < Interface.CurrentControls.Length; i++)
+					foreach (int index in TouchElement.ControlIndices)
 					{
-						if (Interface.CurrentControls[i].Method != Interface.ControlMethod.Touch)
-						{
-							continue;
-						}
-
-						bool EnableOption = false;
-
-						for (int j = 0; j < Translations.CommandInfos.Length; j++)
-						{
-							if (Interface.CurrentControls[i].Command == Translations.CommandInfos[j].Command)
-							{
-								EnableOption = Translations.CommandInfos[j].EnableOption;
-								break;
-							}
-						}
-
-						if (TouchElement.Command == Interface.CurrentControls[i].Command)
-						{
-							if (EnableOption && TouchElement.CommandOption != Interface.CurrentControls[i].Option)
-							{
-								continue;
-							}
-
-							Interface.CurrentControls[i].AnalogState = 0.0;
-							Interface.CurrentControls[i].DigitalState = Interface.DigitalControlState.Released;
-							MainLoop.RemoveControlRepeat(i);
-						}
+						Interface.CurrentControls[index].AnalogState = 0.0;
+						Interface.CurrentControls[index].DigitalState = Interface.DigitalControlState.Released;
+						MainLoop.RemoveControlRepeat(index);
 					}
 				}
 			}

--- a/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
+++ b/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
@@ -931,20 +931,20 @@ namespace OpenBve {
 												{
 													if (Subject == "power")
 													{
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.PowerDecrease, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.PowerIncrease, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.PowerDecrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.PowerIncrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
 													}
 
 													if (Subject == "brake")
 													{
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.BrakeIncrease, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.BrakeDecrease, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.BrakeIncrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.BrakeDecrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
 													}
 
 													if (Subject == "reverser")
 													{
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.ReverserForward, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
-														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, -1, Translations.Command.ReverserBackward, 0, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.ReverserForward } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+														PanelXmlParser.CreateTouchElement(Train.Cars[Car].CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new TrainManager.CommandEntry { Command = Translations.Command.ReverserBackward } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
 													}
 												}
 											}

--- a/source/OpenBVE/Parsers/Panel/PanelAnimatedXmlParser.cs
+++ b/source/OpenBVE/Parsers/Panel/PanelAnimatedXmlParser.cs
@@ -116,9 +116,9 @@ namespace OpenBve.Parsers.Panel
 							Vector3 Position = Vector3.Zero;
 							Vector3 Size = Vector3.Zero;
 							int JumpScreen = GroupIndex - 1;
-							int SoundIndex = -1;
-							Translations.Command Command = Translations.Command.None;
-							int CommandOption = 0;
+							List<int> SoundIndices = new List<int>();
+							List<TrainManager.CommandEntry> CommandEntries = new List<TrainManager.CommandEntry>();
+							TrainManager.CommandEntry CommandEntry = new TrainManager.CommandEntry();
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
@@ -147,13 +147,30 @@ namespace OpenBve.Parsers.Panel
 										}
 										break;
 									case "soundindex":
-										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out SoundIndex))
+										if (Value.Length != 0)
 										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+											int SoundIndex;
+
+											if (!NumberFormats.TryParseIntVb6(Value, out SoundIndex))
+											{
+												Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+											}
+
+											SoundIndices.Add(SoundIndex);
 										}
 										break;
 									case "command":
 										{
+											if (!CommandEntries.Contains(CommandEntry))
+											{
+												CommandEntries.Add(CommandEntry);
+											}
+
+											if (string.Compare(Value, "N/A", StringComparison.InvariantCultureIgnoreCase) == 0)
+											{
+												break;
+											}
+
 											int i;
 											for (i = 0; i < Translations.CommandInfos.Length; i++)
 											{
@@ -168,19 +185,42 @@ namespace OpenBve.Parsers.Panel
 											}
 											else
 											{
-												Command = Translations.CommandInfos[i].Command;
+												CommandEntry.Command = Translations.CommandInfos[i].Command;
 											}
 										}
 										break;
 									case "commandoption":
-										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out CommandOption))
+										if (!CommandEntries.Contains(CommandEntry))
+										{
+											CommandEntries.Add(CommandEntry);
+										}
+
+										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out CommandEntry.Option))
 										{
 											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
+									case "soundentries":
+										if (!KeyNode.HasElements)
+										{
+											Interface.AddMessage(MessageType.Error, false, $"An empty list of touch sound indices was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
+											break;
+										}
+
+										ParseTouchSoundEntryNode(FileName, KeyNode, SoundIndices);
+										break;
+									case "commandentries":
+										if (!KeyNode.HasElements)
+										{
+											Interface.AddMessage(MessageType.Error, false, $"An empty list of touch commands was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
+											break;
+										}
+
+										ParseTouchCommandEntryNode(FileName, KeyNode, CommandEntries);
+										break;
 								}
 							}
-							CreateTouchElement(CarSection.Groups[GroupIndex], Position, Size, JumpScreen, SoundIndex, Command, CommandOption);
+							CreateTouchElement(CarSection.Groups[GroupIndex], Position, Size, JumpScreen, SoundIndices.ToArray(), CommandEntries.ToArray());
 						}
 						break;
 					case "include":
@@ -225,7 +265,119 @@ namespace OpenBve.Parsers.Panel
 			}
 		}
 
-		private static void CreateTouchElement(TrainManager.ElementsGroup Group, Vector3 Position, Vector3 Size, int ScreenIndex, int SoundIndex, Translations.Command Command, int CommandOption)
+		private static void ParseTouchSoundEntryNode(string fileName, XElement parent, ICollection<int> indices)
+		{
+			foreach (XElement childNode in parent.Elements())
+			{
+				if (childNode.Name.LocalName.ToLowerInvariant() != "entry")
+				{
+					Interface.AddMessage(MessageType.Error, false, $"Invalid entry node {childNode.Name.LocalName} in XML node {parent.Name.LocalName} at line {((IXmlLineInfo)childNode).LineNumber}");
+				}
+				else
+				{
+					System.Globalization.CultureInfo culture = System.Globalization.CultureInfo.InvariantCulture;
+
+					string section = childNode.Name.LocalName;
+
+					foreach (XElement keyNode in childNode.Elements())
+					{
+						string key = keyNode.Name.LocalName;
+						string value = keyNode.Value;
+						int lineNumber = ((IXmlLineInfo)keyNode).LineNumber;
+
+						switch (keyNode.Name.LocalName.ToLowerInvariant())
+						{
+							case "index":
+								if (value.Any())
+								{
+									int index;
+
+									if (!NumberFormats.TryParseIntVb6(value, out index))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+									}
+
+									indices.Add(index);
+								}
+								break;
+						}
+					}
+				}
+			}
+		}
+
+		private static void ParseTouchCommandEntryNode(string fileName, XElement parent, ICollection<TrainManager.CommandEntry> entries)
+		{
+			foreach (XElement childNode in parent.Elements())
+			{
+				if (childNode.Name.LocalName.ToLowerInvariant() != "entry")
+				{
+					Interface.AddMessage(MessageType.Error, false, $"Invalid entry node {childNode.Name.LocalName} in XML node {parent.Name.LocalName} at line {((IXmlLineInfo)childNode).LineNumber}");
+				}
+				else
+				{
+					TrainManager.CommandEntry entry = new TrainManager.CommandEntry();
+					System.Globalization.CultureInfo culture = System.Globalization.CultureInfo.InvariantCulture;
+
+					string section = childNode.Name.LocalName;
+
+					foreach (XElement keyNode in childNode.Elements())
+					{
+						string key = keyNode.Name.LocalName;
+						string value = keyNode.Value;
+						int lineNumber = ((IXmlLineInfo)keyNode).LineNumber;
+
+						switch (keyNode.Name.LocalName.ToLowerInvariant())
+						{
+							case "name":
+								if (string.Compare(value, "N/A", StringComparison.InvariantCultureIgnoreCase) == 0)
+								{
+									break;
+								}
+
+								int i;
+
+								for (i = 0; i < Translations.CommandInfos.Length; i++)
+								{
+									if (string.Compare(value, Translations.CommandInfos[i].Name, StringComparison.OrdinalIgnoreCase) == 0)
+									{
+										break;
+									}
+								}
+
+								if (i == Translations.CommandInfos.Length || Translations.CommandInfos[i].Type != Translations.CommandType.Digital)
+								{
+									Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+								}
+								else
+								{
+									entry.Command = Translations.CommandInfos[i].Command;
+								}
+								break;
+							case "option":
+								if (value.Any())
+								{
+									int option;
+
+									if (!NumberFormats.TryParseIntVb6(value, out option))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+									}
+									else
+									{
+										entry.Option = option;
+									}
+								}
+								break;
+						}
+					}
+
+					entries.Add(entry);
+				}
+			}
+		}
+
+		private static void CreateTouchElement(TrainManager.ElementsGroup Group, Vector3 Position, Vector3 Size, int ScreenIndex, int[] SoundIndices, TrainManager.CommandEntry[] CommandEntries)
 		{
 			Vertex t0 = new Vertex(Size.X, Size.Y, -Size.Z);
             Vertex t1 = new Vertex(Size.X, -Size.Y, -Size.Z);
@@ -255,9 +407,8 @@ namespace OpenBve.Parsers.Panel
 			{
 				Element = new AnimatedObject(Program.CurrentHost),
 				JumpScreenIndex = ScreenIndex,
-				SoundIndex = SoundIndex,
-				Command = Command,
-				CommandOption = CommandOption
+				SoundIndices = SoundIndices,
+				ControlIndices = new int[CommandEntries.Length]
 			};
 			Group.TouchElements[n].Element.States = new [] { new ObjectState() };
 			Group.TouchElements[n].Element.States[0].Translation = Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z);
@@ -266,10 +417,14 @@ namespace OpenBve.Parsers.Panel
 			Group.TouchElements[n].Element.internalObject = new ObjectState { Prototype = Object };
 			Program.CurrentHost.CreateDynamicObject(ref Group.TouchElements[n].Element.internalObject);
 			int m = Interface.CurrentControls.Length;
-			Array.Resize(ref Interface.CurrentControls, m + 1);
-			Interface.CurrentControls[m].Command = Command;
-			Interface.CurrentControls[m].Method = Interface.ControlMethod.Touch;
-			Interface.CurrentControls[m].Option = CommandOption;
+			Array.Resize(ref Interface.CurrentControls, m + CommandEntries.Length);
+			for (int i = 0; i < CommandEntries.Length; i++)
+			{
+				Interface.CurrentControls[m + i].Command = CommandEntries[i].Command;
+				Interface.CurrentControls[m + i].Method = Interface.ControlMethod.Touch;
+				Interface.CurrentControls[m + i].Option = CommandEntries[i].Option;
+				Group.TouchElements[n].ControlIndices[i] = m + i;
+			}
 		}
 	}
 }

--- a/source/OpenBVE/Parsers/Panel/PanelXmlParser.cs
+++ b/source/OpenBVE/Parsers/Panel/PanelXmlParser.cs
@@ -421,9 +421,10 @@ namespace OpenBve.Parsers.Panel
 							Vector2 Location = new Vector2();
 							Vector2 Size = new Vector2();
 							int JumpScreen = GroupIndex - 1;
-							int SoundIndex = -1;
-							Translations.Command Command = Translations.Command.None;
-							int CommandOption = 0;
+							List<int> SoundIndices = new List<int>();
+							List<TrainManager.CommandEntry> CommandEntries = new List<TrainManager.CommandEntry>();
+							TrainManager.CommandEntry CommandEntry = new TrainManager.CommandEntry();
+							int Layer = 0;
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
@@ -484,13 +485,32 @@ namespace OpenBve.Parsers.Panel
 										}
 										break;
 									case "soundindex":
-										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out SoundIndex))
+										if (Value.Length != 0)
 										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+											int SoundIndex;
+
+											if (!NumberFormats.TryParseIntVb6(Value, out SoundIndex))
+											{
+												Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+											}
+											else
+											{
+												SoundIndices.Add(SoundIndex);
+											}
 										}
 										break;
 									case "command":
 										{
+											if (!CommandEntries.Contains(CommandEntry))
+											{
+												CommandEntries.Add(CommandEntry);
+											}
+
+											if (string.Compare(Value, "N/A", StringComparison.InvariantCultureIgnoreCase) == 0)
+											{
+												break;
+											}
+
 											int i;
 											for (i = 0; i < Translations.CommandInfos.Length; i++)
 											{
@@ -505,19 +525,48 @@ namespace OpenBve.Parsers.Panel
 											}
 											else
 											{
-												Command = Translations.CommandInfos[i].Command;
+												CommandEntry.Command = Translations.CommandInfos[i].Command;
 											}
 										}
 										break;
 									case "commandoption":
-										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out CommandOption))
+										if (!CommandEntries.Contains(CommandEntry))
+										{
+											CommandEntries.Add(CommandEntry);
+										}
+
+										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out CommandEntry.Option))
 										{
 											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
+									case "soundentries":
+										if (!KeyNode.HasElements)
+										{
+											Interface.AddMessage(MessageType.Error, false, $"An empty list of touch sound indices was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
+											break;
+										}
+
+										ParseTouchSoundEntryNode(FileName, KeyNode, SoundIndices);
+										break;
+									case "commandentries":
+										if (!KeyNode.HasElements)
+										{
+											Interface.AddMessage(MessageType.Error, false, $"An empty list of touch commands was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
+											break;
+										}
+
+										ParseTouchCommandEntryNode(FileName, KeyNode, CommandEntries);
+										break;
+									case "layer":
+										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
+										{
+											Interface.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+										}
+										break;
 								}
 							}
-							CreateTouchElement(CarSection.Groups[GroupIndex], Location, Size, JumpScreen, SoundIndex, Command, CommandOption, new Vector2(0.5, 0.5), PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
+							CreateTouchElement(CarSection.Groups[GroupIndex], Location, Size, JumpScreen, SoundIndices.ToArray(), CommandEntries.ToArray(), new Vector2(0.5, 0.5), (OffsetLayer + Layer) * StackDistance, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver);
 						}
 						break;
 					case "pilotlamp":
@@ -650,7 +699,7 @@ namespace OpenBve.Parsers.Panel
 							{
 								string Key = KeyNode.Name.LocalName;
 								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
 
 								switch (Key.ToLowerInvariant())
 								{
@@ -1547,7 +1596,120 @@ namespace OpenBve.Parsers.Panel
 			}
 		}
 
-		internal static void CreateTouchElement(TrainManager.ElementsGroup Group, Vector2 Location, Vector2 Size, int ScreenIndex, int SoundIndex, Translations.Command Command, int CommandOption, Vector2 RelativeRotationCenter, double PanelResolution, double PanelBottom, Vector2 PanelCenter, Vector3 Driver)
+
+		private static void ParseTouchSoundEntryNode(string fileName, XElement parent, ICollection<int> indices)
+		{
+			foreach (XElement childNode in parent.Elements())
+			{
+				if (childNode.Name.LocalName.ToLowerInvariant() != "entry")
+				{
+					Interface.AddMessage(MessageType.Error, false, $"Invalid entry node {childNode.Name.LocalName} in XML node {parent.Name.LocalName} at line {((IXmlLineInfo)childNode).LineNumber}");
+				}
+				else
+				{
+					System.Globalization.CultureInfo culture = System.Globalization.CultureInfo.InvariantCulture;
+
+					string section = childNode.Name.LocalName;
+
+					foreach (XElement keyNode in childNode.Elements())
+					{
+						string key = keyNode.Name.LocalName;
+						string value = keyNode.Value;
+						int lineNumber = ((IXmlLineInfo)keyNode).LineNumber;
+
+						switch (keyNode.Name.LocalName.ToLowerInvariant())
+						{
+							case "index":
+								if (value.Any())
+								{
+									int index;
+
+									if (!NumberFormats.TryParseIntVb6(value, out index))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+									}
+
+									indices.Add(index);
+								}
+								break;
+						}
+					}
+				}
+			}
+		}
+
+		private static void ParseTouchCommandEntryNode(string fileName, XElement parent, ICollection<TrainManager.CommandEntry> entries)
+		{
+			foreach (XElement childNode in parent.Elements())
+			{
+				if (childNode.Name.LocalName.ToLowerInvariant() != "entry")
+				{
+					Interface.AddMessage(MessageType.Error, false, $"Invalid entry node {childNode.Name.LocalName} in XML node {parent.Name.LocalName} at line {((IXmlLineInfo)childNode).LineNumber}");
+				}
+				else
+				{
+					TrainManager.CommandEntry entry = new TrainManager.CommandEntry();
+					System.Globalization.CultureInfo culture = System.Globalization.CultureInfo.InvariantCulture;
+
+					string section = childNode.Name.LocalName;
+
+					foreach (XElement keyNode in childNode.Elements())
+					{
+						string key = keyNode.Name.LocalName;
+						string value = keyNode.Value;
+						int lineNumber = ((IXmlLineInfo)keyNode).LineNumber;
+
+						switch (keyNode.Name.LocalName.ToLowerInvariant())
+						{
+							case "name":
+								if (string.Compare(value, "N/A", StringComparison.InvariantCultureIgnoreCase) == 0)
+								{
+									break;
+								}
+
+								int i;
+
+								for (i = 0; i < Translations.CommandInfos.Length; i++)
+								{
+									if (string.Compare(value, Translations.CommandInfos[i].Name, StringComparison.OrdinalIgnoreCase) == 0)
+									{
+										break;
+									}
+								}
+
+								if (i == Translations.CommandInfos.Length || Translations.CommandInfos[i].Type != Translations.CommandType.Digital)
+								{
+									Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+								}
+								else
+								{
+									entry.Command = Translations.CommandInfos[i].Command;
+								}
+								break;
+							case "option":
+								if (value.Any())
+								{
+									int option;
+
+									if (!NumberFormats.TryParseIntVb6(value, out option))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"value is invalid in {key} in {section} at line {lineNumber.ToString(culture)} in {fileName}");
+									}
+									else
+									{
+										entry.Option = option;
+									}
+								}
+								break;
+						}
+					}
+
+					entries.Add(entry);
+				}
+			}
+		}
+
+		internal static void CreateTouchElement(TrainManager.ElementsGroup Group, Vector2 Location, Vector2 Size, int ScreenIndex, int[] SoundIndices, TrainManager.CommandEntry[] CommandEntries, Vector2 RelativeRotationCenter, double Distance, double PanelResolution, double PanelBottom, Vector2 PanelCenter, Vector3 Driver)
 		{
 			double WorldWidth, WorldHeight;
 			if (Program.Renderer.Screen.Width >= Program.Renderer.Screen.Height)
@@ -1600,7 +1762,7 @@ namespace OpenBve.Parsers.Panel
 			Vector3 o;
 			o.X = xm + Driver.X;
 			o.Y = ym + Driver.Y;
-			o.Z = EyeDistance + Driver.Z;
+			o.Z = EyeDistance - Distance + Driver.Z;
 			if (Group.TouchElements == null)
 			{
 				Group.TouchElements = new TrainManager.TouchElement[0];
@@ -1611,9 +1773,8 @@ namespace OpenBve.Parsers.Panel
 			{
 				Element = new AnimatedObject(Program.CurrentHost),
 				JumpScreenIndex = ScreenIndex,
-				SoundIndex = SoundIndex,
-				Command = Command,
-				CommandOption = CommandOption
+				SoundIndices = SoundIndices,
+				ControlIndices = new int[CommandEntries.Length]
 			};
 			Group.TouchElements[n].Element.States = new[] { new ObjectState() };
 			Group.TouchElements[n].Element.States[0].Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z);
@@ -1622,10 +1783,14 @@ namespace OpenBve.Parsers.Panel
 			Group.TouchElements[n].Element.internalObject = new ObjectState { Prototype = Object };
 			Program.CurrentHost.CreateDynamicObject(ref Group.TouchElements[n].Element.internalObject);
 			int m = Interface.CurrentControls.Length;
-			Array.Resize(ref Interface.CurrentControls, m + 1);
-			Interface.CurrentControls[m].Command = Command;
-			Interface.CurrentControls[m].Method = Interface.ControlMethod.Touch;
-			Interface.CurrentControls[m].Option = CommandOption;
+			Array.Resize(ref Interface.CurrentControls, m + CommandEntries.Length);
+			for (int i = 0; i < CommandEntries.Length; i++)
+			{
+				Interface.CurrentControls[m + i].Command = CommandEntries[i].Command;
+				Interface.CurrentControls[m + i].Method = Interface.ControlMethod.Touch;
+				Interface.CurrentControls[m + i].Option = CommandEntries[i].Option;
+				Group.TouchElements[n].ControlIndices[i] = m + i;
+			}
 		}
 	}
 }

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSection.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.CarSection.cs
@@ -6,13 +6,18 @@ namespace OpenBve
 	/// <summary>The TrainManager is the root class containing functions to load and manage trains within the simulation world.</summary>
 	public static partial class TrainManager
 	{
+		internal class CommandEntry
+		{
+			internal Translations.Command Command;
+			internal int Option;
+		}
+
 		internal class TouchElement
 		{
 			internal AnimatedObject Element;
 			internal int JumpScreenIndex;
-			internal int SoundIndex;
-			internal Translations.Command Command;
-			internal int CommandOption;
+			internal int[] SoundIndices;
+			internal int[] ControlIndices;
 		}
 
 		internal class ElementsGroup

--- a/source/TrainEditor2/IO/IntermediateFile/Parser.cs
+++ b/source/TrainEditor2/IO/IntermediateFile/Parser.cs
@@ -490,16 +490,53 @@ namespace TrainEditor2.IO.IntermediateFile
 			double[] location = ((string)parent.Element("Location")).Split(',').Select(double.Parse).ToArray();
 			double[] size = ((string)parent.Element("Size")).Split(',').Select(double.Parse).ToArray();
 
-			return new Models.Panels.TouchElement(screen)
+			Models.Panels.TouchElement element = new Models.Panels.TouchElement(screen)
 			{
 				LocationX = location[0],
 				LocationY = location[1],
 				SizeX = size[0],
 				SizeY = size[1],
-				JumpScreen = (int)parent.Element("JumpScreen"),
-				SoundIndex = (int)parent.Element("SoundIndex"),
-				CommandInfo = Translations.CommandInfos.TryGetInfo((Translations.Command)Enum.Parse(typeof(Translations.Command), (string)parent.Element("CommandInfo"))),
-				CommandOption = (int)parent.Element("CommandOption")
+				JumpScreen = (int)parent.Element("JumpScreen")
+			};
+
+			if (parent.Element("SoundIndex") != null)
+			{
+				element.SoundEntries.Add(new Models.Panels.TouchElement.SoundEntry
+				{
+					Index = (int)parent.Element("SoundIndex")
+				});
+			}
+
+			if (parent.Element("CommandInfo") != null && parent.Element("CommandOption") != null)
+			{
+				element.CommandEntries.Add(new Models.Panels.TouchElement.CommandEntry
+				{
+					Info = Translations.CommandInfos.TryGetInfo((Translations.Command)Enum.Parse(typeof(Translations.Command), (string)parent.Element("CommandInfo"))),
+					Option = (int)parent.Element("CommandOption")
+				});
+			}
+
+			element.SoundEntries.AddRange(parent.XPathSelectElements("SoundEntries/Entry").Select(ParseTouchElementSoundEntryNode));
+			element.CommandEntries.AddRange(parent.XPathSelectElements("CommandEntries/Entry").Select(ParseTouchElementCommandEntryNode));
+			element.Layer = (int)parent.Element("Layer");
+
+			return element;
+		}
+
+		private static Models.Panels.TouchElement.SoundEntry ParseTouchElementSoundEntryNode(XElement parent)
+		{
+			return new Models.Panels.TouchElement.SoundEntry
+			{
+				Index = (int)parent.Element("Index")
+			};
+		}
+
+		private static Models.Panels.TouchElement.CommandEntry ParseTouchElementCommandEntryNode(XElement parent)
+		{
+			return new Models.Panels.TouchElement.CommandEntry
+			{
+				Info = Translations.CommandInfos.TryGetInfo((Translations.Command)Enum.Parse(typeof(Translations.Command), (string)parent.Element("Info"))),
+				Option = (int)parent.Element("Option")
 			};
 		}
 

--- a/source/TrainEditor2/IO/IntermediateFile/Writer.cs
+++ b/source/TrainEditor2/IO/IntermediateFile/Writer.cs
@@ -491,10 +491,25 @@ namespace TrainEditor2.IO.IntermediateFile
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
 				new XElement("Size", $"{element.SizeX}, {element.SizeY}"),
 				new XElement("JumpScreen", element.JumpScreen),
-				new XElement("SoundIndex", element.SoundIndex),
-				new XElement("CommandInfo", element.CommandInfo.Command),
-				new XElement("CommandOption", element.CommandOption)
+				new XElement("SoundEntries", element.SoundEntries.Select(WriteTouchElementSoundEntryNode)),
+				new XElement("CommandEntries", element.CommandEntries.Select(WriteTouchElementCommandEntryNode)),
+				new XElement("Layer", element.Layer)
 				));
+		}
+
+		private static XElement WriteTouchElementSoundEntryNode(Models.Panels.TouchElement.SoundEntry entry)
+		{
+			return new XElement("Entry",
+				new XElement("Index", entry.Index)
+			);
+		}
+
+		private static XElement WriteTouchElementCommandEntryNode(Models.Panels.TouchElement.CommandEntry entry)
+		{
+			return new XElement("Entry",
+				new XElement("Info", entry.Info.Command),
+				new XElement("Option", entry.Option)
+				);
 		}
 
 		private static void WriteSoundsNode(XElement parent, Sound sound)

--- a/source/TrainEditor2/IO/Panels/Bve4/Writer.cs
+++ b/source/TrainEditor2/IO/Panels/Bve4/Writer.cs
@@ -176,7 +176,7 @@ namespace TrainEditor2.IO.Panels.Bve4
 				return;
 			}
 
-			builder.AppendLine(string.Format("{0} = {1}", key, string.Join(", ", values)));
+			builder.AppendLine($"{key} = {string.Join(", ", values)}");
 		}
 
 		private static void WriteKey(StringBuilder builder, string key, params int[] values)

--- a/source/TrainEditor2/IO/Panels/Xml/Writer.cs
+++ b/source/TrainEditor2/IO/Panels/Xml/Writer.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using System.Linq;
+using System.Xml.Linq;
 using TrainEditor2.Extensions;
 using TrainEditor2.Models.Panels;
 
@@ -35,18 +36,31 @@ namespace TrainEditor2.IO.Panels.Xml
 
 		private static void WriteThisNode(string fileName, XElement parent, This This)
 		{
-			parent.Add(new XElement("This",
+			XElement thisNode = new XElement("This",
 				new XElement("Resolution", This.Resolution),
 				new XElement("Left", This.Left),
 				new XElement("Right", This.Right),
 				new XElement("Top", This.Top),
-				new XElement("Bottom", This.Bottom),
-				new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, This.DaytimeImage)),
-				new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, This.NighttimeImage)),
+				new XElement("Bottom", This.Bottom)
+			);
+
+			if (!string.IsNullOrEmpty(This.DaytimeImage))
+			{
+				thisNode.Add(new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, This.DaytimeImage)));
+			}
+
+			if (!string.IsNullOrEmpty(This.NighttimeImage))
+			{
+				thisNode.Add(new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, This.NighttimeImage)));
+			}
+
+			thisNode.Add(
 				new XElement("TransparentColor", This.TransparentColor),
 				new XElement("Center", $"{This.CenterX}, {This.CenterY}"),
 				new XElement("Origin", $"{This.OriginX}, {This.OriginY}")
-			));
+			);
+
+			parent.Add(thisNode);
 		}
 
 		private static void WriteScreenNode(string fileName, XElement parent, Screen screen)
@@ -55,7 +69,6 @@ namespace TrainEditor2.IO.Panels.Xml
 				new XElement("Number", screen.Number),
 				new XElement("Layer", screen.Layer)
 			);
-			parent.Add(screenNode);
 
 			foreach (PanelElement element in screen.PanelElements)
 			{
@@ -66,6 +79,8 @@ namespace TrainEditor2.IO.Panels.Xml
 			{
 				WriteTouchElementNode(screenNode, element);
 			}
+
+			parent.Add(screenNode);
 		}
 
 		private static void WritePanelElementNode(string fileName, XElement parent, PanelElement element)
@@ -103,24 +118,46 @@ namespace TrainEditor2.IO.Panels.Xml
 
 		private static void WritePilotLampElementNode(string fileName, XElement parent, PilotLampElement element)
 		{
-			parent.Add(new XElement("PilotLamp",
+			XElement pilotLampNode = new XElement("PilotLamp",
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
 				new XElement("Layer", element.Layer),
-				new XElement("Subject", element.Subject),
-				new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)),
-				new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)),
-				new XElement("TransparentColor", element.TransparentColor)
-			));
+				new XElement("Subject", element.Subject)
+			);
+
+			if (!string.IsNullOrEmpty(element.DaytimeImage))
+			{
+				pilotLampNode.Add(new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)));
+			}
+
+			if (!string.IsNullOrEmpty(element.NighttimeImage))
+			{
+				pilotLampNode.Add(new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)));
+			}
+
+			pilotLampNode.Add(new XElement("TransparentColor", element.TransparentColor));
+
+			parent.Add(pilotLampNode);
 		}
 
 		private static void WriteNeedleElementNode(string fileName, XElement parent, NeedleElement element)
 		{
-			XElement needleNode = new XElement("Node",
+			XElement needleNode = new XElement("Needle",
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
 				new XElement("Layer", element.Layer),
-				new XElement("Subject", element.Subject),
-				new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)),
-				new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)),
+				new XElement("Subject", element.Subject)
+				);
+
+			if (!string.IsNullOrEmpty(element.DaytimeImage))
+			{
+				needleNode.Add(new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)));
+			}
+
+			if (!string.IsNullOrEmpty(element.NighttimeImage))
+			{
+				needleNode.Add(new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)));
+			}
+
+			needleNode.Add(
 				new XElement("TransparentColor", element.TransparentColor),
 				new XElement("Color", element.Color),
 				new XElement("InitialAngle", element.InitialAngle.ToDegrees()),
@@ -156,15 +193,28 @@ namespace TrainEditor2.IO.Panels.Xml
 
 		private static void WriteDigitalNumberElementNode(string fileName, XElement parent, DigitalNumberElement element)
 		{
-			parent.Add(new XElement("DigitalNumber",
+			XElement digitalNumberNode = new XElement("DigitalNumber",
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
 				new XElement("Layer", element.Layer),
-				new XElement("Subject", element.Subject),
-				new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)),
-				new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)),
+				new XElement("Subject", element.Subject)
+			);
+
+			if (!string.IsNullOrEmpty(element.DaytimeImage))
+			{
+				digitalNumberNode.Add(new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)));
+			}
+
+			if (!string.IsNullOrEmpty(element.NighttimeImage))
+			{
+				digitalNumberNode.Add(new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)));
+			}
+
+			digitalNumberNode.Add(
 				new XElement("TransparentColor", element.TransparentColor),
 				new XElement("Interval", element.Interval)
-			));
+				);
+
+			parent.Add(digitalNumberNode);
 		}
 
 		private static void WriteDigitalGaugeElementNode(XElement parent, DigitalGaugeElement element)
@@ -185,18 +235,31 @@ namespace TrainEditor2.IO.Panels.Xml
 
 		private static void WriteLinearGaugeElementNode(string fileName, XElement parent, LinearGaugeElement element)
 		{
-			parent.Add(new XElement("LinearGauge",
+			XElement linearGaugeNode = new XElement("LinearGauge",
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
 				new XElement("Layer", element.Layer),
-				new XElement("Subject", element.Subject),
-				new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)),
-				new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)),
+				new XElement("Subject", element.Subject)
+			);
+
+			if (!string.IsNullOrEmpty(element.DaytimeImage))
+			{
+				linearGaugeNode.Add(new XElement("DaytimeImage", Utilities.MakeRelativePath(fileName, element.DaytimeImage)));
+			}
+
+			if (!string.IsNullOrEmpty(element.NighttimeImage))
+			{
+				linearGaugeNode.Add(new XElement("NighttimeImage", Utilities.MakeRelativePath(fileName, element.NighttimeImage)));
+			}
+
+			linearGaugeNode.Add(
 				new XElement("TransparentColor", element.TransparentColor),
 				new XElement("Minimum", element.Minimum),
 				new XElement("Maximum", element.Maximum),
 				new XElement("Direction", $"{element.DirectionX}, {element.DirectionY}"),
 				new XElement("Width", element.Width)
-			));
+				);
+
+			parent.Add(linearGaugeNode);
 		}
 
 		private static void WriteTimetableElementNode(XElement parent, TimetableElement element)
@@ -212,14 +275,39 @@ namespace TrainEditor2.IO.Panels.Xml
 
 		private static void WriteTouchElementNode(XElement parent, TouchElement element)
 		{
-			parent.Add(new XElement("Touch",
+			XElement touchNode = new XElement("Touch",
 				new XElement("Location", $"{element.LocationX}, {element.LocationY}"),
+				new XElement("Layer", element.Layer),
 				new XElement("Size", $"{element.SizeX}, {element.SizeY}"),
-				new XElement("JumpScreen", element.JumpScreen),
-				new XElement("SoundIndex", element.SoundIndex),
-				new XElement("Command", element.CommandInfo.Name),
-				new XElement("CommandOption", element.CommandOption)
-			));
+				new XElement("JumpScreen", element.JumpScreen)
+			);
+
+			if (element.SoundEntries.Any())
+			{
+				touchNode.Add(new XElement("SoundEntries", element.SoundEntries.Select(WriteTouchElementSoundEntryNode)));
+			}
+
+			if (element.CommandEntries.Any())
+			{
+				touchNode.Add(new XElement("CommandEntries", element.CommandEntries.Select(WriteTouchElementCommandEntryNode)));
+			}
+
+			parent.Add(touchNode);
+		}
+
+		private static XElement WriteTouchElementSoundEntryNode(TouchElement.SoundEntry entry)
+		{
+			return new XElement("Entry",
+				new XElement("Index", entry.Index)
+			);
+		}
+
+		private static XElement WriteTouchElementCommandEntryNode(TouchElement.CommandEntry entry)
+		{
+			return new XElement("Entry",
+				new XElement("Name", entry.Info.Name),
+				new XElement("Option", entry.Option)
+			);
 		}
 	}
 }

--- a/source/TrainEditor2/Models/App.cs
+++ b/source/TrainEditor2/Models/App.cs
@@ -506,6 +506,12 @@ namespace TrainEditor2.Models
 				OnPropertyChanged(new PropertyChangedEventArgs(nameof(Sound)));
 
 				CreateItem();
+
+				Panel.CreateTreeItem();
+				Panel.SelectedTreeItem = Panel.TreeItem;
+
+				Sound.CreateTreeItem();
+				Sound.SelectedTreeItem = Sound.TreeItem;
 			}
 			catch (Exception e)
 			{
@@ -629,12 +635,12 @@ namespace TrainEditor2.Models
 						{
 							ExtensionsCfg.Parse(ExtensionsCfgImportLocation, Train);
 						}
-
-						CreateItem();
 						break;
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
+
+				CreateItem();
 			}
 			catch (Exception e)
 			{
@@ -662,6 +668,9 @@ namespace TrainEditor2.Models
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
+
+				Panel.CreateTreeItem();
+				Panel.SelectedTreeItem = Panel.TreeItem;
 			}
 			catch (Exception e)
 			{
@@ -696,6 +705,9 @@ namespace TrainEditor2.Models
 					default:
 						throw new ArgumentOutOfRangeException();
 				}
+
+				Sound.CreateTreeItem();
+				Sound.SelectedTreeItem = Sound.TreeItem;
 			}
 			catch (Exception e)
 			{
@@ -944,7 +956,7 @@ namespace TrainEditor2.Models
 
 		internal void ResetLogMessages()
 		{
-			VisibleLogMessages.RemoveAll(_ => true);
+			VisibleLogMessages.Clear();
 		}
 
 		internal void ChangeVisibleLogMessages(MessageType type, bool visible)

--- a/source/TrainEditor2/Models/Panels/Panel.cs
+++ b/source/TrainEditor2/Models/Panels/Panel.cs
@@ -142,7 +142,7 @@ namespace TrainEditor2.Models.Panels
 
 		internal void CreateListColumns()
 		{
-			ListColumns.RemoveAll(_ => true);
+			ListColumns.Clear();
 
 			if (SelectedTreeItem == TreeItem.Children[1])
 			{
@@ -234,15 +234,13 @@ namespace TrainEditor2.Models.Panels
 				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Location" });
 				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Size" });
 				ListColumns.Add(new ListViewColumnHeaderModel { Text = "JumpScreen" });
-				ListColumns.Add(new ListViewColumnHeaderModel { Text = "SoundIndex" });
-				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Command" });
-				ListColumns.Add(new ListViewColumnHeaderModel { Text = "CommandOption" });
+				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Layer" });
 			}
 		}
 
 		internal void CreateListItems()
 		{
-			ListItems.RemoveAll(_ => true);
+			ListItems.Clear();
 
 			if (SelectedTreeItem == TreeItem.Children[1])
 			{
@@ -344,7 +342,7 @@ namespace TrainEditor2.Models.Panels
 
 				foreach (TouchElement touch in screen.TouchElements)
 				{
-					ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[6]), Tag = touch };
+					ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[4]), Tag = touch };
 					UpdateListItem(newItem);
 					ListItems.Add(newItem);
 				}
@@ -452,9 +450,7 @@ namespace TrainEditor2.Models.Panels
 				item.Texts[0] = $"{touch.LocationX.ToString(culture)}, {touch.LocationY.ToString(culture)}";
 				item.Texts[1] = $"{touch.SizeX.ToString(culture)}, {touch.SizeY.ToString(culture)}";
 				item.Texts[2] = touch.JumpScreen.ToString(culture);
-				item.Texts[3] = touch.SoundIndex.ToString(culture);
-				item.Texts[4] = touch.CommandInfo.Name;
-				item.Texts[5] = touch.CommandOption.ToString(culture);
+				item.Texts[3] = touch.Layer.ToString(culture);
 			}
 		}
 
@@ -607,7 +603,7 @@ namespace TrainEditor2.Models.Panels
 
 			screen.TouchElements.Add(touch);
 
-			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[6]), Tag = touch };
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[4]), Tag = touch };
 			UpdateListItem(newItem);
 			ListItems.Add(newItem);
 
@@ -763,7 +759,7 @@ namespace TrainEditor2.Models.Panels
 
 			screen.TouchElements.Add(touch);
 
-			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[6]), Tag = touch };
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[4]), Tag = touch };
 			UpdateListItem(newItem);
 			ListItems.Add(newItem);
 

--- a/source/TrainEditor2/Models/Panels/TouchElement.cs
+++ b/source/TrainEditor2/Models/Panels/TouchElement.cs
@@ -1,19 +1,103 @@
 ﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
 using OpenBveApi.Interface;
 using Prism.Mvvm;
+using TrainEditor2.Models.Others;
 
 namespace TrainEditor2.Models.Panels
 {
 	internal class TouchElement : BindableBase, ICloneable
 	{
+		internal class SoundEntry : BindableBase, ICloneable
+		{
+			private int index;
+
+			internal int Index
+			{
+				get
+				{
+					return index;
+				}
+				set
+				{
+					SetProperty(ref index, value);
+				}
+			}
+
+			internal SoundEntry()
+			{
+				Index = -1;
+			}
+
+			public object Clone()
+			{
+				return MemberwiseClone();
+			}
+		}
+
+		internal class CommandEntry : BindableBase, ICloneable
+		{
+			private Translations.CommandInfo info;
+			private int option;
+
+			internal Translations.CommandInfo Info
+			{
+				get
+				{
+					return info;
+				}
+				set
+				{
+					SetProperty(ref info, value);
+				}
+			}
+
+			internal int Option
+			{
+				get
+				{
+					return option;
+				}
+				set
+				{
+					SetProperty(ref option, value);
+				}
+			}
+
+			internal CommandEntry()
+			{
+				Info = Translations.CommandInfos.TryGetInfo(Translations.Command.None);
+				Option = 0;
+			}
+
+			public object Clone()
+			{
+				return MemberwiseClone();
+			}
+		}
+
+		private readonly CultureInfo culture;
+
 		private double locationX;
 		private double locationY;
 		private double sizeX;
 		private double sizeY;
 		private int jumpScreen;
-		private int soundIndex;
-		private Translations.CommandInfo commandInfo;
-		private int commandOption;
+		private int layer;
+
+		private TreeViewItemModel treeItem;
+		private TreeViewItemModel selectedTreeItem;
+
+		private ListViewItemModel selectedListItem;
+
+		internal ObservableCollection<SoundEntry> SoundEntries;
+		internal ObservableCollection<CommandEntry> CommandEntries;
+
+		internal ObservableCollection<ListViewColumnHeaderModel> ListColumns;
+		internal ObservableCollection<ListViewItemModel> ListItems;
 
 		internal double LocationX
 		{
@@ -75,57 +159,227 @@ namespace TrainEditor2.Models.Panels
 			}
 		}
 
-		internal int SoundIndex
+		internal int Layer
 		{
 			get
 			{
-				return soundIndex;
+				return layer;
 			}
 			set
 			{
-				SetProperty(ref soundIndex, value);
+				SetProperty(ref layer, value);
 			}
 		}
 
-		internal Translations.CommandInfo CommandInfo
+		internal TreeViewItemModel TreeItem
 		{
 			get
 			{
-				return commandInfo;
+				return treeItem;
 			}
 			set
 			{
-				SetProperty(ref commandInfo, value);
+				SetProperty(ref treeItem, value);
 			}
 		}
 
-		internal int CommandOption
+		internal TreeViewItemModel SelectedTreeItem
 		{
 			get
 			{
-				return commandOption;
+				return selectedTreeItem;
 			}
 			set
 			{
-				SetProperty(ref commandOption, value);
+				SetProperty(ref selectedTreeItem, value);
+			}
+		}
+
+		internal ListViewItemModel SelectedListItem
+		{
+			get
+			{
+				return selectedListItem;
+			}
+			set
+			{
+				SetProperty(ref selectedListItem, value);
 			}
 		}
 
 		internal TouchElement(Screen screen)
 		{
+			culture = CultureInfo.InvariantCulture;
+
 			LocationX = 0.0;
 			LocationY = 0.0;
 			SizeX = 0.0;
 			SizeY = 0.0;
 			JumpScreen = screen.Number;
-			SoundIndex = -1;
-			CommandInfo = Translations.CommandInfos.TryGetInfo(Translations.Command.None);
-			CommandOption = 0;
+			SoundEntries = new ObservableCollection<SoundEntry>();
+			CommandEntries = new ObservableCollection<CommandEntry>();
+			Layer = 0;
+
+			ListColumns = new ObservableCollection<ListViewColumnHeaderModel>();
+			ListItems = new ObservableCollection<ListViewItemModel>();
+
+			CreateTreeItem();
+			SelectedTreeItem = TreeItem;
 		}
 
 		public object Clone()
 		{
-			return MemberwiseClone();
+			TouchElement touch = (TouchElement)MemberwiseClone();
+			touch.SoundEntries = new ObservableCollection<SoundEntry>(SoundEntries.Select(x => (SoundEntry)x.Clone()));
+			touch.CommandEntries = new ObservableCollection<CommandEntry>(CommandEntries.Select(x => (CommandEntry)x.Clone()));
+
+			touch.ListColumns = new ObservableCollection<ListViewColumnHeaderModel>();
+			touch.ListItems = new ObservableCollection<ListViewItemModel>();
+
+			touch.CreateTreeItem();
+			touch.SelectedTreeItem = touch.TreeItem;
+
+			return touch;
+		}
+
+		internal void CreateTreeItem()
+		{
+			treeItem = new TreeViewItemModel(null) { Title = "TouchElement" };
+			treeItem.Children.Add(new TreeViewItemModel(TreeItem) { Title = "Sounds" });
+			treeItem.Children.Add(new TreeViewItemModel(TreeItem) { Title = "Commands" });
+			OnPropertyChanged(new PropertyChangedEventArgs(nameof(TreeItem)));
+		}
+
+		internal void CreateListColumns()
+		{
+			ListColumns.Clear();
+
+			if (SelectedTreeItem == TreeItem.Children[0])
+			{
+				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Index" });
+			}
+
+			if (SelectedTreeItem == TreeItem.Children[1])
+			{
+				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Name" });
+				ListColumns.Add(new ListViewColumnHeaderModel { Text = "Option" });
+			}
+		}
+
+		internal void CreateListItems()
+		{
+			ListItems.Clear();
+
+			if (SelectedTreeItem == TreeItem.Children[0])
+			{
+				foreach (SoundEntry entry in SoundEntries)
+				{
+					ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[1]), Tag = entry };
+					UpdateListItem(newItem);
+					ListItems.Add(newItem);
+				}
+			}
+
+			if (SelectedTreeItem == TreeItem.Children[1])
+			{
+				foreach (CommandEntry entry in CommandEntries)
+				{
+					ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[2]), Tag = entry };
+					UpdateListItem(newItem);
+					ListItems.Add(newItem);
+				}
+			}
+		}
+
+		internal void UpdateListItem(ListViewItemModel item)
+		{
+			SoundEntry soundEntry = item.Tag as SoundEntry;
+			CommandEntry commandEntry = item.Tag as CommandEntry;
+
+			if (soundEntry != null)
+			{
+				item.Texts[0] = soundEntry.Index.ToString(culture);
+			}
+
+			if (commandEntry != null)
+			{
+				item.Texts[0] = commandEntry.Info.Name;
+				item.Texts[1] = commandEntry.Option.ToString(culture);
+			}
+		}
+
+		internal void AddSoundEntry()
+		{
+			SoundEntry entry = new SoundEntry();
+
+			SoundEntries.Add(entry);
+
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[1]), Tag = entry };
+			UpdateListItem(newItem);
+			ListItems.Add(newItem);
+
+			SelectedListItem = ListItems.Last();
+		}
+
+		internal void AddCommandEntry()
+		{
+			CommandEntry entry = new CommandEntry();
+
+			CommandEntries.Add(entry);
+
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[2]), Tag = entry };
+			UpdateListItem(newItem);
+			ListItems.Add(newItem);
+
+			SelectedListItem = ListItems.Last();
+		}
+
+		internal void CopySoundEntry()
+		{
+			SoundEntry entry = (SoundEntry)((SoundEntry)SelectedListItem.Tag).Clone();
+
+			SoundEntries.Add(entry);
+
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[1]), Tag = entry };
+			UpdateListItem(newItem);
+			ListItems.Add(newItem);
+
+			SelectedListItem = ListItems.Last();
+		}
+
+		internal void CopyCommandEntry()
+		{
+			CommandEntry entry = (CommandEntry)((CommandEntry)SelectedListItem.Tag).Clone();
+
+			CommandEntries.Add(entry);
+
+			ListViewItemModel newItem = new ListViewItemModel { Texts = new ObservableCollection<string>(new string[2]), Tag = entry };
+			UpdateListItem(newItem);
+			ListItems.Add(newItem);
+
+			SelectedListItem = ListItems.Last();
+		}
+
+		internal void RemoveSoundEntry()
+		{
+			SoundEntry entry = (SoundEntry)SelectedListItem.Tag;
+
+			SoundEntries.Remove(entry);
+
+			ListItems.Remove(SelectedListItem);
+
+			SelectedListItem = null;
+		}
+
+		internal void RemoveCommandEntry()
+		{
+			CommandEntry entry = (CommandEntry)SelectedListItem.Tag;
+
+			CommandEntries.Remove(entry);
+
+			ListItems.Remove(SelectedListItem);
+
+			SelectedListItem = null;
 		}
 	}
 }

--- a/source/TrainEditor2/Models/Sounds/Sound.cs
+++ b/source/TrainEditor2/Models/Sounds/Sound.cs
@@ -118,7 +118,7 @@ namespace TrainEditor2.Models.Sounds
 
 		internal void CreateListColumns()
 		{
-			ListColumns.RemoveAll(_ => true);
+			ListColumns.Clear();
 
 			if (TreeItem.Children.Contains(SelectedTreeItem))
 			{
@@ -131,7 +131,7 @@ namespace TrainEditor2.Models.Sounds
 
 		internal void CreateListItems()
 		{
-			ListItems.RemoveAll(_ => true);
+			ListItems.Clear();
 
 			IEnumerable<SoundElement> elements = null;
 

--- a/source/TrainEditor2/TrainEditor2.csproj
+++ b/source/TrainEditor2/TrainEditor2.csproj
@@ -67,6 +67,7 @@
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Reactive, Version=4.1.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.4.1.6\lib\net46\System.Reactive.dll</HintPath>
     </Reference>
@@ -324,6 +325,12 @@
     <Compile Include="Views\FormSubject.Designer.cs">
       <DependentUpon>FormSubject.cs</DependentUpon>
     </Compile>
+    <Compile Include="Views\FormTouch.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Views\FormTouch.Designer.cs">
+      <DependentUpon>FormTouch.cs</DependentUpon>
+    </Compile>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -351,6 +358,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Views\FormSubject.resx">
       <DependentUpon>FormSubject.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Views\FormTouch.resx">
+      <DependentUpon>FormTouch.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="OpenTK.dll.config" />
     <None Include="packages.config" />

--- a/source/TrainEditor2/ViewModels/Panels/ThisViewModel.cs
+++ b/source/TrainEditor2/ViewModels/Panels/ThisViewModel.cs
@@ -175,7 +175,8 @@ namespace TrainEditor2.ViewModels.Panels
 				.ToReactivePropertyAsSynchronized(
 					x => x.TransparentColor,
 					x => x.ToString(),
-					Color24.ParseHexColor
+					Color24.ParseHexColor,
+					ignoreValidationErrorValue: true
 				)
 				.SetValidateNotifyError(x =>
 				{

--- a/source/TrainEditor2/ViewModels/Panels/TouchElementViewModel.cs
+++ b/source/TrainEditor2/ViewModels/Panels/TouchElementViewModel.cs
@@ -1,14 +1,59 @@
-﻿using System.Globalization;
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using OpenBveApi.Interface;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using TrainEditor2.Extensions;
 using TrainEditor2.Models.Panels;
+using TrainEditor2.ViewModels.Others;
 
 namespace TrainEditor2.ViewModels.Panels
 {
 	internal class TouchElementViewModel : BaseViewModel
 	{
+		internal class SoundEntryViewModel : BaseViewModel
+		{
+			internal ReactiveProperty<int> Index
+			{
+				get;
+			}
+
+			internal SoundEntryViewModel(TouchElement.SoundEntry entry)
+			{
+				Index = entry
+					.ToReactivePropertyAsSynchronized(x => x.Index)
+					.AddTo(disposable);
+			}
+		}
+
+		internal class CommandEntryViewModel : BaseViewModel
+		{
+			internal ReactiveProperty<Translations.CommandInfo> Info
+			{
+				get;
+			}
+
+			internal ReactiveProperty<int> Option
+			{
+				get;
+			}
+
+			internal CommandEntryViewModel(TouchElement.CommandEntry entry)
+			{
+				Info = entry
+					.ToReactivePropertyAsSynchronized(x => x.Info)
+					.AddTo(disposable);
+
+				Option = entry
+					.ToReactivePropertyAsSynchronized(x => x.Option)
+					.AddTo(disposable);
+			}
+		}
+
 		internal ReactiveProperty<string> LocationX
 		{
 			get;
@@ -34,17 +79,82 @@ namespace TrainEditor2.ViewModels.Panels
 			get;
 		}
 
-		internal ReactiveProperty<int> SoundIndex
+		internal ReadOnlyReactiveCollection<SoundEntryViewModel> SoundEntries
 		{
 			get;
 		}
 
-		internal ReactiveProperty<Translations.CommandInfo> CommandInfo
+		internal ReadOnlyReactiveCollection<CommandEntryViewModel> CommandEntries
 		{
 			get;
 		}
 
-		internal ReactiveProperty<int> CommandOption
+		internal ReactiveProperty<int> Layer
+		{
+			get;
+		}
+
+		internal ReactiveProperty<TreeViewItemViewModel> TreeItem
+		{
+			get;
+		}
+
+		internal ReactiveProperty<TreeViewItemViewModel> SelectedTreeItem
+		{
+			get;
+		}
+
+		internal ReadOnlyReactiveCollection<ListViewColumnHeaderViewModel> ListColumns
+		{
+			get;
+		}
+
+		internal ReadOnlyReactiveCollection<ListViewItemViewModel> ListItems
+		{
+			get;
+		}
+
+		internal ReactiveProperty<ListViewItemViewModel> SelectedListItem
+		{
+			get;
+		}
+
+		internal ReadOnlyReactivePropertySlim<SoundEntryViewModel> SelectedSoundEntry
+		{
+			get;
+		}
+
+		internal ReadOnlyReactivePropertySlim<CommandEntryViewModel> SelectedCommandEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand AddSoundEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand AddCommandEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand CopySoundEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand CopyCommandEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand RemoveSoundEntry
+		{
+			get;
+		}
+
+		internal ReactiveCommand RemoveCommandEntry
 		{
 			get;
 		}
@@ -52,6 +162,9 @@ namespace TrainEditor2.ViewModels.Panels
 		internal TouchElementViewModel(TouchElement touch)
 		{
 			CultureInfo culture = CultureInfo.InvariantCulture;
+
+			CompositeDisposable treeItemDisposable = new CompositeDisposable();
+			CompositeDisposable listItemDisposable = new CompositeDisposable();
 
 			LocationX = touch
 				.ToReactivePropertyAsSynchronized(
@@ -129,16 +242,144 @@ namespace TrainEditor2.ViewModels.Panels
 				.ToReactivePropertyAsSynchronized(x => x.JumpScreen)
 				.AddTo(disposable);
 
-			SoundIndex = touch
-				.ToReactivePropertyAsSynchronized(x => x.SoundIndex)
+			SoundEntries = touch.SoundEntries
+				.ToReadOnlyReactiveCollection(x => new SoundEntryViewModel(x))
 				.AddTo(disposable);
 
-			CommandInfo = touch
-				.ToReactivePropertyAsSynchronized(x => x.CommandInfo)
+			CommandEntries = touch.CommandEntries
+				.ToReadOnlyReactiveCollection(x => new CommandEntryViewModel(x))
 				.AddTo(disposable);
 
-			CommandOption = touch
-				.ToReactivePropertyAsSynchronized(x => x.CommandOption)
+			Layer = touch
+				.ToReactivePropertyAsSynchronized(x => x.Layer)
+				.AddTo(disposable);
+
+			TreeItem = touch
+				.ObserveProperty(x => x.TreeItem)
+				.Do(_ => TreeItem?.Value.Dispose())
+				.Select(x => new TreeViewItemViewModel(x))
+				.ToReactiveProperty()
+				.AddTo(disposable);
+
+			TreeItem.Subscribe(x =>
+				{
+					treeItemDisposable.Dispose();
+					treeItemDisposable = new CompositeDisposable();
+
+					x.PropertyChangedAsObservable()
+						.ToReadOnlyReactivePropertySlim(mode: ReactivePropertyMode.None)
+						.Subscribe(_ => TreeItem.ForceNotify())
+						.AddTo(treeItemDisposable);
+				})
+				.AddTo(disposable);
+
+			SelectedTreeItem = touch
+				.ToReactivePropertyAsSynchronized(
+					x => x.SelectedTreeItem,
+					x => TreeItem.Value.SearchViewModel(x),
+					x => x?.Model
+				)
+				.AddTo(disposable);
+
+			ListColumns = touch.ListColumns
+				.ToReadOnlyReactiveCollection(x => new ListViewColumnHeaderViewModel(x))
+				.AddTo(disposable);
+
+			ListItems = touch.ListItems
+				.ToReadOnlyReactiveCollection(x => new ListViewItemViewModel(x))
+				.AddTo(disposable);
+
+			SelectedListItem = touch
+				.ToReactivePropertyAsSynchronized(
+					x => x.SelectedListItem,
+					x => ListItems.FirstOrDefault(y => y.Model == x),
+					x => x?.Model
+				)
+				.AddTo(disposable);
+
+			SelectedTreeItem
+				.Subscribe(_ =>
+				{
+					SelectedListItem.Value = null;
+					touch.CreateListColumns();
+					touch.CreateListItems();
+				})
+				.AddTo(disposable);
+
+			SelectedListItem
+				.Where(x => x != null)
+				.Subscribe(x =>
+				{
+					listItemDisposable.Dispose();
+					listItemDisposable = new CompositeDisposable();
+
+					CompositeDisposable tagDisposable = new CompositeDisposable();
+
+					x.Tag
+						.OfType<INotifyPropertyChanged>()
+						.Subscribe(y =>
+						{
+							tagDisposable.Dispose();
+							tagDisposable = new CompositeDisposable();
+
+							y.PropertyChangedAsObservable()
+								.Subscribe(_ => touch.UpdateListItem(x.Model))
+								.AddTo(tagDisposable);
+						})
+						.AddTo(listItemDisposable);
+
+					tagDisposable.AddTo(listItemDisposable);
+				})
+				.AddTo(disposable);
+
+			SelectedSoundEntry = SelectedListItem
+				.Select(x => x?.Tag.Value as TouchElement.SoundEntry)
+				.Do(_ => SelectedSoundEntry?.Value?.Dispose())
+				.Select(x => x != null ? new SoundEntryViewModel(x) : null)
+				.ToReadOnlyReactivePropertySlim()
+				.AddTo(disposable);
+
+			SelectedCommandEntry = SelectedListItem
+				.Select(x => x?.Tag.Value as TouchElement.CommandEntry)
+				.Do(_ => SelectedCommandEntry?.Value?.Dispose())
+				.Select(x => x != null ? new CommandEntryViewModel(x) : null)
+				.ToReadOnlyReactivePropertySlim()
+				.AddTo(disposable);
+
+			AddSoundEntry = SelectedTreeItem
+				.Select(x => x == TreeItem.Value.Children[0])
+				.ToReactiveCommand()
+				.WithSubscribe(touch.AddSoundEntry)
+				.AddTo(disposable);
+
+			AddCommandEntry = SelectedTreeItem
+				.Select(x => x == TreeItem.Value.Children[1])
+				.ToReactiveCommand()
+				.WithSubscribe(touch.AddCommandEntry)
+				.AddTo(disposable);
+
+			CopySoundEntry = SelectedSoundEntry
+				.Select(x => x != null)
+				.ToReactiveCommand()
+				.WithSubscribe(touch.CopySoundEntry)
+				.AddTo(disposable);
+
+			CopyCommandEntry = SelectedCommandEntry
+				.Select(x => x != null)
+				.ToReactiveCommand()
+				.WithSubscribe(touch.CopyCommandEntry)
+				.AddTo(disposable);
+
+			RemoveSoundEntry = SelectedSoundEntry
+				.Select(x => x != null)
+				.ToReactiveCommand()
+				.WithSubscribe(touch.RemoveSoundEntry)
+				.AddTo(disposable);
+
+			RemoveCommandEntry = SelectedCommandEntry
+				.Select(x => x != null)
+				.ToReactiveCommand()
+				.WithSubscribe(touch.RemoveCommandEntry)
 				.AddTo(disposable);
 		}
 	}

--- a/source/TrainEditor2/Views/FormEditor.Designer.cs
+++ b/source/TrainEditor2/Views/FormEditor.Designer.cs
@@ -305,6 +305,8 @@ namespace TrainEditor2.Views
 			this.labelTimetableLocationY = new System.Windows.Forms.Label();
 			this.labelTimetableLocationX = new System.Windows.Forms.Label();
 			this.tabPageTouch = new System.Windows.Forms.TabPage();
+			this.numericUpDownTouchLayer = new System.Windows.Forms.NumericUpDown();
+			this.labelTouchLayer = new System.Windows.Forms.Label();
 			this.buttonTouchSoundCommand = new System.Windows.Forms.Button();
 			this.labelTouchSoundCommand = new System.Windows.Forms.Label();
 			this.numericUpDownTouchJumpScreen = new System.Windows.Forms.NumericUpDown();
@@ -634,8 +636,6 @@ namespace TrainEditor2.Views
 			this.comboBoxHandleType = new System.Windows.Forms.ComboBox();
 			this.labelHandleType = new System.Windows.Forms.Label();
 			this.tabControlEditor = new System.Windows.Forms.TabControl();
-			this.numericUpDownTouchLayer = new System.Windows.Forms.NumericUpDown();
-			this.labelTouchLayer = new System.Windows.Forms.Label();
 			this.panelCars.SuspendLayout();
 			this.panelCarsNavi.SuspendLayout();
 			this.menuStripMenu.SuspendLayout();
@@ -694,6 +694,7 @@ namespace TrainEditor2.Views
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTimetableLayer)).BeginInit();
 			this.groupBoxTimetableLocation.SuspendLayout();
 			this.tabPageTouch.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchJumpScreen)).BeginInit();
 			this.groupBoxTouchSize.SuspendLayout();
 			this.groupBoxTouchLocation.SuspendLayout();
@@ -739,7 +740,6 @@ namespace TrainEditor2.Views
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).BeginInit();
 			this.tabControlEditor.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// panelCars
@@ -1132,6 +1132,11 @@ namespace TrainEditor2.Views
 			// numericUpDownSoundKeyIndex
 			// 
 			this.numericUpDownSoundKeyIndex.Location = new System.Drawing.Point(136, 16);
+			this.numericUpDownSoundKeyIndex.Maximum = new decimal(new int[] {
+            256,
+            0,
+            0,
+            0});
 			this.numericUpDownSoundKeyIndex.Name = "numericUpDownSoundKeyIndex";
 			this.numericUpDownSoundKeyIndex.Size = new System.Drawing.Size(40, 19);
 			this.numericUpDownSoundKeyIndex.TabIndex = 1;
@@ -3318,6 +3323,22 @@ namespace TrainEditor2.Views
 			this.tabPageTouch.TabIndex = 8;
 			this.tabPageTouch.Text = "Touch";
 			this.tabPageTouch.UseVisualStyleBackColor = true;
+			// 
+			// numericUpDownTouchLayer
+			// 
+			this.numericUpDownTouchLayer.Location = new System.Drawing.Point(136, 216);
+			this.numericUpDownTouchLayer.Name = "numericUpDownTouchLayer";
+			this.numericUpDownTouchLayer.Size = new System.Drawing.Size(48, 19);
+			this.numericUpDownTouchLayer.TabIndex = 108;
+			// 
+			// labelTouchLayer
+			// 
+			this.labelTouchLayer.Location = new System.Drawing.Point(8, 216);
+			this.labelTouchLayer.Name = "labelTouchLayer";
+			this.labelTouchLayer.Size = new System.Drawing.Size(120, 16);
+			this.labelTouchLayer.TabIndex = 109;
+			this.labelTouchLayer.Text = "Layer:";
+			this.labelTouchLayer.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
 			// 
 			// buttonTouchSoundCommand
 			// 
@@ -6495,22 +6516,6 @@ namespace TrainEditor2.Views
 			this.tabControlEditor.Size = new System.Drawing.Size(800, 696);
 			this.tabControlEditor.TabIndex = 9;
 			// 
-			// numericUpDownTouchLayer
-			// 
-			this.numericUpDownTouchLayer.Location = new System.Drawing.Point(136, 216);
-			this.numericUpDownTouchLayer.Name = "numericUpDownTouchLayer";
-			this.numericUpDownTouchLayer.Size = new System.Drawing.Size(48, 19);
-			this.numericUpDownTouchLayer.TabIndex = 108;
-			// 
-			// labelTouchLayer
-			// 
-			this.labelTouchLayer.Location = new System.Drawing.Point(8, 216);
-			this.labelTouchLayer.Name = "labelTouchLayer";
-			this.labelTouchLayer.Size = new System.Drawing.Size(120, 16);
-			this.labelTouchLayer.TabIndex = 109;
-			this.labelTouchLayer.Text = "Layer:";
-			this.labelTouchLayer.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
 			// FormEditor
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
@@ -6606,6 +6611,7 @@ namespace TrainEditor2.Views
 			this.groupBoxTimetableLocation.ResumeLayout(false);
 			this.groupBoxTimetableLocation.PerformLayout();
 			this.tabPageTouch.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchJumpScreen)).EndInit();
 			this.groupBoxTouchSize.ResumeLayout(false);
 			this.groupBoxTouchSize.PerformLayout();
@@ -6674,7 +6680,6 @@ namespace TrainEditor2.Views
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).EndInit();
 			this.tabControlEditor.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 

--- a/source/TrainEditor2/Views/FormEditor.Designer.cs
+++ b/source/TrainEditor2/Views/FormEditor.Designer.cs
@@ -33,321 +33,69 @@ namespace TrainEditor2.Views
 		private void InitializeComponent()
 		{
 			this.components = new System.ComponentModel.Container();
-			this.tabControlEditor = new System.Windows.Forms.TabControl();
-			this.tabPageTrain = new System.Windows.Forms.TabPage();
-			this.groupBoxDevice = new System.Windows.Forms.GroupBox();
-			this.labelDoorMaxToleranceUnit = new System.Windows.Forms.Label();
-			this.textBoxDoorMaxTolerance = new System.Windows.Forms.TextBox();
-			this.labelDoorWidthUnit = new System.Windows.Forms.Label();
-			this.textBoxDoorWidth = new System.Windows.Forms.TextBox();
-			this.comboBoxDoorCloseMode = new System.Windows.Forms.ComboBox();
-			this.comboBoxDoorOpenMode = new System.Windows.Forms.ComboBox();
-			this.comboBoxPassAlarm = new System.Windows.Forms.ComboBox();
-			this.comboBoxReAdhesionDevice = new System.Windows.Forms.ComboBox();
-			this.comboBoxAtc = new System.Windows.Forms.ComboBox();
-			this.comboBoxAts = new System.Windows.Forms.ComboBox();
-			this.checkBoxHoldBrake = new System.Windows.Forms.CheckBox();
-			this.checkBoxEb = new System.Windows.Forms.CheckBox();
-			this.checkBoxConstSpeed = new System.Windows.Forms.CheckBox();
-			this.labelDoorMaxTolerance = new System.Windows.Forms.Label();
-			this.labelDoorWidth = new System.Windows.Forms.Label();
-			this.labelDoorCloseMode = new System.Windows.Forms.Label();
-			this.labelDoorOpenMode = new System.Windows.Forms.Label();
-			this.labelPassAlarm = new System.Windows.Forms.Label();
-			this.labelReAdhesionDevice = new System.Windows.Forms.Label();
-			this.labelHoldBrake = new System.Windows.Forms.Label();
-			this.labelConstSpeed = new System.Windows.Forms.Label();
-			this.labelEb = new System.Windows.Forms.Label();
-			this.labelAtc = new System.Windows.Forms.Label();
-			this.labelAts = new System.Windows.Forms.Label();
-			this.groupBoxCab = new System.Windows.Forms.GroupBox();
-			this.comboBoxDriverCar = new System.Windows.Forms.ComboBox();
-			this.labelCabZUnit = new System.Windows.Forms.Label();
-			this.textBoxCabZ = new System.Windows.Forms.TextBox();
-			this.labelCabYUnit = new System.Windows.Forms.Label();
-			this.textBoxCabY = new System.Windows.Forms.TextBox();
-			this.labelCabXUnit = new System.Windows.Forms.Label();
-			this.textBoxCabX = new System.Windows.Forms.TextBox();
-			this.labelDriverCar = new System.Windows.Forms.Label();
-			this.labelCabZ = new System.Windows.Forms.Label();
-			this.labelCabY = new System.Windows.Forms.Label();
-			this.labelCabX = new System.Windows.Forms.Label();
-			this.groupBoxHandle = new System.Windows.Forms.GroupBox();
-			this.numericUpDownLocoBrakeNotches = new System.Windows.Forms.NumericUpDown();
-			this.labelLocoBrakeNotches = new System.Windows.Forms.Label();
-			this.comboBoxLocoBrakeHandleType = new System.Windows.Forms.ComboBox();
-			this.labelLocoBrakeHandleType = new System.Windows.Forms.Label();
-			this.comboBoxEbHandleBehaviour = new System.Windows.Forms.ComboBox();
-			this.labelEbHandleBehaviour = new System.Windows.Forms.Label();
-			this.numericUpDownDriverBrakeNotches = new System.Windows.Forms.NumericUpDown();
-			this.labelDriverBrakeNotches = new System.Windows.Forms.Label();
-			this.numericUpDownDriverPowerNotches = new System.Windows.Forms.NumericUpDown();
-			this.labelDriverPowerNotches = new System.Windows.Forms.Label();
-			this.numericUpDownPowerNotchReduceSteps = new System.Windows.Forms.NumericUpDown();
-			this.labelPowerNotchReduceSteps = new System.Windows.Forms.Label();
-			this.numericUpDownBrakeNotches = new System.Windows.Forms.NumericUpDown();
-			this.labelBrakeNotches = new System.Windows.Forms.Label();
-			this.numericUpDownPowerNotches = new System.Windows.Forms.NumericUpDown();
-			this.labelPowerNotches = new System.Windows.Forms.Label();
-			this.comboBoxHandleType = new System.Windows.Forms.ComboBox();
-			this.labelHandleType = new System.Windows.Forms.Label();
-			this.tabPageCar = new System.Windows.Forms.TabPage();
-			this.groupBoxPressure = new System.Windows.Forms.GroupBox();
-			this.labelBrakePipeNormalPressureUnit = new System.Windows.Forms.Label();
-			this.textBoxBrakePipeNormalPressure = new System.Windows.Forms.TextBox();
-			this.labelBrakePipeNormalPressure = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderServiceMaximumPressureUnit = new System.Windows.Forms.Label();
-			this.labelMainReservoirMaximumPressureUnit = new System.Windows.Forms.Label();
-			this.labelMainReservoirMinimumPressureUnit = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit = new System.Windows.Forms.Label();
-			this.textBoxMainReservoirMaximumPressure = new System.Windows.Forms.TextBox();
-			this.textBoxMainReservoirMinimumPressure = new System.Windows.Forms.TextBox();
-			this.textBoxBrakeCylinderEmergencyMaximumPressure = new System.Windows.Forms.TextBox();
-			this.textBoxBrakeCylinderServiceMaximumPressure = new System.Windows.Forms.TextBox();
-			this.labelMainReservoirMaximumPressure = new System.Windows.Forms.Label();
-			this.labelMainReservoirMinimumPressure = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderServiceMaximumPressure = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderEmergencyMaximumPressure = new System.Windows.Forms.Label();
-			this.groupBoxBrake = new System.Windows.Forms.GroupBox();
-			this.textBoxBrakeControlSpeed = new System.Windows.Forms.TextBox();
-			this.labelBrakeControlSpeedUnit = new System.Windows.Forms.Label();
-			this.comboBoxBrakeControlSystem = new System.Windows.Forms.ComboBox();
-			this.comboBoxLocoBrakeType = new System.Windows.Forms.ComboBox();
-			this.comboBoxBrakeType = new System.Windows.Forms.ComboBox();
-			this.labelLocoBrakeType = new System.Windows.Forms.Label();
-			this.labelBrakeType = new System.Windows.Forms.Label();
-			this.labelBrakeControlSpeed = new System.Windows.Forms.Label();
-			this.labelBrakeControlSystem = new System.Windows.Forms.Label();
-			this.groupBoxMove = new System.Windows.Forms.GroupBox();
-			this.labelBrakeCylinderDownUnit = new System.Windows.Forms.Label();
-			this.textBoxBrakeCylinderDown = new System.Windows.Forms.TextBox();
-			this.labelBrakeCylinderUpUnit = new System.Windows.Forms.Label();
-			this.textBoxBrakeCylinderUp = new System.Windows.Forms.TextBox();
-			this.labelJerkBrakeDownUnit = new System.Windows.Forms.Label();
-			this.textBoxJerkBrakeDown = new System.Windows.Forms.TextBox();
-			this.labelJerkBrakeUpUnit = new System.Windows.Forms.Label();
-			this.textBoxJerkBrakeUp = new System.Windows.Forms.TextBox();
-			this.labelJerkPowerDownUnit = new System.Windows.Forms.Label();
-			this.textBoxJerkPowerDown = new System.Windows.Forms.TextBox();
-			this.labelJerkPowerUpUnit = new System.Windows.Forms.Label();
-			this.textBoxJerkPowerUp = new System.Windows.Forms.TextBox();
-			this.labelJerkPowerUp = new System.Windows.Forms.Label();
-			this.labelJerkPowerDown = new System.Windows.Forms.Label();
-			this.labelJerkBrakeUp = new System.Windows.Forms.Label();
-			this.labelJerkBrakeDown = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderUp = new System.Windows.Forms.Label();
-			this.labelBrakeCylinderDown = new System.Windows.Forms.Label();
-			this.groupBoxDelay = new System.Windows.Forms.GroupBox();
-			this.buttonDelayLocoBrakeSet = new System.Windows.Forms.Button();
-			this.buttonDelayBrakeSet = new System.Windows.Forms.Button();
-			this.buttonDelayPowerSet = new System.Windows.Forms.Button();
-			this.labelDelayLocoBrake = new System.Windows.Forms.Label();
-			this.labelDelayBrake = new System.Windows.Forms.Label();
-			this.labelDelayPower = new System.Windows.Forms.Label();
-			this.groupBoxPerformance = new System.Windows.Forms.GroupBox();
-			this.textBoxAerodynamicDragCoefficient = new System.Windows.Forms.TextBox();
-			this.textBoxCoefficientOfRollingResistance = new System.Windows.Forms.TextBox();
-			this.textBoxCoefficientOfStaticFriction = new System.Windows.Forms.TextBox();
-			this.labelDecelerationUnit = new System.Windows.Forms.Label();
-			this.textBoxDeceleration = new System.Windows.Forms.TextBox();
-			this.labelAerodynamicDragCoefficient = new System.Windows.Forms.Label();
-			this.labelCoefficientOfStaticFriction = new System.Windows.Forms.Label();
-			this.labelDeceleration = new System.Windows.Forms.Label();
-			this.labelCoefficientOfRollingResistance = new System.Windows.Forms.Label();
-			this.groupBoxCarGeneral = new System.Windows.Forms.GroupBox();
-			this.labelUnexposedFrontalAreaUnit = new System.Windows.Forms.Label();
-			this.textBoxUnexposedFrontalArea = new System.Windows.Forms.TextBox();
-			this.labelUnexposedFrontalArea = new System.Windows.Forms.Label();
-			this.labelRearBogie = new System.Windows.Forms.Label();
-			this.labelFrontBogie = new System.Windows.Forms.Label();
-			this.buttonRearBogieSet = new System.Windows.Forms.Button();
-			this.buttonFrontBogieSet = new System.Windows.Forms.Button();
-			this.checkBoxReversed = new System.Windows.Forms.CheckBox();
-			this.checkBoxLoadingSway = new System.Windows.Forms.CheckBox();
-			this.checkBoxDefinedAxles = new System.Windows.Forms.CheckBox();
-			this.checkBoxIsMotorCar = new System.Windows.Forms.CheckBox();
-			this.buttonObjectOpen = new System.Windows.Forms.Button();
-			this.labelExposedFrontalAreaUnit = new System.Windows.Forms.Label();
-			this.labelCenterOfMassHeightUnit = new System.Windows.Forms.Label();
-			this.labelLoadingSway = new System.Windows.Forms.Label();
-			this.labelHeightUnit = new System.Windows.Forms.Label();
-			this.labelWidthUnit = new System.Windows.Forms.Label();
-			this.labelLengthUnit = new System.Windows.Forms.Label();
-			this.labelMassUnit = new System.Windows.Forms.Label();
-			this.textBoxMass = new System.Windows.Forms.TextBox();
-			this.textBoxLength = new System.Windows.Forms.TextBox();
-			this.textBoxWidth = new System.Windows.Forms.TextBox();
-			this.textBoxHeight = new System.Windows.Forms.TextBox();
-			this.textBoxCenterOfMassHeight = new System.Windows.Forms.TextBox();
-			this.textBoxExposedFrontalArea = new System.Windows.Forms.TextBox();
-			this.textBoxObject = new System.Windows.Forms.TextBox();
-			this.labelObject = new System.Windows.Forms.Label();
-			this.labelReversed = new System.Windows.Forms.Label();
-			this.groupBoxAxles = new System.Windows.Forms.GroupBox();
-			this.labelRearAxleUnit = new System.Windows.Forms.Label();
-			this.labelFrontAxleUnit = new System.Windows.Forms.Label();
-			this.textBoxRearAxle = new System.Windows.Forms.TextBox();
-			this.textBoxFrontAxle = new System.Windows.Forms.TextBox();
-			this.labelRearAxle = new System.Windows.Forms.Label();
-			this.labelFrontAxle = new System.Windows.Forms.Label();
-			this.labelDefinedAxles = new System.Windows.Forms.Label();
-			this.labelExposedFrontalArea = new System.Windows.Forms.Label();
-			this.labelCenterOfMassHeight = new System.Windows.Forms.Label();
-			this.labelHeight = new System.Windows.Forms.Label();
-			this.labelWidth = new System.Windows.Forms.Label();
-			this.labelLength = new System.Windows.Forms.Label();
-			this.labelMass = new System.Windows.Forms.Label();
-			this.labelIsMotorCar = new System.Windows.Forms.Label();
-			this.tabPageAccel = new System.Windows.Forms.TabPage();
-			this.pictureBoxAccel = new System.Windows.Forms.PictureBox();
-			this.panelAccel = new System.Windows.Forms.Panel();
-			this.groupBoxPreview = new System.Windows.Forms.GroupBox();
-			this.buttonAccelReset = new System.Windows.Forms.Button();
-			this.buttonAccelZoomOut = new System.Windows.Forms.Button();
-			this.buttonAccelZoomIn = new System.Windows.Forms.Button();
-			this.labelAccelYValue = new System.Windows.Forms.Label();
-			this.labelAccelXValue = new System.Windows.Forms.Label();
-			this.labelAccelXmaxUnit = new System.Windows.Forms.Label();
-			this.labelAccelXminUnit = new System.Windows.Forms.Label();
-			this.labelAccelYmaxUnit = new System.Windows.Forms.Label();
-			this.labelAccelYminUnit = new System.Windows.Forms.Label();
-			this.textBoxAccelYmax = new System.Windows.Forms.TextBox();
-			this.textBoxAccelYmin = new System.Windows.Forms.TextBox();
-			this.textBoxAccelXmax = new System.Windows.Forms.TextBox();
-			this.textBoxAccelXmin = new System.Windows.Forms.TextBox();
-			this.labelAccelYmax = new System.Windows.Forms.Label();
-			this.labelAccelYmin = new System.Windows.Forms.Label();
-			this.labelAccelXmax = new System.Windows.Forms.Label();
-			this.labelAccelXmin = new System.Windows.Forms.Label();
-			this.labelAccelY = new System.Windows.Forms.Label();
-			this.labelAccelX = new System.Windows.Forms.Label();
-			this.checkBoxSubtractDeceleration = new System.Windows.Forms.CheckBox();
-			this.groupBoxParameter = new System.Windows.Forms.GroupBox();
-			this.labeAccelA0Unit = new System.Windows.Forms.Label();
-			this.textBoxAccelA0 = new System.Windows.Forms.TextBox();
-			this.labelAccelA0 = new System.Windows.Forms.Label();
-			this.labelAccelA1Unit = new System.Windows.Forms.Label();
-			this.textBoxAccelA1 = new System.Windows.Forms.TextBox();
-			this.labelAccelA1 = new System.Windows.Forms.Label();
-			this.labelAccelV1Unit = new System.Windows.Forms.Label();
-			this.textBoxAccelV1 = new System.Windows.Forms.TextBox();
-			this.labelAccelV1 = new System.Windows.Forms.Label();
-			this.labelAccelV2Unit = new System.Windows.Forms.Label();
-			this.textBoxAccelV2 = new System.Windows.Forms.TextBox();
-			this.labelAccelV2 = new System.Windows.Forms.Label();
-			this.textBoxAccelE = new System.Windows.Forms.TextBox();
-			this.labelAccelE = new System.Windows.Forms.Label();
-			this.groupBoxNotch = new System.Windows.Forms.GroupBox();
-			this.comboBoxNotch = new System.Windows.Forms.ComboBox();
-			this.tabPageMotor = new System.Windows.Forms.TabPage();
-			this.panelMotorSound = new System.Windows.Forms.Panel();
-			this.toolStripContainerDrawArea = new System.Windows.Forms.ToolStripContainer();
-			this.glControlMotor = new OpenTK.GLControl();
-			this.toolStripToolBar = new System.Windows.Forms.ToolStrip();
-			this.toolStripButtonUndo = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonRedo = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparatorRedo = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButtonTearingOff = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonCopy = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonPaste = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonCleanup = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonDelete = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparatorEdit = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButtonSelect = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonMove = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonDot = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButtonLine = new System.Windows.Forms.ToolStripButton();
-			this.panelMotorSetting = new System.Windows.Forms.Panel();
-			this.groupBoxDirect = new System.Windows.Forms.GroupBox();
-			this.buttonDirectDot = new System.Windows.Forms.Button();
-			this.buttonDirectMove = new System.Windows.Forms.Button();
-			this.textBoxDirectY = new System.Windows.Forms.TextBox();
-			this.labelDirectY = new System.Windows.Forms.Label();
-			this.labelDirectXUnit = new System.Windows.Forms.Label();
-			this.textBoxDirectX = new System.Windows.Forms.TextBox();
-			this.labelDirectX = new System.Windows.Forms.Label();
-			this.groupBoxPlay = new System.Windows.Forms.GroupBox();
-			this.buttonStop = new System.Windows.Forms.Button();
-			this.buttonPause = new System.Windows.Forms.Button();
-			this.buttonPlay = new System.Windows.Forms.Button();
-			this.groupBoxArea = new System.Windows.Forms.GroupBox();
-			this.checkBoxMotorConstant = new System.Windows.Forms.CheckBox();
-			this.checkBoxMotorLoop = new System.Windows.Forms.CheckBox();
-			this.buttonMotorSwap = new System.Windows.Forms.Button();
-			this.textBoxMotorAreaLeft = new System.Windows.Forms.TextBox();
-			this.labelMotorAreaUnit = new System.Windows.Forms.Label();
-			this.textBoxMotorAreaRight = new System.Windows.Forms.TextBox();
-			this.labelMotorAccel = new System.Windows.Forms.Label();
-			this.labelMotorAccelUnit = new System.Windows.Forms.Label();
-			this.textBoxMotorAccel = new System.Windows.Forms.TextBox();
-			this.groupBoxSource = new System.Windows.Forms.GroupBox();
-			this.numericUpDownRunIndex = new System.Windows.Forms.NumericUpDown();
-			this.labelRun = new System.Windows.Forms.Label();
-			this.checkBoxTrack2 = new System.Windows.Forms.CheckBox();
-			this.checkBoxTrack1 = new System.Windows.Forms.CheckBox();
-			this.groupBoxView = new System.Windows.Forms.GroupBox();
-			this.buttonMotorReset = new System.Windows.Forms.Button();
-			this.buttonMotorZoomOut = new System.Windows.Forms.Button();
-			this.buttonMotorZoomIn = new System.Windows.Forms.Button();
-			this.labelMotorMaxVolume = new System.Windows.Forms.Label();
-			this.textBoxMotorMaxVolume = new System.Windows.Forms.TextBox();
-			this.labelMotorMinVolume = new System.Windows.Forms.Label();
-			this.textBoxMotorMinVolume = new System.Windows.Forms.TextBox();
-			this.labelMotorMaxPitch = new System.Windows.Forms.Label();
-			this.textBoxMotorMaxPitch = new System.Windows.Forms.TextBox();
-			this.labelMotorMinPitch = new System.Windows.Forms.Label();
-			this.textBoxMotorMinPitch = new System.Windows.Forms.TextBox();
-			this.labelMotorMaxVelocityUnit = new System.Windows.Forms.Label();
-			this.textBoxMotorMaxVelocity = new System.Windows.Forms.TextBox();
-			this.labelMotorMaxVelocity = new System.Windows.Forms.Label();
-			this.labelMotorMinVelocityUnit = new System.Windows.Forms.Label();
-			this.textBoxMotorMinVelocity = new System.Windows.Forms.TextBox();
-			this.labelMotorMinVelocity = new System.Windows.Forms.Label();
-			this.statusStripStatus = new System.Windows.Forms.StatusStrip();
-			this.toolStripStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabelTool = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabelMode = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabelTrack = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabelType = new System.Windows.Forms.ToolStripStatusLabel();
-			this.menuStripMotor = new System.Windows.Forms.MenuStrip();
-			this.toolStripMenuItemEdit = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemUndo = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemRedo = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparatorUndo = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItemTearingOff = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemCleanup = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemView = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemPower = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemPowerTrack1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemPowerTrack2 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemBrake = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemBrakeTrack1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemBrakeTrack2 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemInput = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemPitch = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemVolume = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemIndex = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripComboBoxIndex = new System.Windows.Forms.ToolStripComboBox();
-			this.toolStripMenuItemTool = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemSelect = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemMove = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemDot = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemLine = new System.Windows.Forms.ToolStripMenuItem();
-			this.tabPageCoupler = new System.Windows.Forms.TabPage();
-			this.groupBoxCouplerGeneral = new System.Windows.Forms.GroupBox();
-			this.buttonCouplerObject = new System.Windows.Forms.Button();
-			this.textBoxCouplerObject = new System.Windows.Forms.TextBox();
-			this.labelCouplerObject = new System.Windows.Forms.Label();
-			this.labelCouplerMaxUnit = new System.Windows.Forms.Label();
-			this.textBoxCouplerMax = new System.Windows.Forms.TextBox();
-			this.labelCouplerMax = new System.Windows.Forms.Label();
-			this.labelCouplerMinUnit = new System.Windows.Forms.Label();
-			this.textBoxCouplerMin = new System.Windows.Forms.TextBox();
-			this.labelCouplerMin = new System.Windows.Forms.Label();
+			this.panelCars = new System.Windows.Forms.Panel();
+			this.treeViewCars = new System.Windows.Forms.TreeView();
+			this.panelCarsNavi = new System.Windows.Forms.Panel();
+			this.buttonCarsCopy = new System.Windows.Forms.Button();
+			this.buttonCarsRemove = new System.Windows.Forms.Button();
+			this.buttonCarsAdd = new System.Windows.Forms.Button();
+			this.buttonCarsUp = new System.Windows.Forms.Button();
+			this.buttonCarsDown = new System.Windows.Forms.Button();
+			this.menuStripMenu = new System.Windows.Forms.MenuStrip();
+			this.toolStripMenuItemFile = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemNew = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemOpen = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparatorOpen = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemSave = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemSaveAs = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparatorSave = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemImport = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemExport = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparatorExport = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemExit = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripComboBoxLanguage = new System.Windows.Forms.ToolStripComboBox();
+			this.toolStripStatusLabelLanguage = new System.Windows.Forms.ToolStripStatusLabel();
+			this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
+			this.tabPageStatus = new System.Windows.Forms.TabPage();
+			this.listViewStatus = new System.Windows.Forms.ListView();
+			this.columnHeaderLevel = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeaderText = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.panelStatusNavi = new System.Windows.Forms.Panel();
+			this.buttonOutputLogs = new System.Windows.Forms.Button();
+			this.menuStripStatus = new System.Windows.Forms.MenuStrip();
+			this.toolStripMenuItemError = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemWarning = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemInfo = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemClear = new System.Windows.Forms.ToolStripMenuItem();
+			this.tabPageSound = new System.Windows.Forms.TabPage();
+			this.panelSoundSetting = new System.Windows.Forms.Panel();
+			this.splitContainerSound = new System.Windows.Forms.SplitContainer();
+			this.treeViewSound = new System.Windows.Forms.TreeView();
+			this.listViewSound = new System.Windows.Forms.ListView();
+			this.panelSoundSettingEdit = new System.Windows.Forms.Panel();
+			this.groupBoxSoundEntry = new System.Windows.Forms.GroupBox();
+			this.buttonSoundRemove = new System.Windows.Forms.Button();
+			this.groupBoxSoundKey = new System.Windows.Forms.GroupBox();
+			this.numericUpDownSoundKeyIndex = new System.Windows.Forms.NumericUpDown();
+			this.comboBoxSoundKey = new System.Windows.Forms.ComboBox();
+			this.buttonSoundAdd = new System.Windows.Forms.Button();
+			this.groupBoxSoundValue = new System.Windows.Forms.GroupBox();
+			this.checkBoxSoundRadius = new System.Windows.Forms.CheckBox();
+			this.checkBoxSoundDefinedPosition = new System.Windows.Forms.CheckBox();
+			this.textBoxSoundRadius = new System.Windows.Forms.TextBox();
+			this.groupBoxSoundPosition = new System.Windows.Forms.GroupBox();
+			this.labelSoundPositionZUnit = new System.Windows.Forms.Label();
+			this.textBoxSoundPositionZ = new System.Windows.Forms.TextBox();
+			this.labelSoundPositionZ = new System.Windows.Forms.Label();
+			this.labelSoundPositionYUnit = new System.Windows.Forms.Label();
+			this.textBoxSoundPositionY = new System.Windows.Forms.TextBox();
+			this.labelSoundPositionY = new System.Windows.Forms.Label();
+			this.labelSoundPositionXUnit = new System.Windows.Forms.Label();
+			this.textBoxSoundPositionX = new System.Windows.Forms.TextBox();
+			this.labelSoundPositionX = new System.Windows.Forms.Label();
+			this.labelSoundFileName = new System.Windows.Forms.Label();
+			this.buttonSoundFileNameOpen = new System.Windows.Forms.Button();
+			this.textBoxSoundFileName = new System.Windows.Forms.TextBox();
 			this.tabPagePanel = new System.Windows.Forms.TabPage();
 			this.splitContainerPanel = new System.Windows.Forms.SplitContainer();
 			this.treeViewPanel = new System.Windows.Forms.TreeView();
@@ -557,12 +305,8 @@ namespace TrainEditor2.Views
 			this.labelTimetableLocationY = new System.Windows.Forms.Label();
 			this.labelTimetableLocationX = new System.Windows.Forms.Label();
 			this.tabPageTouch = new System.Windows.Forms.TabPage();
-			this.comboBoxTouchCommand = new System.Windows.Forms.ComboBox();
-			this.labelTouchCommand = new System.Windows.Forms.Label();
-			this.numericUpDownTouchCommandOption = new System.Windows.Forms.NumericUpDown();
-			this.labelTouchCommandOption = new System.Windows.Forms.Label();
-			this.numericUpDownTouchSoundIndex = new System.Windows.Forms.NumericUpDown();
-			this.labelTouchSoundIndex = new System.Windows.Forms.Label();
+			this.buttonTouchSoundCommand = new System.Windows.Forms.Button();
+			this.labelTouchSoundCommand = new System.Windows.Forms.Label();
 			this.numericUpDownTouchJumpScreen = new System.Windows.Forms.NumericUpDown();
 			this.labelTouchJumpScreen = new System.Windows.Forms.Label();
 			this.groupBoxTouchSize = new System.Windows.Forms.GroupBox();
@@ -575,111 +319,342 @@ namespace TrainEditor2.Views
 			this.textBoxTouchLocationX = new System.Windows.Forms.TextBox();
 			this.labelTouchLocationY = new System.Windows.Forms.Label();
 			this.labelTouchLocationX = new System.Windows.Forms.Label();
-			this.tabPageSound = new System.Windows.Forms.TabPage();
-			this.panelSoundSetting = new System.Windows.Forms.Panel();
-			this.splitContainerSound = new System.Windows.Forms.SplitContainer();
-			this.treeViewSound = new System.Windows.Forms.TreeView();
-			this.listViewSound = new System.Windows.Forms.ListView();
-			this.panelSoundSettingEdit = new System.Windows.Forms.Panel();
-			this.groupBoxSoundEntry = new System.Windows.Forms.GroupBox();
-			this.buttonSoundRemove = new System.Windows.Forms.Button();
-			this.groupBoxSoundKey = new System.Windows.Forms.GroupBox();
-			this.numericUpDownSoundKeyIndex = new System.Windows.Forms.NumericUpDown();
-			this.comboBoxSoundKey = new System.Windows.Forms.ComboBox();
-			this.buttonSoundAdd = new System.Windows.Forms.Button();
-			this.groupBoxSoundValue = new System.Windows.Forms.GroupBox();
-			this.checkBoxSoundRadius = new System.Windows.Forms.CheckBox();
-			this.checkBoxSoundDefinedPosition = new System.Windows.Forms.CheckBox();
-			this.textBoxSoundRadius = new System.Windows.Forms.TextBox();
-			this.groupBoxSoundPosition = new System.Windows.Forms.GroupBox();
-			this.labelSoundPositionZUnit = new System.Windows.Forms.Label();
-			this.textBoxSoundPositionZ = new System.Windows.Forms.TextBox();
-			this.labelSoundPositionZ = new System.Windows.Forms.Label();
-			this.labelSoundPositionYUnit = new System.Windows.Forms.Label();
-			this.textBoxSoundPositionY = new System.Windows.Forms.TextBox();
-			this.labelSoundPositionY = new System.Windows.Forms.Label();
-			this.labelSoundPositionXUnit = new System.Windows.Forms.Label();
-			this.textBoxSoundPositionX = new System.Windows.Forms.TextBox();
-			this.labelSoundPositionX = new System.Windows.Forms.Label();
-			this.labelSoundFileName = new System.Windows.Forms.Label();
-			this.buttonSoundFileNameOpen = new System.Windows.Forms.Button();
-			this.textBoxSoundFileName = new System.Windows.Forms.TextBox();
-			this.tabPageStatus = new System.Windows.Forms.TabPage();
-			this.listViewStatus = new System.Windows.Forms.ListView();
-			this.columnHeaderLevel = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeaderText = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.menuStripStatus = new System.Windows.Forms.MenuStrip();
-			this.toolStripMenuItemError = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemWarning = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemInfo = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemClear = new System.Windows.Forms.ToolStripMenuItem();
-			this.panelCars = new System.Windows.Forms.Panel();
-			this.treeViewCars = new System.Windows.Forms.TreeView();
-			this.panelCarsNavi = new System.Windows.Forms.Panel();
-			this.buttonCarsCopy = new System.Windows.Forms.Button();
-			this.buttonCarsRemove = new System.Windows.Forms.Button();
-			this.buttonCarsAdd = new System.Windows.Forms.Button();
-			this.buttonCarsUp = new System.Windows.Forms.Button();
-			this.buttonCarsDown = new System.Windows.Forms.Button();
-			this.menuStripMenu = new System.Windows.Forms.MenuStrip();
-			this.toolStripMenuItemFile = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemNew = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemOpen = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparatorOpen = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItemSave = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemSaveAs = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparatorSave = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItemImport = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItemExport = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparatorExport = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItemExit = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripComboBoxLanguage = new System.Windows.Forms.ToolStripComboBox();
-			this.toolStripStatusLabelLanguage = new System.Windows.Forms.ToolStripStatusLabel();
-			this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
-			this.panelStatusNavi = new System.Windows.Forms.Panel();
-			this.buttonOutputLogs = new System.Windows.Forms.Button();
-			this.tabControlEditor.SuspendLayout();
-			this.tabPageTrain.SuspendLayout();
-			this.groupBoxDevice.SuspendLayout();
-			this.groupBoxCab.SuspendLayout();
-			this.groupBoxHandle.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownLocoBrakeNotches)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverBrakeNotches)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverPowerNotches)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotchReduceSteps)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).BeginInit();
-			this.tabPageCar.SuspendLayout();
-			this.groupBoxPressure.SuspendLayout();
-			this.groupBoxBrake.SuspendLayout();
-			this.groupBoxMove.SuspendLayout();
-			this.groupBoxDelay.SuspendLayout();
-			this.groupBoxPerformance.SuspendLayout();
-			this.groupBoxCarGeneral.SuspendLayout();
-			this.groupBoxAxles.SuspendLayout();
-			this.tabPageAccel.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBoxAccel)).BeginInit();
-			this.panelAccel.SuspendLayout();
-			this.groupBoxPreview.SuspendLayout();
-			this.groupBoxParameter.SuspendLayout();
-			this.groupBoxNotch.SuspendLayout();
-			this.tabPageMotor.SuspendLayout();
-			this.panelMotorSound.SuspendLayout();
-			this.toolStripContainerDrawArea.ContentPanel.SuspendLayout();
-			this.toolStripContainerDrawArea.TopToolStripPanel.SuspendLayout();
-			this.toolStripContainerDrawArea.SuspendLayout();
-			this.toolStripToolBar.SuspendLayout();
-			this.panelMotorSetting.SuspendLayout();
-			this.groupBoxDirect.SuspendLayout();
-			this.groupBoxPlay.SuspendLayout();
-			this.groupBoxArea.SuspendLayout();
-			this.groupBoxSource.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownRunIndex)).BeginInit();
-			this.groupBoxView.SuspendLayout();
-			this.statusStripStatus.SuspendLayout();
-			this.menuStripMotor.SuspendLayout();
-			this.tabPageCoupler.SuspendLayout();
-			this.groupBoxCouplerGeneral.SuspendLayout();
+			this.tabPageCoupler = new System.Windows.Forms.TabPage();
+			this.groupBoxCouplerGeneral = new System.Windows.Forms.GroupBox();
+			this.buttonCouplerObject = new System.Windows.Forms.Button();
+			this.textBoxCouplerObject = new System.Windows.Forms.TextBox();
+			this.labelCouplerObject = new System.Windows.Forms.Label();
+			this.labelCouplerMaxUnit = new System.Windows.Forms.Label();
+			this.textBoxCouplerMax = new System.Windows.Forms.TextBox();
+			this.labelCouplerMax = new System.Windows.Forms.Label();
+			this.labelCouplerMinUnit = new System.Windows.Forms.Label();
+			this.textBoxCouplerMin = new System.Windows.Forms.TextBox();
+			this.labelCouplerMin = new System.Windows.Forms.Label();
+			this.tabPageMotor = new System.Windows.Forms.TabPage();
+			this.panelMotorSound = new System.Windows.Forms.Panel();
+			this.toolStripContainerDrawArea = new System.Windows.Forms.ToolStripContainer();
+			this.glControlMotor = new OpenTK.GLControl();
+			this.toolStripToolBar = new System.Windows.Forms.ToolStrip();
+			this.toolStripButtonUndo = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonRedo = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparatorRedo = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButtonTearingOff = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonCopy = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonPaste = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonCleanup = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonDelete = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparatorEdit = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButtonSelect = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonMove = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonDot = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonLine = new System.Windows.Forms.ToolStripButton();
+			this.panelMotorSetting = new System.Windows.Forms.Panel();
+			this.groupBoxDirect = new System.Windows.Forms.GroupBox();
+			this.buttonDirectDot = new System.Windows.Forms.Button();
+			this.buttonDirectMove = new System.Windows.Forms.Button();
+			this.textBoxDirectY = new System.Windows.Forms.TextBox();
+			this.labelDirectY = new System.Windows.Forms.Label();
+			this.labelDirectXUnit = new System.Windows.Forms.Label();
+			this.textBoxDirectX = new System.Windows.Forms.TextBox();
+			this.labelDirectX = new System.Windows.Forms.Label();
+			this.groupBoxPlay = new System.Windows.Forms.GroupBox();
+			this.buttonStop = new System.Windows.Forms.Button();
+			this.buttonPause = new System.Windows.Forms.Button();
+			this.buttonPlay = new System.Windows.Forms.Button();
+			this.groupBoxArea = new System.Windows.Forms.GroupBox();
+			this.checkBoxMotorConstant = new System.Windows.Forms.CheckBox();
+			this.checkBoxMotorLoop = new System.Windows.Forms.CheckBox();
+			this.buttonMotorSwap = new System.Windows.Forms.Button();
+			this.textBoxMotorAreaLeft = new System.Windows.Forms.TextBox();
+			this.labelMotorAreaUnit = new System.Windows.Forms.Label();
+			this.textBoxMotorAreaRight = new System.Windows.Forms.TextBox();
+			this.labelMotorAccel = new System.Windows.Forms.Label();
+			this.labelMotorAccelUnit = new System.Windows.Forms.Label();
+			this.textBoxMotorAccel = new System.Windows.Forms.TextBox();
+			this.groupBoxSource = new System.Windows.Forms.GroupBox();
+			this.numericUpDownRunIndex = new System.Windows.Forms.NumericUpDown();
+			this.labelRun = new System.Windows.Forms.Label();
+			this.checkBoxTrack2 = new System.Windows.Forms.CheckBox();
+			this.checkBoxTrack1 = new System.Windows.Forms.CheckBox();
+			this.groupBoxView = new System.Windows.Forms.GroupBox();
+			this.buttonMotorReset = new System.Windows.Forms.Button();
+			this.buttonMotorZoomOut = new System.Windows.Forms.Button();
+			this.buttonMotorZoomIn = new System.Windows.Forms.Button();
+			this.labelMotorMaxVolume = new System.Windows.Forms.Label();
+			this.textBoxMotorMaxVolume = new System.Windows.Forms.TextBox();
+			this.labelMotorMinVolume = new System.Windows.Forms.Label();
+			this.textBoxMotorMinVolume = new System.Windows.Forms.TextBox();
+			this.labelMotorMaxPitch = new System.Windows.Forms.Label();
+			this.textBoxMotorMaxPitch = new System.Windows.Forms.TextBox();
+			this.labelMotorMinPitch = new System.Windows.Forms.Label();
+			this.textBoxMotorMinPitch = new System.Windows.Forms.TextBox();
+			this.labelMotorMaxVelocityUnit = new System.Windows.Forms.Label();
+			this.textBoxMotorMaxVelocity = new System.Windows.Forms.TextBox();
+			this.labelMotorMaxVelocity = new System.Windows.Forms.Label();
+			this.labelMotorMinVelocityUnit = new System.Windows.Forms.Label();
+			this.textBoxMotorMinVelocity = new System.Windows.Forms.TextBox();
+			this.labelMotorMinVelocity = new System.Windows.Forms.Label();
+			this.statusStripStatus = new System.Windows.Forms.StatusStrip();
+			this.toolStripStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabelTool = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabelMode = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabelTrack = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabelType = new System.Windows.Forms.ToolStripStatusLabel();
+			this.menuStripMotor = new System.Windows.Forms.MenuStrip();
+			this.toolStripMenuItemEdit = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemUndo = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemRedo = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparatorUndo = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItemTearingOff = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemCleanup = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemView = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemPower = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemPowerTrack1 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemPowerTrack2 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemBrake = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemBrakeTrack1 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemBrakeTrack2 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemInput = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemPitch = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemVolume = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemIndex = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripComboBoxIndex = new System.Windows.Forms.ToolStripComboBox();
+			this.toolStripMenuItemTool = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemSelect = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemMove = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemDot = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItemLine = new System.Windows.Forms.ToolStripMenuItem();
+			this.tabPageAccel = new System.Windows.Forms.TabPage();
+			this.pictureBoxAccel = new System.Windows.Forms.PictureBox();
+			this.panelAccel = new System.Windows.Forms.Panel();
+			this.groupBoxPreview = new System.Windows.Forms.GroupBox();
+			this.buttonAccelReset = new System.Windows.Forms.Button();
+			this.buttonAccelZoomOut = new System.Windows.Forms.Button();
+			this.buttonAccelZoomIn = new System.Windows.Forms.Button();
+			this.labelAccelYValue = new System.Windows.Forms.Label();
+			this.labelAccelXValue = new System.Windows.Forms.Label();
+			this.labelAccelXmaxUnit = new System.Windows.Forms.Label();
+			this.labelAccelXminUnit = new System.Windows.Forms.Label();
+			this.labelAccelYmaxUnit = new System.Windows.Forms.Label();
+			this.labelAccelYminUnit = new System.Windows.Forms.Label();
+			this.textBoxAccelYmax = new System.Windows.Forms.TextBox();
+			this.textBoxAccelYmin = new System.Windows.Forms.TextBox();
+			this.textBoxAccelXmax = new System.Windows.Forms.TextBox();
+			this.textBoxAccelXmin = new System.Windows.Forms.TextBox();
+			this.labelAccelYmax = new System.Windows.Forms.Label();
+			this.labelAccelYmin = new System.Windows.Forms.Label();
+			this.labelAccelXmax = new System.Windows.Forms.Label();
+			this.labelAccelXmin = new System.Windows.Forms.Label();
+			this.labelAccelY = new System.Windows.Forms.Label();
+			this.labelAccelX = new System.Windows.Forms.Label();
+			this.checkBoxSubtractDeceleration = new System.Windows.Forms.CheckBox();
+			this.groupBoxParameter = new System.Windows.Forms.GroupBox();
+			this.labeAccelA0Unit = new System.Windows.Forms.Label();
+			this.textBoxAccelA0 = new System.Windows.Forms.TextBox();
+			this.labelAccelA0 = new System.Windows.Forms.Label();
+			this.labelAccelA1Unit = new System.Windows.Forms.Label();
+			this.textBoxAccelA1 = new System.Windows.Forms.TextBox();
+			this.labelAccelA1 = new System.Windows.Forms.Label();
+			this.labelAccelV1Unit = new System.Windows.Forms.Label();
+			this.textBoxAccelV1 = new System.Windows.Forms.TextBox();
+			this.labelAccelV1 = new System.Windows.Forms.Label();
+			this.labelAccelV2Unit = new System.Windows.Forms.Label();
+			this.textBoxAccelV2 = new System.Windows.Forms.TextBox();
+			this.labelAccelV2 = new System.Windows.Forms.Label();
+			this.textBoxAccelE = new System.Windows.Forms.TextBox();
+			this.labelAccelE = new System.Windows.Forms.Label();
+			this.groupBoxNotch = new System.Windows.Forms.GroupBox();
+			this.comboBoxNotch = new System.Windows.Forms.ComboBox();
+			this.tabPageCar = new System.Windows.Forms.TabPage();
+			this.groupBoxPressure = new System.Windows.Forms.GroupBox();
+			this.labelBrakePipeNormalPressureUnit = new System.Windows.Forms.Label();
+			this.textBoxBrakePipeNormalPressure = new System.Windows.Forms.TextBox();
+			this.labelBrakePipeNormalPressure = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderServiceMaximumPressureUnit = new System.Windows.Forms.Label();
+			this.labelMainReservoirMaximumPressureUnit = new System.Windows.Forms.Label();
+			this.labelMainReservoirMinimumPressureUnit = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit = new System.Windows.Forms.Label();
+			this.textBoxMainReservoirMaximumPressure = new System.Windows.Forms.TextBox();
+			this.textBoxMainReservoirMinimumPressure = new System.Windows.Forms.TextBox();
+			this.textBoxBrakeCylinderEmergencyMaximumPressure = new System.Windows.Forms.TextBox();
+			this.textBoxBrakeCylinderServiceMaximumPressure = new System.Windows.Forms.TextBox();
+			this.labelMainReservoirMaximumPressure = new System.Windows.Forms.Label();
+			this.labelMainReservoirMinimumPressure = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderServiceMaximumPressure = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderEmergencyMaximumPressure = new System.Windows.Forms.Label();
+			this.groupBoxBrake = new System.Windows.Forms.GroupBox();
+			this.textBoxBrakeControlSpeed = new System.Windows.Forms.TextBox();
+			this.labelBrakeControlSpeedUnit = new System.Windows.Forms.Label();
+			this.comboBoxBrakeControlSystem = new System.Windows.Forms.ComboBox();
+			this.comboBoxLocoBrakeType = new System.Windows.Forms.ComboBox();
+			this.comboBoxBrakeType = new System.Windows.Forms.ComboBox();
+			this.labelLocoBrakeType = new System.Windows.Forms.Label();
+			this.labelBrakeType = new System.Windows.Forms.Label();
+			this.labelBrakeControlSpeed = new System.Windows.Forms.Label();
+			this.labelBrakeControlSystem = new System.Windows.Forms.Label();
+			this.groupBoxMove = new System.Windows.Forms.GroupBox();
+			this.labelBrakeCylinderDownUnit = new System.Windows.Forms.Label();
+			this.textBoxBrakeCylinderDown = new System.Windows.Forms.TextBox();
+			this.labelBrakeCylinderUpUnit = new System.Windows.Forms.Label();
+			this.textBoxBrakeCylinderUp = new System.Windows.Forms.TextBox();
+			this.labelJerkBrakeDownUnit = new System.Windows.Forms.Label();
+			this.textBoxJerkBrakeDown = new System.Windows.Forms.TextBox();
+			this.labelJerkBrakeUpUnit = new System.Windows.Forms.Label();
+			this.textBoxJerkBrakeUp = new System.Windows.Forms.TextBox();
+			this.labelJerkPowerDownUnit = new System.Windows.Forms.Label();
+			this.textBoxJerkPowerDown = new System.Windows.Forms.TextBox();
+			this.labelJerkPowerUpUnit = new System.Windows.Forms.Label();
+			this.textBoxJerkPowerUp = new System.Windows.Forms.TextBox();
+			this.labelJerkPowerUp = new System.Windows.Forms.Label();
+			this.labelJerkPowerDown = new System.Windows.Forms.Label();
+			this.labelJerkBrakeUp = new System.Windows.Forms.Label();
+			this.labelJerkBrakeDown = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderUp = new System.Windows.Forms.Label();
+			this.labelBrakeCylinderDown = new System.Windows.Forms.Label();
+			this.groupBoxDelay = new System.Windows.Forms.GroupBox();
+			this.buttonDelayLocoBrakeSet = new System.Windows.Forms.Button();
+			this.buttonDelayBrakeSet = new System.Windows.Forms.Button();
+			this.buttonDelayPowerSet = new System.Windows.Forms.Button();
+			this.labelDelayLocoBrake = new System.Windows.Forms.Label();
+			this.labelDelayBrake = new System.Windows.Forms.Label();
+			this.labelDelayPower = new System.Windows.Forms.Label();
+			this.groupBoxPerformance = new System.Windows.Forms.GroupBox();
+			this.textBoxAerodynamicDragCoefficient = new System.Windows.Forms.TextBox();
+			this.textBoxCoefficientOfRollingResistance = new System.Windows.Forms.TextBox();
+			this.textBoxCoefficientOfStaticFriction = new System.Windows.Forms.TextBox();
+			this.labelDecelerationUnit = new System.Windows.Forms.Label();
+			this.textBoxDeceleration = new System.Windows.Forms.TextBox();
+			this.labelAerodynamicDragCoefficient = new System.Windows.Forms.Label();
+			this.labelCoefficientOfStaticFriction = new System.Windows.Forms.Label();
+			this.labelDeceleration = new System.Windows.Forms.Label();
+			this.labelCoefficientOfRollingResistance = new System.Windows.Forms.Label();
+			this.groupBoxCarGeneral = new System.Windows.Forms.GroupBox();
+			this.labelUnexposedFrontalAreaUnit = new System.Windows.Forms.Label();
+			this.textBoxUnexposedFrontalArea = new System.Windows.Forms.TextBox();
+			this.labelUnexposedFrontalArea = new System.Windows.Forms.Label();
+			this.labelRearBogie = new System.Windows.Forms.Label();
+			this.labelFrontBogie = new System.Windows.Forms.Label();
+			this.buttonRearBogieSet = new System.Windows.Forms.Button();
+			this.buttonFrontBogieSet = new System.Windows.Forms.Button();
+			this.checkBoxReversed = new System.Windows.Forms.CheckBox();
+			this.checkBoxLoadingSway = new System.Windows.Forms.CheckBox();
+			this.checkBoxDefinedAxles = new System.Windows.Forms.CheckBox();
+			this.checkBoxIsMotorCar = new System.Windows.Forms.CheckBox();
+			this.buttonObjectOpen = new System.Windows.Forms.Button();
+			this.labelExposedFrontalAreaUnit = new System.Windows.Forms.Label();
+			this.labelCenterOfMassHeightUnit = new System.Windows.Forms.Label();
+			this.labelLoadingSway = new System.Windows.Forms.Label();
+			this.labelHeightUnit = new System.Windows.Forms.Label();
+			this.labelWidthUnit = new System.Windows.Forms.Label();
+			this.labelLengthUnit = new System.Windows.Forms.Label();
+			this.labelMassUnit = new System.Windows.Forms.Label();
+			this.textBoxMass = new System.Windows.Forms.TextBox();
+			this.textBoxLength = new System.Windows.Forms.TextBox();
+			this.textBoxWidth = new System.Windows.Forms.TextBox();
+			this.textBoxHeight = new System.Windows.Forms.TextBox();
+			this.textBoxCenterOfMassHeight = new System.Windows.Forms.TextBox();
+			this.textBoxExposedFrontalArea = new System.Windows.Forms.TextBox();
+			this.textBoxObject = new System.Windows.Forms.TextBox();
+			this.labelObject = new System.Windows.Forms.Label();
+			this.labelReversed = new System.Windows.Forms.Label();
+			this.groupBoxAxles = new System.Windows.Forms.GroupBox();
+			this.labelRearAxleUnit = new System.Windows.Forms.Label();
+			this.labelFrontAxleUnit = new System.Windows.Forms.Label();
+			this.textBoxRearAxle = new System.Windows.Forms.TextBox();
+			this.textBoxFrontAxle = new System.Windows.Forms.TextBox();
+			this.labelRearAxle = new System.Windows.Forms.Label();
+			this.labelFrontAxle = new System.Windows.Forms.Label();
+			this.labelDefinedAxles = new System.Windows.Forms.Label();
+			this.labelExposedFrontalArea = new System.Windows.Forms.Label();
+			this.labelCenterOfMassHeight = new System.Windows.Forms.Label();
+			this.labelHeight = new System.Windows.Forms.Label();
+			this.labelWidth = new System.Windows.Forms.Label();
+			this.labelLength = new System.Windows.Forms.Label();
+			this.labelMass = new System.Windows.Forms.Label();
+			this.labelIsMotorCar = new System.Windows.Forms.Label();
+			this.tabPageTrain = new System.Windows.Forms.TabPage();
+			this.groupBoxDevice = new System.Windows.Forms.GroupBox();
+			this.labelDoorMaxToleranceUnit = new System.Windows.Forms.Label();
+			this.textBoxDoorMaxTolerance = new System.Windows.Forms.TextBox();
+			this.labelDoorWidthUnit = new System.Windows.Forms.Label();
+			this.textBoxDoorWidth = new System.Windows.Forms.TextBox();
+			this.comboBoxDoorCloseMode = new System.Windows.Forms.ComboBox();
+			this.comboBoxDoorOpenMode = new System.Windows.Forms.ComboBox();
+			this.comboBoxPassAlarm = new System.Windows.Forms.ComboBox();
+			this.comboBoxReAdhesionDevice = new System.Windows.Forms.ComboBox();
+			this.comboBoxAtc = new System.Windows.Forms.ComboBox();
+			this.comboBoxAts = new System.Windows.Forms.ComboBox();
+			this.checkBoxHoldBrake = new System.Windows.Forms.CheckBox();
+			this.checkBoxEb = new System.Windows.Forms.CheckBox();
+			this.checkBoxConstSpeed = new System.Windows.Forms.CheckBox();
+			this.labelDoorMaxTolerance = new System.Windows.Forms.Label();
+			this.labelDoorWidth = new System.Windows.Forms.Label();
+			this.labelDoorCloseMode = new System.Windows.Forms.Label();
+			this.labelDoorOpenMode = new System.Windows.Forms.Label();
+			this.labelPassAlarm = new System.Windows.Forms.Label();
+			this.labelReAdhesionDevice = new System.Windows.Forms.Label();
+			this.labelHoldBrake = new System.Windows.Forms.Label();
+			this.labelConstSpeed = new System.Windows.Forms.Label();
+			this.labelEb = new System.Windows.Forms.Label();
+			this.labelAtc = new System.Windows.Forms.Label();
+			this.labelAts = new System.Windows.Forms.Label();
+			this.groupBoxCab = new System.Windows.Forms.GroupBox();
+			this.comboBoxDriverCar = new System.Windows.Forms.ComboBox();
+			this.labelCabZUnit = new System.Windows.Forms.Label();
+			this.textBoxCabZ = new System.Windows.Forms.TextBox();
+			this.labelCabYUnit = new System.Windows.Forms.Label();
+			this.textBoxCabY = new System.Windows.Forms.TextBox();
+			this.labelCabXUnit = new System.Windows.Forms.Label();
+			this.textBoxCabX = new System.Windows.Forms.TextBox();
+			this.labelDriverCar = new System.Windows.Forms.Label();
+			this.labelCabZ = new System.Windows.Forms.Label();
+			this.labelCabY = new System.Windows.Forms.Label();
+			this.labelCabX = new System.Windows.Forms.Label();
+			this.groupBoxHandle = new System.Windows.Forms.GroupBox();
+			this.numericUpDownLocoBrakeNotches = new System.Windows.Forms.NumericUpDown();
+			this.labelLocoBrakeNotches = new System.Windows.Forms.Label();
+			this.comboBoxLocoBrakeHandleType = new System.Windows.Forms.ComboBox();
+			this.labelLocoBrakeHandleType = new System.Windows.Forms.Label();
+			this.comboBoxEbHandleBehaviour = new System.Windows.Forms.ComboBox();
+			this.labelEbHandleBehaviour = new System.Windows.Forms.Label();
+			this.numericUpDownDriverBrakeNotches = new System.Windows.Forms.NumericUpDown();
+			this.labelDriverBrakeNotches = new System.Windows.Forms.Label();
+			this.numericUpDownDriverPowerNotches = new System.Windows.Forms.NumericUpDown();
+			this.labelDriverPowerNotches = new System.Windows.Forms.Label();
+			this.numericUpDownPowerNotchReduceSteps = new System.Windows.Forms.NumericUpDown();
+			this.labelPowerNotchReduceSteps = new System.Windows.Forms.Label();
+			this.numericUpDownBrakeNotches = new System.Windows.Forms.NumericUpDown();
+			this.labelBrakeNotches = new System.Windows.Forms.Label();
+			this.numericUpDownPowerNotches = new System.Windows.Forms.NumericUpDown();
+			this.labelPowerNotches = new System.Windows.Forms.Label();
+			this.comboBoxHandleType = new System.Windows.Forms.ComboBox();
+			this.labelHandleType = new System.Windows.Forms.Label();
+			this.tabControlEditor = new System.Windows.Forms.TabControl();
+			this.numericUpDownTouchLayer = new System.Windows.Forms.NumericUpDown();
+			this.labelTouchLayer = new System.Windows.Forms.Label();
+			this.panelCars.SuspendLayout();
+			this.panelCarsNavi.SuspendLayout();
+			this.menuStripMenu.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+			this.tabPageStatus.SuspendLayout();
+			this.panelStatusNavi.SuspendLayout();
+			this.menuStripStatus.SuspendLayout();
+			this.tabPageSound.SuspendLayout();
+			this.panelSoundSetting.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.splitContainerSound)).BeginInit();
+			this.splitContainerSound.Panel1.SuspendLayout();
+			this.splitContainerSound.Panel2.SuspendLayout();
+			this.splitContainerSound.SuspendLayout();
+			this.panelSoundSettingEdit.SuspendLayout();
+			this.groupBoxSoundEntry.SuspendLayout();
+			this.groupBoxSoundKey.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownSoundKeyIndex)).BeginInit();
+			this.groupBoxSoundValue.SuspendLayout();
+			this.groupBoxSoundPosition.SuspendLayout();
 			this.tabPagePanel.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.splitContainerPanel)).BeginInit();
 			this.splitContainerPanel.Panel1.SuspendLayout();
@@ -719,3082 +694,625 @@ namespace TrainEditor2.Views
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTimetableLayer)).BeginInit();
 			this.groupBoxTimetableLocation.SuspendLayout();
 			this.tabPageTouch.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchCommandOption)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchSoundIndex)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchJumpScreen)).BeginInit();
 			this.groupBoxTouchSize.SuspendLayout();
 			this.groupBoxTouchLocation.SuspendLayout();
-			this.tabPageSound.SuspendLayout();
-			this.panelSoundSetting.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainerSound)).BeginInit();
-			this.splitContainerSound.Panel1.SuspendLayout();
-			this.splitContainerSound.Panel2.SuspendLayout();
-			this.splitContainerSound.SuspendLayout();
-			this.panelSoundSettingEdit.SuspendLayout();
-			this.groupBoxSoundEntry.SuspendLayout();
-			this.groupBoxSoundKey.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownSoundKeyIndex)).BeginInit();
-			this.groupBoxSoundValue.SuspendLayout();
-			this.groupBoxSoundPosition.SuspendLayout();
-			this.tabPageStatus.SuspendLayout();
-			this.menuStripStatus.SuspendLayout();
-			this.panelCars.SuspendLayout();
-			this.panelCarsNavi.SuspendLayout();
-			this.menuStripMenu.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
-			this.panelStatusNavi.SuspendLayout();
+			this.tabPageCoupler.SuspendLayout();
+			this.groupBoxCouplerGeneral.SuspendLayout();
+			this.tabPageMotor.SuspendLayout();
+			this.panelMotorSound.SuspendLayout();
+			this.toolStripContainerDrawArea.ContentPanel.SuspendLayout();
+			this.toolStripContainerDrawArea.TopToolStripPanel.SuspendLayout();
+			this.toolStripContainerDrawArea.SuspendLayout();
+			this.toolStripToolBar.SuspendLayout();
+			this.panelMotorSetting.SuspendLayout();
+			this.groupBoxDirect.SuspendLayout();
+			this.groupBoxPlay.SuspendLayout();
+			this.groupBoxArea.SuspendLayout();
+			this.groupBoxSource.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownRunIndex)).BeginInit();
+			this.groupBoxView.SuspendLayout();
+			this.statusStripStatus.SuspendLayout();
+			this.menuStripMotor.SuspendLayout();
+			this.tabPageAccel.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBoxAccel)).BeginInit();
+			this.panelAccel.SuspendLayout();
+			this.groupBoxPreview.SuspendLayout();
+			this.groupBoxParameter.SuspendLayout();
+			this.groupBoxNotch.SuspendLayout();
+			this.tabPageCar.SuspendLayout();
+			this.groupBoxPressure.SuspendLayout();
+			this.groupBoxBrake.SuspendLayout();
+			this.groupBoxMove.SuspendLayout();
+			this.groupBoxDelay.SuspendLayout();
+			this.groupBoxPerformance.SuspendLayout();
+			this.groupBoxCarGeneral.SuspendLayout();
+			this.groupBoxAxles.SuspendLayout();
+			this.tabPageTrain.SuspendLayout();
+			this.groupBoxDevice.SuspendLayout();
+			this.groupBoxCab.SuspendLayout();
+			this.groupBoxHandle.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownLocoBrakeNotches)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverBrakeNotches)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverPowerNotches)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotchReduceSteps)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).BeginInit();
+			this.tabControlEditor.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).BeginInit();
 			this.SuspendLayout();
 			// 
-			// tabControlEditor
-			// 
-			this.tabControlEditor.AllowDrop = true;
-			this.tabControlEditor.Controls.Add(this.tabPageTrain);
-			this.tabControlEditor.Controls.Add(this.tabPageCar);
-			this.tabControlEditor.Controls.Add(this.tabPageAccel);
-			this.tabControlEditor.Controls.Add(this.tabPageMotor);
-			this.tabControlEditor.Controls.Add(this.tabPageCoupler);
-			this.tabControlEditor.Controls.Add(this.tabPagePanel);
-			this.tabControlEditor.Controls.Add(this.tabPageSound);
-			this.tabControlEditor.Controls.Add(this.tabPageStatus);
-			this.tabControlEditor.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tabControlEditor.Location = new System.Drawing.Point(200, 24);
-			this.tabControlEditor.Name = "tabControlEditor";
-			this.tabControlEditor.SelectedIndex = 0;
-			this.tabControlEditor.Size = new System.Drawing.Size(800, 696);
-			this.tabControlEditor.TabIndex = 9;
-			// 
-			// tabPageTrain
-			// 
-			this.tabPageTrain.Controls.Add(this.groupBoxDevice);
-			this.tabPageTrain.Controls.Add(this.groupBoxCab);
-			this.tabPageTrain.Controls.Add(this.groupBoxHandle);
-			this.tabPageTrain.Location = new System.Drawing.Point(4, 22);
-			this.tabPageTrain.Name = "tabPageTrain";
-			this.tabPageTrain.Size = new System.Drawing.Size(792, 670);
-			this.tabPageTrain.TabIndex = 3;
-			this.tabPageTrain.Text = "Train settings";
-			this.tabPageTrain.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxDevice
-			// 
-			this.groupBoxDevice.Controls.Add(this.labelDoorMaxToleranceUnit);
-			this.groupBoxDevice.Controls.Add(this.textBoxDoorMaxTolerance);
-			this.groupBoxDevice.Controls.Add(this.labelDoorWidthUnit);
-			this.groupBoxDevice.Controls.Add(this.textBoxDoorWidth);
-			this.groupBoxDevice.Controls.Add(this.comboBoxDoorCloseMode);
-			this.groupBoxDevice.Controls.Add(this.comboBoxDoorOpenMode);
-			this.groupBoxDevice.Controls.Add(this.comboBoxPassAlarm);
-			this.groupBoxDevice.Controls.Add(this.comboBoxReAdhesionDevice);
-			this.groupBoxDevice.Controls.Add(this.comboBoxAtc);
-			this.groupBoxDevice.Controls.Add(this.comboBoxAts);
-			this.groupBoxDevice.Controls.Add(this.checkBoxHoldBrake);
-			this.groupBoxDevice.Controls.Add(this.checkBoxEb);
-			this.groupBoxDevice.Controls.Add(this.checkBoxConstSpeed);
-			this.groupBoxDevice.Controls.Add(this.labelDoorMaxTolerance);
-			this.groupBoxDevice.Controls.Add(this.labelDoorWidth);
-			this.groupBoxDevice.Controls.Add(this.labelDoorCloseMode);
-			this.groupBoxDevice.Controls.Add(this.labelDoorOpenMode);
-			this.groupBoxDevice.Controls.Add(this.labelPassAlarm);
-			this.groupBoxDevice.Controls.Add(this.labelReAdhesionDevice);
-			this.groupBoxDevice.Controls.Add(this.labelHoldBrake);
-			this.groupBoxDevice.Controls.Add(this.labelConstSpeed);
-			this.groupBoxDevice.Controls.Add(this.labelEb);
-			this.groupBoxDevice.Controls.Add(this.labelAtc);
-			this.groupBoxDevice.Controls.Add(this.labelAts);
-			this.groupBoxDevice.Location = new System.Drawing.Point(432, 8);
-			this.groupBoxDevice.Name = "groupBoxDevice";
-			this.groupBoxDevice.Size = new System.Drawing.Size(336, 288);
-			this.groupBoxDevice.TabIndex = 2;
-			this.groupBoxDevice.TabStop = false;
-			this.groupBoxDevice.Text = "Device";
-			// 
-			// labelDoorMaxToleranceUnit
-			// 
-			this.labelDoorMaxToleranceUnit.Location = new System.Drawing.Point(304, 256);
-			this.labelDoorMaxToleranceUnit.Name = "labelDoorMaxToleranceUnit";
-			this.labelDoorMaxToleranceUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelDoorMaxToleranceUnit.TabIndex = 23;
-			this.labelDoorMaxToleranceUnit.Text = "mm";
-			this.labelDoorMaxToleranceUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxDoorMaxTolerance
-			// 
-			this.textBoxDoorMaxTolerance.Location = new System.Drawing.Point(128, 256);
-			this.textBoxDoorMaxTolerance.Name = "textBoxDoorMaxTolerance";
-			this.textBoxDoorMaxTolerance.Size = new System.Drawing.Size(168, 19);
-			this.textBoxDoorMaxTolerance.TabIndex = 22;
-			// 
-			// labelDoorWidthUnit
-			// 
-			this.labelDoorWidthUnit.Location = new System.Drawing.Point(304, 232);
-			this.labelDoorWidthUnit.Name = "labelDoorWidthUnit";
-			this.labelDoorWidthUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelDoorWidthUnit.TabIndex = 21;
-			this.labelDoorWidthUnit.Text = "mm";
-			this.labelDoorWidthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxDoorWidth
-			// 
-			this.textBoxDoorWidth.Location = new System.Drawing.Point(128, 232);
-			this.textBoxDoorWidth.Name = "textBoxDoorWidth";
-			this.textBoxDoorWidth.Size = new System.Drawing.Size(168, 19);
-			this.textBoxDoorWidth.TabIndex = 20;
-			// 
-			// comboBoxDoorCloseMode
-			// 
-			this.comboBoxDoorCloseMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxDoorCloseMode.FormattingEnabled = true;
-			this.comboBoxDoorCloseMode.Items.AddRange(new object[] {
-            "Semi-automatic",
-            "Automatic",
-            "Manual"});
-			this.comboBoxDoorCloseMode.Location = new System.Drawing.Point(128, 208);
-			this.comboBoxDoorCloseMode.Name = "comboBoxDoorCloseMode";
-			this.comboBoxDoorCloseMode.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxDoorCloseMode.TabIndex = 19;
-			// 
-			// comboBoxDoorOpenMode
-			// 
-			this.comboBoxDoorOpenMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxDoorOpenMode.FormattingEnabled = true;
-			this.comboBoxDoorOpenMode.Items.AddRange(new object[] {
-            "Semi-automatic",
-            "Automatic",
-            "Manual"});
-			this.comboBoxDoorOpenMode.Location = new System.Drawing.Point(128, 184);
-			this.comboBoxDoorOpenMode.Name = "comboBoxDoorOpenMode";
-			this.comboBoxDoorOpenMode.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxDoorOpenMode.TabIndex = 18;
-			// 
-			// comboBoxPassAlarm
-			// 
-			this.comboBoxPassAlarm.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxPassAlarm.FormattingEnabled = true;
-			this.comboBoxPassAlarm.Items.AddRange(new object[] {
-            "None",
-            "Single",
-            "Looping"});
-			this.comboBoxPassAlarm.Location = new System.Drawing.Point(128, 160);
-			this.comboBoxPassAlarm.Name = "comboBoxPassAlarm";
-			this.comboBoxPassAlarm.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxPassAlarm.TabIndex = 17;
-			// 
-			// comboBoxReAdhesionDevice
-			// 
-			this.comboBoxReAdhesionDevice.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxReAdhesionDevice.FormattingEnabled = true;
-			this.comboBoxReAdhesionDevice.Items.AddRange(new object[] {
-            "None",
-            "Type A (instant)",
-            "Type B (slow)",
-            "Type C (medium)",
-            "Type D (fast)"});
-			this.comboBoxReAdhesionDevice.Location = new System.Drawing.Point(128, 136);
-			this.comboBoxReAdhesionDevice.Name = "comboBoxReAdhesionDevice";
-			this.comboBoxReAdhesionDevice.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxReAdhesionDevice.TabIndex = 16;
-			// 
-			// comboBoxAtc
-			// 
-			this.comboBoxAtc.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxAtc.FormattingEnabled = true;
-			this.comboBoxAtc.Items.AddRange(new object[] {
-            "None",
-            "Manual switching",
-            "Automatic switching"});
-			this.comboBoxAtc.Location = new System.Drawing.Point(128, 40);
-			this.comboBoxAtc.Name = "comboBoxAtc";
-			this.comboBoxAtc.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxAtc.TabIndex = 15;
-			// 
-			// comboBoxAts
-			// 
-			this.comboBoxAts.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxAts.FormattingEnabled = true;
-			this.comboBoxAts.Items.AddRange(new object[] {
-            "None",
-            "ATS-SN",
-            "ATS-SN / ATS-P"});
-			this.comboBoxAts.Location = new System.Drawing.Point(128, 16);
-			this.comboBoxAts.Name = "comboBoxAts";
-			this.comboBoxAts.Size = new System.Drawing.Size(168, 20);
-			this.comboBoxAts.TabIndex = 14;
-			// 
-			// checkBoxHoldBrake
-			// 
-			this.checkBoxHoldBrake.Location = new System.Drawing.Point(128, 112);
-			this.checkBoxHoldBrake.Name = "checkBoxHoldBrake";
-			this.checkBoxHoldBrake.Size = new System.Drawing.Size(168, 16);
-			this.checkBoxHoldBrake.TabIndex = 13;
-			this.checkBoxHoldBrake.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxEb
-			// 
-			this.checkBoxEb.Location = new System.Drawing.Point(128, 64);
-			this.checkBoxEb.Name = "checkBoxEb";
-			this.checkBoxEb.Size = new System.Drawing.Size(168, 16);
-			this.checkBoxEb.TabIndex = 12;
-			this.checkBoxEb.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxConstSpeed
-			// 
-			this.checkBoxConstSpeed.Location = new System.Drawing.Point(128, 88);
-			this.checkBoxConstSpeed.Name = "checkBoxConstSpeed";
-			this.checkBoxConstSpeed.Size = new System.Drawing.Size(168, 16);
-			this.checkBoxConstSpeed.TabIndex = 11;
-			this.checkBoxConstSpeed.UseVisualStyleBackColor = true;
-			// 
-			// labelDoorMaxTolerance
-			// 
-			this.labelDoorMaxTolerance.Location = new System.Drawing.Point(8, 256);
-			this.labelDoorMaxTolerance.Name = "labelDoorMaxTolerance";
-			this.labelDoorMaxTolerance.Size = new System.Drawing.Size(112, 16);
-			this.labelDoorMaxTolerance.TabIndex = 10;
-			this.labelDoorMaxTolerance.Text = "DoorMaxTolerance:";
-			this.labelDoorMaxTolerance.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDoorWidth
-			// 
-			this.labelDoorWidth.Location = new System.Drawing.Point(8, 232);
-			this.labelDoorWidth.Name = "labelDoorWidth";
-			this.labelDoorWidth.Size = new System.Drawing.Size(112, 16);
-			this.labelDoorWidth.TabIndex = 9;
-			this.labelDoorWidth.Text = "DoorWidth:";
-			this.labelDoorWidth.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDoorCloseMode
-			// 
-			this.labelDoorCloseMode.Location = new System.Drawing.Point(8, 208);
-			this.labelDoorCloseMode.Name = "labelDoorCloseMode";
-			this.labelDoorCloseMode.Size = new System.Drawing.Size(112, 16);
-			this.labelDoorCloseMode.TabIndex = 8;
-			this.labelDoorCloseMode.Text = "DoorCloseMode:";
-			this.labelDoorCloseMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDoorOpenMode
-			// 
-			this.labelDoorOpenMode.Location = new System.Drawing.Point(8, 184);
-			this.labelDoorOpenMode.Name = "labelDoorOpenMode";
-			this.labelDoorOpenMode.Size = new System.Drawing.Size(112, 16);
-			this.labelDoorOpenMode.TabIndex = 7;
-			this.labelDoorOpenMode.Text = "DoorOpenMode:";
-			this.labelDoorOpenMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelPassAlarm
-			// 
-			this.labelPassAlarm.Location = new System.Drawing.Point(8, 160);
-			this.labelPassAlarm.Name = "labelPassAlarm";
-			this.labelPassAlarm.Size = new System.Drawing.Size(112, 16);
-			this.labelPassAlarm.TabIndex = 6;
-			this.labelPassAlarm.Text = "PassAlarm:";
-			this.labelPassAlarm.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelReAdhesionDevice
-			// 
-			this.labelReAdhesionDevice.Location = new System.Drawing.Point(8, 136);
-			this.labelReAdhesionDevice.Name = "labelReAdhesionDevice";
-			this.labelReAdhesionDevice.Size = new System.Drawing.Size(112, 16);
-			this.labelReAdhesionDevice.TabIndex = 5;
-			this.labelReAdhesionDevice.Text = "ReAdhesionDevice:";
-			this.labelReAdhesionDevice.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelHoldBrake
-			// 
-			this.labelHoldBrake.Location = new System.Drawing.Point(8, 112);
-			this.labelHoldBrake.Name = "labelHoldBrake";
-			this.labelHoldBrake.Size = new System.Drawing.Size(112, 16);
-			this.labelHoldBrake.TabIndex = 4;
-			this.labelHoldBrake.Text = "HoldBrake:";
-			this.labelHoldBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelConstSpeed
-			// 
-			this.labelConstSpeed.Location = new System.Drawing.Point(8, 88);
-			this.labelConstSpeed.Name = "labelConstSpeed";
-			this.labelConstSpeed.Size = new System.Drawing.Size(112, 16);
-			this.labelConstSpeed.TabIndex = 3;
-			this.labelConstSpeed.Text = "ConstSpeed:";
-			this.labelConstSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelEb
-			// 
-			this.labelEb.Location = new System.Drawing.Point(8, 64);
-			this.labelEb.Name = "labelEb";
-			this.labelEb.Size = new System.Drawing.Size(112, 16);
-			this.labelEb.TabIndex = 2;
-			this.labelEb.Text = "Eb:";
-			this.labelEb.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAtc
-			// 
-			this.labelAtc.Location = new System.Drawing.Point(8, 40);
-			this.labelAtc.Name = "labelAtc";
-			this.labelAtc.Size = new System.Drawing.Size(112, 16);
-			this.labelAtc.TabIndex = 1;
-			this.labelAtc.Text = "Atc:";
-			this.labelAtc.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAts
-			// 
-			this.labelAts.Location = new System.Drawing.Point(8, 16);
-			this.labelAts.Name = "labelAts";
-			this.labelAts.Size = new System.Drawing.Size(112, 16);
-			this.labelAts.TabIndex = 0;
-			this.labelAts.Text = "Ats:";
-			this.labelAts.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxCab
-			// 
-			this.groupBoxCab.Controls.Add(this.comboBoxDriverCar);
-			this.groupBoxCab.Controls.Add(this.labelCabZUnit);
-			this.groupBoxCab.Controls.Add(this.textBoxCabZ);
-			this.groupBoxCab.Controls.Add(this.labelCabYUnit);
-			this.groupBoxCab.Controls.Add(this.textBoxCabY);
-			this.groupBoxCab.Controls.Add(this.labelCabXUnit);
-			this.groupBoxCab.Controls.Add(this.textBoxCabX);
-			this.groupBoxCab.Controls.Add(this.labelDriverCar);
-			this.groupBoxCab.Controls.Add(this.labelCabZ);
-			this.groupBoxCab.Controls.Add(this.labelCabY);
-			this.groupBoxCab.Controls.Add(this.labelCabX);
-			this.groupBoxCab.Location = new System.Drawing.Point(8, 256);
-			this.groupBoxCab.Name = "groupBoxCab";
-			this.groupBoxCab.Size = new System.Drawing.Size(416, 120);
-			this.groupBoxCab.TabIndex = 1;
-			this.groupBoxCab.TabStop = false;
-			this.groupBoxCab.Text = "Cab";
-			// 
-			// comboBoxDriverCar
-			// 
-			this.comboBoxDriverCar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxDriverCar.FormattingEnabled = true;
-			this.comboBoxDriverCar.Location = new System.Drawing.Point(192, 88);
-			this.comboBoxDriverCar.Name = "comboBoxDriverCar";
-			this.comboBoxDriverCar.Size = new System.Drawing.Size(184, 20);
-			this.comboBoxDriverCar.TabIndex = 10;
-			// 
-			// labelCabZUnit
-			// 
-			this.labelCabZUnit.Location = new System.Drawing.Point(384, 64);
-			this.labelCabZUnit.Name = "labelCabZUnit";
-			this.labelCabZUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelCabZUnit.TabIndex = 9;
-			this.labelCabZUnit.Text = "mm";
-			this.labelCabZUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxCabZ
-			// 
-			this.textBoxCabZ.Location = new System.Drawing.Point(192, 64);
-			this.textBoxCabZ.Name = "textBoxCabZ";
-			this.textBoxCabZ.Size = new System.Drawing.Size(184, 19);
-			this.textBoxCabZ.TabIndex = 8;
-			// 
-			// labelCabYUnit
-			// 
-			this.labelCabYUnit.Location = new System.Drawing.Point(384, 40);
-			this.labelCabYUnit.Name = "labelCabYUnit";
-			this.labelCabYUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelCabYUnit.TabIndex = 7;
-			this.labelCabYUnit.Text = "mm";
-			this.labelCabYUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxCabY
-			// 
-			this.textBoxCabY.Location = new System.Drawing.Point(192, 40);
-			this.textBoxCabY.Name = "textBoxCabY";
-			this.textBoxCabY.Size = new System.Drawing.Size(184, 19);
-			this.textBoxCabY.TabIndex = 6;
-			// 
-			// labelCabXUnit
-			// 
-			this.labelCabXUnit.Location = new System.Drawing.Point(384, 16);
-			this.labelCabXUnit.Name = "labelCabXUnit";
-			this.labelCabXUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelCabXUnit.TabIndex = 5;
-			this.labelCabXUnit.Text = "mm";
-			this.labelCabXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxCabX
-			// 
-			this.textBoxCabX.Location = new System.Drawing.Point(192, 16);
-			this.textBoxCabX.Name = "textBoxCabX";
-			this.textBoxCabX.Size = new System.Drawing.Size(184, 19);
-			this.textBoxCabX.TabIndex = 4;
-			// 
-			// labelDriverCar
-			// 
-			this.labelDriverCar.Location = new System.Drawing.Point(8, 88);
-			this.labelDriverCar.Name = "labelDriverCar";
-			this.labelDriverCar.Size = new System.Drawing.Size(176, 16);
-			this.labelDriverCar.TabIndex = 3;
-			this.labelDriverCar.Text = "DriverCar:";
-			this.labelDriverCar.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCabZ
-			// 
-			this.labelCabZ.Location = new System.Drawing.Point(8, 64);
-			this.labelCabZ.Name = "labelCabZ";
-			this.labelCabZ.Size = new System.Drawing.Size(176, 16);
-			this.labelCabZ.TabIndex = 2;
-			this.labelCabZ.Text = "Z:";
-			this.labelCabZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCabY
-			// 
-			this.labelCabY.Location = new System.Drawing.Point(8, 40);
-			this.labelCabY.Name = "labelCabY";
-			this.labelCabY.Size = new System.Drawing.Size(176, 16);
-			this.labelCabY.TabIndex = 1;
-			this.labelCabY.Text = "Y:";
-			this.labelCabY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCabX
-			// 
-			this.labelCabX.Location = new System.Drawing.Point(8, 16);
-			this.labelCabX.Name = "labelCabX";
-			this.labelCabX.Size = new System.Drawing.Size(176, 16);
-			this.labelCabX.TabIndex = 0;
-			this.labelCabX.Text = "X:";
-			this.labelCabX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxHandle
-			// 
-			this.groupBoxHandle.Controls.Add(this.numericUpDownLocoBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.labelLocoBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.comboBoxLocoBrakeHandleType);
-			this.groupBoxHandle.Controls.Add(this.labelLocoBrakeHandleType);
-			this.groupBoxHandle.Controls.Add(this.comboBoxEbHandleBehaviour);
-			this.groupBoxHandle.Controls.Add(this.labelEbHandleBehaviour);
-			this.groupBoxHandle.Controls.Add(this.numericUpDownDriverBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.labelDriverBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.numericUpDownDriverPowerNotches);
-			this.groupBoxHandle.Controls.Add(this.labelDriverPowerNotches);
-			this.groupBoxHandle.Controls.Add(this.numericUpDownPowerNotchReduceSteps);
-			this.groupBoxHandle.Controls.Add(this.labelPowerNotchReduceSteps);
-			this.groupBoxHandle.Controls.Add(this.numericUpDownBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.labelBrakeNotches);
-			this.groupBoxHandle.Controls.Add(this.numericUpDownPowerNotches);
-			this.groupBoxHandle.Controls.Add(this.labelPowerNotches);
-			this.groupBoxHandle.Controls.Add(this.comboBoxHandleType);
-			this.groupBoxHandle.Controls.Add(this.labelHandleType);
-			this.groupBoxHandle.Location = new System.Drawing.Point(8, 8);
-			this.groupBoxHandle.Name = "groupBoxHandle";
-			this.groupBoxHandle.Size = new System.Drawing.Size(416, 240);
-			this.groupBoxHandle.TabIndex = 0;
-			this.groupBoxHandle.TabStop = false;
-			this.groupBoxHandle.Text = "Handle";
-			// 
-			// numericUpDownLocoBrakeNotches
-			// 
-			this.numericUpDownLocoBrakeNotches.Location = new System.Drawing.Point(192, 208);
-			this.numericUpDownLocoBrakeNotches.Name = "numericUpDownLocoBrakeNotches";
-			this.numericUpDownLocoBrakeNotches.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownLocoBrakeNotches.TabIndex = 17;
-			// 
-			// labelLocoBrakeNotches
-			// 
-			this.labelLocoBrakeNotches.Location = new System.Drawing.Point(8, 208);
-			this.labelLocoBrakeNotches.Name = "labelLocoBrakeNotches";
-			this.labelLocoBrakeNotches.Size = new System.Drawing.Size(176, 16);
-			this.labelLocoBrakeNotches.TabIndex = 16;
-			this.labelLocoBrakeNotches.Text = "LocoBrakeNotches:";
-			this.labelLocoBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// comboBoxLocoBrakeHandleType
-			// 
-			this.comboBoxLocoBrakeHandleType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxLocoBrakeHandleType.FormattingEnabled = true;
-			this.comboBoxLocoBrakeHandleType.Items.AddRange(new object[] {
-            "Combined",
-            "Independant",
-            "Blocking"});
-			this.comboBoxLocoBrakeHandleType.Location = new System.Drawing.Point(192, 184);
-			this.comboBoxLocoBrakeHandleType.Name = "comboBoxLocoBrakeHandleType";
-			this.comboBoxLocoBrakeHandleType.Size = new System.Drawing.Size(216, 20);
-			this.comboBoxLocoBrakeHandleType.TabIndex = 15;
-			// 
-			// labelLocoBrakeHandleType
-			// 
-			this.labelLocoBrakeHandleType.Location = new System.Drawing.Point(8, 184);
-			this.labelLocoBrakeHandleType.Name = "labelLocoBrakeHandleType";
-			this.labelLocoBrakeHandleType.Size = new System.Drawing.Size(176, 16);
-			this.labelLocoBrakeHandleType.TabIndex = 14;
-			this.labelLocoBrakeHandleType.Text = "LocoBrakeHandleType:";
-			this.labelLocoBrakeHandleType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// comboBoxEbHandleBehaviour
-			// 
-			this.comboBoxEbHandleBehaviour.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxEbHandleBehaviour.FormattingEnabled = true;
-			this.comboBoxEbHandleBehaviour.Items.AddRange(new object[] {
-            "No action",
-            "Return power to neutral",
-            "Return reverser to neutral",
-            "Return power and reverser to neutral"});
-			this.comboBoxEbHandleBehaviour.Location = new System.Drawing.Point(192, 160);
-			this.comboBoxEbHandleBehaviour.Name = "comboBoxEbHandleBehaviour";
-			this.comboBoxEbHandleBehaviour.Size = new System.Drawing.Size(216, 20);
-			this.comboBoxEbHandleBehaviour.TabIndex = 13;
-			// 
-			// labelEbHandleBehaviour
-			// 
-			this.labelEbHandleBehaviour.Location = new System.Drawing.Point(8, 160);
-			this.labelEbHandleBehaviour.Name = "labelEbHandleBehaviour";
-			this.labelEbHandleBehaviour.Size = new System.Drawing.Size(176, 16);
-			this.labelEbHandleBehaviour.TabIndex = 12;
-			this.labelEbHandleBehaviour.Text = "EbHandleBehaviour:";
-			this.labelEbHandleBehaviour.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownDriverBrakeNotches
-			// 
-			this.numericUpDownDriverBrakeNotches.Location = new System.Drawing.Point(192, 136);
-			this.numericUpDownDriverBrakeNotches.Name = "numericUpDownDriverBrakeNotches";
-			this.numericUpDownDriverBrakeNotches.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownDriverBrakeNotches.TabIndex = 11;
-			// 
-			// labelDriverBrakeNotches
-			// 
-			this.labelDriverBrakeNotches.Location = new System.Drawing.Point(8, 136);
-			this.labelDriverBrakeNotches.Name = "labelDriverBrakeNotches";
-			this.labelDriverBrakeNotches.Size = new System.Drawing.Size(176, 16);
-			this.labelDriverBrakeNotches.TabIndex = 10;
-			this.labelDriverBrakeNotches.Text = "DriverBrakeNotches:";
-			this.labelDriverBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownDriverPowerNotches
-			// 
-			this.numericUpDownDriverPowerNotches.Location = new System.Drawing.Point(192, 112);
-			this.numericUpDownDriverPowerNotches.Name = "numericUpDownDriverPowerNotches";
-			this.numericUpDownDriverPowerNotches.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownDriverPowerNotches.TabIndex = 9;
-			// 
-			// labelDriverPowerNotches
-			// 
-			this.labelDriverPowerNotches.Location = new System.Drawing.Point(8, 112);
-			this.labelDriverPowerNotches.Name = "labelDriverPowerNotches";
-			this.labelDriverPowerNotches.Size = new System.Drawing.Size(176, 16);
-			this.labelDriverPowerNotches.TabIndex = 8;
-			this.labelDriverPowerNotches.Text = "DriverPowerNotches:";
-			this.labelDriverPowerNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownPowerNotchReduceSteps
-			// 
-			this.numericUpDownPowerNotchReduceSteps.Location = new System.Drawing.Point(192, 88);
-			this.numericUpDownPowerNotchReduceSteps.Name = "numericUpDownPowerNotchReduceSteps";
-			this.numericUpDownPowerNotchReduceSteps.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownPowerNotchReduceSteps.TabIndex = 7;
-			// 
-			// labelPowerNotchReduceSteps
-			// 
-			this.labelPowerNotchReduceSteps.Location = new System.Drawing.Point(8, 88);
-			this.labelPowerNotchReduceSteps.Name = "labelPowerNotchReduceSteps";
-			this.labelPowerNotchReduceSteps.Size = new System.Drawing.Size(176, 16);
-			this.labelPowerNotchReduceSteps.TabIndex = 6;
-			this.labelPowerNotchReduceSteps.Text = "PowerNotchReduceSteps:";
-			this.labelPowerNotchReduceSteps.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownBrakeNotches
-			// 
-			this.numericUpDownBrakeNotches.Location = new System.Drawing.Point(192, 64);
-			this.numericUpDownBrakeNotches.Name = "numericUpDownBrakeNotches";
-			this.numericUpDownBrakeNotches.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownBrakeNotches.TabIndex = 5;
-			// 
-			// labelBrakeNotches
-			// 
-			this.labelBrakeNotches.Location = new System.Drawing.Point(8, 64);
-			this.labelBrakeNotches.Name = "labelBrakeNotches";
-			this.labelBrakeNotches.Size = new System.Drawing.Size(176, 16);
-			this.labelBrakeNotches.TabIndex = 4;
-			this.labelBrakeNotches.Text = "BrakeNotches:";
-			this.labelBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownPowerNotches
-			// 
-			this.numericUpDownPowerNotches.Location = new System.Drawing.Point(192, 40);
-			this.numericUpDownPowerNotches.Name = "numericUpDownPowerNotches";
-			this.numericUpDownPowerNotches.Size = new System.Drawing.Size(216, 19);
-			this.numericUpDownPowerNotches.TabIndex = 3;
-			// 
-			// labelPowerNotches
-			// 
-			this.labelPowerNotches.Location = new System.Drawing.Point(8, 40);
-			this.labelPowerNotches.Name = "labelPowerNotches";
-			this.labelPowerNotches.Size = new System.Drawing.Size(176, 16);
-			this.labelPowerNotches.TabIndex = 2;
-			this.labelPowerNotches.Text = "PowerNotches:";
-			this.labelPowerNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// comboBoxHandleType
-			// 
-			this.comboBoxHandleType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxHandleType.FormattingEnabled = true;
-			this.comboBoxHandleType.Items.AddRange(new object[] {
-            "Separated",
-            "Combined"});
-			this.comboBoxHandleType.Location = new System.Drawing.Point(192, 16);
-			this.comboBoxHandleType.Name = "comboBoxHandleType";
-			this.comboBoxHandleType.Size = new System.Drawing.Size(216, 20);
-			this.comboBoxHandleType.TabIndex = 1;
-			// 
-			// labelHandleType
-			// 
-			this.labelHandleType.Location = new System.Drawing.Point(8, 16);
-			this.labelHandleType.Name = "labelHandleType";
-			this.labelHandleType.Size = new System.Drawing.Size(176, 16);
-			this.labelHandleType.TabIndex = 0;
-			this.labelHandleType.Text = "HandleType:";
-			this.labelHandleType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// tabPageCar
-			// 
-			this.tabPageCar.Controls.Add(this.groupBoxPressure);
-			this.tabPageCar.Controls.Add(this.groupBoxBrake);
-			this.tabPageCar.Controls.Add(this.groupBoxMove);
-			this.tabPageCar.Controls.Add(this.groupBoxDelay);
-			this.tabPageCar.Controls.Add(this.groupBoxPerformance);
-			this.tabPageCar.Controls.Add(this.groupBoxCarGeneral);
-			this.tabPageCar.Location = new System.Drawing.Point(4, 22);
-			this.tabPageCar.Name = "tabPageCar";
-			this.tabPageCar.Size = new System.Drawing.Size(792, 670);
-			this.tabPageCar.TabIndex = 4;
-			this.tabPageCar.Text = "Car settings";
-			this.tabPageCar.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxPressure
-			// 
-			this.groupBoxPressure.Controls.Add(this.labelBrakePipeNormalPressureUnit);
-			this.groupBoxPressure.Controls.Add(this.textBoxBrakePipeNormalPressure);
-			this.groupBoxPressure.Controls.Add(this.labelBrakePipeNormalPressure);
-			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderServiceMaximumPressureUnit);
-			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMaximumPressureUnit);
-			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMinimumPressureUnit);
-			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderEmergencyMaximumPressureUnit);
-			this.groupBoxPressure.Controls.Add(this.textBoxMainReservoirMaximumPressure);
-			this.groupBoxPressure.Controls.Add(this.textBoxMainReservoirMinimumPressure);
-			this.groupBoxPressure.Controls.Add(this.textBoxBrakeCylinderEmergencyMaximumPressure);
-			this.groupBoxPressure.Controls.Add(this.textBoxBrakeCylinderServiceMaximumPressure);
-			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMaximumPressure);
-			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMinimumPressure);
-			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderServiceMaximumPressure);
-			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderEmergencyMaximumPressure);
-			this.groupBoxPressure.Location = new System.Drawing.Point(288, 440);
-			this.groupBoxPressure.Name = "groupBoxPressure";
-			this.groupBoxPressure.Size = new System.Drawing.Size(448, 144);
-			this.groupBoxPressure.TabIndex = 33;
-			this.groupBoxPressure.TabStop = false;
-			this.groupBoxPressure.Text = "Pressure";
-			// 
-			// labelBrakePipeNormalPressureUnit
-			// 
-			this.labelBrakePipeNormalPressureUnit.Location = new System.Drawing.Point(408, 112);
-			this.labelBrakePipeNormalPressureUnit.Name = "labelBrakePipeNormalPressureUnit";
-			this.labelBrakePipeNormalPressureUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelBrakePipeNormalPressureUnit.TabIndex = 39;
-			this.labelBrakePipeNormalPressureUnit.Text = "kPa";
-			this.labelBrakePipeNormalPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxBrakePipeNormalPressure
-			// 
-			this.textBoxBrakePipeNormalPressure.Location = new System.Drawing.Point(248, 112);
-			this.textBoxBrakePipeNormalPressure.Name = "textBoxBrakePipeNormalPressure";
-			this.textBoxBrakePipeNormalPressure.Size = new System.Drawing.Size(152, 19);
-			this.textBoxBrakePipeNormalPressure.TabIndex = 38;
-			// 
-			// labelBrakePipeNormalPressure
-			// 
-			this.labelBrakePipeNormalPressure.Location = new System.Drawing.Point(8, 112);
-			this.labelBrakePipeNormalPressure.Name = "labelBrakePipeNormalPressure";
-			this.labelBrakePipeNormalPressure.Size = new System.Drawing.Size(232, 16);
-			this.labelBrakePipeNormalPressure.TabIndex = 37;
-			this.labelBrakePipeNormalPressure.Text = "BrakePipeNormalPressure:";
-			this.labelBrakePipeNormalPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeCylinderServiceMaximumPressureUnit
-			// 
-			this.labelBrakeCylinderServiceMaximumPressureUnit.Location = new System.Drawing.Point(408, 16);
-			this.labelBrakeCylinderServiceMaximumPressureUnit.Name = "labelBrakeCylinderServiceMaximumPressureUnit";
-			this.labelBrakeCylinderServiceMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelBrakeCylinderServiceMaximumPressureUnit.TabIndex = 32;
-			this.labelBrakeCylinderServiceMaximumPressureUnit.Text = "kPa";
-			this.labelBrakeCylinderServiceMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelMainReservoirMaximumPressureUnit
-			// 
-			this.labelMainReservoirMaximumPressureUnit.Location = new System.Drawing.Point(408, 88);
-			this.labelMainReservoirMaximumPressureUnit.Name = "labelMainReservoirMaximumPressureUnit";
-			this.labelMainReservoirMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelMainReservoirMaximumPressureUnit.TabIndex = 36;
-			this.labelMainReservoirMaximumPressureUnit.Text = "kPa";
-			this.labelMainReservoirMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelMainReservoirMinimumPressureUnit
-			// 
-			this.labelMainReservoirMinimumPressureUnit.Location = new System.Drawing.Point(408, 64);
-			this.labelMainReservoirMinimumPressureUnit.Name = "labelMainReservoirMinimumPressureUnit";
-			this.labelMainReservoirMinimumPressureUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelMainReservoirMinimumPressureUnit.TabIndex = 35;
-			this.labelMainReservoirMinimumPressureUnit.Text = "kPa";
-			this.labelMainReservoirMinimumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelBrakeCylinderEmergencyMaximumPressureUnit
-			// 
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Location = new System.Drawing.Point(408, 40);
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Name = "labelBrakeCylinderEmergencyMaximumPressureUnit";
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.TabIndex = 34;
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Text = "kPa";
-			this.labelBrakeCylinderEmergencyMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxMainReservoirMaximumPressure
-			// 
-			this.textBoxMainReservoirMaximumPressure.Location = new System.Drawing.Point(248, 88);
-			this.textBoxMainReservoirMaximumPressure.Name = "textBoxMainReservoirMaximumPressure";
-			this.textBoxMainReservoirMaximumPressure.Size = new System.Drawing.Size(152, 19);
-			this.textBoxMainReservoirMaximumPressure.TabIndex = 34;
-			// 
-			// textBoxMainReservoirMinimumPressure
-			// 
-			this.textBoxMainReservoirMinimumPressure.Location = new System.Drawing.Point(248, 64);
-			this.textBoxMainReservoirMinimumPressure.Name = "textBoxMainReservoirMinimumPressure";
-			this.textBoxMainReservoirMinimumPressure.Size = new System.Drawing.Size(152, 19);
-			this.textBoxMainReservoirMinimumPressure.TabIndex = 33;
-			// 
-			// textBoxBrakeCylinderEmergencyMaximumPressure
-			// 
-			this.textBoxBrakeCylinderEmergencyMaximumPressure.Location = new System.Drawing.Point(248, 40);
-			this.textBoxBrakeCylinderEmergencyMaximumPressure.Name = "textBoxBrakeCylinderEmergencyMaximumPressure";
-			this.textBoxBrakeCylinderEmergencyMaximumPressure.Size = new System.Drawing.Size(152, 19);
-			this.textBoxBrakeCylinderEmergencyMaximumPressure.TabIndex = 32;
-			// 
-			// textBoxBrakeCylinderServiceMaximumPressure
-			// 
-			this.textBoxBrakeCylinderServiceMaximumPressure.Location = new System.Drawing.Point(248, 16);
-			this.textBoxBrakeCylinderServiceMaximumPressure.Name = "textBoxBrakeCylinderServiceMaximumPressure";
-			this.textBoxBrakeCylinderServiceMaximumPressure.Size = new System.Drawing.Size(152, 19);
-			this.textBoxBrakeCylinderServiceMaximumPressure.TabIndex = 31;
-			// 
-			// labelMainReservoirMaximumPressure
-			// 
-			this.labelMainReservoirMaximumPressure.Location = new System.Drawing.Point(8, 88);
-			this.labelMainReservoirMaximumPressure.Name = "labelMainReservoirMaximumPressure";
-			this.labelMainReservoirMaximumPressure.Size = new System.Drawing.Size(232, 16);
-			this.labelMainReservoirMaximumPressure.TabIndex = 11;
-			this.labelMainReservoirMaximumPressure.Text = "MainReservoirMaximumPressure:";
-			this.labelMainReservoirMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelMainReservoirMinimumPressure
-			// 
-			this.labelMainReservoirMinimumPressure.Location = new System.Drawing.Point(8, 64);
-			this.labelMainReservoirMinimumPressure.Name = "labelMainReservoirMinimumPressure";
-			this.labelMainReservoirMinimumPressure.Size = new System.Drawing.Size(232, 16);
-			this.labelMainReservoirMinimumPressure.TabIndex = 10;
-			this.labelMainReservoirMinimumPressure.Text = "MainReservoirMinimumPressure:";
-			this.labelMainReservoirMinimumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeCylinderServiceMaximumPressure
-			// 
-			this.labelBrakeCylinderServiceMaximumPressure.Location = new System.Drawing.Point(8, 16);
-			this.labelBrakeCylinderServiceMaximumPressure.Name = "labelBrakeCylinderServiceMaximumPressure";
-			this.labelBrakeCylinderServiceMaximumPressure.Size = new System.Drawing.Size(232, 16);
-			this.labelBrakeCylinderServiceMaximumPressure.TabIndex = 9;
-			this.labelBrakeCylinderServiceMaximumPressure.Text = "BrakeCylinderServiceMaximumPressure:";
-			this.labelBrakeCylinderServiceMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeCylinderEmergencyMaximumPressure
-			// 
-			this.labelBrakeCylinderEmergencyMaximumPressure.Location = new System.Drawing.Point(8, 40);
-			this.labelBrakeCylinderEmergencyMaximumPressure.Name = "labelBrakeCylinderEmergencyMaximumPressure";
-			this.labelBrakeCylinderEmergencyMaximumPressure.Size = new System.Drawing.Size(232, 16);
-			this.labelBrakeCylinderEmergencyMaximumPressure.TabIndex = 8;
-			this.labelBrakeCylinderEmergencyMaximumPressure.Text = "BrakeCylinderEmergencyMaximumPressure:";
-			this.labelBrakeCylinderEmergencyMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxBrake
-			// 
-			this.groupBoxBrake.Controls.Add(this.textBoxBrakeControlSpeed);
-			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSpeedUnit);
-			this.groupBoxBrake.Controls.Add(this.comboBoxBrakeControlSystem);
-			this.groupBoxBrake.Controls.Add(this.comboBoxLocoBrakeType);
-			this.groupBoxBrake.Controls.Add(this.comboBoxBrakeType);
-			this.groupBoxBrake.Controls.Add(this.labelLocoBrakeType);
-			this.groupBoxBrake.Controls.Add(this.labelBrakeType);
-			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSpeed);
-			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSystem);
-			this.groupBoxBrake.Location = new System.Drawing.Point(288, 312);
-			this.groupBoxBrake.Name = "groupBoxBrake";
-			this.groupBoxBrake.Size = new System.Drawing.Size(448, 120);
-			this.groupBoxBrake.TabIndex = 4;
-			this.groupBoxBrake.TabStop = false;
-			this.groupBoxBrake.Text = "Brake";
-			// 
-			// textBoxBrakeControlSpeed
-			// 
-			this.textBoxBrakeControlSpeed.Location = new System.Drawing.Point(136, 88);
-			this.textBoxBrakeControlSpeed.Name = "textBoxBrakeControlSpeed";
-			this.textBoxBrakeControlSpeed.Size = new System.Drawing.Size(264, 19);
-			this.textBoxBrakeControlSpeed.TabIndex = 31;
-			// 
-			// labelBrakeControlSpeedUnit
-			// 
-			this.labelBrakeControlSpeedUnit.Location = new System.Drawing.Point(408, 88);
-			this.labelBrakeControlSpeedUnit.Name = "labelBrakeControlSpeedUnit";
-			this.labelBrakeControlSpeedUnit.Size = new System.Drawing.Size(32, 16);
-			this.labelBrakeControlSpeedUnit.TabIndex = 32;
-			this.labelBrakeControlSpeedUnit.Text = "km/h";
-			this.labelBrakeControlSpeedUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// comboBoxBrakeControlSystem
-			// 
-			this.comboBoxBrakeControlSystem.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxBrakeControlSystem.FormattingEnabled = true;
-			this.comboBoxBrakeControlSystem.Items.AddRange(new object[] {
-            "None",
-            "Closing electromagnetic valve",
-            "Delay-including control"});
-			this.comboBoxBrakeControlSystem.Location = new System.Drawing.Point(136, 64);
-			this.comboBoxBrakeControlSystem.Name = "comboBoxBrakeControlSystem";
-			this.comboBoxBrakeControlSystem.Size = new System.Drawing.Size(264, 20);
-			this.comboBoxBrakeControlSystem.TabIndex = 17;
-			// 
-			// comboBoxLocoBrakeType
-			// 
-			this.comboBoxLocoBrakeType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxLocoBrakeType.FormattingEnabled = true;
-			this.comboBoxLocoBrakeType.Items.AddRange(new object[] {
-            "Not fitted",
-            "Notched air brake",
-            "Air brake with partial release"});
-			this.comboBoxLocoBrakeType.Location = new System.Drawing.Point(136, 40);
-			this.comboBoxLocoBrakeType.Name = "comboBoxLocoBrakeType";
-			this.comboBoxLocoBrakeType.Size = new System.Drawing.Size(264, 20);
-			this.comboBoxLocoBrakeType.TabIndex = 16;
-			// 
-			// comboBoxBrakeType
-			// 
-			this.comboBoxBrakeType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxBrakeType.FormattingEnabled = true;
-			this.comboBoxBrakeType.Items.AddRange(new object[] {
-            "Electromagnetic straight air brake",
-            "Electro-pneumatic air brake without brake pipe",
-            "Air brake with partial release feature"});
-			this.comboBoxBrakeType.Location = new System.Drawing.Point(136, 16);
-			this.comboBoxBrakeType.Name = "comboBoxBrakeType";
-			this.comboBoxBrakeType.Size = new System.Drawing.Size(264, 20);
-			this.comboBoxBrakeType.TabIndex = 15;
-			// 
-			// labelLocoBrakeType
-			// 
-			this.labelLocoBrakeType.Location = new System.Drawing.Point(8, 40);
-			this.labelLocoBrakeType.Name = "labelLocoBrakeType";
-			this.labelLocoBrakeType.Size = new System.Drawing.Size(120, 16);
-			this.labelLocoBrakeType.TabIndex = 8;
-			this.labelLocoBrakeType.Text = "LocoBrakeType:";
-			this.labelLocoBrakeType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeType
-			// 
-			this.labelBrakeType.Location = new System.Drawing.Point(8, 16);
-			this.labelBrakeType.Name = "labelBrakeType";
-			this.labelBrakeType.Size = new System.Drawing.Size(120, 16);
-			this.labelBrakeType.TabIndex = 7;
-			this.labelBrakeType.Text = "BrakeType:";
-			this.labelBrakeType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeControlSpeed
-			// 
-			this.labelBrakeControlSpeed.Location = new System.Drawing.Point(8, 88);
-			this.labelBrakeControlSpeed.Name = "labelBrakeControlSpeed";
-			this.labelBrakeControlSpeed.Size = new System.Drawing.Size(120, 16);
-			this.labelBrakeControlSpeed.TabIndex = 6;
-			this.labelBrakeControlSpeed.Text = "BrakeControlSpeed:";
-			this.labelBrakeControlSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeControlSystem
-			// 
-			this.labelBrakeControlSystem.Location = new System.Drawing.Point(8, 64);
-			this.labelBrakeControlSystem.Name = "labelBrakeControlSystem";
-			this.labelBrakeControlSystem.Size = new System.Drawing.Size(120, 16);
-			this.labelBrakeControlSystem.TabIndex = 5;
-			this.labelBrakeControlSystem.Text = "BrakeControlSystem:";
-			this.labelBrakeControlSystem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxMove
-			// 
-			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderDownUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxBrakeCylinderDown);
-			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderUpUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxBrakeCylinderUp);
-			this.groupBoxMove.Controls.Add(this.labelJerkBrakeDownUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxJerkBrakeDown);
-			this.groupBoxMove.Controls.Add(this.labelJerkBrakeUpUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxJerkBrakeUp);
-			this.groupBoxMove.Controls.Add(this.labelJerkPowerDownUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxJerkPowerDown);
-			this.groupBoxMove.Controls.Add(this.labelJerkPowerUpUnit);
-			this.groupBoxMove.Controls.Add(this.textBoxJerkPowerUp);
-			this.groupBoxMove.Controls.Add(this.labelJerkPowerUp);
-			this.groupBoxMove.Controls.Add(this.labelJerkPowerDown);
-			this.groupBoxMove.Controls.Add(this.labelJerkBrakeUp);
-			this.groupBoxMove.Controls.Add(this.labelJerkBrakeDown);
-			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderUp);
-			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderDown);
-			this.groupBoxMove.Location = new System.Drawing.Point(288, 136);
-			this.groupBoxMove.Name = "groupBoxMove";
-			this.groupBoxMove.Size = new System.Drawing.Size(448, 168);
-			this.groupBoxMove.TabIndex = 3;
-			this.groupBoxMove.TabStop = false;
-			this.groupBoxMove.Text = "Move";
-			// 
-			// labelBrakeCylinderDownUnit
-			// 
-			this.labelBrakeCylinderDownUnit.Location = new System.Drawing.Point(376, 136);
-			this.labelBrakeCylinderDownUnit.Name = "labelBrakeCylinderDownUnit";
-			this.labelBrakeCylinderDownUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelBrakeCylinderDownUnit.TabIndex = 31;
-			this.labelBrakeCylinderDownUnit.Text = "kPa/s";
-			this.labelBrakeCylinderDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxBrakeCylinderDown
-			// 
-			this.textBoxBrakeCylinderDown.Location = new System.Drawing.Point(184, 136);
-			this.textBoxBrakeCylinderDown.Name = "textBoxBrakeCylinderDown";
-			this.textBoxBrakeCylinderDown.Size = new System.Drawing.Size(184, 19);
-			this.textBoxBrakeCylinderDown.TabIndex = 30;
-			// 
-			// labelBrakeCylinderUpUnit
-			// 
-			this.labelBrakeCylinderUpUnit.Location = new System.Drawing.Point(376, 112);
-			this.labelBrakeCylinderUpUnit.Name = "labelBrakeCylinderUpUnit";
-			this.labelBrakeCylinderUpUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelBrakeCylinderUpUnit.TabIndex = 29;
-			this.labelBrakeCylinderUpUnit.Text = "kPa/s";
-			this.labelBrakeCylinderUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxBrakeCylinderUp
-			// 
-			this.textBoxBrakeCylinderUp.Location = new System.Drawing.Point(184, 112);
-			this.textBoxBrakeCylinderUp.Name = "textBoxBrakeCylinderUp";
-			this.textBoxBrakeCylinderUp.Size = new System.Drawing.Size(184, 19);
-			this.textBoxBrakeCylinderUp.TabIndex = 28;
-			// 
-			// labelJerkBrakeDownUnit
-			// 
-			this.labelJerkBrakeDownUnit.Location = new System.Drawing.Point(376, 88);
-			this.labelJerkBrakeDownUnit.Name = "labelJerkBrakeDownUnit";
-			this.labelJerkBrakeDownUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelJerkBrakeDownUnit.TabIndex = 27;
-			this.labelJerkBrakeDownUnit.Text = "1/100 m/s³";
-			this.labelJerkBrakeDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxJerkBrakeDown
-			// 
-			this.textBoxJerkBrakeDown.Location = new System.Drawing.Point(184, 88);
-			this.textBoxJerkBrakeDown.Name = "textBoxJerkBrakeDown";
-			this.textBoxJerkBrakeDown.Size = new System.Drawing.Size(184, 19);
-			this.textBoxJerkBrakeDown.TabIndex = 26;
-			// 
-			// labelJerkBrakeUpUnit
-			// 
-			this.labelJerkBrakeUpUnit.Location = new System.Drawing.Point(376, 64);
-			this.labelJerkBrakeUpUnit.Name = "labelJerkBrakeUpUnit";
-			this.labelJerkBrakeUpUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelJerkBrakeUpUnit.TabIndex = 25;
-			this.labelJerkBrakeUpUnit.Text = "1/100 m/s³";
-			this.labelJerkBrakeUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxJerkBrakeUp
-			// 
-			this.textBoxJerkBrakeUp.Location = new System.Drawing.Point(184, 64);
-			this.textBoxJerkBrakeUp.Name = "textBoxJerkBrakeUp";
-			this.textBoxJerkBrakeUp.Size = new System.Drawing.Size(184, 19);
-			this.textBoxJerkBrakeUp.TabIndex = 24;
-			// 
-			// labelJerkPowerDownUnit
-			// 
-			this.labelJerkPowerDownUnit.Location = new System.Drawing.Point(376, 40);
-			this.labelJerkPowerDownUnit.Name = "labelJerkPowerDownUnit";
-			this.labelJerkPowerDownUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelJerkPowerDownUnit.TabIndex = 23;
-			this.labelJerkPowerDownUnit.Text = "1/100 m/s³";
-			this.labelJerkPowerDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxJerkPowerDown
-			// 
-			this.textBoxJerkPowerDown.Location = new System.Drawing.Point(184, 40);
-			this.textBoxJerkPowerDown.Name = "textBoxJerkPowerDown";
-			this.textBoxJerkPowerDown.Size = new System.Drawing.Size(184, 19);
-			this.textBoxJerkPowerDown.TabIndex = 22;
-			// 
-			// labelJerkPowerUpUnit
-			// 
-			this.labelJerkPowerUpUnit.Location = new System.Drawing.Point(376, 16);
-			this.labelJerkPowerUpUnit.Name = "labelJerkPowerUpUnit";
-			this.labelJerkPowerUpUnit.Size = new System.Drawing.Size(64, 16);
-			this.labelJerkPowerUpUnit.TabIndex = 21;
-			this.labelJerkPowerUpUnit.Text = "1/100 m/s³";
-			this.labelJerkPowerUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxJerkPowerUp
-			// 
-			this.textBoxJerkPowerUp.Location = new System.Drawing.Point(184, 16);
-			this.textBoxJerkPowerUp.Name = "textBoxJerkPowerUp";
-			this.textBoxJerkPowerUp.Size = new System.Drawing.Size(184, 19);
-			this.textBoxJerkPowerUp.TabIndex = 20;
-			// 
-			// labelJerkPowerUp
-			// 
-			this.labelJerkPowerUp.Location = new System.Drawing.Point(8, 16);
-			this.labelJerkPowerUp.Name = "labelJerkPowerUp";
-			this.labelJerkPowerUp.Size = new System.Drawing.Size(168, 16);
-			this.labelJerkPowerUp.TabIndex = 6;
-			this.labelJerkPowerUp.Text = "JerkPowerUp:";
-			this.labelJerkPowerUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelJerkPowerDown
-			// 
-			this.labelJerkPowerDown.Location = new System.Drawing.Point(8, 40);
-			this.labelJerkPowerDown.Name = "labelJerkPowerDown";
-			this.labelJerkPowerDown.Size = new System.Drawing.Size(168, 16);
-			this.labelJerkPowerDown.TabIndex = 5;
-			this.labelJerkPowerDown.Text = "JerkPowerDown:";
-			this.labelJerkPowerDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelJerkBrakeUp
-			// 
-			this.labelJerkBrakeUp.Location = new System.Drawing.Point(8, 64);
-			this.labelJerkBrakeUp.Name = "labelJerkBrakeUp";
-			this.labelJerkBrakeUp.Size = new System.Drawing.Size(168, 16);
-			this.labelJerkBrakeUp.TabIndex = 4;
-			this.labelJerkBrakeUp.Text = "JerkBrakeUp:";
-			this.labelJerkBrakeUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelJerkBrakeDown
-			// 
-			this.labelJerkBrakeDown.Location = new System.Drawing.Point(8, 88);
-			this.labelJerkBrakeDown.Name = "labelJerkBrakeDown";
-			this.labelJerkBrakeDown.Size = new System.Drawing.Size(168, 16);
-			this.labelJerkBrakeDown.TabIndex = 3;
-			this.labelJerkBrakeDown.Text = "JerkBrakeDown:";
-			this.labelJerkBrakeDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeCylinderUp
-			// 
-			this.labelBrakeCylinderUp.Location = new System.Drawing.Point(8, 112);
-			this.labelBrakeCylinderUp.Name = "labelBrakeCylinderUp";
-			this.labelBrakeCylinderUp.Size = new System.Drawing.Size(168, 16);
-			this.labelBrakeCylinderUp.TabIndex = 2;
-			this.labelBrakeCylinderUp.Text = "BrakeCylinderUp:";
-			this.labelBrakeCylinderUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelBrakeCylinderDown
-			// 
-			this.labelBrakeCylinderDown.Location = new System.Drawing.Point(8, 136);
-			this.labelBrakeCylinderDown.Name = "labelBrakeCylinderDown";
-			this.labelBrakeCylinderDown.Size = new System.Drawing.Size(168, 16);
-			this.labelBrakeCylinderDown.TabIndex = 1;
-			this.labelBrakeCylinderDown.Text = "BrakeCylinderDown:";
-			this.labelBrakeCylinderDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxDelay
-			// 
-			this.groupBoxDelay.Controls.Add(this.buttonDelayLocoBrakeSet);
-			this.groupBoxDelay.Controls.Add(this.buttonDelayBrakeSet);
-			this.groupBoxDelay.Controls.Add(this.buttonDelayPowerSet);
-			this.groupBoxDelay.Controls.Add(this.labelDelayLocoBrake);
-			this.groupBoxDelay.Controls.Add(this.labelDelayBrake);
-			this.groupBoxDelay.Controls.Add(this.labelDelayPower);
-			this.groupBoxDelay.Location = new System.Drawing.Point(8, 480);
-			this.groupBoxDelay.Name = "groupBoxDelay";
-			this.groupBoxDelay.Size = new System.Drawing.Size(272, 96);
-			this.groupBoxDelay.TabIndex = 2;
-			this.groupBoxDelay.TabStop = false;
-			this.groupBoxDelay.Text = "Delay";
-			// 
-			// buttonDelayLocoBrakeSet
-			// 
-			this.buttonDelayLocoBrakeSet.Location = new System.Drawing.Point(160, 64);
-			this.buttonDelayLocoBrakeSet.Name = "buttonDelayLocoBrakeSet";
-			this.buttonDelayLocoBrakeSet.Size = new System.Drawing.Size(48, 19);
-			this.buttonDelayLocoBrakeSet.TabIndex = 37;
-			this.buttonDelayLocoBrakeSet.Text = "Set...";
-			this.buttonDelayLocoBrakeSet.UseVisualStyleBackColor = true;
-			this.buttonDelayLocoBrakeSet.Click += new System.EventHandler(this.ButtonDelayLocoBrakeSet_Click);
-			// 
-			// buttonDelayBrakeSet
-			// 
-			this.buttonDelayBrakeSet.Location = new System.Drawing.Point(160, 40);
-			this.buttonDelayBrakeSet.Name = "buttonDelayBrakeSet";
-			this.buttonDelayBrakeSet.Size = new System.Drawing.Size(48, 19);
-			this.buttonDelayBrakeSet.TabIndex = 35;
-			this.buttonDelayBrakeSet.Text = "Set...";
-			this.buttonDelayBrakeSet.UseVisualStyleBackColor = true;
-			this.buttonDelayBrakeSet.Click += new System.EventHandler(this.ButtonDelayBrakeSet_Click);
-			// 
-			// buttonDelayPowerSet
-			// 
-			this.buttonDelayPowerSet.Location = new System.Drawing.Point(160, 16);
-			this.buttonDelayPowerSet.Name = "buttonDelayPowerSet";
-			this.buttonDelayPowerSet.Size = new System.Drawing.Size(48, 19);
-			this.buttonDelayPowerSet.TabIndex = 33;
-			this.buttonDelayPowerSet.Text = "Set...";
-			this.buttonDelayPowerSet.UseVisualStyleBackColor = true;
-			this.buttonDelayPowerSet.Click += new System.EventHandler(this.ButtonDelayPowerSet_Click);
-			// 
-			// labelDelayLocoBrake
-			// 
-			this.labelDelayLocoBrake.Location = new System.Drawing.Point(8, 64);
-			this.labelDelayLocoBrake.Name = "labelDelayLocoBrake";
-			this.labelDelayLocoBrake.Size = new System.Drawing.Size(144, 16);
-			this.labelDelayLocoBrake.TabIndex = 6;
-			this.labelDelayLocoBrake.Text = "LocoBrake:";
-			this.labelDelayLocoBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDelayBrake
-			// 
-			this.labelDelayBrake.Location = new System.Drawing.Point(8, 40);
-			this.labelDelayBrake.Name = "labelDelayBrake";
-			this.labelDelayBrake.Size = new System.Drawing.Size(144, 16);
-			this.labelDelayBrake.TabIndex = 4;
-			this.labelDelayBrake.Text = "Brake:";
-			this.labelDelayBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDelayPower
-			// 
-			this.labelDelayPower.Location = new System.Drawing.Point(8, 16);
-			this.labelDelayPower.Name = "labelDelayPower";
-			this.labelDelayPower.Size = new System.Drawing.Size(144, 16);
-			this.labelDelayPower.TabIndex = 2;
-			this.labelDelayPower.Text = "Power:";
-			this.labelDelayPower.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxPerformance
-			// 
-			this.groupBoxPerformance.Controls.Add(this.textBoxAerodynamicDragCoefficient);
-			this.groupBoxPerformance.Controls.Add(this.textBoxCoefficientOfRollingResistance);
-			this.groupBoxPerformance.Controls.Add(this.textBoxCoefficientOfStaticFriction);
-			this.groupBoxPerformance.Controls.Add(this.labelDecelerationUnit);
-			this.groupBoxPerformance.Controls.Add(this.textBoxDeceleration);
-			this.groupBoxPerformance.Controls.Add(this.labelAerodynamicDragCoefficient);
-			this.groupBoxPerformance.Controls.Add(this.labelCoefficientOfStaticFriction);
-			this.groupBoxPerformance.Controls.Add(this.labelDeceleration);
-			this.groupBoxPerformance.Controls.Add(this.labelCoefficientOfRollingResistance);
-			this.groupBoxPerformance.Location = new System.Drawing.Point(288, 8);
-			this.groupBoxPerformance.Name = "groupBoxPerformance";
-			this.groupBoxPerformance.Size = new System.Drawing.Size(448, 120);
-			this.groupBoxPerformance.TabIndex = 1;
-			this.groupBoxPerformance.TabStop = false;
-			this.groupBoxPerformance.Text = "Performance";
-			// 
-			// textBoxAerodynamicDragCoefficient
-			// 
-			this.textBoxAerodynamicDragCoefficient.Location = new System.Drawing.Point(184, 88);
-			this.textBoxAerodynamicDragCoefficient.Name = "textBoxAerodynamicDragCoefficient";
-			this.textBoxAerodynamicDragCoefficient.Size = new System.Drawing.Size(184, 19);
-			this.textBoxAerodynamicDragCoefficient.TabIndex = 25;
-			// 
-			// textBoxCoefficientOfRollingResistance
-			// 
-			this.textBoxCoefficientOfRollingResistance.Location = new System.Drawing.Point(184, 64);
-			this.textBoxCoefficientOfRollingResistance.Name = "textBoxCoefficientOfRollingResistance";
-			this.textBoxCoefficientOfRollingResistance.Size = new System.Drawing.Size(184, 19);
-			this.textBoxCoefficientOfRollingResistance.TabIndex = 24;
-			// 
-			// textBoxCoefficientOfStaticFriction
-			// 
-			this.textBoxCoefficientOfStaticFriction.Location = new System.Drawing.Point(184, 40);
-			this.textBoxCoefficientOfStaticFriction.Name = "textBoxCoefficientOfStaticFriction";
-			this.textBoxCoefficientOfStaticFriction.Size = new System.Drawing.Size(184, 19);
-			this.textBoxCoefficientOfStaticFriction.TabIndex = 23;
-			// 
-			// labelDecelerationUnit
-			// 
-			this.labelDecelerationUnit.Location = new System.Drawing.Point(376, 16);
-			this.labelDecelerationUnit.Name = "labelDecelerationUnit";
-			this.labelDecelerationUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelDecelerationUnit.TabIndex = 22;
-			this.labelDecelerationUnit.Text = "km/h/s";
-			this.labelDecelerationUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxDeceleration
-			// 
-			this.textBoxDeceleration.Location = new System.Drawing.Point(184, 16);
-			this.textBoxDeceleration.Name = "textBoxDeceleration";
-			this.textBoxDeceleration.Size = new System.Drawing.Size(184, 19);
-			this.textBoxDeceleration.TabIndex = 20;
-			// 
-			// labelAerodynamicDragCoefficient
-			// 
-			this.labelAerodynamicDragCoefficient.Location = new System.Drawing.Point(8, 88);
-			this.labelAerodynamicDragCoefficient.Name = "labelAerodynamicDragCoefficient";
-			this.labelAerodynamicDragCoefficient.Size = new System.Drawing.Size(168, 16);
-			this.labelAerodynamicDragCoefficient.TabIndex = 5;
-			this.labelAerodynamicDragCoefficient.Text = "AerodynamicDragCoefficient:";
-			this.labelAerodynamicDragCoefficient.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCoefficientOfStaticFriction
-			// 
-			this.labelCoefficientOfStaticFriction.Location = new System.Drawing.Point(8, 40);
-			this.labelCoefficientOfStaticFriction.Name = "labelCoefficientOfStaticFriction";
-			this.labelCoefficientOfStaticFriction.Size = new System.Drawing.Size(168, 16);
-			this.labelCoefficientOfStaticFriction.TabIndex = 4;
-			this.labelCoefficientOfStaticFriction.Text = "CoefficientOfStaticFriction:";
-			this.labelCoefficientOfStaticFriction.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDeceleration
-			// 
-			this.labelDeceleration.Location = new System.Drawing.Point(8, 16);
-			this.labelDeceleration.Name = "labelDeceleration";
-			this.labelDeceleration.Size = new System.Drawing.Size(168, 16);
-			this.labelDeceleration.TabIndex = 3;
-			this.labelDeceleration.Text = "Deceleration:";
-			this.labelDeceleration.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCoefficientOfRollingResistance
-			// 
-			this.labelCoefficientOfRollingResistance.Location = new System.Drawing.Point(8, 64);
-			this.labelCoefficientOfRollingResistance.Name = "labelCoefficientOfRollingResistance";
-			this.labelCoefficientOfRollingResistance.Size = new System.Drawing.Size(168, 16);
-			this.labelCoefficientOfRollingResistance.TabIndex = 2;
-			this.labelCoefficientOfRollingResistance.Text = "CoefficientOfRollingResistance:";
-			this.labelCoefficientOfRollingResistance.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxCarGeneral
-			// 
-			this.groupBoxCarGeneral.Controls.Add(this.labelUnexposedFrontalAreaUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxUnexposedFrontalArea);
-			this.groupBoxCarGeneral.Controls.Add(this.labelUnexposedFrontalArea);
-			this.groupBoxCarGeneral.Controls.Add(this.labelRearBogie);
-			this.groupBoxCarGeneral.Controls.Add(this.labelFrontBogie);
-			this.groupBoxCarGeneral.Controls.Add(this.buttonRearBogieSet);
-			this.groupBoxCarGeneral.Controls.Add(this.buttonFrontBogieSet);
-			this.groupBoxCarGeneral.Controls.Add(this.checkBoxReversed);
-			this.groupBoxCarGeneral.Controls.Add(this.checkBoxLoadingSway);
-			this.groupBoxCarGeneral.Controls.Add(this.checkBoxDefinedAxles);
-			this.groupBoxCarGeneral.Controls.Add(this.checkBoxIsMotorCar);
-			this.groupBoxCarGeneral.Controls.Add(this.buttonObjectOpen);
-			this.groupBoxCarGeneral.Controls.Add(this.labelExposedFrontalAreaUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.labelCenterOfMassHeightUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.labelLoadingSway);
-			this.groupBoxCarGeneral.Controls.Add(this.labelHeightUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.labelWidthUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.labelLengthUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.labelMassUnit);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxMass);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxLength);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxWidth);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxHeight);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxCenterOfMassHeight);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxExposedFrontalArea);
-			this.groupBoxCarGeneral.Controls.Add(this.textBoxObject);
-			this.groupBoxCarGeneral.Controls.Add(this.labelObject);
-			this.groupBoxCarGeneral.Controls.Add(this.labelReversed);
-			this.groupBoxCarGeneral.Controls.Add(this.groupBoxAxles);
-			this.groupBoxCarGeneral.Controls.Add(this.labelDefinedAxles);
-			this.groupBoxCarGeneral.Controls.Add(this.labelExposedFrontalArea);
-			this.groupBoxCarGeneral.Controls.Add(this.labelCenterOfMassHeight);
-			this.groupBoxCarGeneral.Controls.Add(this.labelHeight);
-			this.groupBoxCarGeneral.Controls.Add(this.labelWidth);
-			this.groupBoxCarGeneral.Controls.Add(this.labelLength);
-			this.groupBoxCarGeneral.Controls.Add(this.labelMass);
-			this.groupBoxCarGeneral.Controls.Add(this.labelIsMotorCar);
-			this.groupBoxCarGeneral.Location = new System.Drawing.Point(8, 8);
-			this.groupBoxCarGeneral.Name = "groupBoxCarGeneral";
-			this.groupBoxCarGeneral.Size = new System.Drawing.Size(272, 464);
-			this.groupBoxCarGeneral.TabIndex = 0;
-			this.groupBoxCarGeneral.TabStop = false;
-			this.groupBoxCarGeneral.Text = "General";
-			// 
-			// labelUnexposedFrontalAreaUnit
-			// 
-			this.labelUnexposedFrontalAreaUnit.Location = new System.Drawing.Point(216, 184);
-			this.labelUnexposedFrontalAreaUnit.Name = "labelUnexposedFrontalAreaUnit";
-			this.labelUnexposedFrontalAreaUnit.Size = new System.Drawing.Size(40, 16);
-			this.labelUnexposedFrontalAreaUnit.TabIndex = 38;
-			this.labelUnexposedFrontalAreaUnit.Text = "m²";
-			this.labelUnexposedFrontalAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxUnexposedFrontalArea
-			// 
-			this.textBoxUnexposedFrontalArea.Location = new System.Drawing.Point(160, 184);
-			this.textBoxUnexposedFrontalArea.Name = "textBoxUnexposedFrontalArea";
-			this.textBoxUnexposedFrontalArea.Size = new System.Drawing.Size(48, 19);
-			this.textBoxUnexposedFrontalArea.TabIndex = 37;
-			// 
-			// labelUnexposedFrontalArea
-			// 
-			this.labelUnexposedFrontalArea.Location = new System.Drawing.Point(8, 184);
-			this.labelUnexposedFrontalArea.Name = "labelUnexposedFrontalArea";
-			this.labelUnexposedFrontalArea.Size = new System.Drawing.Size(144, 16);
-			this.labelUnexposedFrontalArea.TabIndex = 36;
-			this.labelUnexposedFrontalArea.Text = "UnexposedFrontalArea:";
-			this.labelUnexposedFrontalArea.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelRearBogie
-			// 
-			this.labelRearBogie.Location = new System.Drawing.Point(8, 336);
-			this.labelRearBogie.Name = "labelRearBogie";
-			this.labelRearBogie.Size = new System.Drawing.Size(144, 16);
-			this.labelRearBogie.TabIndex = 35;
-			this.labelRearBogie.Text = "RearBogie:";
-			this.labelRearBogie.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelFrontBogie
-			// 
-			this.labelFrontBogie.Location = new System.Drawing.Point(8, 312);
-			this.labelFrontBogie.Name = "labelFrontBogie";
-			this.labelFrontBogie.Size = new System.Drawing.Size(144, 16);
-			this.labelFrontBogie.TabIndex = 34;
-			this.labelFrontBogie.Text = "FrontBogie:";
-			this.labelFrontBogie.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// buttonRearBogieSet
-			// 
-			this.buttonRearBogieSet.Location = new System.Drawing.Point(160, 336);
-			this.buttonRearBogieSet.Name = "buttonRearBogieSet";
-			this.buttonRearBogieSet.Size = new System.Drawing.Size(48, 19);
-			this.buttonRearBogieSet.TabIndex = 33;
-			this.buttonRearBogieSet.Text = "Set...";
-			this.buttonRearBogieSet.UseVisualStyleBackColor = true;
-			this.buttonRearBogieSet.Click += new System.EventHandler(this.ButtonRearBogieSet_Click);
-			// 
-			// buttonFrontBogieSet
-			// 
-			this.buttonFrontBogieSet.Location = new System.Drawing.Point(160, 312);
-			this.buttonFrontBogieSet.Name = "buttonFrontBogieSet";
-			this.buttonFrontBogieSet.Size = new System.Drawing.Size(48, 19);
-			this.buttonFrontBogieSet.TabIndex = 32;
-			this.buttonFrontBogieSet.Text = "Set...";
-			this.buttonFrontBogieSet.UseVisualStyleBackColor = true;
-			this.buttonFrontBogieSet.Click += new System.EventHandler(this.ButtonFrontBogieSet_Click);
-			// 
-			// checkBoxReversed
-			// 
-			this.checkBoxReversed.Location = new System.Drawing.Point(160, 384);
-			this.checkBoxReversed.Name = "checkBoxReversed";
-			this.checkBoxReversed.Size = new System.Drawing.Size(48, 16);
-			this.checkBoxReversed.TabIndex = 31;
-			this.checkBoxReversed.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxLoadingSway
-			// 
-			this.checkBoxLoadingSway.Location = new System.Drawing.Point(160, 360);
-			this.checkBoxLoadingSway.Name = "checkBoxLoadingSway";
-			this.checkBoxLoadingSway.Size = new System.Drawing.Size(48, 16);
-			this.checkBoxLoadingSway.TabIndex = 30;
-			this.checkBoxLoadingSway.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxDefinedAxles
-			// 
-			this.checkBoxDefinedAxles.Location = new System.Drawing.Point(160, 208);
-			this.checkBoxDefinedAxles.Name = "checkBoxDefinedAxles";
-			this.checkBoxDefinedAxles.Size = new System.Drawing.Size(48, 16);
-			this.checkBoxDefinedAxles.TabIndex = 29;
-			this.checkBoxDefinedAxles.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxIsMotorCar
-			// 
-			this.checkBoxIsMotorCar.Location = new System.Drawing.Point(160, 16);
-			this.checkBoxIsMotorCar.Name = "checkBoxIsMotorCar";
-			this.checkBoxIsMotorCar.Size = new System.Drawing.Size(48, 16);
-			this.checkBoxIsMotorCar.TabIndex = 28;
-			this.checkBoxIsMotorCar.UseVisualStyleBackColor = true;
-			// 
-			// buttonObjectOpen
-			// 
-			this.buttonObjectOpen.Location = new System.Drawing.Point(208, 432);
-			this.buttonObjectOpen.Name = "buttonObjectOpen";
-			this.buttonObjectOpen.Size = new System.Drawing.Size(56, 19);
-			this.buttonObjectOpen.TabIndex = 3;
-			this.buttonObjectOpen.Text = "Open...";
-			this.buttonObjectOpen.UseVisualStyleBackColor = true;
-			this.buttonObjectOpen.Click += new System.EventHandler(this.ButtonObjectOpen_Click);
-			// 
-			// labelExposedFrontalAreaUnit
-			// 
-			this.labelExposedFrontalAreaUnit.Location = new System.Drawing.Point(216, 160);
-			this.labelExposedFrontalAreaUnit.Name = "labelExposedFrontalAreaUnit";
-			this.labelExposedFrontalAreaUnit.Size = new System.Drawing.Size(40, 16);
-			this.labelExposedFrontalAreaUnit.TabIndex = 27;
-			this.labelExposedFrontalAreaUnit.Text = "m²";
-			this.labelExposedFrontalAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelCenterOfMassHeightUnit
-			// 
-			this.labelCenterOfMassHeightUnit.Location = new System.Drawing.Point(216, 136);
-			this.labelCenterOfMassHeightUnit.Name = "labelCenterOfMassHeightUnit";
-			this.labelCenterOfMassHeightUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelCenterOfMassHeightUnit.TabIndex = 24;
-			this.labelCenterOfMassHeightUnit.Text = "m";
-			this.labelCenterOfMassHeightUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelLoadingSway
-			// 
-			this.labelLoadingSway.Location = new System.Drawing.Point(8, 360);
-			this.labelLoadingSway.Name = "labelLoadingSway";
-			this.labelLoadingSway.Size = new System.Drawing.Size(144, 16);
-			this.labelLoadingSway.TabIndex = 11;
-			this.labelLoadingSway.Text = "LoadingSway:";
-			this.labelLoadingSway.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelHeightUnit
-			// 
-			this.labelHeightUnit.Location = new System.Drawing.Point(216, 112);
-			this.labelHeightUnit.Name = "labelHeightUnit";
-			this.labelHeightUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelHeightUnit.TabIndex = 23;
-			this.labelHeightUnit.Text = "m";
-			this.labelHeightUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelWidthUnit
-			// 
-			this.labelWidthUnit.Location = new System.Drawing.Point(216, 88);
-			this.labelWidthUnit.Name = "labelWidthUnit";
-			this.labelWidthUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelWidthUnit.TabIndex = 22;
-			this.labelWidthUnit.Text = "m";
-			this.labelWidthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelLengthUnit
-			// 
-			this.labelLengthUnit.Location = new System.Drawing.Point(216, 64);
-			this.labelLengthUnit.Name = "labelLengthUnit";
-			this.labelLengthUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelLengthUnit.TabIndex = 21;
-			this.labelLengthUnit.Text = "m";
-			this.labelLengthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelMassUnit
-			// 
-			this.labelMassUnit.Location = new System.Drawing.Point(216, 40);
-			this.labelMassUnit.Name = "labelMassUnit";
-			this.labelMassUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelMassUnit.TabIndex = 20;
-			this.labelMassUnit.Text = "1000 kg";
-			this.labelMassUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxMass
-			// 
-			this.textBoxMass.Location = new System.Drawing.Point(160, 40);
-			this.textBoxMass.Name = "textBoxMass";
-			this.textBoxMass.Size = new System.Drawing.Size(48, 19);
-			this.textBoxMass.TabIndex = 19;
-			// 
-			// textBoxLength
-			// 
-			this.textBoxLength.Location = new System.Drawing.Point(160, 64);
-			this.textBoxLength.Name = "textBoxLength";
-			this.textBoxLength.Size = new System.Drawing.Size(48, 19);
-			this.textBoxLength.TabIndex = 18;
-			// 
-			// textBoxWidth
-			// 
-			this.textBoxWidth.Location = new System.Drawing.Point(160, 88);
-			this.textBoxWidth.Name = "textBoxWidth";
-			this.textBoxWidth.Size = new System.Drawing.Size(48, 19);
-			this.textBoxWidth.TabIndex = 17;
-			// 
-			// textBoxHeight
-			// 
-			this.textBoxHeight.Location = new System.Drawing.Point(160, 112);
-			this.textBoxHeight.Name = "textBoxHeight";
-			this.textBoxHeight.Size = new System.Drawing.Size(48, 19);
-			this.textBoxHeight.TabIndex = 16;
-			// 
-			// textBoxCenterOfMassHeight
-			// 
-			this.textBoxCenterOfMassHeight.Location = new System.Drawing.Point(160, 136);
-			this.textBoxCenterOfMassHeight.Name = "textBoxCenterOfMassHeight";
-			this.textBoxCenterOfMassHeight.Size = new System.Drawing.Size(48, 19);
-			this.textBoxCenterOfMassHeight.TabIndex = 15;
-			// 
-			// textBoxExposedFrontalArea
-			// 
-			this.textBoxExposedFrontalArea.Location = new System.Drawing.Point(160, 160);
-			this.textBoxExposedFrontalArea.Name = "textBoxExposedFrontalArea";
-			this.textBoxExposedFrontalArea.Size = new System.Drawing.Size(48, 19);
-			this.textBoxExposedFrontalArea.TabIndex = 14;
-			// 
-			// textBoxObject
-			// 
-			this.textBoxObject.Location = new System.Drawing.Point(160, 408);
-			this.textBoxObject.Name = "textBoxObject";
-			this.textBoxObject.Size = new System.Drawing.Size(104, 19);
-			this.textBoxObject.TabIndex = 13;
-			// 
-			// labelObject
-			// 
-			this.labelObject.Location = new System.Drawing.Point(8, 408);
-			this.labelObject.Name = "labelObject";
-			this.labelObject.Size = new System.Drawing.Size(144, 16);
-			this.labelObject.TabIndex = 10;
-			this.labelObject.Text = "Object:";
-			this.labelObject.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelReversed
-			// 
-			this.labelReversed.Location = new System.Drawing.Point(8, 384);
-			this.labelReversed.Name = "labelReversed";
-			this.labelReversed.Size = new System.Drawing.Size(144, 16);
-			this.labelReversed.TabIndex = 9;
-			this.labelReversed.Text = "Reversed:";
-			this.labelReversed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxAxles
-			// 
-			this.groupBoxAxles.Controls.Add(this.labelRearAxleUnit);
-			this.groupBoxAxles.Controls.Add(this.labelFrontAxleUnit);
-			this.groupBoxAxles.Controls.Add(this.textBoxRearAxle);
-			this.groupBoxAxles.Controls.Add(this.textBoxFrontAxle);
-			this.groupBoxAxles.Controls.Add(this.labelRearAxle);
-			this.groupBoxAxles.Controls.Add(this.labelFrontAxle);
-			this.groupBoxAxles.Location = new System.Drawing.Point(8, 232);
-			this.groupBoxAxles.Name = "groupBoxAxles";
-			this.groupBoxAxles.Size = new System.Drawing.Size(256, 72);
-			this.groupBoxAxles.TabIndex = 8;
-			this.groupBoxAxles.TabStop = false;
-			this.groupBoxAxles.Text = "Axles";
-			// 
-			// labelRearAxleUnit
-			// 
-			this.labelRearAxleUnit.Location = new System.Drawing.Point(208, 40);
-			this.labelRearAxleUnit.Name = "labelRearAxleUnit";
-			this.labelRearAxleUnit.Size = new System.Drawing.Size(40, 16);
-			this.labelRearAxleUnit.TabIndex = 26;
-			this.labelRearAxleUnit.Text = "m";
-			this.labelRearAxleUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelFrontAxleUnit
-			// 
-			this.labelFrontAxleUnit.Location = new System.Drawing.Point(208, 16);
-			this.labelFrontAxleUnit.Name = "labelFrontAxleUnit";
-			this.labelFrontAxleUnit.Size = new System.Drawing.Size(40, 16);
-			this.labelFrontAxleUnit.TabIndex = 25;
-			this.labelFrontAxleUnit.Text = "m";
-			this.labelFrontAxleUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxRearAxle
-			// 
-			this.textBoxRearAxle.Location = new System.Drawing.Point(152, 40);
-			this.textBoxRearAxle.Name = "textBoxRearAxle";
-			this.textBoxRearAxle.Size = new System.Drawing.Size(48, 19);
-			this.textBoxRearAxle.TabIndex = 12;
-			// 
-			// textBoxFrontAxle
-			// 
-			this.textBoxFrontAxle.Location = new System.Drawing.Point(152, 16);
-			this.textBoxFrontAxle.Name = "textBoxFrontAxle";
-			this.textBoxFrontAxle.Size = new System.Drawing.Size(48, 19);
-			this.textBoxFrontAxle.TabIndex = 11;
-			// 
-			// labelRearAxle
-			// 
-			this.labelRearAxle.Location = new System.Drawing.Point(8, 40);
-			this.labelRearAxle.Name = "labelRearAxle";
-			this.labelRearAxle.Size = new System.Drawing.Size(136, 16);
-			this.labelRearAxle.TabIndex = 10;
-			this.labelRearAxle.Text = "RearAxle:";
-			this.labelRearAxle.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelFrontAxle
-			// 
-			this.labelFrontAxle.Location = new System.Drawing.Point(8, 16);
-			this.labelFrontAxle.Name = "labelFrontAxle";
-			this.labelFrontAxle.Size = new System.Drawing.Size(136, 16);
-			this.labelFrontAxle.TabIndex = 9;
-			this.labelFrontAxle.Text = "FrontAxle:";
-			this.labelFrontAxle.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDefinedAxles
-			// 
-			this.labelDefinedAxles.Location = new System.Drawing.Point(8, 208);
-			this.labelDefinedAxles.Name = "labelDefinedAxles";
-			this.labelDefinedAxles.Size = new System.Drawing.Size(144, 16);
-			this.labelDefinedAxles.TabIndex = 7;
-			this.labelDefinedAxles.Text = "DefinedAxles:";
-			this.labelDefinedAxles.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelExposedFrontalArea
-			// 
-			this.labelExposedFrontalArea.Location = new System.Drawing.Point(8, 160);
-			this.labelExposedFrontalArea.Name = "labelExposedFrontalArea";
-			this.labelExposedFrontalArea.Size = new System.Drawing.Size(144, 16);
-			this.labelExposedFrontalArea.TabIndex = 6;
-			this.labelExposedFrontalArea.Text = "ExposedFrontalArea:";
-			this.labelExposedFrontalArea.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCenterOfMassHeight
-			// 
-			this.labelCenterOfMassHeight.Location = new System.Drawing.Point(8, 136);
-			this.labelCenterOfMassHeight.Name = "labelCenterOfMassHeight";
-			this.labelCenterOfMassHeight.Size = new System.Drawing.Size(144, 16);
-			this.labelCenterOfMassHeight.TabIndex = 5;
-			this.labelCenterOfMassHeight.Text = "CenterOfMassHeight:";
-			this.labelCenterOfMassHeight.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelHeight
-			// 
-			this.labelHeight.Location = new System.Drawing.Point(8, 112);
-			this.labelHeight.Name = "labelHeight";
-			this.labelHeight.Size = new System.Drawing.Size(144, 16);
-			this.labelHeight.TabIndex = 4;
-			this.labelHeight.Text = "Height:";
-			this.labelHeight.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelWidth
-			// 
-			this.labelWidth.Location = new System.Drawing.Point(8, 88);
-			this.labelWidth.Name = "labelWidth";
-			this.labelWidth.Size = new System.Drawing.Size(144, 16);
-			this.labelWidth.TabIndex = 3;
-			this.labelWidth.Text = "Width:";
-			this.labelWidth.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelLength
-			// 
-			this.labelLength.Location = new System.Drawing.Point(8, 64);
-			this.labelLength.Name = "labelLength";
-			this.labelLength.Size = new System.Drawing.Size(144, 16);
-			this.labelLength.TabIndex = 2;
-			this.labelLength.Text = "Length:";
-			this.labelLength.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelMass
-			// 
-			this.labelMass.Location = new System.Drawing.Point(8, 40);
-			this.labelMass.Name = "labelMass";
-			this.labelMass.Size = new System.Drawing.Size(144, 16);
-			this.labelMass.TabIndex = 1;
-			this.labelMass.Text = "Mass:";
-			this.labelMass.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelIsMotorCar
-			// 
-			this.labelIsMotorCar.Location = new System.Drawing.Point(8, 16);
-			this.labelIsMotorCar.Name = "labelIsMotorCar";
-			this.labelIsMotorCar.Size = new System.Drawing.Size(144, 16);
-			this.labelIsMotorCar.TabIndex = 0;
-			this.labelIsMotorCar.Text = "IsMotorCar:";
-			this.labelIsMotorCar.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// tabPageAccel
-			// 
-			this.tabPageAccel.Controls.Add(this.pictureBoxAccel);
-			this.tabPageAccel.Controls.Add(this.panelAccel);
-			this.tabPageAccel.Location = new System.Drawing.Point(4, 22);
-			this.tabPageAccel.Name = "tabPageAccel";
-			this.tabPageAccel.Size = new System.Drawing.Size(792, 670);
-			this.tabPageAccel.TabIndex = 5;
-			this.tabPageAccel.Text = "Acceleration settings";
-			this.tabPageAccel.UseVisualStyleBackColor = true;
-			// 
-			// pictureBoxAccel
-			// 
-			this.pictureBoxAccel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.pictureBoxAccel.Location = new System.Drawing.Point(0, 0);
-			this.pictureBoxAccel.Name = "pictureBoxAccel";
-			this.pictureBoxAccel.Size = new System.Drawing.Size(576, 670);
-			this.pictureBoxAccel.TabIndex = 1;
-			this.pictureBoxAccel.TabStop = false;
-			this.pictureBoxAccel.MouseEnter += new System.EventHandler(this.PictureBoxAccel_MouseEnter);
-			this.pictureBoxAccel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PictureBoxAccel_MouseMove);
-			// 
-			// panelAccel
-			// 
-			this.panelAccel.Controls.Add(this.groupBoxPreview);
-			this.panelAccel.Controls.Add(this.groupBoxParameter);
-			this.panelAccel.Controls.Add(this.groupBoxNotch);
-			this.panelAccel.Dock = System.Windows.Forms.DockStyle.Right;
-			this.panelAccel.Location = new System.Drawing.Point(576, 0);
-			this.panelAccel.Name = "panelAccel";
-			this.panelAccel.Size = new System.Drawing.Size(216, 670);
-			this.panelAccel.TabIndex = 0;
-			// 
-			// groupBoxPreview
-			// 
-			this.groupBoxPreview.Controls.Add(this.buttonAccelReset);
-			this.groupBoxPreview.Controls.Add(this.buttonAccelZoomOut);
-			this.groupBoxPreview.Controls.Add(this.buttonAccelZoomIn);
-			this.groupBoxPreview.Controls.Add(this.labelAccelYValue);
-			this.groupBoxPreview.Controls.Add(this.labelAccelXValue);
-			this.groupBoxPreview.Controls.Add(this.labelAccelXmaxUnit);
-			this.groupBoxPreview.Controls.Add(this.labelAccelXminUnit);
-			this.groupBoxPreview.Controls.Add(this.labelAccelYmaxUnit);
-			this.groupBoxPreview.Controls.Add(this.labelAccelYminUnit);
-			this.groupBoxPreview.Controls.Add(this.textBoxAccelYmax);
-			this.groupBoxPreview.Controls.Add(this.textBoxAccelYmin);
-			this.groupBoxPreview.Controls.Add(this.textBoxAccelXmax);
-			this.groupBoxPreview.Controls.Add(this.textBoxAccelXmin);
-			this.groupBoxPreview.Controls.Add(this.labelAccelYmax);
-			this.groupBoxPreview.Controls.Add(this.labelAccelYmin);
-			this.groupBoxPreview.Controls.Add(this.labelAccelXmax);
-			this.groupBoxPreview.Controls.Add(this.labelAccelXmin);
-			this.groupBoxPreview.Controls.Add(this.labelAccelY);
-			this.groupBoxPreview.Controls.Add(this.labelAccelX);
-			this.groupBoxPreview.Controls.Add(this.checkBoxSubtractDeceleration);
-			this.groupBoxPreview.Location = new System.Drawing.Point(8, 216);
-			this.groupBoxPreview.Name = "groupBoxPreview";
-			this.groupBoxPreview.Size = new System.Drawing.Size(200, 232);
-			this.groupBoxPreview.TabIndex = 2;
-			this.groupBoxPreview.TabStop = false;
-			this.groupBoxPreview.Text = "Preview";
-			// 
-			// buttonAccelReset
-			// 
-			this.buttonAccelReset.Location = new System.Drawing.Point(136, 200);
-			this.buttonAccelReset.Name = "buttonAccelReset";
-			this.buttonAccelReset.Size = new System.Drawing.Size(56, 24);
-			this.buttonAccelReset.TabIndex = 42;
-			this.buttonAccelReset.UseVisualStyleBackColor = true;
-			// 
-			// buttonAccelZoomOut
-			// 
-			this.buttonAccelZoomOut.Location = new System.Drawing.Point(72, 200);
-			this.buttonAccelZoomOut.Name = "buttonAccelZoomOut";
-			this.buttonAccelZoomOut.Size = new System.Drawing.Size(56, 24);
-			this.buttonAccelZoomOut.TabIndex = 41;
-			this.buttonAccelZoomOut.UseVisualStyleBackColor = true;
-			// 
-			// buttonAccelZoomIn
-			// 
-			this.buttonAccelZoomIn.Location = new System.Drawing.Point(8, 200);
-			this.buttonAccelZoomIn.Name = "buttonAccelZoomIn";
-			this.buttonAccelZoomIn.Size = new System.Drawing.Size(56, 24);
-			this.buttonAccelZoomIn.TabIndex = 40;
-			this.buttonAccelZoomIn.UseVisualStyleBackColor = true;
-			// 
-			// labelAccelYValue
-			// 
-			this.labelAccelYValue.Location = new System.Drawing.Point(88, 80);
-			this.labelAccelYValue.Name = "labelAccelYValue";
-			this.labelAccelYValue.Size = new System.Drawing.Size(104, 16);
-			this.labelAccelYValue.TabIndex = 39;
-			this.labelAccelYValue.Text = "0.00 km/h/s";
-			this.labelAccelYValue.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelAccelXValue
-			// 
-			this.labelAccelXValue.Location = new System.Drawing.Point(88, 56);
-			this.labelAccelXValue.Name = "labelAccelXValue";
-			this.labelAccelXValue.Size = new System.Drawing.Size(104, 16);
-			this.labelAccelXValue.TabIndex = 38;
-			this.labelAccelXValue.Text = "0.00 km/h";
-			this.labelAccelXValue.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelAccelXmaxUnit
-			// 
-			this.labelAccelXmaxUnit.Location = new System.Drawing.Point(144, 128);
-			this.labelAccelXmaxUnit.Name = "labelAccelXmaxUnit";
-			this.labelAccelXmaxUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelXmaxUnit.TabIndex = 37;
-			this.labelAccelXmaxUnit.Text = "km/h";
-			this.labelAccelXmaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelAccelXminUnit
-			// 
-			this.labelAccelXminUnit.Location = new System.Drawing.Point(144, 104);
-			this.labelAccelXminUnit.Name = "labelAccelXminUnit";
-			this.labelAccelXminUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelXminUnit.TabIndex = 36;
-			this.labelAccelXminUnit.Text = "km/h";
-			this.labelAccelXminUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelAccelYmaxUnit
-			// 
-			this.labelAccelYmaxUnit.Location = new System.Drawing.Point(144, 176);
-			this.labelAccelYmaxUnit.Name = "labelAccelYmaxUnit";
-			this.labelAccelYmaxUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelYmaxUnit.TabIndex = 35;
-			this.labelAccelYmaxUnit.Text = "km/h/s";
-			this.labelAccelYmaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelAccelYminUnit
-			// 
-			this.labelAccelYminUnit.Location = new System.Drawing.Point(144, 152);
-			this.labelAccelYminUnit.Name = "labelAccelYminUnit";
-			this.labelAccelYminUnit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelYminUnit.TabIndex = 34;
-			this.labelAccelYminUnit.Text = "km/h/s";
-			this.labelAccelYminUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxAccelYmax
-			// 
-			this.textBoxAccelYmax.Location = new System.Drawing.Point(88, 176);
-			this.textBoxAccelYmax.Name = "textBoxAccelYmax";
-			this.textBoxAccelYmax.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelYmax.TabIndex = 25;
-			// 
-			// textBoxAccelYmin
-			// 
-			this.textBoxAccelYmin.Location = new System.Drawing.Point(88, 152);
-			this.textBoxAccelYmin.Name = "textBoxAccelYmin";
-			this.textBoxAccelYmin.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelYmin.TabIndex = 24;
-			// 
-			// textBoxAccelXmax
-			// 
-			this.textBoxAccelXmax.Location = new System.Drawing.Point(88, 128);
-			this.textBoxAccelXmax.Name = "textBoxAccelXmax";
-			this.textBoxAccelXmax.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelXmax.TabIndex = 23;
-			// 
-			// textBoxAccelXmin
-			// 
-			this.textBoxAccelXmin.Location = new System.Drawing.Point(88, 104);
-			this.textBoxAccelXmin.Name = "textBoxAccelXmin";
-			this.textBoxAccelXmin.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelXmin.TabIndex = 22;
-			// 
-			// labelAccelYmax
-			// 
-			this.labelAccelYmax.Location = new System.Drawing.Point(8, 176);
-			this.labelAccelYmax.Name = "labelAccelYmax";
-			this.labelAccelYmax.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelYmax.TabIndex = 8;
-			this.labelAccelYmax.Text = "Ymax:";
-			this.labelAccelYmax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelYmin
-			// 
-			this.labelAccelYmin.Location = new System.Drawing.Point(8, 152);
-			this.labelAccelYmin.Name = "labelAccelYmin";
-			this.labelAccelYmin.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelYmin.TabIndex = 7;
-			this.labelAccelYmin.Text = "Ymin:";
-			this.labelAccelYmin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelXmax
-			// 
-			this.labelAccelXmax.Location = new System.Drawing.Point(8, 128);
-			this.labelAccelXmax.Name = "labelAccelXmax";
-			this.labelAccelXmax.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelXmax.TabIndex = 6;
-			this.labelAccelXmax.Text = "Xmax:";
-			this.labelAccelXmax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelXmin
-			// 
-			this.labelAccelXmin.Location = new System.Drawing.Point(8, 104);
-			this.labelAccelXmin.Name = "labelAccelXmin";
-			this.labelAccelXmin.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelXmin.TabIndex = 5;
-			this.labelAccelXmin.Text = "Xmin:";
-			this.labelAccelXmin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelY
-			// 
-			this.labelAccelY.Location = new System.Drawing.Point(8, 80);
-			this.labelAccelY.Name = "labelAccelY";
-			this.labelAccelY.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelY.TabIndex = 4;
-			this.labelAccelY.Text = "Y:";
-			this.labelAccelY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelX
-			// 
-			this.labelAccelX.Location = new System.Drawing.Point(8, 56);
-			this.labelAccelX.Name = "labelAccelX";
-			this.labelAccelX.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelX.TabIndex = 3;
-			this.labelAccelX.Text = "X:";
-			this.labelAccelX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// checkBoxSubtractDeceleration
-			// 
-			this.checkBoxSubtractDeceleration.Location = new System.Drawing.Point(8, 16);
-			this.checkBoxSubtractDeceleration.Name = "checkBoxSubtractDeceleration";
-			this.checkBoxSubtractDeceleration.Size = new System.Drawing.Size(184, 32);
-			this.checkBoxSubtractDeceleration.TabIndex = 0;
-			this.checkBoxSubtractDeceleration.Text = "Subtract deceleration due to air and rolling resistance";
-			this.checkBoxSubtractDeceleration.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxParameter
-			// 
-			this.groupBoxParameter.Controls.Add(this.labeAccelA0Unit);
-			this.groupBoxParameter.Controls.Add(this.textBoxAccelA0);
-			this.groupBoxParameter.Controls.Add(this.labelAccelA0);
-			this.groupBoxParameter.Controls.Add(this.labelAccelA1Unit);
-			this.groupBoxParameter.Controls.Add(this.textBoxAccelA1);
-			this.groupBoxParameter.Controls.Add(this.labelAccelA1);
-			this.groupBoxParameter.Controls.Add(this.labelAccelV1Unit);
-			this.groupBoxParameter.Controls.Add(this.textBoxAccelV1);
-			this.groupBoxParameter.Controls.Add(this.labelAccelV1);
-			this.groupBoxParameter.Controls.Add(this.labelAccelV2Unit);
-			this.groupBoxParameter.Controls.Add(this.textBoxAccelV2);
-			this.groupBoxParameter.Controls.Add(this.labelAccelV2);
-			this.groupBoxParameter.Controls.Add(this.textBoxAccelE);
-			this.groupBoxParameter.Controls.Add(this.labelAccelE);
-			this.groupBoxParameter.Location = new System.Drawing.Point(8, 64);
-			this.groupBoxParameter.Name = "groupBoxParameter";
-			this.groupBoxParameter.Size = new System.Drawing.Size(200, 144);
-			this.groupBoxParameter.TabIndex = 1;
-			this.groupBoxParameter.TabStop = false;
-			this.groupBoxParameter.Text = "Parameter";
-			// 
-			// labeAccelA0Unit
-			// 
-			this.labeAccelA0Unit.Location = new System.Drawing.Point(144, 16);
-			this.labeAccelA0Unit.Name = "labeAccelA0Unit";
-			this.labeAccelA0Unit.Size = new System.Drawing.Size(48, 16);
-			this.labeAccelA0Unit.TabIndex = 33;
-			this.labeAccelA0Unit.Text = "km/h/s";
-			this.labeAccelA0Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxAccelA0
-			// 
-			this.textBoxAccelA0.Location = new System.Drawing.Point(88, 16);
-			this.textBoxAccelA0.Name = "textBoxAccelA0";
-			this.textBoxAccelA0.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelA0.TabIndex = 32;
-			// 
-			// labelAccelA0
-			// 
-			this.labelAccelA0.Location = new System.Drawing.Point(8, 16);
-			this.labelAccelA0.Name = "labelAccelA0";
-			this.labelAccelA0.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelA0.TabIndex = 31;
-			this.labelAccelA0.Text = "a0:";
-			this.labelAccelA0.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelA1Unit
-			// 
-			this.labelAccelA1Unit.Location = new System.Drawing.Point(144, 40);
-			this.labelAccelA1Unit.Name = "labelAccelA1Unit";
-			this.labelAccelA1Unit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelA1Unit.TabIndex = 30;
-			this.labelAccelA1Unit.Text = "km/h/s";
-			this.labelAccelA1Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxAccelA1
-			// 
-			this.textBoxAccelA1.Location = new System.Drawing.Point(88, 40);
-			this.textBoxAccelA1.Name = "textBoxAccelA1";
-			this.textBoxAccelA1.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelA1.TabIndex = 29;
-			// 
-			// labelAccelA1
-			// 
-			this.labelAccelA1.Location = new System.Drawing.Point(8, 40);
-			this.labelAccelA1.Name = "labelAccelA1";
-			this.labelAccelA1.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelA1.TabIndex = 28;
-			this.labelAccelA1.Text = "a1:";
-			this.labelAccelA1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelV1Unit
-			// 
-			this.labelAccelV1Unit.Location = new System.Drawing.Point(144, 64);
-			this.labelAccelV1Unit.Name = "labelAccelV1Unit";
-			this.labelAccelV1Unit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelV1Unit.TabIndex = 27;
-			this.labelAccelV1Unit.Text = "km/h";
-			this.labelAccelV1Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxAccelV1
-			// 
-			this.textBoxAccelV1.Location = new System.Drawing.Point(88, 64);
-			this.textBoxAccelV1.Name = "textBoxAccelV1";
-			this.textBoxAccelV1.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelV1.TabIndex = 26;
-			// 
-			// labelAccelV1
-			// 
-			this.labelAccelV1.Location = new System.Drawing.Point(8, 64);
-			this.labelAccelV1.Name = "labelAccelV1";
-			this.labelAccelV1.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelV1.TabIndex = 25;
-			this.labelAccelV1.Text = "v1:";
-			this.labelAccelV1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelAccelV2Unit
-			// 
-			this.labelAccelV2Unit.Location = new System.Drawing.Point(144, 88);
-			this.labelAccelV2Unit.Name = "labelAccelV2Unit";
-			this.labelAccelV2Unit.Size = new System.Drawing.Size(48, 16);
-			this.labelAccelV2Unit.TabIndex = 24;
-			this.labelAccelV2Unit.Text = "km/h";
-			this.labelAccelV2Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxAccelV2
-			// 
-			this.textBoxAccelV2.Location = new System.Drawing.Point(88, 88);
-			this.textBoxAccelV2.Name = "textBoxAccelV2";
-			this.textBoxAccelV2.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelV2.TabIndex = 23;
-			// 
-			// labelAccelV2
-			// 
-			this.labelAccelV2.Location = new System.Drawing.Point(8, 88);
-			this.labelAccelV2.Name = "labelAccelV2";
-			this.labelAccelV2.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelV2.TabIndex = 22;
-			this.labelAccelV2.Text = "v2:";
-			this.labelAccelV2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// textBoxAccelE
-			// 
-			this.textBoxAccelE.Location = new System.Drawing.Point(88, 112);
-			this.textBoxAccelE.Name = "textBoxAccelE";
-			this.textBoxAccelE.Size = new System.Drawing.Size(48, 19);
-			this.textBoxAccelE.TabIndex = 21;
-			// 
-			// labelAccelE
-			// 
-			this.labelAccelE.Location = new System.Drawing.Point(8, 112);
-			this.labelAccelE.Name = "labelAccelE";
-			this.labelAccelE.Size = new System.Drawing.Size(72, 16);
-			this.labelAccelE.TabIndex = 2;
-			this.labelAccelE.Text = "e (2.0):";
-			this.labelAccelE.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxNotch
-			// 
-			this.groupBoxNotch.Controls.Add(this.comboBoxNotch);
-			this.groupBoxNotch.Location = new System.Drawing.Point(8, 8);
-			this.groupBoxNotch.Name = "groupBoxNotch";
-			this.groupBoxNotch.Size = new System.Drawing.Size(200, 48);
-			this.groupBoxNotch.TabIndex = 0;
-			this.groupBoxNotch.TabStop = false;
-			this.groupBoxNotch.Text = "Notch";
-			// 
-			// comboBoxNotch
-			// 
-			this.comboBoxNotch.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxNotch.FormattingEnabled = true;
-			this.comboBoxNotch.Location = new System.Drawing.Point(8, 16);
-			this.comboBoxNotch.Name = "comboBoxNotch";
-			this.comboBoxNotch.Size = new System.Drawing.Size(72, 20);
-			this.comboBoxNotch.TabIndex = 0;
-			// 
-			// tabPageMotor
-			// 
-			this.tabPageMotor.Controls.Add(this.panelMotorSound);
-			this.tabPageMotor.Location = new System.Drawing.Point(4, 22);
-			this.tabPageMotor.Name = "tabPageMotor";
-			this.tabPageMotor.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPageMotor.Size = new System.Drawing.Size(792, 670);
-			this.tabPageMotor.TabIndex = 1;
-			this.tabPageMotor.Text = "Motor sound settings";
-			this.tabPageMotor.UseVisualStyleBackColor = true;
-			// 
-			// panelMotorSound
-			// 
-			this.panelMotorSound.Controls.Add(this.toolStripContainerDrawArea);
-			this.panelMotorSound.Controls.Add(this.panelMotorSetting);
-			this.panelMotorSound.Controls.Add(this.statusStripStatus);
-			this.panelMotorSound.Controls.Add(this.menuStripMotor);
-			this.panelMotorSound.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.panelMotorSound.Location = new System.Drawing.Point(3, 3);
-			this.panelMotorSound.Name = "panelMotorSound";
-			this.panelMotorSound.Size = new System.Drawing.Size(786, 664);
-			this.panelMotorSound.TabIndex = 5;
-			// 
-			// toolStripContainerDrawArea
-			// 
-			// 
-			// toolStripContainerDrawArea.ContentPanel
-			// 
-			this.toolStripContainerDrawArea.ContentPanel.Controls.Add(this.glControlMotor);
-			this.toolStripContainerDrawArea.ContentPanel.Size = new System.Drawing.Size(568, 593);
-			this.toolStripContainerDrawArea.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.toolStripContainerDrawArea.Location = new System.Drawing.Point(0, 24);
-			this.toolStripContainerDrawArea.Name = "toolStripContainerDrawArea";
-			this.toolStripContainerDrawArea.Size = new System.Drawing.Size(568, 618);
-			this.toolStripContainerDrawArea.TabIndex = 4;
-			this.toolStripContainerDrawArea.Text = "toolStripContainer1";
-			// 
-			// toolStripContainerDrawArea.TopToolStripPanel
-			// 
-			this.toolStripContainerDrawArea.TopToolStripPanel.Controls.Add(this.toolStripToolBar);
-			// 
-			// glControlMotor
-			// 
-			this.glControlMotor.BackColor = System.Drawing.Color.Black;
-			this.glControlMotor.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.glControlMotor.Location = new System.Drawing.Point(0, 0);
-			this.glControlMotor.Name = "glControlMotor";
-			this.glControlMotor.Size = new System.Drawing.Size(568, 593);
-			this.glControlMotor.TabIndex = 0;
-			this.glControlMotor.VSync = false;
-			this.glControlMotor.Load += new System.EventHandler(this.glControlMotor_Load);
-			this.glControlMotor.Paint += new System.Windows.Forms.PaintEventHandler(this.GlControlMotor_Paint);
-			this.glControlMotor.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GlControlMotor_KeyDown);
-			this.glControlMotor.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseDown);
-			this.glControlMotor.MouseEnter += new System.EventHandler(this.GlControlMotor_MouseEnter);
-			this.glControlMotor.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseMove);
-			this.glControlMotor.MouseUp += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseUp);
-			this.glControlMotor.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.GlControlMotor_PreviewKeyDown);
-			// 
-			// toolStripToolBar
-			// 
-			this.toolStripToolBar.Dock = System.Windows.Forms.DockStyle.None;
-			this.toolStripToolBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripButtonUndo,
-            this.toolStripButtonRedo,
-            this.toolStripSeparatorRedo,
-            this.toolStripButtonTearingOff,
-            this.toolStripButtonCopy,
-            this.toolStripButtonPaste,
-            this.toolStripButtonCleanup,
-            this.toolStripButtonDelete,
-            this.toolStripSeparatorEdit,
-            this.toolStripButtonSelect,
-            this.toolStripButtonMove,
-            this.toolStripButtonDot,
-            this.toolStripButtonLine});
-			this.toolStripToolBar.Location = new System.Drawing.Point(3, 0);
-			this.toolStripToolBar.Name = "toolStripToolBar";
-			this.toolStripToolBar.Size = new System.Drawing.Size(275, 25);
-			this.toolStripToolBar.TabIndex = 0;
-			// 
-			// toolStripButtonUndo
-			// 
-			this.toolStripButtonUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonUndo.Name = "toolStripButtonUndo";
-			this.toolStripButtonUndo.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonUndo.Text = "Undo (Ctrl+Z)";
-			// 
-			// toolStripButtonRedo
-			// 
-			this.toolStripButtonRedo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonRedo.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonRedo.Name = "toolStripButtonRedo";
-			this.toolStripButtonRedo.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonRedo.Text = "Redo (Ctrl+Y)";
-			// 
-			// toolStripSeparatorRedo
-			// 
-			this.toolStripSeparatorRedo.Name = "toolStripSeparatorRedo";
-			this.toolStripSeparatorRedo.Size = new System.Drawing.Size(6, 25);
-			// 
-			// toolStripButtonTearingOff
-			// 
-			this.toolStripButtonTearingOff.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonTearingOff.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonTearingOff.Name = "toolStripButtonTearingOff";
-			this.toolStripButtonTearingOff.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonTearingOff.Text = "Cut (Ctrl+X)";
-			// 
-			// toolStripButtonCopy
-			// 
-			this.toolStripButtonCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonCopy.Name = "toolStripButtonCopy";
-			this.toolStripButtonCopy.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonCopy.Text = "Copy (Ctrl+C)";
-			// 
-			// toolStripButtonPaste
-			// 
-			this.toolStripButtonPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonPaste.Name = "toolStripButtonPaste";
-			this.toolStripButtonPaste.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonPaste.Text = "Paste (Ctrl+V)";
-			// 
-			// toolStripButtonCleanup
-			// 
-			this.toolStripButtonCleanup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonCleanup.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonCleanup.Name = "toolStripButtonCleanup";
-			this.toolStripButtonCleanup.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonCleanup.Text = "Cleanup";
-			// 
-			// toolStripButtonDelete
-			// 
-			this.toolStripButtonDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonDelete.Name = "toolStripButtonDelete";
-			this.toolStripButtonDelete.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonDelete.Text = "Delete (Del)";
-			// 
-			// toolStripSeparatorEdit
-			// 
-			this.toolStripSeparatorEdit.Name = "toolStripSeparatorEdit";
-			this.toolStripSeparatorEdit.Size = new System.Drawing.Size(6, 25);
-			// 
-			// toolStripButtonSelect
-			// 
-			this.toolStripButtonSelect.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonSelect.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonSelect.Name = "toolStripButtonSelect";
-			this.toolStripButtonSelect.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonSelect.Text = "Select (Alt+A)";
-			// 
-			// toolStripButtonMove
-			// 
-			this.toolStripButtonMove.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonMove.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonMove.Name = "toolStripButtonMove";
-			this.toolStripButtonMove.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonMove.Text = "Move (Alt+S)";
-			// 
-			// toolStripButtonDot
-			// 
-			this.toolStripButtonDot.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonDot.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonDot.Name = "toolStripButtonDot";
-			this.toolStripButtonDot.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonDot.Text = "Dot (Alt+D)";
-			// 
-			// toolStripButtonLine
-			// 
-			this.toolStripButtonLine.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.toolStripButtonLine.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButtonLine.Name = "toolStripButtonLine";
-			this.toolStripButtonLine.Size = new System.Drawing.Size(23, 22);
-			this.toolStripButtonLine.Text = "Line (Alt+F)";
-			// 
-			// panelMotorSetting
-			// 
-			this.panelMotorSetting.Controls.Add(this.groupBoxDirect);
-			this.panelMotorSetting.Controls.Add(this.groupBoxPlay);
-			this.panelMotorSetting.Controls.Add(this.groupBoxView);
-			this.panelMotorSetting.Dock = System.Windows.Forms.DockStyle.Right;
-			this.panelMotorSetting.Location = new System.Drawing.Point(568, 24);
-			this.panelMotorSetting.Name = "panelMotorSetting";
-			this.panelMotorSetting.Size = new System.Drawing.Size(218, 618);
-			this.panelMotorSetting.TabIndex = 3;
-			// 
-			// groupBoxDirect
-			// 
-			this.groupBoxDirect.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.groupBoxDirect.Controls.Add(this.buttonDirectDot);
-			this.groupBoxDirect.Controls.Add(this.buttonDirectMove);
-			this.groupBoxDirect.Controls.Add(this.textBoxDirectY);
-			this.groupBoxDirect.Controls.Add(this.labelDirectY);
-			this.groupBoxDirect.Controls.Add(this.labelDirectXUnit);
-			this.groupBoxDirect.Controls.Add(this.textBoxDirectX);
-			this.groupBoxDirect.Controls.Add(this.labelDirectX);
-			this.groupBoxDirect.Location = new System.Drawing.Point(8, 254);
-			this.groupBoxDirect.Name = "groupBoxDirect";
-			this.groupBoxDirect.Size = new System.Drawing.Size(200, 96);
-			this.groupBoxDirect.TabIndex = 2;
-			this.groupBoxDirect.TabStop = false;
-			this.groupBoxDirect.Text = "Direct input";
-			// 
-			// buttonDirectDot
-			// 
-			this.buttonDirectDot.Location = new System.Drawing.Point(8, 64);
-			this.buttonDirectDot.Name = "buttonDirectDot";
-			this.buttonDirectDot.Size = new System.Drawing.Size(56, 24);
-			this.buttonDirectDot.TabIndex = 22;
-			this.buttonDirectDot.UseVisualStyleBackColor = true;
-			// 
-			// buttonDirectMove
-			// 
-			this.buttonDirectMove.Location = new System.Drawing.Point(72, 64);
-			this.buttonDirectMove.Name = "buttonDirectMove";
-			this.buttonDirectMove.Size = new System.Drawing.Size(56, 24);
-			this.buttonDirectMove.TabIndex = 21;
-			this.buttonDirectMove.UseVisualStyleBackColor = true;
-			// 
-			// textBoxDirectY
-			// 
-			this.textBoxDirectY.Location = new System.Drawing.Point(112, 40);
-			this.textBoxDirectY.Name = "textBoxDirectY";
-			this.textBoxDirectY.Size = new System.Drawing.Size(40, 19);
-			this.textBoxDirectY.TabIndex = 19;
-			// 
-			// labelDirectY
-			// 
-			this.labelDirectY.Location = new System.Drawing.Point(8, 40);
-			this.labelDirectY.Name = "labelDirectY";
-			this.labelDirectY.Size = new System.Drawing.Size(96, 16);
-			this.labelDirectY.TabIndex = 18;
-			this.labelDirectY.Text = "y coordinate:";
-			this.labelDirectY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelDirectXUnit
-			// 
-			this.labelDirectXUnit.Location = new System.Drawing.Point(160, 16);
-			this.labelDirectXUnit.Name = "labelDirectXUnit";
-			this.labelDirectXUnit.Size = new System.Drawing.Size(32, 16);
-			this.labelDirectXUnit.TabIndex = 17;
-			this.labelDirectXUnit.Text = "km/h";
-			this.labelDirectXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxDirectX
-			// 
-			this.textBoxDirectX.Location = new System.Drawing.Point(112, 16);
-			this.textBoxDirectX.Name = "textBoxDirectX";
-			this.textBoxDirectX.Size = new System.Drawing.Size(40, 19);
-			this.textBoxDirectX.TabIndex = 16;
-			// 
-			// labelDirectX
-			// 
-			this.labelDirectX.Location = new System.Drawing.Point(8, 16);
-			this.labelDirectX.Name = "labelDirectX";
-			this.labelDirectX.Size = new System.Drawing.Size(96, 16);
-			this.labelDirectX.TabIndex = 15;
-			this.labelDirectX.Text = "x coordinate:";
-			this.labelDirectX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// groupBoxPlay
-			// 
-			this.groupBoxPlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.groupBoxPlay.Controls.Add(this.buttonStop);
-			this.groupBoxPlay.Controls.Add(this.buttonPause);
-			this.groupBoxPlay.Controls.Add(this.buttonPlay);
-			this.groupBoxPlay.Controls.Add(this.groupBoxArea);
-			this.groupBoxPlay.Controls.Add(this.groupBoxSource);
-			this.groupBoxPlay.Location = new System.Drawing.Point(8, 359);
-			this.groupBoxPlay.Name = "groupBoxPlay";
-			this.groupBoxPlay.Size = new System.Drawing.Size(200, 248);
-			this.groupBoxPlay.TabIndex = 1;
-			this.groupBoxPlay.TabStop = false;
-			this.groupBoxPlay.Text = "Playback setting";
-			// 
-			// buttonStop
-			// 
-			this.buttonStop.Location = new System.Drawing.Point(136, 216);
-			this.buttonStop.Name = "buttonStop";
-			this.buttonStop.Size = new System.Drawing.Size(56, 24);
-			this.buttonStop.TabIndex = 4;
-			this.buttonStop.UseVisualStyleBackColor = true;
-			// 
-			// buttonPause
-			// 
-			this.buttonPause.Location = new System.Drawing.Point(72, 216);
-			this.buttonPause.Name = "buttonPause";
-			this.buttonPause.Size = new System.Drawing.Size(56, 24);
-			this.buttonPause.TabIndex = 3;
-			this.buttonPause.UseVisualStyleBackColor = true;
-			// 
-			// buttonPlay
-			// 
-			this.buttonPlay.Location = new System.Drawing.Point(8, 216);
-			this.buttonPlay.Name = "buttonPlay";
-			this.buttonPlay.Size = new System.Drawing.Size(56, 24);
-			this.buttonPlay.TabIndex = 2;
-			this.buttonPlay.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxArea
-			// 
-			this.groupBoxArea.Controls.Add(this.checkBoxMotorConstant);
-			this.groupBoxArea.Controls.Add(this.checkBoxMotorLoop);
-			this.groupBoxArea.Controls.Add(this.buttonMotorSwap);
-			this.groupBoxArea.Controls.Add(this.textBoxMotorAreaLeft);
-			this.groupBoxArea.Controls.Add(this.labelMotorAreaUnit);
-			this.groupBoxArea.Controls.Add(this.textBoxMotorAreaRight);
-			this.groupBoxArea.Controls.Add(this.labelMotorAccel);
-			this.groupBoxArea.Controls.Add(this.labelMotorAccelUnit);
-			this.groupBoxArea.Controls.Add(this.textBoxMotorAccel);
-			this.groupBoxArea.Location = new System.Drawing.Point(8, 88);
-			this.groupBoxArea.Name = "groupBoxArea";
-			this.groupBoxArea.Size = new System.Drawing.Size(184, 120);
-			this.groupBoxArea.TabIndex = 1;
-			this.groupBoxArea.TabStop = false;
-			this.groupBoxArea.Text = "Area setting";
-			// 
-			// checkBoxMotorConstant
-			// 
-			this.checkBoxMotorConstant.AutoSize = true;
-			this.checkBoxMotorConstant.Location = new System.Drawing.Point(8, 40);
-			this.checkBoxMotorConstant.Name = "checkBoxMotorConstant";
-			this.checkBoxMotorConstant.Size = new System.Drawing.Size(104, 16);
-			this.checkBoxMotorConstant.TabIndex = 19;
-			this.checkBoxMotorConstant.Text = "Constant speed";
-			this.checkBoxMotorConstant.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxMotorLoop
-			// 
-			this.checkBoxMotorLoop.AutoSize = true;
-			this.checkBoxMotorLoop.Location = new System.Drawing.Point(8, 16);
-			this.checkBoxMotorLoop.Name = "checkBoxMotorLoop";
-			this.checkBoxMotorLoop.Size = new System.Drawing.Size(97, 16);
-			this.checkBoxMotorLoop.TabIndex = 18;
-			this.checkBoxMotorLoop.Text = "Loop playback";
-			this.checkBoxMotorLoop.UseVisualStyleBackColor = true;
-			// 
-			// buttonMotorSwap
-			// 
-			this.buttonMotorSwap.Location = new System.Drawing.Point(56, 88);
-			this.buttonMotorSwap.Name = "buttonMotorSwap";
-			this.buttonMotorSwap.Size = new System.Drawing.Size(32, 19);
-			this.buttonMotorSwap.TabIndex = 17;
-			this.buttonMotorSwap.UseVisualStyleBackColor = true;
-			// 
-			// textBoxMotorAreaLeft
-			// 
-			this.textBoxMotorAreaLeft.Location = new System.Drawing.Point(8, 88);
-			this.textBoxMotorAreaLeft.Name = "textBoxMotorAreaLeft";
-			this.textBoxMotorAreaLeft.Size = new System.Drawing.Size(40, 19);
-			this.textBoxMotorAreaLeft.TabIndex = 16;
-			// 
-			// labelMotorAreaUnit
-			// 
-			this.labelMotorAreaUnit.Location = new System.Drawing.Point(144, 88);
-			this.labelMotorAreaUnit.Name = "labelMotorAreaUnit";
-			this.labelMotorAreaUnit.Size = new System.Drawing.Size(32, 16);
-			this.labelMotorAreaUnit.TabIndex = 15;
-			this.labelMotorAreaUnit.Text = "km/h";
-			this.labelMotorAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxMotorAreaRight
-			// 
-			this.textBoxMotorAreaRight.Location = new System.Drawing.Point(96, 88);
-			this.textBoxMotorAreaRight.Name = "textBoxMotorAreaRight";
-			this.textBoxMotorAreaRight.Size = new System.Drawing.Size(40, 19);
-			this.textBoxMotorAreaRight.TabIndex = 3;
-			// 
-			// labelMotorAccel
-			// 
-			this.labelMotorAccel.Location = new System.Drawing.Point(8, 64);
-			this.labelMotorAccel.Name = "labelMotorAccel";
-			this.labelMotorAccel.Size = new System.Drawing.Size(72, 16);
-			this.labelMotorAccel.TabIndex = 2;
-			this.labelMotorAccel.Text = "Acceleration:";
-			this.labelMotorAccel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelMotorAccelUnit
-			// 
-			this.labelMotorAccelUnit.Location = new System.Drawing.Point(128, 64);
-			this.labelMotorAccelUnit.Name = "labelMotorAccelUnit";
-			this.labelMotorAccelUnit.Size = new System.Drawing.Size(44, 16);
-			this.labelMotorAccelUnit.TabIndex = 1;
-			this.labelMotorAccelUnit.Text = "km/h/s";
-			this.labelMotorAccelUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxMotorAccel
-			// 
-			this.textBoxMotorAccel.Location = new System.Drawing.Point(88, 64);
-			this.textBoxMotorAccel.Name = "textBoxMotorAccel";
-			this.textBoxMotorAccel.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorAccel.TabIndex = 0;
-			// 
-			// groupBoxSource
-			// 
-			this.groupBoxSource.Controls.Add(this.numericUpDownRunIndex);
-			this.groupBoxSource.Controls.Add(this.labelRun);
-			this.groupBoxSource.Controls.Add(this.checkBoxTrack2);
-			this.groupBoxSource.Controls.Add(this.checkBoxTrack1);
-			this.groupBoxSource.Location = new System.Drawing.Point(8, 16);
-			this.groupBoxSource.Name = "groupBoxSource";
-			this.groupBoxSource.Size = new System.Drawing.Size(184, 64);
-			this.groupBoxSource.TabIndex = 0;
-			this.groupBoxSource.TabStop = false;
-			this.groupBoxSource.Text = "Sound source setting";
-			// 
-			// numericUpDownRunIndex
-			// 
-			this.numericUpDownRunIndex.Location = new System.Drawing.Point(112, 16);
-			this.numericUpDownRunIndex.Maximum = new decimal(new int[] {
-            256,
-            0,
-            0,
-            0});
-			this.numericUpDownRunIndex.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-			this.numericUpDownRunIndex.Name = "numericUpDownRunIndex";
-			this.numericUpDownRunIndex.Size = new System.Drawing.Size(48, 19);
-			this.numericUpDownRunIndex.TabIndex = 16;
-			this.numericUpDownRunIndex.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-			// 
-			// labelRun
-			// 
-			this.labelRun.Location = new System.Drawing.Point(8, 16);
-			this.labelRun.Name = "labelRun";
-			this.labelRun.Size = new System.Drawing.Size(96, 16);
-			this.labelRun.TabIndex = 4;
-			this.labelRun.Text = "Running sound:";
-			this.labelRun.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// checkBoxTrack2
-			// 
-			this.checkBoxTrack2.AutoSize = true;
-			this.checkBoxTrack2.Location = new System.Drawing.Point(96, 40);
-			this.checkBoxTrack2.Name = "checkBoxTrack2";
-			this.checkBoxTrack2.Size = new System.Drawing.Size(59, 16);
-			this.checkBoxTrack2.TabIndex = 2;
-			this.checkBoxTrack2.Text = "Track2";
-			this.checkBoxTrack2.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxTrack1
-			// 
-			this.checkBoxTrack1.AutoSize = true;
-			this.checkBoxTrack1.Location = new System.Drawing.Point(8, 40);
-			this.checkBoxTrack1.Name = "checkBoxTrack1";
-			this.checkBoxTrack1.Size = new System.Drawing.Size(59, 16);
-			this.checkBoxTrack1.TabIndex = 1;
-			this.checkBoxTrack1.Text = "Track1";
-			this.checkBoxTrack1.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxView
-			// 
-			this.groupBoxView.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.groupBoxView.Controls.Add(this.buttonMotorReset);
-			this.groupBoxView.Controls.Add(this.buttonMotorZoomOut);
-			this.groupBoxView.Controls.Add(this.buttonMotorZoomIn);
-			this.groupBoxView.Controls.Add(this.labelMotorMaxVolume);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMaxVolume);
-			this.groupBoxView.Controls.Add(this.labelMotorMinVolume);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMinVolume);
-			this.groupBoxView.Controls.Add(this.labelMotorMaxPitch);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMaxPitch);
-			this.groupBoxView.Controls.Add(this.labelMotorMinPitch);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMinPitch);
-			this.groupBoxView.Controls.Add(this.labelMotorMaxVelocityUnit);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMaxVelocity);
-			this.groupBoxView.Controls.Add(this.labelMotorMaxVelocity);
-			this.groupBoxView.Controls.Add(this.labelMotorMinVelocityUnit);
-			this.groupBoxView.Controls.Add(this.textBoxMotorMinVelocity);
-			this.groupBoxView.Controls.Add(this.labelMotorMinVelocity);
-			this.groupBoxView.Location = new System.Drawing.Point(8, 54);
-			this.groupBoxView.Name = "groupBoxView";
-			this.groupBoxView.Size = new System.Drawing.Size(200, 192);
-			this.groupBoxView.TabIndex = 0;
-			this.groupBoxView.TabStop = false;
-			this.groupBoxView.Text = "View setting";
-			// 
-			// buttonMotorReset
-			// 
-			this.buttonMotorReset.Location = new System.Drawing.Point(136, 160);
-			this.buttonMotorReset.Name = "buttonMotorReset";
-			this.buttonMotorReset.Size = new System.Drawing.Size(56, 24);
-			this.buttonMotorReset.TabIndex = 25;
-			this.buttonMotorReset.UseVisualStyleBackColor = true;
-			// 
-			// buttonMotorZoomOut
-			// 
-			this.buttonMotorZoomOut.Location = new System.Drawing.Point(72, 160);
-			this.buttonMotorZoomOut.Name = "buttonMotorZoomOut";
-			this.buttonMotorZoomOut.Size = new System.Drawing.Size(56, 24);
-			this.buttonMotorZoomOut.TabIndex = 24;
-			this.buttonMotorZoomOut.UseVisualStyleBackColor = true;
-			// 
-			// buttonMotorZoomIn
-			// 
-			this.buttonMotorZoomIn.Location = new System.Drawing.Point(8, 160);
-			this.buttonMotorZoomIn.Name = "buttonMotorZoomIn";
-			this.buttonMotorZoomIn.Size = new System.Drawing.Size(56, 24);
-			this.buttonMotorZoomIn.TabIndex = 23;
-			this.buttonMotorZoomIn.UseVisualStyleBackColor = true;
-			// 
-			// labelMotorMaxVolume
-			// 
-			this.labelMotorMaxVolume.Location = new System.Drawing.Point(8, 136);
-			this.labelMotorMaxVolume.Name = "labelMotorMaxVolume";
-			this.labelMotorMaxVolume.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMaxVolume.TabIndex = 14;
-			this.labelMotorMaxVolume.Text = "y-max(Volume):";
-			this.labelMotorMaxVolume.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// textBoxMotorMaxVolume
-			// 
-			this.textBoxMotorMaxVolume.Location = new System.Drawing.Point(120, 136);
-			this.textBoxMotorMaxVolume.Name = "textBoxMotorMaxVolume";
-			this.textBoxMotorMaxVolume.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMaxVolume.TabIndex = 13;
-			// 
-			// labelMotorMinVolume
-			// 
-			this.labelMotorMinVolume.Location = new System.Drawing.Point(8, 112);
-			this.labelMotorMinVolume.Name = "labelMotorMinVolume";
-			this.labelMotorMinVolume.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMinVolume.TabIndex = 12;
-			this.labelMotorMinVolume.Text = "y-min(Volume):";
-			this.labelMotorMinVolume.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// textBoxMotorMinVolume
-			// 
-			this.textBoxMotorMinVolume.Location = new System.Drawing.Point(120, 112);
-			this.textBoxMotorMinVolume.Name = "textBoxMotorMinVolume";
-			this.textBoxMotorMinVolume.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMinVolume.TabIndex = 11;
-			// 
-			// labelMotorMaxPitch
-			// 
-			this.labelMotorMaxPitch.Location = new System.Drawing.Point(8, 88);
-			this.labelMotorMaxPitch.Name = "labelMotorMaxPitch";
-			this.labelMotorMaxPitch.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMaxPitch.TabIndex = 10;
-			this.labelMotorMaxPitch.Text = "y-max(Pitch):";
-			this.labelMotorMaxPitch.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// textBoxMotorMaxPitch
-			// 
-			this.textBoxMotorMaxPitch.Location = new System.Drawing.Point(120, 88);
-			this.textBoxMotorMaxPitch.Name = "textBoxMotorMaxPitch";
-			this.textBoxMotorMaxPitch.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMaxPitch.TabIndex = 9;
-			// 
-			// labelMotorMinPitch
-			// 
-			this.labelMotorMinPitch.Location = new System.Drawing.Point(8, 64);
-			this.labelMotorMinPitch.Name = "labelMotorMinPitch";
-			this.labelMotorMinPitch.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMinPitch.TabIndex = 8;
-			this.labelMotorMinPitch.Text = "y-min(Pitch):";
-			this.labelMotorMinPitch.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// textBoxMotorMinPitch
-			// 
-			this.textBoxMotorMinPitch.Location = new System.Drawing.Point(120, 64);
-			this.textBoxMotorMinPitch.Name = "textBoxMotorMinPitch";
-			this.textBoxMotorMinPitch.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMinPitch.TabIndex = 7;
-			// 
-			// labelMotorMaxVelocityUnit
-			// 
-			this.labelMotorMaxVelocityUnit.Location = new System.Drawing.Point(160, 40);
-			this.labelMotorMaxVelocityUnit.Name = "labelMotorMaxVelocityUnit";
-			this.labelMotorMaxVelocityUnit.Size = new System.Drawing.Size(32, 16);
-			this.labelMotorMaxVelocityUnit.TabIndex = 5;
-			this.labelMotorMaxVelocityUnit.Text = "km/h";
-			this.labelMotorMaxVelocityUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxMotorMaxVelocity
-			// 
-			this.textBoxMotorMaxVelocity.Location = new System.Drawing.Point(120, 40);
-			this.textBoxMotorMaxVelocity.Name = "textBoxMotorMaxVelocity";
-			this.textBoxMotorMaxVelocity.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMaxVelocity.TabIndex = 4;
-			// 
-			// labelMotorMaxVelocity
-			// 
-			this.labelMotorMaxVelocity.Location = new System.Drawing.Point(8, 40);
-			this.labelMotorMaxVelocity.Name = "labelMotorMaxVelocity";
-			this.labelMotorMaxVelocity.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMaxVelocity.TabIndex = 3;
-			this.labelMotorMaxVelocity.Text = "x-max(Velocity):";
-			this.labelMotorMaxVelocity.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelMotorMinVelocityUnit
-			// 
-			this.labelMotorMinVelocityUnit.Location = new System.Drawing.Point(160, 16);
-			this.labelMotorMinVelocityUnit.Name = "labelMotorMinVelocityUnit";
-			this.labelMotorMinVelocityUnit.Size = new System.Drawing.Size(32, 16);
-			this.labelMotorMinVelocityUnit.TabIndex = 2;
-			this.labelMotorMinVelocityUnit.Text = "km/h";
-			this.labelMotorMinVelocityUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxMotorMinVelocity
-			// 
-			this.textBoxMotorMinVelocity.Location = new System.Drawing.Point(120, 16);
-			this.textBoxMotorMinVelocity.Name = "textBoxMotorMinVelocity";
-			this.textBoxMotorMinVelocity.Size = new System.Drawing.Size(32, 19);
-			this.textBoxMotorMinVelocity.TabIndex = 1;
-			// 
-			// labelMotorMinVelocity
-			// 
-			this.labelMotorMinVelocity.Location = new System.Drawing.Point(8, 16);
-			this.labelMotorMinVelocity.Name = "labelMotorMinVelocity";
-			this.labelMotorMinVelocity.Size = new System.Drawing.Size(104, 16);
-			this.labelMotorMinVelocity.TabIndex = 0;
-			this.labelMotorMinVelocity.Text = "x-min(Velocity):";
-			this.labelMotorMinVelocity.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// statusStripStatus
-			// 
-			this.statusStripStatus.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripStatusLabelY,
-            this.toolStripStatusLabelX,
-            this.toolStripStatusLabelTool,
-            this.toolStripStatusLabelMode,
-            this.toolStripStatusLabelTrack,
-            this.toolStripStatusLabelType});
-			this.statusStripStatus.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-			this.statusStripStatus.Location = new System.Drawing.Point(0, 642);
-			this.statusStripStatus.Name = "statusStripStatus";
-			this.statusStripStatus.Size = new System.Drawing.Size(786, 22);
-			this.statusStripStatus.TabIndex = 1;
-			this.statusStripStatus.Text = "statusStrip1";
-			// 
-			// toolStripStatusLabelY
-			// 
-			this.toolStripStatusLabelY.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelY.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelY.Name = "toolStripStatusLabelY";
-			this.toolStripStatusLabelY.Size = new System.Drawing.Size(16, 17);
-			this.toolStripStatusLabelY.Text = "Y";
-			// 
-			// toolStripStatusLabelX
-			// 
-			this.toolStripStatusLabelX.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelX.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelX.Name = "toolStripStatusLabelX";
-			this.toolStripStatusLabelX.Size = new System.Drawing.Size(16, 17);
-			this.toolStripStatusLabelX.Text = "X";
-			// 
-			// toolStripStatusLabelTool
-			// 
-			this.toolStripStatusLabelTool.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelTool.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelTool.Name = "toolStripStatusLabelTool";
-			this.toolStripStatusLabelTool.Size = new System.Drawing.Size(31, 17);
-			this.toolStripStatusLabelTool.Text = "Tool";
-			// 
-			// toolStripStatusLabelMode
-			// 
-			this.toolStripStatusLabelMode.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelMode.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelMode.Name = "toolStripStatusLabelMode";
-			this.toolStripStatusLabelMode.Size = new System.Drawing.Size(36, 17);
-			this.toolStripStatusLabelMode.Text = "Mode";
-			// 
-			// toolStripStatusLabelTrack
-			// 
-			this.toolStripStatusLabelTrack.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelTrack.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelTrack.Name = "toolStripStatusLabelTrack";
-			this.toolStripStatusLabelTrack.Size = new System.Drawing.Size(38, 17);
-			this.toolStripStatusLabelTrack.Text = "Track";
-			// 
-			// toolStripStatusLabelType
-			// 
-			this.toolStripStatusLabelType.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelType.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-			this.toolStripStatusLabelType.Name = "toolStripStatusLabelType";
-			this.toolStripStatusLabelType.Size = new System.Drawing.Size(34, 17);
-			this.toolStripStatusLabelType.Text = "Type";
-			// 
-			// menuStripMotor
-			// 
-			this.menuStripMotor.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemEdit,
-            this.toolStripMenuItemView,
-            this.toolStripMenuItemInput,
-            this.toolStripMenuItemTool});
-			this.menuStripMotor.Location = new System.Drawing.Point(0, 0);
-			this.menuStripMotor.Name = "menuStripMotor";
-			this.menuStripMotor.Size = new System.Drawing.Size(786, 24);
-			this.menuStripMotor.TabIndex = 0;
-			this.menuStripMotor.Text = "menuStrip1";
-			// 
-			// toolStripMenuItemEdit
-			// 
-			this.toolStripMenuItemEdit.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemUndo,
-            this.toolStripMenuItemRedo,
-            this.toolStripSeparatorUndo,
-            this.toolStripMenuItemTearingOff,
-            this.toolStripMenuItemCopy,
-            this.toolStripMenuItemPaste,
-            this.toolStripMenuItemCleanup,
-            this.toolStripMenuItemDelete});
-			this.toolStripMenuItemEdit.Name = "toolStripMenuItemEdit";
-			this.toolStripMenuItemEdit.Size = new System.Drawing.Size(52, 20);
-			this.toolStripMenuItemEdit.Text = "Edit(&E)";
-			// 
-			// toolStripMenuItemUndo
-			// 
-			this.toolStripMenuItemUndo.Name = "toolStripMenuItemUndo";
-			this.toolStripMenuItemUndo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-			this.toolStripMenuItemUndo.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemUndo.Text = "Undo(&U)";
-			// 
-			// toolStripMenuItemRedo
-			// 
-			this.toolStripMenuItemRedo.Name = "toolStripMenuItemRedo";
-			this.toolStripMenuItemRedo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-			this.toolStripMenuItemRedo.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemRedo.Text = "Redo(&R)";
-			// 
-			// toolStripSeparatorUndo
-			// 
-			this.toolStripSeparatorUndo.Name = "toolStripSeparatorUndo";
-			this.toolStripSeparatorUndo.Size = new System.Drawing.Size(149, 6);
-			// 
-			// toolStripMenuItemTearingOff
-			// 
-			this.toolStripMenuItemTearingOff.Name = "toolStripMenuItemTearingOff";
-			this.toolStripMenuItemTearingOff.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-			this.toolStripMenuItemTearingOff.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemTearingOff.Text = "Cut(&T)";
-			// 
-			// toolStripMenuItemCopy
-			// 
-			this.toolStripMenuItemCopy.Name = "toolStripMenuItemCopy";
-			this.toolStripMenuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.toolStripMenuItemCopy.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemCopy.Text = "Copy(&C)";
-			// 
-			// toolStripMenuItemPaste
-			// 
-			this.toolStripMenuItemPaste.Name = "toolStripMenuItemPaste";
-			this.toolStripMenuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-			this.toolStripMenuItemPaste.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemPaste.Text = "Paste(&P)";
-			// 
-			// toolStripMenuItemCleanup
-			// 
-			this.toolStripMenuItemCleanup.Name = "toolStripMenuItemCleanup";
-			this.toolStripMenuItemCleanup.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemCleanup.Text = "Cleanup";
-			// 
-			// toolStripMenuItemDelete
-			// 
-			this.toolStripMenuItemDelete.Name = "toolStripMenuItemDelete";
-			this.toolStripMenuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.toolStripMenuItemDelete.Size = new System.Drawing.Size(152, 22);
-			this.toolStripMenuItemDelete.Text = "Delete(&D)";
-			// 
-			// toolStripMenuItemView
-			// 
-			this.toolStripMenuItemView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemPower,
-            this.toolStripMenuItemBrake});
-			this.toolStripMenuItemView.Name = "toolStripMenuItemView";
-			this.toolStripMenuItemView.Size = new System.Drawing.Size(58, 20);
-			this.toolStripMenuItemView.Text = "View(&V)";
-			// 
-			// toolStripMenuItemPower
-			// 
-			this.toolStripMenuItemPower.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemPowerTrack1,
-            this.toolStripMenuItemPowerTrack2});
-			this.toolStripMenuItemPower.Name = "toolStripMenuItemPower";
-			this.toolStripMenuItemPower.Size = new System.Drawing.Size(116, 22);
-			this.toolStripMenuItemPower.Text = "Power(&P)";
-			// 
-			// toolStripMenuItemPowerTrack1
-			// 
-			this.toolStripMenuItemPowerTrack1.Name = "toolStripMenuItemPowerTrack1";
-			this.toolStripMenuItemPowerTrack1.Size = new System.Drawing.Size(119, 22);
-			this.toolStripMenuItemPowerTrack1.Text = "Track1(&1)";
-			// 
-			// toolStripMenuItemPowerTrack2
-			// 
-			this.toolStripMenuItemPowerTrack2.Name = "toolStripMenuItemPowerTrack2";
-			this.toolStripMenuItemPowerTrack2.Size = new System.Drawing.Size(119, 22);
-			this.toolStripMenuItemPowerTrack2.Text = "Track2(&2)";
-			// 
-			// toolStripMenuItemBrake
-			// 
-			this.toolStripMenuItemBrake.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemBrakeTrack1,
-            this.toolStripMenuItemBrakeTrack2});
-			this.toolStripMenuItemBrake.Name = "toolStripMenuItemBrake";
-			this.toolStripMenuItemBrake.Size = new System.Drawing.Size(116, 22);
-			this.toolStripMenuItemBrake.Text = "Brake(&B)";
-			// 
-			// toolStripMenuItemBrakeTrack1
-			// 
-			this.toolStripMenuItemBrakeTrack1.Name = "toolStripMenuItemBrakeTrack1";
-			this.toolStripMenuItemBrakeTrack1.Size = new System.Drawing.Size(119, 22);
-			this.toolStripMenuItemBrakeTrack1.Text = "Track1(&1)";
-			// 
-			// toolStripMenuItemBrakeTrack2
-			// 
-			this.toolStripMenuItemBrakeTrack2.Name = "toolStripMenuItemBrakeTrack2";
-			this.toolStripMenuItemBrakeTrack2.Size = new System.Drawing.Size(119, 22);
-			this.toolStripMenuItemBrakeTrack2.Text = "Track2(&2)";
-			// 
-			// toolStripMenuItemInput
-			// 
-			this.toolStripMenuItemInput.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemPitch,
-            this.toolStripMenuItemVolume,
-            this.toolStripMenuItemIndex});
-			this.toolStripMenuItemInput.Name = "toolStripMenuItemInput";
-			this.toolStripMenuItemInput.Size = new System.Drawing.Size(53, 20);
-			this.toolStripMenuItemInput.Text = "Input(I)";
-			// 
-			// toolStripMenuItemPitch
-			// 
-			this.toolStripMenuItemPitch.Name = "toolStripMenuItemPitch";
-			this.toolStripMenuItemPitch.Size = new System.Drawing.Size(181, 22);
-			this.toolStripMenuItemPitch.Text = "Pitch(&P)";
-			// 
-			// toolStripMenuItemVolume
-			// 
-			this.toolStripMenuItemVolume.Name = "toolStripMenuItemVolume";
-			this.toolStripMenuItemVolume.Size = new System.Drawing.Size(181, 22);
-			this.toolStripMenuItemVolume.Text = "Volume(&V)";
-			// 
-			// toolStripMenuItemIndex
-			// 
-			this.toolStripMenuItemIndex.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripComboBoxIndex});
-			this.toolStripMenuItemIndex.Name = "toolStripMenuItemIndex";
-			this.toolStripMenuItemIndex.Size = new System.Drawing.Size(181, 22);
-			this.toolStripMenuItemIndex.Text = "Sound source index(&I)";
-			// 
-			// toolStripComboBoxIndex
-			// 
-			this.toolStripComboBoxIndex.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.toolStripComboBoxIndex.Items.AddRange(new object[] {
-            "None",
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15"});
-			this.toolStripComboBoxIndex.Name = "toolStripComboBoxIndex";
-			this.toolStripComboBoxIndex.Size = new System.Drawing.Size(121, 20);
-			// 
-			// toolStripMenuItemTool
-			// 
-			this.toolStripMenuItemTool.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemSelect,
-            this.toolStripMenuItemMove,
-            this.toolStripMenuItemDot,
-            this.toolStripMenuItemLine});
-			this.toolStripMenuItemTool.Name = "toolStripMenuItemTool";
-			this.toolStripMenuItemTool.Size = new System.Drawing.Size(54, 20);
-			this.toolStripMenuItemTool.Text = "Tool(&T)";
-			// 
-			// toolStripMenuItemSelect
-			// 
-			this.toolStripMenuItemSelect.Name = "toolStripMenuItemSelect";
-			this.toolStripMenuItemSelect.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.A)));
-			this.toolStripMenuItemSelect.Size = new System.Drawing.Size(151, 22);
-			this.toolStripMenuItemSelect.Text = "Select(&S)";
-			// 
-			// toolStripMenuItemMove
-			// 
-			this.toolStripMenuItemMove.Name = "toolStripMenuItemMove";
-			this.toolStripMenuItemMove.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S)));
-			this.toolStripMenuItemMove.Size = new System.Drawing.Size(151, 22);
-			this.toolStripMenuItemMove.Text = "Move(&M)";
-			// 
-			// toolStripMenuItemDot
-			// 
-			this.toolStripMenuItemDot.Name = "toolStripMenuItemDot";
-			this.toolStripMenuItemDot.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D)));
-			this.toolStripMenuItemDot.Size = new System.Drawing.Size(151, 22);
-			this.toolStripMenuItemDot.Text = "Dot(&D)";
-			// 
-			// toolStripMenuItemLine
-			// 
-			this.toolStripMenuItemLine.Name = "toolStripMenuItemLine";
-			this.toolStripMenuItemLine.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F)));
-			this.toolStripMenuItemLine.Size = new System.Drawing.Size(151, 22);
-			this.toolStripMenuItemLine.Text = "Line(&L)";
-			// 
-			// tabPageCoupler
-			// 
-			this.tabPageCoupler.Controls.Add(this.groupBoxCouplerGeneral);
-			this.tabPageCoupler.Location = new System.Drawing.Point(4, 22);
-			this.tabPageCoupler.Name = "tabPageCoupler";
-			this.tabPageCoupler.Size = new System.Drawing.Size(792, 670);
-			this.tabPageCoupler.TabIndex = 7;
-			this.tabPageCoupler.Text = "Coupler settings";
-			this.tabPageCoupler.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxCouplerGeneral
-			// 
-			this.groupBoxCouplerGeneral.Controls.Add(this.buttonCouplerObject);
-			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerObject);
-			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerObject);
-			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMaxUnit);
-			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerMax);
-			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMax);
-			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMinUnit);
-			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerMin);
-			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMin);
-			this.groupBoxCouplerGeneral.Location = new System.Drawing.Point(8, 8);
-			this.groupBoxCouplerGeneral.Name = "groupBoxCouplerGeneral";
-			this.groupBoxCouplerGeneral.Size = new System.Drawing.Size(196, 115);
-			this.groupBoxCouplerGeneral.TabIndex = 0;
-			this.groupBoxCouplerGeneral.TabStop = false;
-			this.groupBoxCouplerGeneral.Text = "General";
-			// 
-			// buttonCouplerObject
-			// 
-			this.buttonCouplerObject.Location = new System.Drawing.Point(134, 88);
-			this.buttonCouplerObject.Name = "buttonCouplerObject";
-			this.buttonCouplerObject.Size = new System.Drawing.Size(56, 19);
-			this.buttonCouplerObject.TabIndex = 30;
-			this.buttonCouplerObject.Text = "Open...";
-			this.buttonCouplerObject.UseVisualStyleBackColor = true;
-			this.buttonCouplerObject.Click += new System.EventHandler(this.buttonCouplerObject_Click);
-			// 
-			// textBoxCouplerObject
-			// 
-			this.textBoxCouplerObject.Location = new System.Drawing.Point(60, 64);
-			this.textBoxCouplerObject.Name = "textBoxCouplerObject";
-			this.textBoxCouplerObject.Size = new System.Drawing.Size(130, 19);
-			this.textBoxCouplerObject.TabIndex = 29;
-			// 
-			// labelCouplerObject
-			// 
-			this.labelCouplerObject.Location = new System.Drawing.Point(8, 64);
-			this.labelCouplerObject.Name = "labelCouplerObject";
-			this.labelCouplerObject.Size = new System.Drawing.Size(46, 16);
-			this.labelCouplerObject.TabIndex = 28;
-			this.labelCouplerObject.Text = "Object:";
-			this.labelCouplerObject.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCouplerMaxUnit
-			// 
-			this.labelCouplerMaxUnit.Location = new System.Drawing.Point(116, 40);
-			this.labelCouplerMaxUnit.Name = "labelCouplerMaxUnit";
-			this.labelCouplerMaxUnit.Size = new System.Drawing.Size(16, 16);
-			this.labelCouplerMaxUnit.TabIndex = 27;
-			this.labelCouplerMaxUnit.Text = "m";
-			this.labelCouplerMaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxCouplerMax
-			// 
-			this.textBoxCouplerMax.Location = new System.Drawing.Point(60, 40);
-			this.textBoxCouplerMax.Name = "textBoxCouplerMax";
-			this.textBoxCouplerMax.Size = new System.Drawing.Size(48, 19);
-			this.textBoxCouplerMax.TabIndex = 26;
-			// 
-			// labelCouplerMax
-			// 
-			this.labelCouplerMax.Location = new System.Drawing.Point(8, 40);
-			this.labelCouplerMax.Name = "labelCouplerMax";
-			this.labelCouplerMax.Size = new System.Drawing.Size(32, 16);
-			this.labelCouplerMax.TabIndex = 25;
-			this.labelCouplerMax.Text = "Max:";
-			this.labelCouplerMax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelCouplerMinUnit
-			// 
-			this.labelCouplerMinUnit.Location = new System.Drawing.Point(116, 16);
-			this.labelCouplerMinUnit.Name = "labelCouplerMinUnit";
-			this.labelCouplerMinUnit.Size = new System.Drawing.Size(16, 16);
-			this.labelCouplerMinUnit.TabIndex = 24;
-			this.labelCouplerMinUnit.Text = "m";
-			this.labelCouplerMinUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxCouplerMin
-			// 
-			this.textBoxCouplerMin.Location = new System.Drawing.Point(60, 16);
-			this.textBoxCouplerMin.Name = "textBoxCouplerMin";
-			this.textBoxCouplerMin.Size = new System.Drawing.Size(48, 19);
-			this.textBoxCouplerMin.TabIndex = 23;
-			// 
-			// labelCouplerMin
-			// 
-			this.labelCouplerMin.Location = new System.Drawing.Point(8, 16);
-			this.labelCouplerMin.Name = "labelCouplerMin";
-			this.labelCouplerMin.Size = new System.Drawing.Size(32, 16);
-			this.labelCouplerMin.TabIndex = 22;
-			this.labelCouplerMin.Text = "Min:";
-			this.labelCouplerMin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// panelCars
+			// 
+			this.panelCars.Controls.Add(this.treeViewCars);
+			this.panelCars.Controls.Add(this.panelCarsNavi);
+			this.panelCars.Dock = System.Windows.Forms.DockStyle.Left;
+			this.panelCars.Location = new System.Drawing.Point(0, 24);
+			this.panelCars.Name = "panelCars";
+			this.panelCars.Size = new System.Drawing.Size(200, 696);
+			this.panelCars.TabIndex = 10;
+			// 
+			// treeViewCars
+			// 
+			this.treeViewCars.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.treeViewCars.HideSelection = false;
+			this.treeViewCars.Location = new System.Drawing.Point(0, 0);
+			this.treeViewCars.Name = "treeViewCars";
+			this.treeViewCars.Size = new System.Drawing.Size(200, 624);
+			this.treeViewCars.TabIndex = 2;
+			// 
+			// panelCarsNavi
+			// 
+			this.panelCarsNavi.Controls.Add(this.buttonCarsCopy);
+			this.panelCarsNavi.Controls.Add(this.buttonCarsRemove);
+			this.panelCarsNavi.Controls.Add(this.buttonCarsAdd);
+			this.panelCarsNavi.Controls.Add(this.buttonCarsUp);
+			this.panelCarsNavi.Controls.Add(this.buttonCarsDown);
+			this.panelCarsNavi.Dock = System.Windows.Forms.DockStyle.Bottom;
+			this.panelCarsNavi.Location = new System.Drawing.Point(0, 624);
+			this.panelCarsNavi.Name = "panelCarsNavi";
+			this.panelCarsNavi.Size = new System.Drawing.Size(200, 72);
+			this.panelCarsNavi.TabIndex = 3;
+			// 
+			// buttonCarsCopy
+			// 
+			this.buttonCarsCopy.Location = new System.Drawing.Point(72, 40);
+			this.buttonCarsCopy.Name = "buttonCarsCopy";
+			this.buttonCarsCopy.Size = new System.Drawing.Size(56, 24);
+			this.buttonCarsCopy.TabIndex = 5;
+			this.buttonCarsCopy.Text = "Copy";
+			this.buttonCarsCopy.UseVisualStyleBackColor = true;
+			// 
+			// buttonCarsRemove
+			// 
+			this.buttonCarsRemove.Location = new System.Drawing.Point(136, 8);
+			this.buttonCarsRemove.Name = "buttonCarsRemove";
+			this.buttonCarsRemove.Size = new System.Drawing.Size(56, 24);
+			this.buttonCarsRemove.TabIndex = 3;
+			this.buttonCarsRemove.Text = "Remove";
+			this.buttonCarsRemove.UseVisualStyleBackColor = true;
+			// 
+			// buttonCarsAdd
+			// 
+			this.buttonCarsAdd.Location = new System.Drawing.Point(72, 8);
+			this.buttonCarsAdd.Name = "buttonCarsAdd";
+			this.buttonCarsAdd.Size = new System.Drawing.Size(56, 24);
+			this.buttonCarsAdd.TabIndex = 2;
+			this.buttonCarsAdd.Text = "Add";
+			this.buttonCarsAdd.UseVisualStyleBackColor = true;
+			// 
+			// buttonCarsUp
+			// 
+			this.buttonCarsUp.Location = new System.Drawing.Point(8, 8);
+			this.buttonCarsUp.Name = "buttonCarsUp";
+			this.buttonCarsUp.Size = new System.Drawing.Size(56, 24);
+			this.buttonCarsUp.TabIndex = 0;
+			this.buttonCarsUp.Text = "Up";
+			this.buttonCarsUp.UseVisualStyleBackColor = true;
+			// 
+			// buttonCarsDown
+			// 
+			this.buttonCarsDown.Location = new System.Drawing.Point(8, 40);
+			this.buttonCarsDown.Name = "buttonCarsDown";
+			this.buttonCarsDown.Size = new System.Drawing.Size(56, 24);
+			this.buttonCarsDown.TabIndex = 1;
+			this.buttonCarsDown.Text = "Down";
+			this.buttonCarsDown.UseVisualStyleBackColor = true;
+			// 
+			// menuStripMenu
+			// 
+			this.menuStripMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemFile,
+            this.toolStripComboBoxLanguage,
+            this.toolStripStatusLabelLanguage});
+			this.menuStripMenu.Location = new System.Drawing.Point(0, 0);
+			this.menuStripMenu.Name = "menuStripMenu";
+			this.menuStripMenu.Size = new System.Drawing.Size(1000, 24);
+			this.menuStripMenu.TabIndex = 8;
+			this.menuStripMenu.Text = "menuStrip1";
+			// 
+			// toolStripMenuItemFile
+			// 
+			this.toolStripMenuItemFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemNew,
+            this.toolStripMenuItemOpen,
+            this.toolStripSeparatorOpen,
+            this.toolStripMenuItemSave,
+            this.toolStripMenuItemSaveAs,
+            this.toolStripSeparatorSave,
+            this.toolStripMenuItemImport,
+            this.toolStripMenuItemExport,
+            this.toolStripSeparatorExport,
+            this.toolStripMenuItemExit});
+			this.toolStripMenuItemFile.Name = "toolStripMenuItemFile";
+			this.toolStripMenuItemFile.Size = new System.Drawing.Size(51, 20);
+			this.toolStripMenuItemFile.Text = "File(&F)";
+			// 
+			// toolStripMenuItemNew
+			// 
+			this.toolStripMenuItemNew.Name = "toolStripMenuItemNew";
+			this.toolStripMenuItemNew.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+			this.toolStripMenuItemNew.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemNew.Text = "New(&N)";
+			// 
+			// toolStripMenuItemOpen
+			// 
+			this.toolStripMenuItemOpen.Name = "toolStripMenuItemOpen";
+			this.toolStripMenuItemOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+			this.toolStripMenuItemOpen.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemOpen.Text = "Open...(&O)";
+			// 
+			// toolStripSeparatorOpen
+			// 
+			this.toolStripSeparatorOpen.Name = "toolStripSeparatorOpen";
+			this.toolStripSeparatorOpen.Size = new System.Drawing.Size(197, 6);
+			// 
+			// toolStripMenuItemSave
+			// 
+			this.toolStripMenuItemSave.Name = "toolStripMenuItemSave";
+			this.toolStripMenuItemSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+			this.toolStripMenuItemSave.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemSave.Text = "Save(&S)";
+			// 
+			// toolStripMenuItemSaveAs
+			// 
+			this.toolStripMenuItemSaveAs.Name = "toolStripMenuItemSaveAs";
+			this.toolStripMenuItemSaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            | System.Windows.Forms.Keys.S)));
+			this.toolStripMenuItemSaveAs.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemSaveAs.Text = "Save as...(&A)";
+			// 
+			// toolStripSeparatorSave
+			// 
+			this.toolStripSeparatorSave.Name = "toolStripSeparatorSave";
+			this.toolStripSeparatorSave.Size = new System.Drawing.Size(197, 6);
+			// 
+			// toolStripMenuItemImport
+			// 
+			this.toolStripMenuItemImport.Name = "toolStripMenuItemImport";
+			this.toolStripMenuItemImport.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemImport.Text = "Import...";
+			this.toolStripMenuItemImport.Click += new System.EventHandler(this.ToolStripMenuItemImport_Click);
+			// 
+			// toolStripMenuItemExport
+			// 
+			this.toolStripMenuItemExport.Name = "toolStripMenuItemExport";
+			this.toolStripMenuItemExport.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemExport.Text = "Export...";
+			this.toolStripMenuItemExport.Click += new System.EventHandler(this.ToolStripMenuItemExport_Click);
+			// 
+			// toolStripSeparatorExport
+			// 
+			this.toolStripSeparatorExport.Name = "toolStripSeparatorExport";
+			this.toolStripSeparatorExport.Size = new System.Drawing.Size(197, 6);
+			// 
+			// toolStripMenuItemExit
+			// 
+			this.toolStripMenuItemExit.Name = "toolStripMenuItemExit";
+			this.toolStripMenuItemExit.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+			this.toolStripMenuItemExit.Size = new System.Drawing.Size(200, 22);
+			this.toolStripMenuItemExit.Text = "Exit(&X)";
+			this.toolStripMenuItemExit.Click += new System.EventHandler(this.ToolStripMenuItemExit_Click);
+			// 
+			// toolStripComboBoxLanguage
+			// 
+			this.toolStripComboBoxLanguage.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripComboBoxLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.toolStripComboBoxLanguage.Name = "toolStripComboBoxLanguage";
+			this.toolStripComboBoxLanguage.Size = new System.Drawing.Size(150, 20);
+			this.toolStripComboBoxLanguage.SelectedIndexChanged += new System.EventHandler(this.ToolStripComboBoxLanguage_SelectedIndexChanged);
+			// 
+			// toolStripStatusLabelLanguage
+			// 
+			this.toolStripStatusLabelLanguage.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelLanguage.Name = "toolStripStatusLabelLanguage";
+			this.toolStripStatusLabelLanguage.Size = new System.Drawing.Size(55, 15);
+			this.toolStripStatusLabelLanguage.Text = "Language:";
+			// 
+			// errorProvider
+			// 
+			this.errorProvider.ContainerControl = this;
+			// 
+			// tabPageStatus
+			// 
+			this.tabPageStatus.Controls.Add(this.listViewStatus);
+			this.tabPageStatus.Controls.Add(this.panelStatusNavi);
+			this.tabPageStatus.Controls.Add(this.menuStripStatus);
+			this.tabPageStatus.Location = new System.Drawing.Point(4, 22);
+			this.tabPageStatus.Name = "tabPageStatus";
+			this.tabPageStatus.Size = new System.Drawing.Size(792, 670);
+			this.tabPageStatus.TabIndex = 6;
+			this.tabPageStatus.Text = "Status (0)";
+			this.tabPageStatus.UseVisualStyleBackColor = true;
+			// 
+			// listViewStatus
+			// 
+			this.listViewStatus.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.columnHeaderLevel,
+            this.columnHeaderText});
+			this.listViewStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.listViewStatus.FullRowSelect = true;
+			this.listViewStatus.HideSelection = false;
+			this.listViewStatus.Location = new System.Drawing.Point(0, 24);
+			this.listViewStatus.MultiSelect = false;
+			this.listViewStatus.Name = "listViewStatus";
+			this.listViewStatus.Size = new System.Drawing.Size(792, 608);
+			this.listViewStatus.TabIndex = 0;
+			this.listViewStatus.UseCompatibleStateImageBehavior = false;
+			this.listViewStatus.View = System.Windows.Forms.View.Details;
+			// 
+			// columnHeaderLevel
+			// 
+			this.columnHeaderLevel.Text = "Level";
+			// 
+			// columnHeaderText
+			// 
+			this.columnHeaderText.Text = "Description";
+			// 
+			// panelStatusNavi
+			// 
+			this.panelStatusNavi.Controls.Add(this.buttonOutputLogs);
+			this.panelStatusNavi.Dock = System.Windows.Forms.DockStyle.Bottom;
+			this.panelStatusNavi.Location = new System.Drawing.Point(0, 632);
+			this.panelStatusNavi.Name = "panelStatusNavi";
+			this.panelStatusNavi.Size = new System.Drawing.Size(792, 38);
+			this.panelStatusNavi.TabIndex = 4;
+			// 
+			// buttonOutputLogs
+			// 
+			this.buttonOutputLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.buttonOutputLogs.Location = new System.Drawing.Point(704, 8);
+			this.buttonOutputLogs.Name = "buttonOutputLogs";
+			this.buttonOutputLogs.Size = new System.Drawing.Size(80, 24);
+			this.buttonOutputLogs.TabIndex = 0;
+			this.buttonOutputLogs.Text = "Output logs...";
+			this.buttonOutputLogs.UseVisualStyleBackColor = true;
+			// 
+			// menuStripStatus
+			// 
+			this.menuStripStatus.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemError,
+            this.toolStripMenuItemWarning,
+            this.toolStripMenuItemInfo,
+            this.toolStripMenuItemClear});
+			this.menuStripStatus.Location = new System.Drawing.Point(0, 0);
+			this.menuStripStatus.Name = "menuStripStatus";
+			this.menuStripStatus.Size = new System.Drawing.Size(792, 24);
+			this.menuStripStatus.TabIndex = 1;
+			this.menuStripStatus.Text = "menuStrip1";
+			// 
+			// toolStripMenuItemError
+			// 
+			this.toolStripMenuItemError.Name = "toolStripMenuItemError";
+			this.toolStripMenuItemError.Size = new System.Drawing.Size(52, 20);
+			this.toolStripMenuItemError.Text = "0 Error";
+			// 
+			// toolStripMenuItemWarning
+			// 
+			this.toolStripMenuItemWarning.Name = "toolStripMenuItemWarning";
+			this.toolStripMenuItemWarning.Size = new System.Drawing.Size(67, 20);
+			this.toolStripMenuItemWarning.Text = "0 Warning";
+			// 
+			// toolStripMenuItemInfo
+			// 
+			this.toolStripMenuItemInfo.Name = "toolStripMenuItemInfo";
+			this.toolStripMenuItemInfo.Size = new System.Drawing.Size(84, 20);
+			this.toolStripMenuItemInfo.Text = "0 Information";
+			// 
+			// toolStripMenuItemClear
+			// 
+			this.toolStripMenuItemClear.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripMenuItemClear.Name = "toolStripMenuItemClear";
+			this.toolStripMenuItemClear.Size = new System.Drawing.Size(44, 20);
+			this.toolStripMenuItemClear.Text = "Clear";
+			// 
+			// tabPageSound
+			// 
+			this.tabPageSound.Controls.Add(this.panelSoundSetting);
+			this.tabPageSound.Location = new System.Drawing.Point(4, 22);
+			this.tabPageSound.Name = "tabPageSound";
+			this.tabPageSound.Padding = new System.Windows.Forms.Padding(3);
+			this.tabPageSound.Size = new System.Drawing.Size(792, 670);
+			this.tabPageSound.TabIndex = 0;
+			this.tabPageSound.Text = "Sound settings";
+			this.tabPageSound.UseVisualStyleBackColor = true;
+			// 
+			// panelSoundSetting
+			// 
+			this.panelSoundSetting.Controls.Add(this.splitContainerSound);
+			this.panelSoundSetting.Controls.Add(this.panelSoundSettingEdit);
+			this.panelSoundSetting.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.panelSoundSetting.Location = new System.Drawing.Point(3, 3);
+			this.panelSoundSetting.Name = "panelSoundSetting";
+			this.panelSoundSetting.Size = new System.Drawing.Size(786, 664);
+			this.panelSoundSetting.TabIndex = 0;
+			// 
+			// splitContainerSound
+			// 
+			this.splitContainerSound.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.splitContainerSound.Location = new System.Drawing.Point(0, 0);
+			this.splitContainerSound.Name = "splitContainerSound";
+			// 
+			// splitContainerSound.Panel1
+			// 
+			this.splitContainerSound.Panel1.Controls.Add(this.treeViewSound);
+			// 
+			// splitContainerSound.Panel2
+			// 
+			this.splitContainerSound.Panel2.Controls.Add(this.listViewSound);
+			this.splitContainerSound.Size = new System.Drawing.Size(570, 664);
+			this.splitContainerSound.SplitterDistance = 190;
+			this.splitContainerSound.TabIndex = 2;
+			// 
+			// treeViewSound
+			// 
+			this.treeViewSound.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.treeViewSound.HideSelection = false;
+			this.treeViewSound.Location = new System.Drawing.Point(0, 0);
+			this.treeViewSound.Name = "treeViewSound";
+			this.treeViewSound.Size = new System.Drawing.Size(190, 664);
+			this.treeViewSound.TabIndex = 0;
+			// 
+			// listViewSound
+			// 
+			this.listViewSound.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.listViewSound.FullRowSelect = true;
+			this.listViewSound.HideSelection = false;
+			this.listViewSound.Location = new System.Drawing.Point(0, 0);
+			this.listViewSound.MultiSelect = false;
+			this.listViewSound.Name = "listViewSound";
+			this.listViewSound.Size = new System.Drawing.Size(376, 664);
+			this.listViewSound.TabIndex = 0;
+			this.listViewSound.UseCompatibleStateImageBehavior = false;
+			this.listViewSound.View = System.Windows.Forms.View.Details;
+			// 
+			// panelSoundSettingEdit
+			// 
+			this.panelSoundSettingEdit.Controls.Add(this.groupBoxSoundEntry);
+			this.panelSoundSettingEdit.Dock = System.Windows.Forms.DockStyle.Right;
+			this.panelSoundSettingEdit.Location = new System.Drawing.Point(570, 0);
+			this.panelSoundSettingEdit.Name = "panelSoundSettingEdit";
+			this.panelSoundSettingEdit.Size = new System.Drawing.Size(216, 664);
+			this.panelSoundSettingEdit.TabIndex = 1;
+			// 
+			// groupBoxSoundEntry
+			// 
+			this.groupBoxSoundEntry.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBoxSoundEntry.Controls.Add(this.buttonSoundRemove);
+			this.groupBoxSoundEntry.Controls.Add(this.groupBoxSoundKey);
+			this.groupBoxSoundEntry.Controls.Add(this.buttonSoundAdd);
+			this.groupBoxSoundEntry.Controls.Add(this.groupBoxSoundValue);
+			this.groupBoxSoundEntry.Location = new System.Drawing.Point(8, 320);
+			this.groupBoxSoundEntry.Name = "groupBoxSoundEntry";
+			this.groupBoxSoundEntry.Size = new System.Drawing.Size(200, 336);
+			this.groupBoxSoundEntry.TabIndex = 6;
+			this.groupBoxSoundEntry.TabStop = false;
+			this.groupBoxSoundEntry.Text = "Edit entry";
+			// 
+			// buttonSoundRemove
+			// 
+			this.buttonSoundRemove.Location = new System.Drawing.Point(72, 304);
+			this.buttonSoundRemove.Name = "buttonSoundRemove";
+			this.buttonSoundRemove.Size = new System.Drawing.Size(56, 24);
+			this.buttonSoundRemove.TabIndex = 4;
+			this.buttonSoundRemove.Text = "Remove";
+			this.buttonSoundRemove.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxSoundKey
+			// 
+			this.groupBoxSoundKey.Controls.Add(this.numericUpDownSoundKeyIndex);
+			this.groupBoxSoundKey.Controls.Add(this.comboBoxSoundKey);
+			this.groupBoxSoundKey.Location = new System.Drawing.Point(8, 16);
+			this.groupBoxSoundKey.Name = "groupBoxSoundKey";
+			this.groupBoxSoundKey.Size = new System.Drawing.Size(184, 48);
+			this.groupBoxSoundKey.TabIndex = 1;
+			this.groupBoxSoundKey.TabStop = false;
+			this.groupBoxSoundKey.Text = "Key type select";
+			// 
+			// numericUpDownSoundKeyIndex
+			// 
+			this.numericUpDownSoundKeyIndex.Location = new System.Drawing.Point(136, 16);
+			this.numericUpDownSoundKeyIndex.Name = "numericUpDownSoundKeyIndex";
+			this.numericUpDownSoundKeyIndex.Size = new System.Drawing.Size(40, 19);
+			this.numericUpDownSoundKeyIndex.TabIndex = 1;
+			// 
+			// comboBoxSoundKey
+			// 
+			this.comboBoxSoundKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxSoundKey.FormattingEnabled = true;
+			this.comboBoxSoundKey.Location = new System.Drawing.Point(8, 16);
+			this.comboBoxSoundKey.Name = "comboBoxSoundKey";
+			this.comboBoxSoundKey.Size = new System.Drawing.Size(120, 20);
+			this.comboBoxSoundKey.TabIndex = 0;
+			// 
+			// buttonSoundAdd
+			// 
+			this.buttonSoundAdd.Location = new System.Drawing.Point(8, 304);
+			this.buttonSoundAdd.Name = "buttonSoundAdd";
+			this.buttonSoundAdd.Size = new System.Drawing.Size(56, 24);
+			this.buttonSoundAdd.TabIndex = 3;
+			this.buttonSoundAdd.Text = "Add";
+			this.buttonSoundAdd.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxSoundValue
+			// 
+			this.groupBoxSoundValue.Controls.Add(this.checkBoxSoundRadius);
+			this.groupBoxSoundValue.Controls.Add(this.checkBoxSoundDefinedPosition);
+			this.groupBoxSoundValue.Controls.Add(this.textBoxSoundRadius);
+			this.groupBoxSoundValue.Controls.Add(this.groupBoxSoundPosition);
+			this.groupBoxSoundValue.Controls.Add(this.labelSoundFileName);
+			this.groupBoxSoundValue.Controls.Add(this.buttonSoundFileNameOpen);
+			this.groupBoxSoundValue.Controls.Add(this.textBoxSoundFileName);
+			this.groupBoxSoundValue.Location = new System.Drawing.Point(8, 72);
+			this.groupBoxSoundValue.Name = "groupBoxSoundValue";
+			this.groupBoxSoundValue.Size = new System.Drawing.Size(184, 224);
+			this.groupBoxSoundValue.TabIndex = 2;
+			this.groupBoxSoundValue.TabStop = false;
+			this.groupBoxSoundValue.Text = "Input value";
+			// 
+			// checkBoxSoundRadius
+			// 
+			this.checkBoxSoundRadius.Location = new System.Drawing.Point(8, 72);
+			this.checkBoxSoundRadius.Name = "checkBoxSoundRadius";
+			this.checkBoxSoundRadius.Size = new System.Drawing.Size(80, 16);
+			this.checkBoxSoundRadius.TabIndex = 22;
+			this.checkBoxSoundRadius.Text = "Radius:";
+			this.checkBoxSoundRadius.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxSoundDefinedPosition
+			// 
+			this.checkBoxSoundDefinedPosition.Location = new System.Drawing.Point(8, 96);
+			this.checkBoxSoundDefinedPosition.Name = "checkBoxSoundDefinedPosition";
+			this.checkBoxSoundDefinedPosition.Size = new System.Drawing.Size(104, 16);
+			this.checkBoxSoundDefinedPosition.TabIndex = 21;
+			this.checkBoxSoundDefinedPosition.Text = "Position setting";
+			this.checkBoxSoundDefinedPosition.UseVisualStyleBackColor = true;
+			// 
+			// textBoxSoundRadius
+			// 
+			this.textBoxSoundRadius.Location = new System.Drawing.Point(96, 72);
+			this.textBoxSoundRadius.Name = "textBoxSoundRadius";
+			this.textBoxSoundRadius.Size = new System.Drawing.Size(56, 19);
+			this.textBoxSoundRadius.TabIndex = 20;
+			// 
+			// groupBoxSoundPosition
+			// 
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionZUnit);
+			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionZ);
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionZ);
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionYUnit);
+			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionY);
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionY);
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionXUnit);
+			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionX);
+			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionX);
+			this.groupBoxSoundPosition.Location = new System.Drawing.Point(8, 120);
+			this.groupBoxSoundPosition.Name = "groupBoxSoundPosition";
+			this.groupBoxSoundPosition.Size = new System.Drawing.Size(168, 96);
+			this.groupBoxSoundPosition.TabIndex = 3;
+			this.groupBoxSoundPosition.TabStop = false;
+			this.groupBoxSoundPosition.Text = "Position";
+			// 
+			// labelSoundPositionZUnit
+			// 
+			this.labelSoundPositionZUnit.Location = new System.Drawing.Point(152, 64);
+			this.labelSoundPositionZUnit.Name = "labelSoundPositionZUnit";
+			this.labelSoundPositionZUnit.Size = new System.Drawing.Size(8, 16);
+			this.labelSoundPositionZUnit.TabIndex = 26;
+			this.labelSoundPositionZUnit.Text = "m";
+			this.labelSoundPositionZUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxSoundPositionZ
+			// 
+			this.textBoxSoundPositionZ.Location = new System.Drawing.Point(88, 64);
+			this.textBoxSoundPositionZ.Name = "textBoxSoundPositionZ";
+			this.textBoxSoundPositionZ.Size = new System.Drawing.Size(56, 19);
+			this.textBoxSoundPositionZ.TabIndex = 25;
+			// 
+			// labelSoundPositionZ
+			// 
+			this.labelSoundPositionZ.Location = new System.Drawing.Point(8, 64);
+			this.labelSoundPositionZ.Name = "labelSoundPositionZ";
+			this.labelSoundPositionZ.Size = new System.Drawing.Size(72, 16);
+			this.labelSoundPositionZ.TabIndex = 24;
+			this.labelSoundPositionZ.Text = "z coordinate:";
+			this.labelSoundPositionZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelSoundPositionYUnit
+			// 
+			this.labelSoundPositionYUnit.Location = new System.Drawing.Point(152, 40);
+			this.labelSoundPositionYUnit.Name = "labelSoundPositionYUnit";
+			this.labelSoundPositionYUnit.Size = new System.Drawing.Size(8, 16);
+			this.labelSoundPositionYUnit.TabIndex = 23;
+			this.labelSoundPositionYUnit.Text = "m";
+			this.labelSoundPositionYUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxSoundPositionY
+			// 
+			this.textBoxSoundPositionY.Location = new System.Drawing.Point(88, 40);
+			this.textBoxSoundPositionY.Name = "textBoxSoundPositionY";
+			this.textBoxSoundPositionY.Size = new System.Drawing.Size(56, 19);
+			this.textBoxSoundPositionY.TabIndex = 22;
+			// 
+			// labelSoundPositionY
+			// 
+			this.labelSoundPositionY.Location = new System.Drawing.Point(8, 40);
+			this.labelSoundPositionY.Name = "labelSoundPositionY";
+			this.labelSoundPositionY.Size = new System.Drawing.Size(72, 16);
+			this.labelSoundPositionY.TabIndex = 21;
+			this.labelSoundPositionY.Text = "y coordinate:";
+			this.labelSoundPositionY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelSoundPositionXUnit
+			// 
+			this.labelSoundPositionXUnit.Location = new System.Drawing.Point(152, 16);
+			this.labelSoundPositionXUnit.Name = "labelSoundPositionXUnit";
+			this.labelSoundPositionXUnit.Size = new System.Drawing.Size(8, 16);
+			this.labelSoundPositionXUnit.TabIndex = 20;
+			this.labelSoundPositionXUnit.Text = "m";
+			this.labelSoundPositionXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxSoundPositionX
+			// 
+			this.textBoxSoundPositionX.Location = new System.Drawing.Point(88, 16);
+			this.textBoxSoundPositionX.Name = "textBoxSoundPositionX";
+			this.textBoxSoundPositionX.Size = new System.Drawing.Size(56, 19);
+			this.textBoxSoundPositionX.TabIndex = 19;
+			// 
+			// labelSoundPositionX
+			// 
+			this.labelSoundPositionX.Location = new System.Drawing.Point(8, 16);
+			this.labelSoundPositionX.Name = "labelSoundPositionX";
+			this.labelSoundPositionX.Size = new System.Drawing.Size(72, 16);
+			this.labelSoundPositionX.TabIndex = 18;
+			this.labelSoundPositionX.Text = "x coordinate:";
+			this.labelSoundPositionX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelSoundFileName
+			// 
+			this.labelSoundFileName.Location = new System.Drawing.Point(8, 16);
+			this.labelSoundFileName.Name = "labelSoundFileName";
+			this.labelSoundFileName.Size = new System.Drawing.Size(56, 16);
+			this.labelSoundFileName.TabIndex = 2;
+			this.labelSoundFileName.Text = "Filename:";
+			this.labelSoundFileName.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// buttonSoundFileNameOpen
+			// 
+			this.buttonSoundFileNameOpen.Location = new System.Drawing.Point(120, 40);
+			this.buttonSoundFileNameOpen.Name = "buttonSoundFileNameOpen";
+			this.buttonSoundFileNameOpen.Size = new System.Drawing.Size(56, 24);
+			this.buttonSoundFileNameOpen.TabIndex = 1;
+			this.buttonSoundFileNameOpen.Text = "Open...";
+			this.buttonSoundFileNameOpen.UseVisualStyleBackColor = true;
+			this.buttonSoundFileNameOpen.Click += new System.EventHandler(this.ButtonSoundFileNameOpen_Click);
+			// 
+			// textBoxSoundFileName
+			// 
+			this.textBoxSoundFileName.Location = new System.Drawing.Point(72, 16);
+			this.textBoxSoundFileName.Name = "textBoxSoundFileName";
+			this.textBoxSoundFileName.Size = new System.Drawing.Size(104, 19);
+			this.textBoxSoundFileName.TabIndex = 0;
 			// 
 			// tabPagePanel
 			// 
@@ -5786,12 +3304,10 @@ namespace TrainEditor2.Views
 			// 
 			// tabPageTouch
 			// 
-			this.tabPageTouch.Controls.Add(this.comboBoxTouchCommand);
-			this.tabPageTouch.Controls.Add(this.labelTouchCommand);
-			this.tabPageTouch.Controls.Add(this.numericUpDownTouchCommandOption);
-			this.tabPageTouch.Controls.Add(this.labelTouchCommandOption);
-			this.tabPageTouch.Controls.Add(this.numericUpDownTouchSoundIndex);
-			this.tabPageTouch.Controls.Add(this.labelTouchSoundIndex);
+			this.tabPageTouch.Controls.Add(this.numericUpDownTouchLayer);
+			this.tabPageTouch.Controls.Add(this.labelTouchLayer);
+			this.tabPageTouch.Controls.Add(this.buttonTouchSoundCommand);
+			this.tabPageTouch.Controls.Add(this.labelTouchSoundCommand);
 			this.tabPageTouch.Controls.Add(this.numericUpDownTouchJumpScreen);
 			this.tabPageTouch.Controls.Add(this.labelTouchJumpScreen);
 			this.tabPageTouch.Controls.Add(this.groupBoxTouchSize);
@@ -5803,65 +3319,24 @@ namespace TrainEditor2.Views
 			this.tabPageTouch.Text = "Touch";
 			this.tabPageTouch.UseVisualStyleBackColor = true;
 			// 
-			// comboBoxTouchCommand
+			// buttonTouchSoundCommand
 			// 
-			this.comboBoxTouchCommand.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxTouchCommand.FormattingEnabled = true;
-			this.comboBoxTouchCommand.Location = new System.Drawing.Point(136, 216);
-			this.comboBoxTouchCommand.Name = "comboBoxTouchCommand";
-			this.comboBoxTouchCommand.Size = new System.Drawing.Size(104, 20);
-			this.comboBoxTouchCommand.TabIndex = 111;
+			this.buttonTouchSoundCommand.Location = new System.Drawing.Point(136, 192);
+			this.buttonTouchSoundCommand.Name = "buttonTouchSoundCommand";
+			this.buttonTouchSoundCommand.Size = new System.Drawing.Size(48, 19);
+			this.buttonTouchSoundCommand.TabIndex = 107;
+			this.buttonTouchSoundCommand.Text = "Set...";
+			this.buttonTouchSoundCommand.UseVisualStyleBackColor = true;
+			this.buttonTouchSoundCommand.Click += new System.EventHandler(this.ButtonTouchSoundCommand_Click);
 			// 
-			// labelTouchCommand
+			// labelTouchSoundCommand
 			// 
-			this.labelTouchCommand.Location = new System.Drawing.Point(8, 216);
-			this.labelTouchCommand.Name = "labelTouchCommand";
-			this.labelTouchCommand.Size = new System.Drawing.Size(120, 16);
-			this.labelTouchCommand.TabIndex = 110;
-			this.labelTouchCommand.Text = "Command:";
-			this.labelTouchCommand.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownTouchCommandOption
-			// 
-			this.numericUpDownTouchCommandOption.Location = new System.Drawing.Point(136, 240);
-			this.numericUpDownTouchCommandOption.Name = "numericUpDownTouchCommandOption";
-			this.numericUpDownTouchCommandOption.Size = new System.Drawing.Size(48, 19);
-			this.numericUpDownTouchCommandOption.TabIndex = 109;
-			// 
-			// labelTouchCommandOption
-			// 
-			this.labelTouchCommandOption.Location = new System.Drawing.Point(8, 240);
-			this.labelTouchCommandOption.Name = "labelTouchCommandOption";
-			this.labelTouchCommandOption.Size = new System.Drawing.Size(120, 16);
-			this.labelTouchCommandOption.TabIndex = 108;
-			this.labelTouchCommandOption.Text = "CommandOption:";
-			this.labelTouchCommandOption.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// numericUpDownTouchSoundIndex
-			// 
-			this.numericUpDownTouchSoundIndex.Location = new System.Drawing.Point(136, 192);
-			this.numericUpDownTouchSoundIndex.Maximum = new decimal(new int[] {
-            256,
-            0,
-            0,
-            0});
-			this.numericUpDownTouchSoundIndex.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-			this.numericUpDownTouchSoundIndex.Name = "numericUpDownTouchSoundIndex";
-			this.numericUpDownTouchSoundIndex.Size = new System.Drawing.Size(48, 19);
-			this.numericUpDownTouchSoundIndex.TabIndex = 107;
-			// 
-			// labelTouchSoundIndex
-			// 
-			this.labelTouchSoundIndex.Location = new System.Drawing.Point(8, 192);
-			this.labelTouchSoundIndex.Name = "labelTouchSoundIndex";
-			this.labelTouchSoundIndex.Size = new System.Drawing.Size(120, 16);
-			this.labelTouchSoundIndex.TabIndex = 106;
-			this.labelTouchSoundIndex.Text = "SoundIndex:";
-			this.labelTouchSoundIndex.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			this.labelTouchSoundCommand.Location = new System.Drawing.Point(8, 192);
+			this.labelTouchSoundCommand.Name = "labelTouchSoundCommand";
+			this.labelTouchSoundCommand.Size = new System.Drawing.Size(120, 16);
+			this.labelTouchSoundCommand.TabIndex = 106;
+			this.labelTouchSoundCommand.Text = "Sound and Command:";
+			this.labelTouchSoundCommand.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
 			// 
 			// numericUpDownTouchJumpScreen
 			// 
@@ -5969,577 +3444,3072 @@ namespace TrainEditor2.Views
 			this.labelTouchLocationX.Text = "X:";
 			this.labelTouchLocationX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
 			// 
-			// tabPageSound
-			// 
-			this.tabPageSound.Controls.Add(this.panelSoundSetting);
-			this.tabPageSound.Location = new System.Drawing.Point(4, 22);
-			this.tabPageSound.Name = "tabPageSound";
-			this.tabPageSound.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPageSound.Size = new System.Drawing.Size(792, 670);
-			this.tabPageSound.TabIndex = 0;
-			this.tabPageSound.Text = "Sound settings";
-			this.tabPageSound.UseVisualStyleBackColor = true;
-			// 
-			// panelSoundSetting
-			// 
-			this.panelSoundSetting.Controls.Add(this.splitContainerSound);
-			this.panelSoundSetting.Controls.Add(this.panelSoundSettingEdit);
-			this.panelSoundSetting.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.panelSoundSetting.Location = new System.Drawing.Point(3, 3);
-			this.panelSoundSetting.Name = "panelSoundSetting";
-			this.panelSoundSetting.Size = new System.Drawing.Size(786, 664);
-			this.panelSoundSetting.TabIndex = 0;
-			// 
-			// splitContainerSound
-			// 
-			this.splitContainerSound.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.splitContainerSound.Location = new System.Drawing.Point(0, 0);
-			this.splitContainerSound.Name = "splitContainerSound";
-			// 
-			// splitContainerSound.Panel1
-			// 
-			this.splitContainerSound.Panel1.Controls.Add(this.treeViewSound);
-			// 
-			// splitContainerSound.Panel2
-			// 
-			this.splitContainerSound.Panel2.Controls.Add(this.listViewSound);
-			this.splitContainerSound.Size = new System.Drawing.Size(570, 664);
-			this.splitContainerSound.SplitterDistance = 190;
-			this.splitContainerSound.TabIndex = 2;
-			// 
-			// treeViewSound
-			// 
-			this.treeViewSound.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.treeViewSound.HideSelection = false;
-			this.treeViewSound.Location = new System.Drawing.Point(0, 0);
-			this.treeViewSound.Name = "treeViewSound";
-			this.treeViewSound.Size = new System.Drawing.Size(190, 664);
-			this.treeViewSound.TabIndex = 0;
-			// 
-			// listViewSound
-			// 
-			this.listViewSound.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.listViewSound.FullRowSelect = true;
-			this.listViewSound.HideSelection = false;
-			this.listViewSound.Location = new System.Drawing.Point(0, 0);
-			this.listViewSound.MultiSelect = false;
-			this.listViewSound.Name = "listViewSound";
-			this.listViewSound.Size = new System.Drawing.Size(376, 664);
-			this.listViewSound.TabIndex = 0;
-			this.listViewSound.UseCompatibleStateImageBehavior = false;
-			this.listViewSound.View = System.Windows.Forms.View.Details;
-			// 
-			// panelSoundSettingEdit
-			// 
-			this.panelSoundSettingEdit.Controls.Add(this.groupBoxSoundEntry);
-			this.panelSoundSettingEdit.Dock = System.Windows.Forms.DockStyle.Right;
-			this.panelSoundSettingEdit.Location = new System.Drawing.Point(570, 0);
-			this.panelSoundSettingEdit.Name = "panelSoundSettingEdit";
-			this.panelSoundSettingEdit.Size = new System.Drawing.Size(216, 664);
-			this.panelSoundSettingEdit.TabIndex = 1;
-			// 
-			// groupBoxSoundEntry
-			// 
-			this.groupBoxSoundEntry.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.groupBoxSoundEntry.Controls.Add(this.buttonSoundRemove);
-			this.groupBoxSoundEntry.Controls.Add(this.groupBoxSoundKey);
-			this.groupBoxSoundEntry.Controls.Add(this.buttonSoundAdd);
-			this.groupBoxSoundEntry.Controls.Add(this.groupBoxSoundValue);
-			this.groupBoxSoundEntry.Location = new System.Drawing.Point(8, 320);
-			this.groupBoxSoundEntry.Name = "groupBoxSoundEntry";
-			this.groupBoxSoundEntry.Size = new System.Drawing.Size(200, 336);
-			this.groupBoxSoundEntry.TabIndex = 6;
-			this.groupBoxSoundEntry.TabStop = false;
-			this.groupBoxSoundEntry.Text = "Edit entry";
-			// 
-			// buttonSoundRemove
-			// 
-			this.buttonSoundRemove.Location = new System.Drawing.Point(72, 304);
-			this.buttonSoundRemove.Name = "buttonSoundRemove";
-			this.buttonSoundRemove.Size = new System.Drawing.Size(56, 24);
-			this.buttonSoundRemove.TabIndex = 4;
-			this.buttonSoundRemove.Text = "Remove";
-			this.buttonSoundRemove.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxSoundKey
-			// 
-			this.groupBoxSoundKey.Controls.Add(this.numericUpDownSoundKeyIndex);
-			this.groupBoxSoundKey.Controls.Add(this.comboBoxSoundKey);
-			this.groupBoxSoundKey.Location = new System.Drawing.Point(8, 16);
-			this.groupBoxSoundKey.Name = "groupBoxSoundKey";
-			this.groupBoxSoundKey.Size = new System.Drawing.Size(184, 48);
-			this.groupBoxSoundKey.TabIndex = 1;
-			this.groupBoxSoundKey.TabStop = false;
-			this.groupBoxSoundKey.Text = "Key type select";
-			// 
-			// numericUpDownSoundKeyIndex
-			// 
-			this.numericUpDownSoundKeyIndex.Location = new System.Drawing.Point(136, 16);
-			this.numericUpDownSoundKeyIndex.Name = "numericUpDownSoundKeyIndex";
-			this.numericUpDownSoundKeyIndex.Size = new System.Drawing.Size(40, 19);
-			this.numericUpDownSoundKeyIndex.TabIndex = 1;
-			// 
-			// comboBoxSoundKey
-			// 
-			this.comboBoxSoundKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxSoundKey.FormattingEnabled = true;
-			this.comboBoxSoundKey.Location = new System.Drawing.Point(8, 16);
-			this.comboBoxSoundKey.Name = "comboBoxSoundKey";
-			this.comboBoxSoundKey.Size = new System.Drawing.Size(120, 20);
-			this.comboBoxSoundKey.TabIndex = 0;
-			// 
-			// buttonSoundAdd
-			// 
-			this.buttonSoundAdd.Location = new System.Drawing.Point(8, 304);
-			this.buttonSoundAdd.Name = "buttonSoundAdd";
-			this.buttonSoundAdd.Size = new System.Drawing.Size(56, 24);
-			this.buttonSoundAdd.TabIndex = 3;
-			this.buttonSoundAdd.Text = "Add";
-			this.buttonSoundAdd.UseVisualStyleBackColor = true;
-			// 
-			// groupBoxSoundValue
-			// 
-			this.groupBoxSoundValue.Controls.Add(this.checkBoxSoundRadius);
-			this.groupBoxSoundValue.Controls.Add(this.checkBoxSoundDefinedPosition);
-			this.groupBoxSoundValue.Controls.Add(this.textBoxSoundRadius);
-			this.groupBoxSoundValue.Controls.Add(this.groupBoxSoundPosition);
-			this.groupBoxSoundValue.Controls.Add(this.labelSoundFileName);
-			this.groupBoxSoundValue.Controls.Add(this.buttonSoundFileNameOpen);
-			this.groupBoxSoundValue.Controls.Add(this.textBoxSoundFileName);
-			this.groupBoxSoundValue.Location = new System.Drawing.Point(8, 72);
-			this.groupBoxSoundValue.Name = "groupBoxSoundValue";
-			this.groupBoxSoundValue.Size = new System.Drawing.Size(184, 224);
-			this.groupBoxSoundValue.TabIndex = 2;
-			this.groupBoxSoundValue.TabStop = false;
-			this.groupBoxSoundValue.Text = "Input value";
-			// 
-			// checkBoxSoundRadius
-			// 
-			this.checkBoxSoundRadius.Location = new System.Drawing.Point(8, 72);
-			this.checkBoxSoundRadius.Name = "checkBoxSoundRadius";
-			this.checkBoxSoundRadius.Size = new System.Drawing.Size(80, 16);
-			this.checkBoxSoundRadius.TabIndex = 22;
-			this.checkBoxSoundRadius.Text = "Radius:";
-			this.checkBoxSoundRadius.UseVisualStyleBackColor = true;
-			// 
-			// checkBoxSoundDefinedPosition
-			// 
-			this.checkBoxSoundDefinedPosition.Location = new System.Drawing.Point(8, 96);
-			this.checkBoxSoundDefinedPosition.Name = "checkBoxSoundDefinedPosition";
-			this.checkBoxSoundDefinedPosition.Size = new System.Drawing.Size(104, 16);
-			this.checkBoxSoundDefinedPosition.TabIndex = 21;
-			this.checkBoxSoundDefinedPosition.Text = "Position setting";
-			this.checkBoxSoundDefinedPosition.UseVisualStyleBackColor = true;
-			// 
-			// textBoxSoundRadius
-			// 
-			this.textBoxSoundRadius.Location = new System.Drawing.Point(96, 72);
-			this.textBoxSoundRadius.Name = "textBoxSoundRadius";
-			this.textBoxSoundRadius.Size = new System.Drawing.Size(56, 19);
-			this.textBoxSoundRadius.TabIndex = 20;
-			// 
-			// groupBoxSoundPosition
-			// 
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionZUnit);
-			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionZ);
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionZ);
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionYUnit);
-			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionY);
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionY);
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionXUnit);
-			this.groupBoxSoundPosition.Controls.Add(this.textBoxSoundPositionX);
-			this.groupBoxSoundPosition.Controls.Add(this.labelSoundPositionX);
-			this.groupBoxSoundPosition.Location = new System.Drawing.Point(8, 120);
-			this.groupBoxSoundPosition.Name = "groupBoxSoundPosition";
-			this.groupBoxSoundPosition.Size = new System.Drawing.Size(168, 96);
-			this.groupBoxSoundPosition.TabIndex = 3;
-			this.groupBoxSoundPosition.TabStop = false;
-			this.groupBoxSoundPosition.Text = "Position";
-			// 
-			// labelSoundPositionZUnit
-			// 
-			this.labelSoundPositionZUnit.Location = new System.Drawing.Point(152, 64);
-			this.labelSoundPositionZUnit.Name = "labelSoundPositionZUnit";
-			this.labelSoundPositionZUnit.Size = new System.Drawing.Size(8, 16);
-			this.labelSoundPositionZUnit.TabIndex = 26;
-			this.labelSoundPositionZUnit.Text = "m";
-			this.labelSoundPositionZUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxSoundPositionZ
-			// 
-			this.textBoxSoundPositionZ.Location = new System.Drawing.Point(88, 64);
-			this.textBoxSoundPositionZ.Name = "textBoxSoundPositionZ";
-			this.textBoxSoundPositionZ.Size = new System.Drawing.Size(56, 19);
-			this.textBoxSoundPositionZ.TabIndex = 25;
-			// 
-			// labelSoundPositionZ
-			// 
-			this.labelSoundPositionZ.Location = new System.Drawing.Point(8, 64);
-			this.labelSoundPositionZ.Name = "labelSoundPositionZ";
-			this.labelSoundPositionZ.Size = new System.Drawing.Size(72, 16);
-			this.labelSoundPositionZ.TabIndex = 24;
-			this.labelSoundPositionZ.Text = "z coordinate:";
-			this.labelSoundPositionZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelSoundPositionYUnit
-			// 
-			this.labelSoundPositionYUnit.Location = new System.Drawing.Point(152, 40);
-			this.labelSoundPositionYUnit.Name = "labelSoundPositionYUnit";
-			this.labelSoundPositionYUnit.Size = new System.Drawing.Size(8, 16);
-			this.labelSoundPositionYUnit.TabIndex = 23;
-			this.labelSoundPositionYUnit.Text = "m";
-			this.labelSoundPositionYUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxSoundPositionY
-			// 
-			this.textBoxSoundPositionY.Location = new System.Drawing.Point(88, 40);
-			this.textBoxSoundPositionY.Name = "textBoxSoundPositionY";
-			this.textBoxSoundPositionY.Size = new System.Drawing.Size(56, 19);
-			this.textBoxSoundPositionY.TabIndex = 22;
-			// 
-			// labelSoundPositionY
-			// 
-			this.labelSoundPositionY.Location = new System.Drawing.Point(8, 40);
-			this.labelSoundPositionY.Name = "labelSoundPositionY";
-			this.labelSoundPositionY.Size = new System.Drawing.Size(72, 16);
-			this.labelSoundPositionY.TabIndex = 21;
-			this.labelSoundPositionY.Text = "y coordinate:";
-			this.labelSoundPositionY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelSoundPositionXUnit
-			// 
-			this.labelSoundPositionXUnit.Location = new System.Drawing.Point(152, 16);
-			this.labelSoundPositionXUnit.Name = "labelSoundPositionXUnit";
-			this.labelSoundPositionXUnit.Size = new System.Drawing.Size(8, 16);
-			this.labelSoundPositionXUnit.TabIndex = 20;
-			this.labelSoundPositionXUnit.Text = "m";
-			this.labelSoundPositionXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxSoundPositionX
-			// 
-			this.textBoxSoundPositionX.Location = new System.Drawing.Point(88, 16);
-			this.textBoxSoundPositionX.Name = "textBoxSoundPositionX";
-			this.textBoxSoundPositionX.Size = new System.Drawing.Size(56, 19);
-			this.textBoxSoundPositionX.TabIndex = 19;
-			// 
-			// labelSoundPositionX
-			// 
-			this.labelSoundPositionX.Location = new System.Drawing.Point(8, 16);
-			this.labelSoundPositionX.Name = "labelSoundPositionX";
-			this.labelSoundPositionX.Size = new System.Drawing.Size(72, 16);
-			this.labelSoundPositionX.TabIndex = 18;
-			this.labelSoundPositionX.Text = "x coordinate:";
-			this.labelSoundPositionX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// labelSoundFileName
-			// 
-			this.labelSoundFileName.Location = new System.Drawing.Point(8, 16);
-			this.labelSoundFileName.Name = "labelSoundFileName";
-			this.labelSoundFileName.Size = new System.Drawing.Size(56, 16);
-			this.labelSoundFileName.TabIndex = 2;
-			this.labelSoundFileName.Text = "Filename:";
-			this.labelSoundFileName.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// buttonSoundFileNameOpen
-			// 
-			this.buttonSoundFileNameOpen.Location = new System.Drawing.Point(120, 40);
-			this.buttonSoundFileNameOpen.Name = "buttonSoundFileNameOpen";
-			this.buttonSoundFileNameOpen.Size = new System.Drawing.Size(56, 24);
-			this.buttonSoundFileNameOpen.TabIndex = 1;
-			this.buttonSoundFileNameOpen.Text = "Open...";
-			this.buttonSoundFileNameOpen.UseVisualStyleBackColor = true;
-			this.buttonSoundFileNameOpen.Click += new System.EventHandler(this.ButtonSoundFileNameOpen_Click);
-			// 
-			// textBoxSoundFileName
-			// 
-			this.textBoxSoundFileName.Location = new System.Drawing.Point(72, 16);
-			this.textBoxSoundFileName.Name = "textBoxSoundFileName";
-			this.textBoxSoundFileName.Size = new System.Drawing.Size(104, 19);
-			this.textBoxSoundFileName.TabIndex = 0;
-			// 
-			// tabPageStatus
-			// 
-			this.tabPageStatus.Controls.Add(this.listViewStatus);
-			this.tabPageStatus.Controls.Add(this.panelStatusNavi);
-			this.tabPageStatus.Controls.Add(this.menuStripStatus);
-			this.tabPageStatus.Location = new System.Drawing.Point(4, 22);
-			this.tabPageStatus.Name = "tabPageStatus";
-			this.tabPageStatus.Size = new System.Drawing.Size(792, 670);
-			this.tabPageStatus.TabIndex = 6;
-			this.tabPageStatus.Text = "Status (0)";
-			this.tabPageStatus.UseVisualStyleBackColor = true;
-			// 
-			// listViewStatus
-			// 
-			this.listViewStatus.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.columnHeaderLevel,
-            this.columnHeaderText});
-			this.listViewStatus.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.listViewStatus.FullRowSelect = true;
-			this.listViewStatus.HideSelection = false;
-			this.listViewStatus.Location = new System.Drawing.Point(0, 24);
-			this.listViewStatus.MultiSelect = false;
-			this.listViewStatus.Name = "listViewStatus";
-			this.listViewStatus.Size = new System.Drawing.Size(792, 608);
-			this.listViewStatus.TabIndex = 0;
-			this.listViewStatus.UseCompatibleStateImageBehavior = false;
-			this.listViewStatus.View = System.Windows.Forms.View.Details;
-			// 
-			// columnHeaderLevel
-			// 
-			this.columnHeaderLevel.Text = "Level";
-			// 
-			// columnHeaderText
-			// 
-			this.columnHeaderText.Text = "Description";
-			// 
-			// menuStripStatus
-			// 
-			this.menuStripStatus.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemError,
-            this.toolStripMenuItemWarning,
-            this.toolStripMenuItemInfo,
-            this.toolStripMenuItemClear});
-			this.menuStripStatus.Location = new System.Drawing.Point(0, 0);
-			this.menuStripStatus.Name = "menuStripStatus";
-			this.menuStripStatus.Size = new System.Drawing.Size(792, 24);
-			this.menuStripStatus.TabIndex = 1;
-			this.menuStripStatus.Text = "menuStrip1";
-			// 
-			// toolStripMenuItemError
-			// 
-			this.toolStripMenuItemError.Name = "toolStripMenuItemError";
-			this.toolStripMenuItemError.Size = new System.Drawing.Size(52, 20);
-			this.toolStripMenuItemError.Text = "0 Error";
-			// 
-			// toolStripMenuItemWarning
-			// 
-			this.toolStripMenuItemWarning.Name = "toolStripMenuItemWarning";
-			this.toolStripMenuItemWarning.Size = new System.Drawing.Size(67, 20);
-			this.toolStripMenuItemWarning.Text = "0 Warning";
-			// 
-			// toolStripMenuItemInfo
-			// 
-			this.toolStripMenuItemInfo.Name = "toolStripMenuItemInfo";
-			this.toolStripMenuItemInfo.Size = new System.Drawing.Size(84, 20);
-			this.toolStripMenuItemInfo.Text = "0 Information";
-			// 
-			// toolStripMenuItemClear
-			// 
-			this.toolStripMenuItemClear.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripMenuItemClear.Name = "toolStripMenuItemClear";
-			this.toolStripMenuItemClear.Size = new System.Drawing.Size(44, 20);
-			this.toolStripMenuItemClear.Text = "Clear";
-			// 
-			// panelCars
-			// 
-			this.panelCars.Controls.Add(this.treeViewCars);
-			this.panelCars.Controls.Add(this.panelCarsNavi);
-			this.panelCars.Dock = System.Windows.Forms.DockStyle.Left;
-			this.panelCars.Location = new System.Drawing.Point(0, 24);
-			this.panelCars.Name = "panelCars";
-			this.panelCars.Size = new System.Drawing.Size(200, 696);
-			this.panelCars.TabIndex = 10;
-			// 
-			// treeViewCars
-			// 
-			this.treeViewCars.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.treeViewCars.HideSelection = false;
-			this.treeViewCars.Location = new System.Drawing.Point(0, 0);
-			this.treeViewCars.Name = "treeViewCars";
-			this.treeViewCars.Size = new System.Drawing.Size(200, 624);
-			this.treeViewCars.TabIndex = 2;
-			// 
-			// panelCarsNavi
-			// 
-			this.panelCarsNavi.Controls.Add(this.buttonCarsCopy);
-			this.panelCarsNavi.Controls.Add(this.buttonCarsRemove);
-			this.panelCarsNavi.Controls.Add(this.buttonCarsAdd);
-			this.panelCarsNavi.Controls.Add(this.buttonCarsUp);
-			this.panelCarsNavi.Controls.Add(this.buttonCarsDown);
-			this.panelCarsNavi.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.panelCarsNavi.Location = new System.Drawing.Point(0, 624);
-			this.panelCarsNavi.Name = "panelCarsNavi";
-			this.panelCarsNavi.Size = new System.Drawing.Size(200, 72);
-			this.panelCarsNavi.TabIndex = 3;
-			// 
-			// buttonCarsCopy
-			// 
-			this.buttonCarsCopy.Location = new System.Drawing.Point(72, 40);
-			this.buttonCarsCopy.Name = "buttonCarsCopy";
-			this.buttonCarsCopy.Size = new System.Drawing.Size(56, 24);
-			this.buttonCarsCopy.TabIndex = 5;
-			this.buttonCarsCopy.Text = "Copy";
-			this.buttonCarsCopy.UseVisualStyleBackColor = true;
-			// 
-			// buttonCarsRemove
-			// 
-			this.buttonCarsRemove.Location = new System.Drawing.Point(136, 8);
-			this.buttonCarsRemove.Name = "buttonCarsRemove";
-			this.buttonCarsRemove.Size = new System.Drawing.Size(56, 24);
-			this.buttonCarsRemove.TabIndex = 3;
-			this.buttonCarsRemove.Text = "Remove";
-			this.buttonCarsRemove.UseVisualStyleBackColor = true;
-			// 
-			// buttonCarsAdd
-			// 
-			this.buttonCarsAdd.Location = new System.Drawing.Point(72, 8);
-			this.buttonCarsAdd.Name = "buttonCarsAdd";
-			this.buttonCarsAdd.Size = new System.Drawing.Size(56, 24);
-			this.buttonCarsAdd.TabIndex = 2;
-			this.buttonCarsAdd.Text = "Add";
-			this.buttonCarsAdd.UseVisualStyleBackColor = true;
-			// 
-			// buttonCarsUp
-			// 
-			this.buttonCarsUp.Location = new System.Drawing.Point(8, 8);
-			this.buttonCarsUp.Name = "buttonCarsUp";
-			this.buttonCarsUp.Size = new System.Drawing.Size(56, 24);
-			this.buttonCarsUp.TabIndex = 0;
-			this.buttonCarsUp.Text = "Up";
-			this.buttonCarsUp.UseVisualStyleBackColor = true;
-			// 
-			// buttonCarsDown
-			// 
-			this.buttonCarsDown.Location = new System.Drawing.Point(8, 40);
-			this.buttonCarsDown.Name = "buttonCarsDown";
-			this.buttonCarsDown.Size = new System.Drawing.Size(56, 24);
-			this.buttonCarsDown.TabIndex = 1;
-			this.buttonCarsDown.Text = "Down";
-			this.buttonCarsDown.UseVisualStyleBackColor = true;
-			// 
-			// menuStripMenu
-			// 
-			this.menuStripMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemFile,
-            this.toolStripComboBoxLanguage,
-            this.toolStripStatusLabelLanguage});
-			this.menuStripMenu.Location = new System.Drawing.Point(0, 0);
-			this.menuStripMenu.Name = "menuStripMenu";
-			this.menuStripMenu.Size = new System.Drawing.Size(1000, 24);
-			this.menuStripMenu.TabIndex = 8;
-			this.menuStripMenu.Text = "menuStrip1";
-			// 
-			// toolStripMenuItemFile
-			// 
-			this.toolStripMenuItemFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemNew,
-            this.toolStripMenuItemOpen,
-            this.toolStripSeparatorOpen,
-            this.toolStripMenuItemSave,
-            this.toolStripMenuItemSaveAs,
-            this.toolStripSeparatorSave,
-            this.toolStripMenuItemImport,
-            this.toolStripMenuItemExport,
-            this.toolStripSeparatorExport,
-            this.toolStripMenuItemExit});
-			this.toolStripMenuItemFile.Name = "toolStripMenuItemFile";
-			this.toolStripMenuItemFile.Size = new System.Drawing.Size(51, 20);
-			this.toolStripMenuItemFile.Text = "File(&F)";
-			// 
-			// toolStripMenuItemNew
-			// 
-			this.toolStripMenuItemNew.Name = "toolStripMenuItemNew";
-			this.toolStripMenuItemNew.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.toolStripMenuItemNew.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemNew.Text = "New(&N)";
-			// 
-			// toolStripMenuItemOpen
-			// 
-			this.toolStripMenuItemOpen.Name = "toolStripMenuItemOpen";
-			this.toolStripMenuItemOpen.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.toolStripMenuItemOpen.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemOpen.Text = "Open...(&O)";
-			// 
-			// toolStripSeparatorOpen
-			// 
-			this.toolStripSeparatorOpen.Name = "toolStripSeparatorOpen";
-			this.toolStripSeparatorOpen.Size = new System.Drawing.Size(197, 6);
-			// 
-			// toolStripMenuItemSave
-			// 
-			this.toolStripMenuItemSave.Name = "toolStripMenuItemSave";
-			this.toolStripMenuItemSave.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.toolStripMenuItemSave.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemSave.Text = "Save(&S)";
-			// 
-			// toolStripMenuItemSaveAs
-			// 
-			this.toolStripMenuItemSaveAs.Name = "toolStripMenuItemSaveAs";
-			this.toolStripMenuItemSaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.S)));
-			this.toolStripMenuItemSaveAs.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemSaveAs.Text = "Save as...(&A)";
-			// 
-			// toolStripSeparatorSave
-			// 
-			this.toolStripSeparatorSave.Name = "toolStripSeparatorSave";
-			this.toolStripSeparatorSave.Size = new System.Drawing.Size(197, 6);
-			// 
-			// toolStripMenuItemImport
-			// 
-			this.toolStripMenuItemImport.Name = "toolStripMenuItemImport";
-			this.toolStripMenuItemImport.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemImport.Text = "Import...";
-			this.toolStripMenuItemImport.Click += new System.EventHandler(this.ToolStripMenuItemImport_Click);
-			// 
-			// toolStripMenuItemExport
-			// 
-			this.toolStripMenuItemExport.Name = "toolStripMenuItemExport";
-			this.toolStripMenuItemExport.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemExport.Text = "Export...";
-			this.toolStripMenuItemExport.Click += new System.EventHandler(this.ToolStripMenuItemExport_Click);
-			// 
-			// toolStripSeparatorExport
-			// 
-			this.toolStripSeparatorExport.Name = "toolStripSeparatorExport";
-			this.toolStripSeparatorExport.Size = new System.Drawing.Size(197, 6);
-			// 
-			// toolStripMenuItemExit
-			// 
-			this.toolStripMenuItemExit.Name = "toolStripMenuItemExit";
-			this.toolStripMenuItemExit.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.toolStripMenuItemExit.Size = new System.Drawing.Size(200, 22);
-			this.toolStripMenuItemExit.Text = "Exit(&X)";
-			this.toolStripMenuItemExit.Click += new System.EventHandler(this.ToolStripMenuItemExit_Click);
-			// 
-			// toolStripComboBoxLanguage
-			// 
-			this.toolStripComboBoxLanguage.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripComboBoxLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.toolStripComboBoxLanguage.Name = "toolStripComboBoxLanguage";
-			this.toolStripComboBoxLanguage.Size = new System.Drawing.Size(150, 20);
-			this.toolStripComboBoxLanguage.SelectedIndexChanged += new System.EventHandler(this.ToolStripComboBoxLanguage_SelectedIndexChanged);
-			// 
-			// toolStripStatusLabelLanguage
-			// 
-			this.toolStripStatusLabelLanguage.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripStatusLabelLanguage.Name = "toolStripStatusLabelLanguage";
-			this.toolStripStatusLabelLanguage.Size = new System.Drawing.Size(55, 15);
-			this.toolStripStatusLabelLanguage.Text = "Language:";
-			// 
-			// errorProvider
-			// 
-			this.errorProvider.ContainerControl = this;
-			// 
-			// panelStatusNavi
-			// 
-			this.panelStatusNavi.Controls.Add(this.buttonOutputLogs);
-			this.panelStatusNavi.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.panelStatusNavi.Location = new System.Drawing.Point(0, 632);
-			this.panelStatusNavi.Name = "panelStatusNavi";
-			this.panelStatusNavi.Size = new System.Drawing.Size(792, 38);
-			this.panelStatusNavi.TabIndex = 4;
-			// 
-			// buttonOutputLogs
-			// 
-			this.buttonOutputLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonOutputLogs.Location = new System.Drawing.Point(704, 8);
-			this.buttonOutputLogs.Name = "buttonOutputLogs";
-			this.buttonOutputLogs.Size = new System.Drawing.Size(80, 24);
-			this.buttonOutputLogs.TabIndex = 0;
-			this.buttonOutputLogs.Text = "Output logs...";
-			this.buttonOutputLogs.UseVisualStyleBackColor = true;
+			// tabPageCoupler
+			// 
+			this.tabPageCoupler.Controls.Add(this.groupBoxCouplerGeneral);
+			this.tabPageCoupler.Location = new System.Drawing.Point(4, 22);
+			this.tabPageCoupler.Name = "tabPageCoupler";
+			this.tabPageCoupler.Size = new System.Drawing.Size(792, 670);
+			this.tabPageCoupler.TabIndex = 7;
+			this.tabPageCoupler.Text = "Coupler settings";
+			this.tabPageCoupler.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxCouplerGeneral
+			// 
+			this.groupBoxCouplerGeneral.Controls.Add(this.buttonCouplerObject);
+			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerObject);
+			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerObject);
+			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMaxUnit);
+			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerMax);
+			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMax);
+			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMinUnit);
+			this.groupBoxCouplerGeneral.Controls.Add(this.textBoxCouplerMin);
+			this.groupBoxCouplerGeneral.Controls.Add(this.labelCouplerMin);
+			this.groupBoxCouplerGeneral.Location = new System.Drawing.Point(8, 8);
+			this.groupBoxCouplerGeneral.Name = "groupBoxCouplerGeneral";
+			this.groupBoxCouplerGeneral.Size = new System.Drawing.Size(196, 115);
+			this.groupBoxCouplerGeneral.TabIndex = 0;
+			this.groupBoxCouplerGeneral.TabStop = false;
+			this.groupBoxCouplerGeneral.Text = "General";
+			// 
+			// buttonCouplerObject
+			// 
+			this.buttonCouplerObject.Location = new System.Drawing.Point(134, 88);
+			this.buttonCouplerObject.Name = "buttonCouplerObject";
+			this.buttonCouplerObject.Size = new System.Drawing.Size(56, 19);
+			this.buttonCouplerObject.TabIndex = 30;
+			this.buttonCouplerObject.Text = "Open...";
+			this.buttonCouplerObject.UseVisualStyleBackColor = true;
+			this.buttonCouplerObject.Click += new System.EventHandler(this.ButtonCouplerObject_Click);
+			// 
+			// textBoxCouplerObject
+			// 
+			this.textBoxCouplerObject.Location = new System.Drawing.Point(60, 64);
+			this.textBoxCouplerObject.Name = "textBoxCouplerObject";
+			this.textBoxCouplerObject.Size = new System.Drawing.Size(130, 19);
+			this.textBoxCouplerObject.TabIndex = 29;
+			// 
+			// labelCouplerObject
+			// 
+			this.labelCouplerObject.Location = new System.Drawing.Point(8, 64);
+			this.labelCouplerObject.Name = "labelCouplerObject";
+			this.labelCouplerObject.Size = new System.Drawing.Size(46, 16);
+			this.labelCouplerObject.TabIndex = 28;
+			this.labelCouplerObject.Text = "Object:";
+			this.labelCouplerObject.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCouplerMaxUnit
+			// 
+			this.labelCouplerMaxUnit.Location = new System.Drawing.Point(116, 40);
+			this.labelCouplerMaxUnit.Name = "labelCouplerMaxUnit";
+			this.labelCouplerMaxUnit.Size = new System.Drawing.Size(16, 16);
+			this.labelCouplerMaxUnit.TabIndex = 27;
+			this.labelCouplerMaxUnit.Text = "m";
+			this.labelCouplerMaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxCouplerMax
+			// 
+			this.textBoxCouplerMax.Location = new System.Drawing.Point(60, 40);
+			this.textBoxCouplerMax.Name = "textBoxCouplerMax";
+			this.textBoxCouplerMax.Size = new System.Drawing.Size(48, 19);
+			this.textBoxCouplerMax.TabIndex = 26;
+			// 
+			// labelCouplerMax
+			// 
+			this.labelCouplerMax.Location = new System.Drawing.Point(8, 40);
+			this.labelCouplerMax.Name = "labelCouplerMax";
+			this.labelCouplerMax.Size = new System.Drawing.Size(32, 16);
+			this.labelCouplerMax.TabIndex = 25;
+			this.labelCouplerMax.Text = "Max:";
+			this.labelCouplerMax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCouplerMinUnit
+			// 
+			this.labelCouplerMinUnit.Location = new System.Drawing.Point(116, 16);
+			this.labelCouplerMinUnit.Name = "labelCouplerMinUnit";
+			this.labelCouplerMinUnit.Size = new System.Drawing.Size(16, 16);
+			this.labelCouplerMinUnit.TabIndex = 24;
+			this.labelCouplerMinUnit.Text = "m";
+			this.labelCouplerMinUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxCouplerMin
+			// 
+			this.textBoxCouplerMin.Location = new System.Drawing.Point(60, 16);
+			this.textBoxCouplerMin.Name = "textBoxCouplerMin";
+			this.textBoxCouplerMin.Size = new System.Drawing.Size(48, 19);
+			this.textBoxCouplerMin.TabIndex = 23;
+			// 
+			// labelCouplerMin
+			// 
+			this.labelCouplerMin.Location = new System.Drawing.Point(8, 16);
+			this.labelCouplerMin.Name = "labelCouplerMin";
+			this.labelCouplerMin.Size = new System.Drawing.Size(32, 16);
+			this.labelCouplerMin.TabIndex = 22;
+			this.labelCouplerMin.Text = "Min:";
+			this.labelCouplerMin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// tabPageMotor
+			// 
+			this.tabPageMotor.Controls.Add(this.panelMotorSound);
+			this.tabPageMotor.Location = new System.Drawing.Point(4, 22);
+			this.tabPageMotor.Name = "tabPageMotor";
+			this.tabPageMotor.Padding = new System.Windows.Forms.Padding(3);
+			this.tabPageMotor.Size = new System.Drawing.Size(792, 670);
+			this.tabPageMotor.TabIndex = 1;
+			this.tabPageMotor.Text = "Motor sound settings";
+			this.tabPageMotor.UseVisualStyleBackColor = true;
+			// 
+			// panelMotorSound
+			// 
+			this.panelMotorSound.Controls.Add(this.toolStripContainerDrawArea);
+			this.panelMotorSound.Controls.Add(this.panelMotorSetting);
+			this.panelMotorSound.Controls.Add(this.statusStripStatus);
+			this.panelMotorSound.Controls.Add(this.menuStripMotor);
+			this.panelMotorSound.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.panelMotorSound.Location = new System.Drawing.Point(3, 3);
+			this.panelMotorSound.Name = "panelMotorSound";
+			this.panelMotorSound.Size = new System.Drawing.Size(786, 664);
+			this.panelMotorSound.TabIndex = 5;
+			// 
+			// toolStripContainerDrawArea
+			// 
+			// 
+			// toolStripContainerDrawArea.ContentPanel
+			// 
+			this.toolStripContainerDrawArea.ContentPanel.Controls.Add(this.glControlMotor);
+			this.toolStripContainerDrawArea.ContentPanel.Size = new System.Drawing.Size(568, 593);
+			this.toolStripContainerDrawArea.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.toolStripContainerDrawArea.Location = new System.Drawing.Point(0, 24);
+			this.toolStripContainerDrawArea.Name = "toolStripContainerDrawArea";
+			this.toolStripContainerDrawArea.Size = new System.Drawing.Size(568, 618);
+			this.toolStripContainerDrawArea.TabIndex = 4;
+			this.toolStripContainerDrawArea.Text = "toolStripContainer1";
+			// 
+			// toolStripContainerDrawArea.TopToolStripPanel
+			// 
+			this.toolStripContainerDrawArea.TopToolStripPanel.Controls.Add(this.toolStripToolBar);
+			// 
+			// glControlMotor
+			// 
+			this.glControlMotor.BackColor = System.Drawing.Color.Black;
+			this.glControlMotor.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.glControlMotor.Location = new System.Drawing.Point(0, 0);
+			this.glControlMotor.Name = "glControlMotor";
+			this.glControlMotor.Size = new System.Drawing.Size(568, 593);
+			this.glControlMotor.TabIndex = 0;
+			this.glControlMotor.VSync = false;
+			this.glControlMotor.Load += new System.EventHandler(this.GlControlMotor_Load);
+			this.glControlMotor.Paint += new System.Windows.Forms.PaintEventHandler(this.GlControlMotor_Paint);
+			this.glControlMotor.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GlControlMotor_KeyDown);
+			this.glControlMotor.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseDown);
+			this.glControlMotor.MouseEnter += new System.EventHandler(this.GlControlMotor_MouseEnter);
+			this.glControlMotor.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseMove);
+			this.glControlMotor.MouseUp += new System.Windows.Forms.MouseEventHandler(this.GlControlMotor_MouseUp);
+			this.glControlMotor.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.GlControlMotor_PreviewKeyDown);
+			// 
+			// toolStripToolBar
+			// 
+			this.toolStripToolBar.Dock = System.Windows.Forms.DockStyle.None;
+			this.toolStripToolBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripButtonUndo,
+            this.toolStripButtonRedo,
+            this.toolStripSeparatorRedo,
+            this.toolStripButtonTearingOff,
+            this.toolStripButtonCopy,
+            this.toolStripButtonPaste,
+            this.toolStripButtonCleanup,
+            this.toolStripButtonDelete,
+            this.toolStripSeparatorEdit,
+            this.toolStripButtonSelect,
+            this.toolStripButtonMove,
+            this.toolStripButtonDot,
+            this.toolStripButtonLine});
+			this.toolStripToolBar.Location = new System.Drawing.Point(3, 0);
+			this.toolStripToolBar.Name = "toolStripToolBar";
+			this.toolStripToolBar.Size = new System.Drawing.Size(275, 25);
+			this.toolStripToolBar.TabIndex = 0;
+			// 
+			// toolStripButtonUndo
+			// 
+			this.toolStripButtonUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonUndo.Name = "toolStripButtonUndo";
+			this.toolStripButtonUndo.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonUndo.Text = "Undo (Ctrl+Z)";
+			// 
+			// toolStripButtonRedo
+			// 
+			this.toolStripButtonRedo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonRedo.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonRedo.Name = "toolStripButtonRedo";
+			this.toolStripButtonRedo.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonRedo.Text = "Redo (Ctrl+Y)";
+			// 
+			// toolStripSeparatorRedo
+			// 
+			this.toolStripSeparatorRedo.Name = "toolStripSeparatorRedo";
+			this.toolStripSeparatorRedo.Size = new System.Drawing.Size(6, 25);
+			// 
+			// toolStripButtonTearingOff
+			// 
+			this.toolStripButtonTearingOff.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonTearingOff.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonTearingOff.Name = "toolStripButtonTearingOff";
+			this.toolStripButtonTearingOff.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonTearingOff.Text = "Cut (Ctrl+X)";
+			// 
+			// toolStripButtonCopy
+			// 
+			this.toolStripButtonCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonCopy.Name = "toolStripButtonCopy";
+			this.toolStripButtonCopy.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonCopy.Text = "Copy (Ctrl+C)";
+			// 
+			// toolStripButtonPaste
+			// 
+			this.toolStripButtonPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonPaste.Name = "toolStripButtonPaste";
+			this.toolStripButtonPaste.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonPaste.Text = "Paste (Ctrl+V)";
+			// 
+			// toolStripButtonCleanup
+			// 
+			this.toolStripButtonCleanup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonCleanup.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonCleanup.Name = "toolStripButtonCleanup";
+			this.toolStripButtonCleanup.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonCleanup.Text = "Cleanup";
+			// 
+			// toolStripButtonDelete
+			// 
+			this.toolStripButtonDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonDelete.Name = "toolStripButtonDelete";
+			this.toolStripButtonDelete.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonDelete.Text = "Delete (Del)";
+			// 
+			// toolStripSeparatorEdit
+			// 
+			this.toolStripSeparatorEdit.Name = "toolStripSeparatorEdit";
+			this.toolStripSeparatorEdit.Size = new System.Drawing.Size(6, 25);
+			// 
+			// toolStripButtonSelect
+			// 
+			this.toolStripButtonSelect.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonSelect.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonSelect.Name = "toolStripButtonSelect";
+			this.toolStripButtonSelect.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonSelect.Text = "Select (Alt+A)";
+			// 
+			// toolStripButtonMove
+			// 
+			this.toolStripButtonMove.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonMove.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonMove.Name = "toolStripButtonMove";
+			this.toolStripButtonMove.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonMove.Text = "Move (Alt+S)";
+			// 
+			// toolStripButtonDot
+			// 
+			this.toolStripButtonDot.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonDot.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonDot.Name = "toolStripButtonDot";
+			this.toolStripButtonDot.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonDot.Text = "Dot (Alt+D)";
+			// 
+			// toolStripButtonLine
+			// 
+			this.toolStripButtonLine.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonLine.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonLine.Name = "toolStripButtonLine";
+			this.toolStripButtonLine.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonLine.Text = "Line (Alt+F)";
+			// 
+			// panelMotorSetting
+			// 
+			this.panelMotorSetting.Controls.Add(this.groupBoxDirect);
+			this.panelMotorSetting.Controls.Add(this.groupBoxPlay);
+			this.panelMotorSetting.Controls.Add(this.groupBoxView);
+			this.panelMotorSetting.Dock = System.Windows.Forms.DockStyle.Right;
+			this.panelMotorSetting.Location = new System.Drawing.Point(568, 24);
+			this.panelMotorSetting.Name = "panelMotorSetting";
+			this.panelMotorSetting.Size = new System.Drawing.Size(218, 618);
+			this.panelMotorSetting.TabIndex = 3;
+			// 
+			// groupBoxDirect
+			// 
+			this.groupBoxDirect.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBoxDirect.Controls.Add(this.buttonDirectDot);
+			this.groupBoxDirect.Controls.Add(this.buttonDirectMove);
+			this.groupBoxDirect.Controls.Add(this.textBoxDirectY);
+			this.groupBoxDirect.Controls.Add(this.labelDirectY);
+			this.groupBoxDirect.Controls.Add(this.labelDirectXUnit);
+			this.groupBoxDirect.Controls.Add(this.textBoxDirectX);
+			this.groupBoxDirect.Controls.Add(this.labelDirectX);
+			this.groupBoxDirect.Location = new System.Drawing.Point(8, 254);
+			this.groupBoxDirect.Name = "groupBoxDirect";
+			this.groupBoxDirect.Size = new System.Drawing.Size(200, 96);
+			this.groupBoxDirect.TabIndex = 2;
+			this.groupBoxDirect.TabStop = false;
+			this.groupBoxDirect.Text = "Direct input";
+			// 
+			// buttonDirectDot
+			// 
+			this.buttonDirectDot.Location = new System.Drawing.Point(8, 64);
+			this.buttonDirectDot.Name = "buttonDirectDot";
+			this.buttonDirectDot.Size = new System.Drawing.Size(56, 24);
+			this.buttonDirectDot.TabIndex = 22;
+			this.buttonDirectDot.UseVisualStyleBackColor = true;
+			// 
+			// buttonDirectMove
+			// 
+			this.buttonDirectMove.Location = new System.Drawing.Point(72, 64);
+			this.buttonDirectMove.Name = "buttonDirectMove";
+			this.buttonDirectMove.Size = new System.Drawing.Size(56, 24);
+			this.buttonDirectMove.TabIndex = 21;
+			this.buttonDirectMove.UseVisualStyleBackColor = true;
+			// 
+			// textBoxDirectY
+			// 
+			this.textBoxDirectY.Location = new System.Drawing.Point(112, 40);
+			this.textBoxDirectY.Name = "textBoxDirectY";
+			this.textBoxDirectY.Size = new System.Drawing.Size(40, 19);
+			this.textBoxDirectY.TabIndex = 19;
+			// 
+			// labelDirectY
+			// 
+			this.labelDirectY.Location = new System.Drawing.Point(8, 40);
+			this.labelDirectY.Name = "labelDirectY";
+			this.labelDirectY.Size = new System.Drawing.Size(96, 16);
+			this.labelDirectY.TabIndex = 18;
+			this.labelDirectY.Text = "y coordinate:";
+			this.labelDirectY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDirectXUnit
+			// 
+			this.labelDirectXUnit.Location = new System.Drawing.Point(160, 16);
+			this.labelDirectXUnit.Name = "labelDirectXUnit";
+			this.labelDirectXUnit.Size = new System.Drawing.Size(32, 16);
+			this.labelDirectXUnit.TabIndex = 17;
+			this.labelDirectXUnit.Text = "km/h";
+			this.labelDirectXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxDirectX
+			// 
+			this.textBoxDirectX.Location = new System.Drawing.Point(112, 16);
+			this.textBoxDirectX.Name = "textBoxDirectX";
+			this.textBoxDirectX.Size = new System.Drawing.Size(40, 19);
+			this.textBoxDirectX.TabIndex = 16;
+			// 
+			// labelDirectX
+			// 
+			this.labelDirectX.Location = new System.Drawing.Point(8, 16);
+			this.labelDirectX.Name = "labelDirectX";
+			this.labelDirectX.Size = new System.Drawing.Size(96, 16);
+			this.labelDirectX.TabIndex = 15;
+			this.labelDirectX.Text = "x coordinate:";
+			this.labelDirectX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxPlay
+			// 
+			this.groupBoxPlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBoxPlay.Controls.Add(this.buttonStop);
+			this.groupBoxPlay.Controls.Add(this.buttonPause);
+			this.groupBoxPlay.Controls.Add(this.buttonPlay);
+			this.groupBoxPlay.Controls.Add(this.groupBoxArea);
+			this.groupBoxPlay.Controls.Add(this.groupBoxSource);
+			this.groupBoxPlay.Location = new System.Drawing.Point(8, 359);
+			this.groupBoxPlay.Name = "groupBoxPlay";
+			this.groupBoxPlay.Size = new System.Drawing.Size(200, 248);
+			this.groupBoxPlay.TabIndex = 1;
+			this.groupBoxPlay.TabStop = false;
+			this.groupBoxPlay.Text = "Playback setting";
+			// 
+			// buttonStop
+			// 
+			this.buttonStop.Location = new System.Drawing.Point(136, 216);
+			this.buttonStop.Name = "buttonStop";
+			this.buttonStop.Size = new System.Drawing.Size(56, 24);
+			this.buttonStop.TabIndex = 4;
+			this.buttonStop.UseVisualStyleBackColor = true;
+			// 
+			// buttonPause
+			// 
+			this.buttonPause.Location = new System.Drawing.Point(72, 216);
+			this.buttonPause.Name = "buttonPause";
+			this.buttonPause.Size = new System.Drawing.Size(56, 24);
+			this.buttonPause.TabIndex = 3;
+			this.buttonPause.UseVisualStyleBackColor = true;
+			// 
+			// buttonPlay
+			// 
+			this.buttonPlay.Location = new System.Drawing.Point(8, 216);
+			this.buttonPlay.Name = "buttonPlay";
+			this.buttonPlay.Size = new System.Drawing.Size(56, 24);
+			this.buttonPlay.TabIndex = 2;
+			this.buttonPlay.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxArea
+			// 
+			this.groupBoxArea.Controls.Add(this.checkBoxMotorConstant);
+			this.groupBoxArea.Controls.Add(this.checkBoxMotorLoop);
+			this.groupBoxArea.Controls.Add(this.buttonMotorSwap);
+			this.groupBoxArea.Controls.Add(this.textBoxMotorAreaLeft);
+			this.groupBoxArea.Controls.Add(this.labelMotorAreaUnit);
+			this.groupBoxArea.Controls.Add(this.textBoxMotorAreaRight);
+			this.groupBoxArea.Controls.Add(this.labelMotorAccel);
+			this.groupBoxArea.Controls.Add(this.labelMotorAccelUnit);
+			this.groupBoxArea.Controls.Add(this.textBoxMotorAccel);
+			this.groupBoxArea.Location = new System.Drawing.Point(8, 88);
+			this.groupBoxArea.Name = "groupBoxArea";
+			this.groupBoxArea.Size = new System.Drawing.Size(184, 120);
+			this.groupBoxArea.TabIndex = 1;
+			this.groupBoxArea.TabStop = false;
+			this.groupBoxArea.Text = "Area setting";
+			// 
+			// checkBoxMotorConstant
+			// 
+			this.checkBoxMotorConstant.AutoSize = true;
+			this.checkBoxMotorConstant.Location = new System.Drawing.Point(8, 40);
+			this.checkBoxMotorConstant.Name = "checkBoxMotorConstant";
+			this.checkBoxMotorConstant.Size = new System.Drawing.Size(104, 16);
+			this.checkBoxMotorConstant.TabIndex = 19;
+			this.checkBoxMotorConstant.Text = "Constant speed";
+			this.checkBoxMotorConstant.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxMotorLoop
+			// 
+			this.checkBoxMotorLoop.AutoSize = true;
+			this.checkBoxMotorLoop.Location = new System.Drawing.Point(8, 16);
+			this.checkBoxMotorLoop.Name = "checkBoxMotorLoop";
+			this.checkBoxMotorLoop.Size = new System.Drawing.Size(97, 16);
+			this.checkBoxMotorLoop.TabIndex = 18;
+			this.checkBoxMotorLoop.Text = "Loop playback";
+			this.checkBoxMotorLoop.UseVisualStyleBackColor = true;
+			// 
+			// buttonMotorSwap
+			// 
+			this.buttonMotorSwap.Location = new System.Drawing.Point(56, 88);
+			this.buttonMotorSwap.Name = "buttonMotorSwap";
+			this.buttonMotorSwap.Size = new System.Drawing.Size(32, 19);
+			this.buttonMotorSwap.TabIndex = 17;
+			this.buttonMotorSwap.UseVisualStyleBackColor = true;
+			// 
+			// textBoxMotorAreaLeft
+			// 
+			this.textBoxMotorAreaLeft.Location = new System.Drawing.Point(8, 88);
+			this.textBoxMotorAreaLeft.Name = "textBoxMotorAreaLeft";
+			this.textBoxMotorAreaLeft.Size = new System.Drawing.Size(40, 19);
+			this.textBoxMotorAreaLeft.TabIndex = 16;
+			// 
+			// labelMotorAreaUnit
+			// 
+			this.labelMotorAreaUnit.Location = new System.Drawing.Point(144, 88);
+			this.labelMotorAreaUnit.Name = "labelMotorAreaUnit";
+			this.labelMotorAreaUnit.Size = new System.Drawing.Size(32, 16);
+			this.labelMotorAreaUnit.TabIndex = 15;
+			this.labelMotorAreaUnit.Text = "km/h";
+			this.labelMotorAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxMotorAreaRight
+			// 
+			this.textBoxMotorAreaRight.Location = new System.Drawing.Point(96, 88);
+			this.textBoxMotorAreaRight.Name = "textBoxMotorAreaRight";
+			this.textBoxMotorAreaRight.Size = new System.Drawing.Size(40, 19);
+			this.textBoxMotorAreaRight.TabIndex = 3;
+			// 
+			// labelMotorAccel
+			// 
+			this.labelMotorAccel.Location = new System.Drawing.Point(8, 64);
+			this.labelMotorAccel.Name = "labelMotorAccel";
+			this.labelMotorAccel.Size = new System.Drawing.Size(72, 16);
+			this.labelMotorAccel.TabIndex = 2;
+			this.labelMotorAccel.Text = "Acceleration:";
+			this.labelMotorAccel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelMotorAccelUnit
+			// 
+			this.labelMotorAccelUnit.Location = new System.Drawing.Point(128, 64);
+			this.labelMotorAccelUnit.Name = "labelMotorAccelUnit";
+			this.labelMotorAccelUnit.Size = new System.Drawing.Size(44, 16);
+			this.labelMotorAccelUnit.TabIndex = 1;
+			this.labelMotorAccelUnit.Text = "km/h/s";
+			this.labelMotorAccelUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxMotorAccel
+			// 
+			this.textBoxMotorAccel.Location = new System.Drawing.Point(88, 64);
+			this.textBoxMotorAccel.Name = "textBoxMotorAccel";
+			this.textBoxMotorAccel.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorAccel.TabIndex = 0;
+			// 
+			// groupBoxSource
+			// 
+			this.groupBoxSource.Controls.Add(this.numericUpDownRunIndex);
+			this.groupBoxSource.Controls.Add(this.labelRun);
+			this.groupBoxSource.Controls.Add(this.checkBoxTrack2);
+			this.groupBoxSource.Controls.Add(this.checkBoxTrack1);
+			this.groupBoxSource.Location = new System.Drawing.Point(8, 16);
+			this.groupBoxSource.Name = "groupBoxSource";
+			this.groupBoxSource.Size = new System.Drawing.Size(184, 64);
+			this.groupBoxSource.TabIndex = 0;
+			this.groupBoxSource.TabStop = false;
+			this.groupBoxSource.Text = "Sound source setting";
+			// 
+			// numericUpDownRunIndex
+			// 
+			this.numericUpDownRunIndex.Location = new System.Drawing.Point(112, 16);
+			this.numericUpDownRunIndex.Maximum = new decimal(new int[] {
+            256,
+            0,
+            0,
+            0});
+			this.numericUpDownRunIndex.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+			this.numericUpDownRunIndex.Name = "numericUpDownRunIndex";
+			this.numericUpDownRunIndex.Size = new System.Drawing.Size(48, 19);
+			this.numericUpDownRunIndex.TabIndex = 16;
+			this.numericUpDownRunIndex.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+			// 
+			// labelRun
+			// 
+			this.labelRun.Location = new System.Drawing.Point(8, 16);
+			this.labelRun.Name = "labelRun";
+			this.labelRun.Size = new System.Drawing.Size(96, 16);
+			this.labelRun.TabIndex = 4;
+			this.labelRun.Text = "Running sound:";
+			this.labelRun.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// checkBoxTrack2
+			// 
+			this.checkBoxTrack2.AutoSize = true;
+			this.checkBoxTrack2.Location = new System.Drawing.Point(96, 40);
+			this.checkBoxTrack2.Name = "checkBoxTrack2";
+			this.checkBoxTrack2.Size = new System.Drawing.Size(59, 16);
+			this.checkBoxTrack2.TabIndex = 2;
+			this.checkBoxTrack2.Text = "Track2";
+			this.checkBoxTrack2.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxTrack1
+			// 
+			this.checkBoxTrack1.AutoSize = true;
+			this.checkBoxTrack1.Location = new System.Drawing.Point(8, 40);
+			this.checkBoxTrack1.Name = "checkBoxTrack1";
+			this.checkBoxTrack1.Size = new System.Drawing.Size(59, 16);
+			this.checkBoxTrack1.TabIndex = 1;
+			this.checkBoxTrack1.Text = "Track1";
+			this.checkBoxTrack1.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxView
+			// 
+			this.groupBoxView.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBoxView.Controls.Add(this.buttonMotorReset);
+			this.groupBoxView.Controls.Add(this.buttonMotorZoomOut);
+			this.groupBoxView.Controls.Add(this.buttonMotorZoomIn);
+			this.groupBoxView.Controls.Add(this.labelMotorMaxVolume);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMaxVolume);
+			this.groupBoxView.Controls.Add(this.labelMotorMinVolume);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMinVolume);
+			this.groupBoxView.Controls.Add(this.labelMotorMaxPitch);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMaxPitch);
+			this.groupBoxView.Controls.Add(this.labelMotorMinPitch);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMinPitch);
+			this.groupBoxView.Controls.Add(this.labelMotorMaxVelocityUnit);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMaxVelocity);
+			this.groupBoxView.Controls.Add(this.labelMotorMaxVelocity);
+			this.groupBoxView.Controls.Add(this.labelMotorMinVelocityUnit);
+			this.groupBoxView.Controls.Add(this.textBoxMotorMinVelocity);
+			this.groupBoxView.Controls.Add(this.labelMotorMinVelocity);
+			this.groupBoxView.Location = new System.Drawing.Point(8, 54);
+			this.groupBoxView.Name = "groupBoxView";
+			this.groupBoxView.Size = new System.Drawing.Size(200, 192);
+			this.groupBoxView.TabIndex = 0;
+			this.groupBoxView.TabStop = false;
+			this.groupBoxView.Text = "View setting";
+			// 
+			// buttonMotorReset
+			// 
+			this.buttonMotorReset.Location = new System.Drawing.Point(136, 160);
+			this.buttonMotorReset.Name = "buttonMotorReset";
+			this.buttonMotorReset.Size = new System.Drawing.Size(56, 24);
+			this.buttonMotorReset.TabIndex = 25;
+			this.buttonMotorReset.UseVisualStyleBackColor = true;
+			// 
+			// buttonMotorZoomOut
+			// 
+			this.buttonMotorZoomOut.Location = new System.Drawing.Point(72, 160);
+			this.buttonMotorZoomOut.Name = "buttonMotorZoomOut";
+			this.buttonMotorZoomOut.Size = new System.Drawing.Size(56, 24);
+			this.buttonMotorZoomOut.TabIndex = 24;
+			this.buttonMotorZoomOut.UseVisualStyleBackColor = true;
+			// 
+			// buttonMotorZoomIn
+			// 
+			this.buttonMotorZoomIn.Location = new System.Drawing.Point(8, 160);
+			this.buttonMotorZoomIn.Name = "buttonMotorZoomIn";
+			this.buttonMotorZoomIn.Size = new System.Drawing.Size(56, 24);
+			this.buttonMotorZoomIn.TabIndex = 23;
+			this.buttonMotorZoomIn.UseVisualStyleBackColor = true;
+			// 
+			// labelMotorMaxVolume
+			// 
+			this.labelMotorMaxVolume.Location = new System.Drawing.Point(8, 136);
+			this.labelMotorMaxVolume.Name = "labelMotorMaxVolume";
+			this.labelMotorMaxVolume.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMaxVolume.TabIndex = 14;
+			this.labelMotorMaxVolume.Text = "y-max(Volume):";
+			this.labelMotorMaxVolume.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// textBoxMotorMaxVolume
+			// 
+			this.textBoxMotorMaxVolume.Location = new System.Drawing.Point(120, 136);
+			this.textBoxMotorMaxVolume.Name = "textBoxMotorMaxVolume";
+			this.textBoxMotorMaxVolume.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMaxVolume.TabIndex = 13;
+			// 
+			// labelMotorMinVolume
+			// 
+			this.labelMotorMinVolume.Location = new System.Drawing.Point(8, 112);
+			this.labelMotorMinVolume.Name = "labelMotorMinVolume";
+			this.labelMotorMinVolume.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMinVolume.TabIndex = 12;
+			this.labelMotorMinVolume.Text = "y-min(Volume):";
+			this.labelMotorMinVolume.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// textBoxMotorMinVolume
+			// 
+			this.textBoxMotorMinVolume.Location = new System.Drawing.Point(120, 112);
+			this.textBoxMotorMinVolume.Name = "textBoxMotorMinVolume";
+			this.textBoxMotorMinVolume.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMinVolume.TabIndex = 11;
+			// 
+			// labelMotorMaxPitch
+			// 
+			this.labelMotorMaxPitch.Location = new System.Drawing.Point(8, 88);
+			this.labelMotorMaxPitch.Name = "labelMotorMaxPitch";
+			this.labelMotorMaxPitch.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMaxPitch.TabIndex = 10;
+			this.labelMotorMaxPitch.Text = "y-max(Pitch):";
+			this.labelMotorMaxPitch.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// textBoxMotorMaxPitch
+			// 
+			this.textBoxMotorMaxPitch.Location = new System.Drawing.Point(120, 88);
+			this.textBoxMotorMaxPitch.Name = "textBoxMotorMaxPitch";
+			this.textBoxMotorMaxPitch.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMaxPitch.TabIndex = 9;
+			// 
+			// labelMotorMinPitch
+			// 
+			this.labelMotorMinPitch.Location = new System.Drawing.Point(8, 64);
+			this.labelMotorMinPitch.Name = "labelMotorMinPitch";
+			this.labelMotorMinPitch.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMinPitch.TabIndex = 8;
+			this.labelMotorMinPitch.Text = "y-min(Pitch):";
+			this.labelMotorMinPitch.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// textBoxMotorMinPitch
+			// 
+			this.textBoxMotorMinPitch.Location = new System.Drawing.Point(120, 64);
+			this.textBoxMotorMinPitch.Name = "textBoxMotorMinPitch";
+			this.textBoxMotorMinPitch.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMinPitch.TabIndex = 7;
+			// 
+			// labelMotorMaxVelocityUnit
+			// 
+			this.labelMotorMaxVelocityUnit.Location = new System.Drawing.Point(160, 40);
+			this.labelMotorMaxVelocityUnit.Name = "labelMotorMaxVelocityUnit";
+			this.labelMotorMaxVelocityUnit.Size = new System.Drawing.Size(32, 16);
+			this.labelMotorMaxVelocityUnit.TabIndex = 5;
+			this.labelMotorMaxVelocityUnit.Text = "km/h";
+			this.labelMotorMaxVelocityUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxMotorMaxVelocity
+			// 
+			this.textBoxMotorMaxVelocity.Location = new System.Drawing.Point(120, 40);
+			this.textBoxMotorMaxVelocity.Name = "textBoxMotorMaxVelocity";
+			this.textBoxMotorMaxVelocity.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMaxVelocity.TabIndex = 4;
+			// 
+			// labelMotorMaxVelocity
+			// 
+			this.labelMotorMaxVelocity.Location = new System.Drawing.Point(8, 40);
+			this.labelMotorMaxVelocity.Name = "labelMotorMaxVelocity";
+			this.labelMotorMaxVelocity.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMaxVelocity.TabIndex = 3;
+			this.labelMotorMaxVelocity.Text = "x-max(Velocity):";
+			this.labelMotorMaxVelocity.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelMotorMinVelocityUnit
+			// 
+			this.labelMotorMinVelocityUnit.Location = new System.Drawing.Point(160, 16);
+			this.labelMotorMinVelocityUnit.Name = "labelMotorMinVelocityUnit";
+			this.labelMotorMinVelocityUnit.Size = new System.Drawing.Size(32, 16);
+			this.labelMotorMinVelocityUnit.TabIndex = 2;
+			this.labelMotorMinVelocityUnit.Text = "km/h";
+			this.labelMotorMinVelocityUnit.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// textBoxMotorMinVelocity
+			// 
+			this.textBoxMotorMinVelocity.Location = new System.Drawing.Point(120, 16);
+			this.textBoxMotorMinVelocity.Name = "textBoxMotorMinVelocity";
+			this.textBoxMotorMinVelocity.Size = new System.Drawing.Size(32, 19);
+			this.textBoxMotorMinVelocity.TabIndex = 1;
+			// 
+			// labelMotorMinVelocity
+			// 
+			this.labelMotorMinVelocity.Location = new System.Drawing.Point(8, 16);
+			this.labelMotorMinVelocity.Name = "labelMotorMinVelocity";
+			this.labelMotorMinVelocity.Size = new System.Drawing.Size(104, 16);
+			this.labelMotorMinVelocity.TabIndex = 0;
+			this.labelMotorMinVelocity.Text = "x-min(Velocity):";
+			this.labelMotorMinVelocity.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// statusStripStatus
+			// 
+			this.statusStripStatus.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabelY,
+            this.toolStripStatusLabelX,
+            this.toolStripStatusLabelTool,
+            this.toolStripStatusLabelMode,
+            this.toolStripStatusLabelTrack,
+            this.toolStripStatusLabelType});
+			this.statusStripStatus.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+			this.statusStripStatus.Location = new System.Drawing.Point(0, 642);
+			this.statusStripStatus.Name = "statusStripStatus";
+			this.statusStripStatus.Size = new System.Drawing.Size(786, 22);
+			this.statusStripStatus.TabIndex = 1;
+			this.statusStripStatus.Text = "statusStrip1";
+			// 
+			// toolStripStatusLabelY
+			// 
+			this.toolStripStatusLabelY.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelY.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelY.Name = "toolStripStatusLabelY";
+			this.toolStripStatusLabelY.Size = new System.Drawing.Size(16, 17);
+			this.toolStripStatusLabelY.Text = "Y";
+			// 
+			// toolStripStatusLabelX
+			// 
+			this.toolStripStatusLabelX.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelX.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelX.Name = "toolStripStatusLabelX";
+			this.toolStripStatusLabelX.Size = new System.Drawing.Size(16, 17);
+			this.toolStripStatusLabelX.Text = "X";
+			// 
+			// toolStripStatusLabelTool
+			// 
+			this.toolStripStatusLabelTool.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelTool.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelTool.Name = "toolStripStatusLabelTool";
+			this.toolStripStatusLabelTool.Size = new System.Drawing.Size(31, 17);
+			this.toolStripStatusLabelTool.Text = "Tool";
+			// 
+			// toolStripStatusLabelMode
+			// 
+			this.toolStripStatusLabelMode.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelMode.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelMode.Name = "toolStripStatusLabelMode";
+			this.toolStripStatusLabelMode.Size = new System.Drawing.Size(36, 17);
+			this.toolStripStatusLabelMode.Text = "Mode";
+			// 
+			// toolStripStatusLabelTrack
+			// 
+			this.toolStripStatusLabelTrack.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelTrack.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelTrack.Name = "toolStripStatusLabelTrack";
+			this.toolStripStatusLabelTrack.Size = new System.Drawing.Size(38, 17);
+			this.toolStripStatusLabelTrack.Text = "Track";
+			// 
+			// toolStripStatusLabelType
+			// 
+			this.toolStripStatusLabelType.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripStatusLabelType.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+			this.toolStripStatusLabelType.Name = "toolStripStatusLabelType";
+			this.toolStripStatusLabelType.Size = new System.Drawing.Size(34, 17);
+			this.toolStripStatusLabelType.Text = "Type";
+			// 
+			// menuStripMotor
+			// 
+			this.menuStripMotor.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemEdit,
+            this.toolStripMenuItemView,
+            this.toolStripMenuItemInput,
+            this.toolStripMenuItemTool});
+			this.menuStripMotor.Location = new System.Drawing.Point(0, 0);
+			this.menuStripMotor.Name = "menuStripMotor";
+			this.menuStripMotor.Size = new System.Drawing.Size(786, 24);
+			this.menuStripMotor.TabIndex = 0;
+			this.menuStripMotor.Text = "menuStrip1";
+			// 
+			// toolStripMenuItemEdit
+			// 
+			this.toolStripMenuItemEdit.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemUndo,
+            this.toolStripMenuItemRedo,
+            this.toolStripSeparatorUndo,
+            this.toolStripMenuItemTearingOff,
+            this.toolStripMenuItemCopy,
+            this.toolStripMenuItemPaste,
+            this.toolStripMenuItemCleanup,
+            this.toolStripMenuItemDelete});
+			this.toolStripMenuItemEdit.Name = "toolStripMenuItemEdit";
+			this.toolStripMenuItemEdit.Size = new System.Drawing.Size(52, 20);
+			this.toolStripMenuItemEdit.Text = "Edit(&E)";
+			// 
+			// toolStripMenuItemUndo
+			// 
+			this.toolStripMenuItemUndo.Name = "toolStripMenuItemUndo";
+			this.toolStripMenuItemUndo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
+			this.toolStripMenuItemUndo.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemUndo.Text = "Undo(&U)";
+			// 
+			// toolStripMenuItemRedo
+			// 
+			this.toolStripMenuItemRedo.Name = "toolStripMenuItemRedo";
+			this.toolStripMenuItemRedo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
+			this.toolStripMenuItemRedo.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemRedo.Text = "Redo(&R)";
+			// 
+			// toolStripSeparatorUndo
+			// 
+			this.toolStripSeparatorUndo.Name = "toolStripSeparatorUndo";
+			this.toolStripSeparatorUndo.Size = new System.Drawing.Size(149, 6);
+			// 
+			// toolStripMenuItemTearingOff
+			// 
+			this.toolStripMenuItemTearingOff.Name = "toolStripMenuItemTearingOff";
+			this.toolStripMenuItemTearingOff.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+			this.toolStripMenuItemTearingOff.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemTearingOff.Text = "Cut(&T)";
+			// 
+			// toolStripMenuItemCopy
+			// 
+			this.toolStripMenuItemCopy.Name = "toolStripMenuItemCopy";
+			this.toolStripMenuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+			this.toolStripMenuItemCopy.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemCopy.Text = "Copy(&C)";
+			// 
+			// toolStripMenuItemPaste
+			// 
+			this.toolStripMenuItemPaste.Name = "toolStripMenuItemPaste";
+			this.toolStripMenuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+			this.toolStripMenuItemPaste.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemPaste.Text = "Paste(&P)";
+			// 
+			// toolStripMenuItemCleanup
+			// 
+			this.toolStripMenuItemCleanup.Name = "toolStripMenuItemCleanup";
+			this.toolStripMenuItemCleanup.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemCleanup.Text = "Cleanup";
+			// 
+			// toolStripMenuItemDelete
+			// 
+			this.toolStripMenuItemDelete.Name = "toolStripMenuItemDelete";
+			this.toolStripMenuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+			this.toolStripMenuItemDelete.Size = new System.Drawing.Size(152, 22);
+			this.toolStripMenuItemDelete.Text = "Delete(&D)";
+			// 
+			// toolStripMenuItemView
+			// 
+			this.toolStripMenuItemView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemPower,
+            this.toolStripMenuItemBrake});
+			this.toolStripMenuItemView.Name = "toolStripMenuItemView";
+			this.toolStripMenuItemView.Size = new System.Drawing.Size(58, 20);
+			this.toolStripMenuItemView.Text = "View(&V)";
+			// 
+			// toolStripMenuItemPower
+			// 
+			this.toolStripMenuItemPower.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemPowerTrack1,
+            this.toolStripMenuItemPowerTrack2});
+			this.toolStripMenuItemPower.Name = "toolStripMenuItemPower";
+			this.toolStripMenuItemPower.Size = new System.Drawing.Size(116, 22);
+			this.toolStripMenuItemPower.Text = "Power(&P)";
+			// 
+			// toolStripMenuItemPowerTrack1
+			// 
+			this.toolStripMenuItemPowerTrack1.Name = "toolStripMenuItemPowerTrack1";
+			this.toolStripMenuItemPowerTrack1.Size = new System.Drawing.Size(119, 22);
+			this.toolStripMenuItemPowerTrack1.Text = "Track1(&1)";
+			// 
+			// toolStripMenuItemPowerTrack2
+			// 
+			this.toolStripMenuItemPowerTrack2.Name = "toolStripMenuItemPowerTrack2";
+			this.toolStripMenuItemPowerTrack2.Size = new System.Drawing.Size(119, 22);
+			this.toolStripMenuItemPowerTrack2.Text = "Track2(&2)";
+			// 
+			// toolStripMenuItemBrake
+			// 
+			this.toolStripMenuItemBrake.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemBrakeTrack1,
+            this.toolStripMenuItemBrakeTrack2});
+			this.toolStripMenuItemBrake.Name = "toolStripMenuItemBrake";
+			this.toolStripMenuItemBrake.Size = new System.Drawing.Size(116, 22);
+			this.toolStripMenuItemBrake.Text = "Brake(&B)";
+			// 
+			// toolStripMenuItemBrakeTrack1
+			// 
+			this.toolStripMenuItemBrakeTrack1.Name = "toolStripMenuItemBrakeTrack1";
+			this.toolStripMenuItemBrakeTrack1.Size = new System.Drawing.Size(119, 22);
+			this.toolStripMenuItemBrakeTrack1.Text = "Track1(&1)";
+			// 
+			// toolStripMenuItemBrakeTrack2
+			// 
+			this.toolStripMenuItemBrakeTrack2.Name = "toolStripMenuItemBrakeTrack2";
+			this.toolStripMenuItemBrakeTrack2.Size = new System.Drawing.Size(119, 22);
+			this.toolStripMenuItemBrakeTrack2.Text = "Track2(&2)";
+			// 
+			// toolStripMenuItemInput
+			// 
+			this.toolStripMenuItemInput.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemPitch,
+            this.toolStripMenuItemVolume,
+            this.toolStripMenuItemIndex});
+			this.toolStripMenuItemInput.Name = "toolStripMenuItemInput";
+			this.toolStripMenuItemInput.Size = new System.Drawing.Size(53, 20);
+			this.toolStripMenuItemInput.Text = "Input(I)";
+			// 
+			// toolStripMenuItemPitch
+			// 
+			this.toolStripMenuItemPitch.Name = "toolStripMenuItemPitch";
+			this.toolStripMenuItemPitch.Size = new System.Drawing.Size(181, 22);
+			this.toolStripMenuItemPitch.Text = "Pitch(&P)";
+			// 
+			// toolStripMenuItemVolume
+			// 
+			this.toolStripMenuItemVolume.Name = "toolStripMenuItemVolume";
+			this.toolStripMenuItemVolume.Size = new System.Drawing.Size(181, 22);
+			this.toolStripMenuItemVolume.Text = "Volume(&V)";
+			// 
+			// toolStripMenuItemIndex
+			// 
+			this.toolStripMenuItemIndex.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripComboBoxIndex});
+			this.toolStripMenuItemIndex.Name = "toolStripMenuItemIndex";
+			this.toolStripMenuItemIndex.Size = new System.Drawing.Size(181, 22);
+			this.toolStripMenuItemIndex.Text = "Sound source index(&I)";
+			// 
+			// toolStripComboBoxIndex
+			// 
+			this.toolStripComboBoxIndex.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.toolStripComboBoxIndex.Items.AddRange(new object[] {
+            "None",
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15"});
+			this.toolStripComboBoxIndex.Name = "toolStripComboBoxIndex";
+			this.toolStripComboBoxIndex.Size = new System.Drawing.Size(121, 20);
+			// 
+			// toolStripMenuItemTool
+			// 
+			this.toolStripMenuItemTool.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemSelect,
+            this.toolStripMenuItemMove,
+            this.toolStripMenuItemDot,
+            this.toolStripMenuItemLine});
+			this.toolStripMenuItemTool.Name = "toolStripMenuItemTool";
+			this.toolStripMenuItemTool.Size = new System.Drawing.Size(54, 20);
+			this.toolStripMenuItemTool.Text = "Tool(&T)";
+			// 
+			// toolStripMenuItemSelect
+			// 
+			this.toolStripMenuItemSelect.Name = "toolStripMenuItemSelect";
+			this.toolStripMenuItemSelect.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.A)));
+			this.toolStripMenuItemSelect.Size = new System.Drawing.Size(151, 22);
+			this.toolStripMenuItemSelect.Text = "Select(&S)";
+			// 
+			// toolStripMenuItemMove
+			// 
+			this.toolStripMenuItemMove.Name = "toolStripMenuItemMove";
+			this.toolStripMenuItemMove.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S)));
+			this.toolStripMenuItemMove.Size = new System.Drawing.Size(151, 22);
+			this.toolStripMenuItemMove.Text = "Move(&M)";
+			// 
+			// toolStripMenuItemDot
+			// 
+			this.toolStripMenuItemDot.Name = "toolStripMenuItemDot";
+			this.toolStripMenuItemDot.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D)));
+			this.toolStripMenuItemDot.Size = new System.Drawing.Size(151, 22);
+			this.toolStripMenuItemDot.Text = "Dot(&D)";
+			// 
+			// toolStripMenuItemLine
+			// 
+			this.toolStripMenuItemLine.Name = "toolStripMenuItemLine";
+			this.toolStripMenuItemLine.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F)));
+			this.toolStripMenuItemLine.Size = new System.Drawing.Size(151, 22);
+			this.toolStripMenuItemLine.Text = "Line(&L)";
+			// 
+			// tabPageAccel
+			// 
+			this.tabPageAccel.Controls.Add(this.pictureBoxAccel);
+			this.tabPageAccel.Controls.Add(this.panelAccel);
+			this.tabPageAccel.Location = new System.Drawing.Point(4, 22);
+			this.tabPageAccel.Name = "tabPageAccel";
+			this.tabPageAccel.Size = new System.Drawing.Size(792, 670);
+			this.tabPageAccel.TabIndex = 5;
+			this.tabPageAccel.Text = "Acceleration settings";
+			this.tabPageAccel.UseVisualStyleBackColor = true;
+			// 
+			// pictureBoxAccel
+			// 
+			this.pictureBoxAccel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.pictureBoxAccel.Location = new System.Drawing.Point(0, 0);
+			this.pictureBoxAccel.Name = "pictureBoxAccel";
+			this.pictureBoxAccel.Size = new System.Drawing.Size(576, 670);
+			this.pictureBoxAccel.TabIndex = 1;
+			this.pictureBoxAccel.TabStop = false;
+			this.pictureBoxAccel.MouseEnter += new System.EventHandler(this.PictureBoxAccel_MouseEnter);
+			this.pictureBoxAccel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PictureBoxAccel_MouseMove);
+			// 
+			// panelAccel
+			// 
+			this.panelAccel.Controls.Add(this.groupBoxPreview);
+			this.panelAccel.Controls.Add(this.groupBoxParameter);
+			this.panelAccel.Controls.Add(this.groupBoxNotch);
+			this.panelAccel.Dock = System.Windows.Forms.DockStyle.Right;
+			this.panelAccel.Location = new System.Drawing.Point(576, 0);
+			this.panelAccel.Name = "panelAccel";
+			this.panelAccel.Size = new System.Drawing.Size(216, 670);
+			this.panelAccel.TabIndex = 0;
+			// 
+			// groupBoxPreview
+			// 
+			this.groupBoxPreview.Controls.Add(this.buttonAccelReset);
+			this.groupBoxPreview.Controls.Add(this.buttonAccelZoomOut);
+			this.groupBoxPreview.Controls.Add(this.buttonAccelZoomIn);
+			this.groupBoxPreview.Controls.Add(this.labelAccelYValue);
+			this.groupBoxPreview.Controls.Add(this.labelAccelXValue);
+			this.groupBoxPreview.Controls.Add(this.labelAccelXmaxUnit);
+			this.groupBoxPreview.Controls.Add(this.labelAccelXminUnit);
+			this.groupBoxPreview.Controls.Add(this.labelAccelYmaxUnit);
+			this.groupBoxPreview.Controls.Add(this.labelAccelYminUnit);
+			this.groupBoxPreview.Controls.Add(this.textBoxAccelYmax);
+			this.groupBoxPreview.Controls.Add(this.textBoxAccelYmin);
+			this.groupBoxPreview.Controls.Add(this.textBoxAccelXmax);
+			this.groupBoxPreview.Controls.Add(this.textBoxAccelXmin);
+			this.groupBoxPreview.Controls.Add(this.labelAccelYmax);
+			this.groupBoxPreview.Controls.Add(this.labelAccelYmin);
+			this.groupBoxPreview.Controls.Add(this.labelAccelXmax);
+			this.groupBoxPreview.Controls.Add(this.labelAccelXmin);
+			this.groupBoxPreview.Controls.Add(this.labelAccelY);
+			this.groupBoxPreview.Controls.Add(this.labelAccelX);
+			this.groupBoxPreview.Controls.Add(this.checkBoxSubtractDeceleration);
+			this.groupBoxPreview.Location = new System.Drawing.Point(8, 216);
+			this.groupBoxPreview.Name = "groupBoxPreview";
+			this.groupBoxPreview.Size = new System.Drawing.Size(200, 232);
+			this.groupBoxPreview.TabIndex = 2;
+			this.groupBoxPreview.TabStop = false;
+			this.groupBoxPreview.Text = "Preview";
+			// 
+			// buttonAccelReset
+			// 
+			this.buttonAccelReset.Location = new System.Drawing.Point(136, 200);
+			this.buttonAccelReset.Name = "buttonAccelReset";
+			this.buttonAccelReset.Size = new System.Drawing.Size(56, 24);
+			this.buttonAccelReset.TabIndex = 42;
+			this.buttonAccelReset.UseVisualStyleBackColor = true;
+			// 
+			// buttonAccelZoomOut
+			// 
+			this.buttonAccelZoomOut.Location = new System.Drawing.Point(72, 200);
+			this.buttonAccelZoomOut.Name = "buttonAccelZoomOut";
+			this.buttonAccelZoomOut.Size = new System.Drawing.Size(56, 24);
+			this.buttonAccelZoomOut.TabIndex = 41;
+			this.buttonAccelZoomOut.UseVisualStyleBackColor = true;
+			// 
+			// buttonAccelZoomIn
+			// 
+			this.buttonAccelZoomIn.Location = new System.Drawing.Point(8, 200);
+			this.buttonAccelZoomIn.Name = "buttonAccelZoomIn";
+			this.buttonAccelZoomIn.Size = new System.Drawing.Size(56, 24);
+			this.buttonAccelZoomIn.TabIndex = 40;
+			this.buttonAccelZoomIn.UseVisualStyleBackColor = true;
+			// 
+			// labelAccelYValue
+			// 
+			this.labelAccelYValue.Location = new System.Drawing.Point(88, 80);
+			this.labelAccelYValue.Name = "labelAccelYValue";
+			this.labelAccelYValue.Size = new System.Drawing.Size(104, 16);
+			this.labelAccelYValue.TabIndex = 39;
+			this.labelAccelYValue.Text = "0.00 km/h/s";
+			this.labelAccelYValue.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelAccelXValue
+			// 
+			this.labelAccelXValue.Location = new System.Drawing.Point(88, 56);
+			this.labelAccelXValue.Name = "labelAccelXValue";
+			this.labelAccelXValue.Size = new System.Drawing.Size(104, 16);
+			this.labelAccelXValue.TabIndex = 38;
+			this.labelAccelXValue.Text = "0.00 km/h";
+			this.labelAccelXValue.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelAccelXmaxUnit
+			// 
+			this.labelAccelXmaxUnit.Location = new System.Drawing.Point(144, 128);
+			this.labelAccelXmaxUnit.Name = "labelAccelXmaxUnit";
+			this.labelAccelXmaxUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelXmaxUnit.TabIndex = 37;
+			this.labelAccelXmaxUnit.Text = "km/h";
+			this.labelAccelXmaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelAccelXminUnit
+			// 
+			this.labelAccelXminUnit.Location = new System.Drawing.Point(144, 104);
+			this.labelAccelXminUnit.Name = "labelAccelXminUnit";
+			this.labelAccelXminUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelXminUnit.TabIndex = 36;
+			this.labelAccelXminUnit.Text = "km/h";
+			this.labelAccelXminUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelAccelYmaxUnit
+			// 
+			this.labelAccelYmaxUnit.Location = new System.Drawing.Point(144, 176);
+			this.labelAccelYmaxUnit.Name = "labelAccelYmaxUnit";
+			this.labelAccelYmaxUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelYmaxUnit.TabIndex = 35;
+			this.labelAccelYmaxUnit.Text = "km/h/s";
+			this.labelAccelYmaxUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelAccelYminUnit
+			// 
+			this.labelAccelYminUnit.Location = new System.Drawing.Point(144, 152);
+			this.labelAccelYminUnit.Name = "labelAccelYminUnit";
+			this.labelAccelYminUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelYminUnit.TabIndex = 34;
+			this.labelAccelYminUnit.Text = "km/h/s";
+			this.labelAccelYminUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxAccelYmax
+			// 
+			this.textBoxAccelYmax.Location = new System.Drawing.Point(88, 176);
+			this.textBoxAccelYmax.Name = "textBoxAccelYmax";
+			this.textBoxAccelYmax.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelYmax.TabIndex = 25;
+			// 
+			// textBoxAccelYmin
+			// 
+			this.textBoxAccelYmin.Location = new System.Drawing.Point(88, 152);
+			this.textBoxAccelYmin.Name = "textBoxAccelYmin";
+			this.textBoxAccelYmin.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelYmin.TabIndex = 24;
+			// 
+			// textBoxAccelXmax
+			// 
+			this.textBoxAccelXmax.Location = new System.Drawing.Point(88, 128);
+			this.textBoxAccelXmax.Name = "textBoxAccelXmax";
+			this.textBoxAccelXmax.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelXmax.TabIndex = 23;
+			// 
+			// textBoxAccelXmin
+			// 
+			this.textBoxAccelXmin.Location = new System.Drawing.Point(88, 104);
+			this.textBoxAccelXmin.Name = "textBoxAccelXmin";
+			this.textBoxAccelXmin.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelXmin.TabIndex = 22;
+			// 
+			// labelAccelYmax
+			// 
+			this.labelAccelYmax.Location = new System.Drawing.Point(8, 176);
+			this.labelAccelYmax.Name = "labelAccelYmax";
+			this.labelAccelYmax.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelYmax.TabIndex = 8;
+			this.labelAccelYmax.Text = "Ymax:";
+			this.labelAccelYmax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelYmin
+			// 
+			this.labelAccelYmin.Location = new System.Drawing.Point(8, 152);
+			this.labelAccelYmin.Name = "labelAccelYmin";
+			this.labelAccelYmin.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelYmin.TabIndex = 7;
+			this.labelAccelYmin.Text = "Ymin:";
+			this.labelAccelYmin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelXmax
+			// 
+			this.labelAccelXmax.Location = new System.Drawing.Point(8, 128);
+			this.labelAccelXmax.Name = "labelAccelXmax";
+			this.labelAccelXmax.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelXmax.TabIndex = 6;
+			this.labelAccelXmax.Text = "Xmax:";
+			this.labelAccelXmax.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelXmin
+			// 
+			this.labelAccelXmin.Location = new System.Drawing.Point(8, 104);
+			this.labelAccelXmin.Name = "labelAccelXmin";
+			this.labelAccelXmin.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelXmin.TabIndex = 5;
+			this.labelAccelXmin.Text = "Xmin:";
+			this.labelAccelXmin.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelY
+			// 
+			this.labelAccelY.Location = new System.Drawing.Point(8, 80);
+			this.labelAccelY.Name = "labelAccelY";
+			this.labelAccelY.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelY.TabIndex = 4;
+			this.labelAccelY.Text = "Y:";
+			this.labelAccelY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelX
+			// 
+			this.labelAccelX.Location = new System.Drawing.Point(8, 56);
+			this.labelAccelX.Name = "labelAccelX";
+			this.labelAccelX.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelX.TabIndex = 3;
+			this.labelAccelX.Text = "X:";
+			this.labelAccelX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// checkBoxSubtractDeceleration
+			// 
+			this.checkBoxSubtractDeceleration.Location = new System.Drawing.Point(8, 16);
+			this.checkBoxSubtractDeceleration.Name = "checkBoxSubtractDeceleration";
+			this.checkBoxSubtractDeceleration.Size = new System.Drawing.Size(184, 32);
+			this.checkBoxSubtractDeceleration.TabIndex = 0;
+			this.checkBoxSubtractDeceleration.Text = "Subtract deceleration due to air and rolling resistance";
+			this.checkBoxSubtractDeceleration.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxParameter
+			// 
+			this.groupBoxParameter.Controls.Add(this.labeAccelA0Unit);
+			this.groupBoxParameter.Controls.Add(this.textBoxAccelA0);
+			this.groupBoxParameter.Controls.Add(this.labelAccelA0);
+			this.groupBoxParameter.Controls.Add(this.labelAccelA1Unit);
+			this.groupBoxParameter.Controls.Add(this.textBoxAccelA1);
+			this.groupBoxParameter.Controls.Add(this.labelAccelA1);
+			this.groupBoxParameter.Controls.Add(this.labelAccelV1Unit);
+			this.groupBoxParameter.Controls.Add(this.textBoxAccelV1);
+			this.groupBoxParameter.Controls.Add(this.labelAccelV1);
+			this.groupBoxParameter.Controls.Add(this.labelAccelV2Unit);
+			this.groupBoxParameter.Controls.Add(this.textBoxAccelV2);
+			this.groupBoxParameter.Controls.Add(this.labelAccelV2);
+			this.groupBoxParameter.Controls.Add(this.textBoxAccelE);
+			this.groupBoxParameter.Controls.Add(this.labelAccelE);
+			this.groupBoxParameter.Location = new System.Drawing.Point(8, 64);
+			this.groupBoxParameter.Name = "groupBoxParameter";
+			this.groupBoxParameter.Size = new System.Drawing.Size(200, 144);
+			this.groupBoxParameter.TabIndex = 1;
+			this.groupBoxParameter.TabStop = false;
+			this.groupBoxParameter.Text = "Parameter";
+			// 
+			// labeAccelA0Unit
+			// 
+			this.labeAccelA0Unit.Location = new System.Drawing.Point(144, 16);
+			this.labeAccelA0Unit.Name = "labeAccelA0Unit";
+			this.labeAccelA0Unit.Size = new System.Drawing.Size(48, 16);
+			this.labeAccelA0Unit.TabIndex = 33;
+			this.labeAccelA0Unit.Text = "km/h/s";
+			this.labeAccelA0Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxAccelA0
+			// 
+			this.textBoxAccelA0.Location = new System.Drawing.Point(88, 16);
+			this.textBoxAccelA0.Name = "textBoxAccelA0";
+			this.textBoxAccelA0.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelA0.TabIndex = 32;
+			// 
+			// labelAccelA0
+			// 
+			this.labelAccelA0.Location = new System.Drawing.Point(8, 16);
+			this.labelAccelA0.Name = "labelAccelA0";
+			this.labelAccelA0.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelA0.TabIndex = 31;
+			this.labelAccelA0.Text = "a0:";
+			this.labelAccelA0.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelA1Unit
+			// 
+			this.labelAccelA1Unit.Location = new System.Drawing.Point(144, 40);
+			this.labelAccelA1Unit.Name = "labelAccelA1Unit";
+			this.labelAccelA1Unit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelA1Unit.TabIndex = 30;
+			this.labelAccelA1Unit.Text = "km/h/s";
+			this.labelAccelA1Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxAccelA1
+			// 
+			this.textBoxAccelA1.Location = new System.Drawing.Point(88, 40);
+			this.textBoxAccelA1.Name = "textBoxAccelA1";
+			this.textBoxAccelA1.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelA1.TabIndex = 29;
+			// 
+			// labelAccelA1
+			// 
+			this.labelAccelA1.Location = new System.Drawing.Point(8, 40);
+			this.labelAccelA1.Name = "labelAccelA1";
+			this.labelAccelA1.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelA1.TabIndex = 28;
+			this.labelAccelA1.Text = "a1:";
+			this.labelAccelA1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelV1Unit
+			// 
+			this.labelAccelV1Unit.Location = new System.Drawing.Point(144, 64);
+			this.labelAccelV1Unit.Name = "labelAccelV1Unit";
+			this.labelAccelV1Unit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelV1Unit.TabIndex = 27;
+			this.labelAccelV1Unit.Text = "km/h";
+			this.labelAccelV1Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxAccelV1
+			// 
+			this.textBoxAccelV1.Location = new System.Drawing.Point(88, 64);
+			this.textBoxAccelV1.Name = "textBoxAccelV1";
+			this.textBoxAccelV1.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelV1.TabIndex = 26;
+			// 
+			// labelAccelV1
+			// 
+			this.labelAccelV1.Location = new System.Drawing.Point(8, 64);
+			this.labelAccelV1.Name = "labelAccelV1";
+			this.labelAccelV1.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelV1.TabIndex = 25;
+			this.labelAccelV1.Text = "v1:";
+			this.labelAccelV1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAccelV2Unit
+			// 
+			this.labelAccelV2Unit.Location = new System.Drawing.Point(144, 88);
+			this.labelAccelV2Unit.Name = "labelAccelV2Unit";
+			this.labelAccelV2Unit.Size = new System.Drawing.Size(48, 16);
+			this.labelAccelV2Unit.TabIndex = 24;
+			this.labelAccelV2Unit.Text = "km/h";
+			this.labelAccelV2Unit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxAccelV2
+			// 
+			this.textBoxAccelV2.Location = new System.Drawing.Point(88, 88);
+			this.textBoxAccelV2.Name = "textBoxAccelV2";
+			this.textBoxAccelV2.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelV2.TabIndex = 23;
+			// 
+			// labelAccelV2
+			// 
+			this.labelAccelV2.Location = new System.Drawing.Point(8, 88);
+			this.labelAccelV2.Name = "labelAccelV2";
+			this.labelAccelV2.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelV2.TabIndex = 22;
+			this.labelAccelV2.Text = "v2:";
+			this.labelAccelV2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// textBoxAccelE
+			// 
+			this.textBoxAccelE.Location = new System.Drawing.Point(88, 112);
+			this.textBoxAccelE.Name = "textBoxAccelE";
+			this.textBoxAccelE.Size = new System.Drawing.Size(48, 19);
+			this.textBoxAccelE.TabIndex = 21;
+			// 
+			// labelAccelE
+			// 
+			this.labelAccelE.Location = new System.Drawing.Point(8, 112);
+			this.labelAccelE.Name = "labelAccelE";
+			this.labelAccelE.Size = new System.Drawing.Size(72, 16);
+			this.labelAccelE.TabIndex = 2;
+			this.labelAccelE.Text = "e (2.0):";
+			this.labelAccelE.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxNotch
+			// 
+			this.groupBoxNotch.Controls.Add(this.comboBoxNotch);
+			this.groupBoxNotch.Location = new System.Drawing.Point(8, 8);
+			this.groupBoxNotch.Name = "groupBoxNotch";
+			this.groupBoxNotch.Size = new System.Drawing.Size(200, 48);
+			this.groupBoxNotch.TabIndex = 0;
+			this.groupBoxNotch.TabStop = false;
+			this.groupBoxNotch.Text = "Notch";
+			// 
+			// comboBoxNotch
+			// 
+			this.comboBoxNotch.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxNotch.FormattingEnabled = true;
+			this.comboBoxNotch.Location = new System.Drawing.Point(8, 16);
+			this.comboBoxNotch.Name = "comboBoxNotch";
+			this.comboBoxNotch.Size = new System.Drawing.Size(72, 20);
+			this.comboBoxNotch.TabIndex = 0;
+			// 
+			// tabPageCar
+			// 
+			this.tabPageCar.Controls.Add(this.groupBoxPressure);
+			this.tabPageCar.Controls.Add(this.groupBoxBrake);
+			this.tabPageCar.Controls.Add(this.groupBoxMove);
+			this.tabPageCar.Controls.Add(this.groupBoxDelay);
+			this.tabPageCar.Controls.Add(this.groupBoxPerformance);
+			this.tabPageCar.Controls.Add(this.groupBoxCarGeneral);
+			this.tabPageCar.Location = new System.Drawing.Point(4, 22);
+			this.tabPageCar.Name = "tabPageCar";
+			this.tabPageCar.Size = new System.Drawing.Size(792, 670);
+			this.tabPageCar.TabIndex = 4;
+			this.tabPageCar.Text = "Car settings";
+			this.tabPageCar.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxPressure
+			// 
+			this.groupBoxPressure.Controls.Add(this.labelBrakePipeNormalPressureUnit);
+			this.groupBoxPressure.Controls.Add(this.textBoxBrakePipeNormalPressure);
+			this.groupBoxPressure.Controls.Add(this.labelBrakePipeNormalPressure);
+			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderServiceMaximumPressureUnit);
+			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMaximumPressureUnit);
+			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMinimumPressureUnit);
+			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderEmergencyMaximumPressureUnit);
+			this.groupBoxPressure.Controls.Add(this.textBoxMainReservoirMaximumPressure);
+			this.groupBoxPressure.Controls.Add(this.textBoxMainReservoirMinimumPressure);
+			this.groupBoxPressure.Controls.Add(this.textBoxBrakeCylinderEmergencyMaximumPressure);
+			this.groupBoxPressure.Controls.Add(this.textBoxBrakeCylinderServiceMaximumPressure);
+			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMaximumPressure);
+			this.groupBoxPressure.Controls.Add(this.labelMainReservoirMinimumPressure);
+			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderServiceMaximumPressure);
+			this.groupBoxPressure.Controls.Add(this.labelBrakeCylinderEmergencyMaximumPressure);
+			this.groupBoxPressure.Location = new System.Drawing.Point(288, 440);
+			this.groupBoxPressure.Name = "groupBoxPressure";
+			this.groupBoxPressure.Size = new System.Drawing.Size(448, 144);
+			this.groupBoxPressure.TabIndex = 33;
+			this.groupBoxPressure.TabStop = false;
+			this.groupBoxPressure.Text = "Pressure";
+			// 
+			// labelBrakePipeNormalPressureUnit
+			// 
+			this.labelBrakePipeNormalPressureUnit.Location = new System.Drawing.Point(408, 112);
+			this.labelBrakePipeNormalPressureUnit.Name = "labelBrakePipeNormalPressureUnit";
+			this.labelBrakePipeNormalPressureUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelBrakePipeNormalPressureUnit.TabIndex = 39;
+			this.labelBrakePipeNormalPressureUnit.Text = "kPa";
+			this.labelBrakePipeNormalPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxBrakePipeNormalPressure
+			// 
+			this.textBoxBrakePipeNormalPressure.Location = new System.Drawing.Point(248, 112);
+			this.textBoxBrakePipeNormalPressure.Name = "textBoxBrakePipeNormalPressure";
+			this.textBoxBrakePipeNormalPressure.Size = new System.Drawing.Size(152, 19);
+			this.textBoxBrakePipeNormalPressure.TabIndex = 38;
+			// 
+			// labelBrakePipeNormalPressure
+			// 
+			this.labelBrakePipeNormalPressure.Location = new System.Drawing.Point(8, 112);
+			this.labelBrakePipeNormalPressure.Name = "labelBrakePipeNormalPressure";
+			this.labelBrakePipeNormalPressure.Size = new System.Drawing.Size(232, 16);
+			this.labelBrakePipeNormalPressure.TabIndex = 37;
+			this.labelBrakePipeNormalPressure.Text = "BrakePipeNormalPressure:";
+			this.labelBrakePipeNormalPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeCylinderServiceMaximumPressureUnit
+			// 
+			this.labelBrakeCylinderServiceMaximumPressureUnit.Location = new System.Drawing.Point(408, 16);
+			this.labelBrakeCylinderServiceMaximumPressureUnit.Name = "labelBrakeCylinderServiceMaximumPressureUnit";
+			this.labelBrakeCylinderServiceMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelBrakeCylinderServiceMaximumPressureUnit.TabIndex = 32;
+			this.labelBrakeCylinderServiceMaximumPressureUnit.Text = "kPa";
+			this.labelBrakeCylinderServiceMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelMainReservoirMaximumPressureUnit
+			// 
+			this.labelMainReservoirMaximumPressureUnit.Location = new System.Drawing.Point(408, 88);
+			this.labelMainReservoirMaximumPressureUnit.Name = "labelMainReservoirMaximumPressureUnit";
+			this.labelMainReservoirMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelMainReservoirMaximumPressureUnit.TabIndex = 36;
+			this.labelMainReservoirMaximumPressureUnit.Text = "kPa";
+			this.labelMainReservoirMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelMainReservoirMinimumPressureUnit
+			// 
+			this.labelMainReservoirMinimumPressureUnit.Location = new System.Drawing.Point(408, 64);
+			this.labelMainReservoirMinimumPressureUnit.Name = "labelMainReservoirMinimumPressureUnit";
+			this.labelMainReservoirMinimumPressureUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelMainReservoirMinimumPressureUnit.TabIndex = 35;
+			this.labelMainReservoirMinimumPressureUnit.Text = "kPa";
+			this.labelMainReservoirMinimumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelBrakeCylinderEmergencyMaximumPressureUnit
+			// 
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Location = new System.Drawing.Point(408, 40);
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Name = "labelBrakeCylinderEmergencyMaximumPressureUnit";
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.TabIndex = 34;
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.Text = "kPa";
+			this.labelBrakeCylinderEmergencyMaximumPressureUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxMainReservoirMaximumPressure
+			// 
+			this.textBoxMainReservoirMaximumPressure.Location = new System.Drawing.Point(248, 88);
+			this.textBoxMainReservoirMaximumPressure.Name = "textBoxMainReservoirMaximumPressure";
+			this.textBoxMainReservoirMaximumPressure.Size = new System.Drawing.Size(152, 19);
+			this.textBoxMainReservoirMaximumPressure.TabIndex = 34;
+			// 
+			// textBoxMainReservoirMinimumPressure
+			// 
+			this.textBoxMainReservoirMinimumPressure.Location = new System.Drawing.Point(248, 64);
+			this.textBoxMainReservoirMinimumPressure.Name = "textBoxMainReservoirMinimumPressure";
+			this.textBoxMainReservoirMinimumPressure.Size = new System.Drawing.Size(152, 19);
+			this.textBoxMainReservoirMinimumPressure.TabIndex = 33;
+			// 
+			// textBoxBrakeCylinderEmergencyMaximumPressure
+			// 
+			this.textBoxBrakeCylinderEmergencyMaximumPressure.Location = new System.Drawing.Point(248, 40);
+			this.textBoxBrakeCylinderEmergencyMaximumPressure.Name = "textBoxBrakeCylinderEmergencyMaximumPressure";
+			this.textBoxBrakeCylinderEmergencyMaximumPressure.Size = new System.Drawing.Size(152, 19);
+			this.textBoxBrakeCylinderEmergencyMaximumPressure.TabIndex = 32;
+			// 
+			// textBoxBrakeCylinderServiceMaximumPressure
+			// 
+			this.textBoxBrakeCylinderServiceMaximumPressure.Location = new System.Drawing.Point(248, 16);
+			this.textBoxBrakeCylinderServiceMaximumPressure.Name = "textBoxBrakeCylinderServiceMaximumPressure";
+			this.textBoxBrakeCylinderServiceMaximumPressure.Size = new System.Drawing.Size(152, 19);
+			this.textBoxBrakeCylinderServiceMaximumPressure.TabIndex = 31;
+			// 
+			// labelMainReservoirMaximumPressure
+			// 
+			this.labelMainReservoirMaximumPressure.Location = new System.Drawing.Point(8, 88);
+			this.labelMainReservoirMaximumPressure.Name = "labelMainReservoirMaximumPressure";
+			this.labelMainReservoirMaximumPressure.Size = new System.Drawing.Size(232, 16);
+			this.labelMainReservoirMaximumPressure.TabIndex = 11;
+			this.labelMainReservoirMaximumPressure.Text = "MainReservoirMaximumPressure:";
+			this.labelMainReservoirMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelMainReservoirMinimumPressure
+			// 
+			this.labelMainReservoirMinimumPressure.Location = new System.Drawing.Point(8, 64);
+			this.labelMainReservoirMinimumPressure.Name = "labelMainReservoirMinimumPressure";
+			this.labelMainReservoirMinimumPressure.Size = new System.Drawing.Size(232, 16);
+			this.labelMainReservoirMinimumPressure.TabIndex = 10;
+			this.labelMainReservoirMinimumPressure.Text = "MainReservoirMinimumPressure:";
+			this.labelMainReservoirMinimumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeCylinderServiceMaximumPressure
+			// 
+			this.labelBrakeCylinderServiceMaximumPressure.Location = new System.Drawing.Point(8, 16);
+			this.labelBrakeCylinderServiceMaximumPressure.Name = "labelBrakeCylinderServiceMaximumPressure";
+			this.labelBrakeCylinderServiceMaximumPressure.Size = new System.Drawing.Size(232, 16);
+			this.labelBrakeCylinderServiceMaximumPressure.TabIndex = 9;
+			this.labelBrakeCylinderServiceMaximumPressure.Text = "BrakeCylinderServiceMaximumPressure:";
+			this.labelBrakeCylinderServiceMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeCylinderEmergencyMaximumPressure
+			// 
+			this.labelBrakeCylinderEmergencyMaximumPressure.Location = new System.Drawing.Point(8, 40);
+			this.labelBrakeCylinderEmergencyMaximumPressure.Name = "labelBrakeCylinderEmergencyMaximumPressure";
+			this.labelBrakeCylinderEmergencyMaximumPressure.Size = new System.Drawing.Size(232, 16);
+			this.labelBrakeCylinderEmergencyMaximumPressure.TabIndex = 8;
+			this.labelBrakeCylinderEmergencyMaximumPressure.Text = "BrakeCylinderEmergencyMaximumPressure:";
+			this.labelBrakeCylinderEmergencyMaximumPressure.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxBrake
+			// 
+			this.groupBoxBrake.Controls.Add(this.textBoxBrakeControlSpeed);
+			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSpeedUnit);
+			this.groupBoxBrake.Controls.Add(this.comboBoxBrakeControlSystem);
+			this.groupBoxBrake.Controls.Add(this.comboBoxLocoBrakeType);
+			this.groupBoxBrake.Controls.Add(this.comboBoxBrakeType);
+			this.groupBoxBrake.Controls.Add(this.labelLocoBrakeType);
+			this.groupBoxBrake.Controls.Add(this.labelBrakeType);
+			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSpeed);
+			this.groupBoxBrake.Controls.Add(this.labelBrakeControlSystem);
+			this.groupBoxBrake.Location = new System.Drawing.Point(288, 312);
+			this.groupBoxBrake.Name = "groupBoxBrake";
+			this.groupBoxBrake.Size = new System.Drawing.Size(448, 120);
+			this.groupBoxBrake.TabIndex = 4;
+			this.groupBoxBrake.TabStop = false;
+			this.groupBoxBrake.Text = "Brake";
+			// 
+			// textBoxBrakeControlSpeed
+			// 
+			this.textBoxBrakeControlSpeed.Location = new System.Drawing.Point(136, 88);
+			this.textBoxBrakeControlSpeed.Name = "textBoxBrakeControlSpeed";
+			this.textBoxBrakeControlSpeed.Size = new System.Drawing.Size(264, 19);
+			this.textBoxBrakeControlSpeed.TabIndex = 31;
+			// 
+			// labelBrakeControlSpeedUnit
+			// 
+			this.labelBrakeControlSpeedUnit.Location = new System.Drawing.Point(408, 88);
+			this.labelBrakeControlSpeedUnit.Name = "labelBrakeControlSpeedUnit";
+			this.labelBrakeControlSpeedUnit.Size = new System.Drawing.Size(32, 16);
+			this.labelBrakeControlSpeedUnit.TabIndex = 32;
+			this.labelBrakeControlSpeedUnit.Text = "km/h";
+			this.labelBrakeControlSpeedUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// comboBoxBrakeControlSystem
+			// 
+			this.comboBoxBrakeControlSystem.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxBrakeControlSystem.FormattingEnabled = true;
+			this.comboBoxBrakeControlSystem.Items.AddRange(new object[] {
+            "None",
+            "Closing electromagnetic valve",
+            "Delay-including control"});
+			this.comboBoxBrakeControlSystem.Location = new System.Drawing.Point(136, 64);
+			this.comboBoxBrakeControlSystem.Name = "comboBoxBrakeControlSystem";
+			this.comboBoxBrakeControlSystem.Size = new System.Drawing.Size(264, 20);
+			this.comboBoxBrakeControlSystem.TabIndex = 17;
+			// 
+			// comboBoxLocoBrakeType
+			// 
+			this.comboBoxLocoBrakeType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxLocoBrakeType.FormattingEnabled = true;
+			this.comboBoxLocoBrakeType.Items.AddRange(new object[] {
+            "Not fitted",
+            "Notched air brake",
+            "Air brake with partial release"});
+			this.comboBoxLocoBrakeType.Location = new System.Drawing.Point(136, 40);
+			this.comboBoxLocoBrakeType.Name = "comboBoxLocoBrakeType";
+			this.comboBoxLocoBrakeType.Size = new System.Drawing.Size(264, 20);
+			this.comboBoxLocoBrakeType.TabIndex = 16;
+			// 
+			// comboBoxBrakeType
+			// 
+			this.comboBoxBrakeType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxBrakeType.FormattingEnabled = true;
+			this.comboBoxBrakeType.Items.AddRange(new object[] {
+            "Electromagnetic straight air brake",
+            "Electro-pneumatic air brake without brake pipe",
+            "Air brake with partial release feature"});
+			this.comboBoxBrakeType.Location = new System.Drawing.Point(136, 16);
+			this.comboBoxBrakeType.Name = "comboBoxBrakeType";
+			this.comboBoxBrakeType.Size = new System.Drawing.Size(264, 20);
+			this.comboBoxBrakeType.TabIndex = 15;
+			// 
+			// labelLocoBrakeType
+			// 
+			this.labelLocoBrakeType.Location = new System.Drawing.Point(8, 40);
+			this.labelLocoBrakeType.Name = "labelLocoBrakeType";
+			this.labelLocoBrakeType.Size = new System.Drawing.Size(120, 16);
+			this.labelLocoBrakeType.TabIndex = 8;
+			this.labelLocoBrakeType.Text = "LocoBrakeType:";
+			this.labelLocoBrakeType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeType
+			// 
+			this.labelBrakeType.Location = new System.Drawing.Point(8, 16);
+			this.labelBrakeType.Name = "labelBrakeType";
+			this.labelBrakeType.Size = new System.Drawing.Size(120, 16);
+			this.labelBrakeType.TabIndex = 7;
+			this.labelBrakeType.Text = "BrakeType:";
+			this.labelBrakeType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeControlSpeed
+			// 
+			this.labelBrakeControlSpeed.Location = new System.Drawing.Point(8, 88);
+			this.labelBrakeControlSpeed.Name = "labelBrakeControlSpeed";
+			this.labelBrakeControlSpeed.Size = new System.Drawing.Size(120, 16);
+			this.labelBrakeControlSpeed.TabIndex = 6;
+			this.labelBrakeControlSpeed.Text = "BrakeControlSpeed:";
+			this.labelBrakeControlSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeControlSystem
+			// 
+			this.labelBrakeControlSystem.Location = new System.Drawing.Point(8, 64);
+			this.labelBrakeControlSystem.Name = "labelBrakeControlSystem";
+			this.labelBrakeControlSystem.Size = new System.Drawing.Size(120, 16);
+			this.labelBrakeControlSystem.TabIndex = 5;
+			this.labelBrakeControlSystem.Text = "BrakeControlSystem:";
+			this.labelBrakeControlSystem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxMove
+			// 
+			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderDownUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxBrakeCylinderDown);
+			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderUpUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxBrakeCylinderUp);
+			this.groupBoxMove.Controls.Add(this.labelJerkBrakeDownUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxJerkBrakeDown);
+			this.groupBoxMove.Controls.Add(this.labelJerkBrakeUpUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxJerkBrakeUp);
+			this.groupBoxMove.Controls.Add(this.labelJerkPowerDownUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxJerkPowerDown);
+			this.groupBoxMove.Controls.Add(this.labelJerkPowerUpUnit);
+			this.groupBoxMove.Controls.Add(this.textBoxJerkPowerUp);
+			this.groupBoxMove.Controls.Add(this.labelJerkPowerUp);
+			this.groupBoxMove.Controls.Add(this.labelJerkPowerDown);
+			this.groupBoxMove.Controls.Add(this.labelJerkBrakeUp);
+			this.groupBoxMove.Controls.Add(this.labelJerkBrakeDown);
+			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderUp);
+			this.groupBoxMove.Controls.Add(this.labelBrakeCylinderDown);
+			this.groupBoxMove.Location = new System.Drawing.Point(288, 136);
+			this.groupBoxMove.Name = "groupBoxMove";
+			this.groupBoxMove.Size = new System.Drawing.Size(448, 168);
+			this.groupBoxMove.TabIndex = 3;
+			this.groupBoxMove.TabStop = false;
+			this.groupBoxMove.Text = "Move";
+			// 
+			// labelBrakeCylinderDownUnit
+			// 
+			this.labelBrakeCylinderDownUnit.Location = new System.Drawing.Point(376, 136);
+			this.labelBrakeCylinderDownUnit.Name = "labelBrakeCylinderDownUnit";
+			this.labelBrakeCylinderDownUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelBrakeCylinderDownUnit.TabIndex = 31;
+			this.labelBrakeCylinderDownUnit.Text = "kPa/s";
+			this.labelBrakeCylinderDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxBrakeCylinderDown
+			// 
+			this.textBoxBrakeCylinderDown.Location = new System.Drawing.Point(184, 136);
+			this.textBoxBrakeCylinderDown.Name = "textBoxBrakeCylinderDown";
+			this.textBoxBrakeCylinderDown.Size = new System.Drawing.Size(184, 19);
+			this.textBoxBrakeCylinderDown.TabIndex = 30;
+			// 
+			// labelBrakeCylinderUpUnit
+			// 
+			this.labelBrakeCylinderUpUnit.Location = new System.Drawing.Point(376, 112);
+			this.labelBrakeCylinderUpUnit.Name = "labelBrakeCylinderUpUnit";
+			this.labelBrakeCylinderUpUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelBrakeCylinderUpUnit.TabIndex = 29;
+			this.labelBrakeCylinderUpUnit.Text = "kPa/s";
+			this.labelBrakeCylinderUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxBrakeCylinderUp
+			// 
+			this.textBoxBrakeCylinderUp.Location = new System.Drawing.Point(184, 112);
+			this.textBoxBrakeCylinderUp.Name = "textBoxBrakeCylinderUp";
+			this.textBoxBrakeCylinderUp.Size = new System.Drawing.Size(184, 19);
+			this.textBoxBrakeCylinderUp.TabIndex = 28;
+			// 
+			// labelJerkBrakeDownUnit
+			// 
+			this.labelJerkBrakeDownUnit.Location = new System.Drawing.Point(376, 88);
+			this.labelJerkBrakeDownUnit.Name = "labelJerkBrakeDownUnit";
+			this.labelJerkBrakeDownUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelJerkBrakeDownUnit.TabIndex = 27;
+			this.labelJerkBrakeDownUnit.Text = "1/100 m/s³";
+			this.labelJerkBrakeDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxJerkBrakeDown
+			// 
+			this.textBoxJerkBrakeDown.Location = new System.Drawing.Point(184, 88);
+			this.textBoxJerkBrakeDown.Name = "textBoxJerkBrakeDown";
+			this.textBoxJerkBrakeDown.Size = new System.Drawing.Size(184, 19);
+			this.textBoxJerkBrakeDown.TabIndex = 26;
+			// 
+			// labelJerkBrakeUpUnit
+			// 
+			this.labelJerkBrakeUpUnit.Location = new System.Drawing.Point(376, 64);
+			this.labelJerkBrakeUpUnit.Name = "labelJerkBrakeUpUnit";
+			this.labelJerkBrakeUpUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelJerkBrakeUpUnit.TabIndex = 25;
+			this.labelJerkBrakeUpUnit.Text = "1/100 m/s³";
+			this.labelJerkBrakeUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxJerkBrakeUp
+			// 
+			this.textBoxJerkBrakeUp.Location = new System.Drawing.Point(184, 64);
+			this.textBoxJerkBrakeUp.Name = "textBoxJerkBrakeUp";
+			this.textBoxJerkBrakeUp.Size = new System.Drawing.Size(184, 19);
+			this.textBoxJerkBrakeUp.TabIndex = 24;
+			// 
+			// labelJerkPowerDownUnit
+			// 
+			this.labelJerkPowerDownUnit.Location = new System.Drawing.Point(376, 40);
+			this.labelJerkPowerDownUnit.Name = "labelJerkPowerDownUnit";
+			this.labelJerkPowerDownUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelJerkPowerDownUnit.TabIndex = 23;
+			this.labelJerkPowerDownUnit.Text = "1/100 m/s³";
+			this.labelJerkPowerDownUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxJerkPowerDown
+			// 
+			this.textBoxJerkPowerDown.Location = new System.Drawing.Point(184, 40);
+			this.textBoxJerkPowerDown.Name = "textBoxJerkPowerDown";
+			this.textBoxJerkPowerDown.Size = new System.Drawing.Size(184, 19);
+			this.textBoxJerkPowerDown.TabIndex = 22;
+			// 
+			// labelJerkPowerUpUnit
+			// 
+			this.labelJerkPowerUpUnit.Location = new System.Drawing.Point(376, 16);
+			this.labelJerkPowerUpUnit.Name = "labelJerkPowerUpUnit";
+			this.labelJerkPowerUpUnit.Size = new System.Drawing.Size(64, 16);
+			this.labelJerkPowerUpUnit.TabIndex = 21;
+			this.labelJerkPowerUpUnit.Text = "1/100 m/s³";
+			this.labelJerkPowerUpUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxJerkPowerUp
+			// 
+			this.textBoxJerkPowerUp.Location = new System.Drawing.Point(184, 16);
+			this.textBoxJerkPowerUp.Name = "textBoxJerkPowerUp";
+			this.textBoxJerkPowerUp.Size = new System.Drawing.Size(184, 19);
+			this.textBoxJerkPowerUp.TabIndex = 20;
+			// 
+			// labelJerkPowerUp
+			// 
+			this.labelJerkPowerUp.Location = new System.Drawing.Point(8, 16);
+			this.labelJerkPowerUp.Name = "labelJerkPowerUp";
+			this.labelJerkPowerUp.Size = new System.Drawing.Size(168, 16);
+			this.labelJerkPowerUp.TabIndex = 6;
+			this.labelJerkPowerUp.Text = "JerkPowerUp:";
+			this.labelJerkPowerUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelJerkPowerDown
+			// 
+			this.labelJerkPowerDown.Location = new System.Drawing.Point(8, 40);
+			this.labelJerkPowerDown.Name = "labelJerkPowerDown";
+			this.labelJerkPowerDown.Size = new System.Drawing.Size(168, 16);
+			this.labelJerkPowerDown.TabIndex = 5;
+			this.labelJerkPowerDown.Text = "JerkPowerDown:";
+			this.labelJerkPowerDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelJerkBrakeUp
+			// 
+			this.labelJerkBrakeUp.Location = new System.Drawing.Point(8, 64);
+			this.labelJerkBrakeUp.Name = "labelJerkBrakeUp";
+			this.labelJerkBrakeUp.Size = new System.Drawing.Size(168, 16);
+			this.labelJerkBrakeUp.TabIndex = 4;
+			this.labelJerkBrakeUp.Text = "JerkBrakeUp:";
+			this.labelJerkBrakeUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelJerkBrakeDown
+			// 
+			this.labelJerkBrakeDown.Location = new System.Drawing.Point(8, 88);
+			this.labelJerkBrakeDown.Name = "labelJerkBrakeDown";
+			this.labelJerkBrakeDown.Size = new System.Drawing.Size(168, 16);
+			this.labelJerkBrakeDown.TabIndex = 3;
+			this.labelJerkBrakeDown.Text = "JerkBrakeDown:";
+			this.labelJerkBrakeDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeCylinderUp
+			// 
+			this.labelBrakeCylinderUp.Location = new System.Drawing.Point(8, 112);
+			this.labelBrakeCylinderUp.Name = "labelBrakeCylinderUp";
+			this.labelBrakeCylinderUp.Size = new System.Drawing.Size(168, 16);
+			this.labelBrakeCylinderUp.TabIndex = 2;
+			this.labelBrakeCylinderUp.Text = "BrakeCylinderUp:";
+			this.labelBrakeCylinderUp.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelBrakeCylinderDown
+			// 
+			this.labelBrakeCylinderDown.Location = new System.Drawing.Point(8, 136);
+			this.labelBrakeCylinderDown.Name = "labelBrakeCylinderDown";
+			this.labelBrakeCylinderDown.Size = new System.Drawing.Size(168, 16);
+			this.labelBrakeCylinderDown.TabIndex = 1;
+			this.labelBrakeCylinderDown.Text = "BrakeCylinderDown:";
+			this.labelBrakeCylinderDown.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxDelay
+			// 
+			this.groupBoxDelay.Controls.Add(this.buttonDelayLocoBrakeSet);
+			this.groupBoxDelay.Controls.Add(this.buttonDelayBrakeSet);
+			this.groupBoxDelay.Controls.Add(this.buttonDelayPowerSet);
+			this.groupBoxDelay.Controls.Add(this.labelDelayLocoBrake);
+			this.groupBoxDelay.Controls.Add(this.labelDelayBrake);
+			this.groupBoxDelay.Controls.Add(this.labelDelayPower);
+			this.groupBoxDelay.Location = new System.Drawing.Point(8, 480);
+			this.groupBoxDelay.Name = "groupBoxDelay";
+			this.groupBoxDelay.Size = new System.Drawing.Size(272, 96);
+			this.groupBoxDelay.TabIndex = 2;
+			this.groupBoxDelay.TabStop = false;
+			this.groupBoxDelay.Text = "Delay";
+			// 
+			// buttonDelayLocoBrakeSet
+			// 
+			this.buttonDelayLocoBrakeSet.Location = new System.Drawing.Point(160, 64);
+			this.buttonDelayLocoBrakeSet.Name = "buttonDelayLocoBrakeSet";
+			this.buttonDelayLocoBrakeSet.Size = new System.Drawing.Size(48, 19);
+			this.buttonDelayLocoBrakeSet.TabIndex = 37;
+			this.buttonDelayLocoBrakeSet.Text = "Set...";
+			this.buttonDelayLocoBrakeSet.UseVisualStyleBackColor = true;
+			this.buttonDelayLocoBrakeSet.Click += new System.EventHandler(this.ButtonDelayLocoBrakeSet_Click);
+			// 
+			// buttonDelayBrakeSet
+			// 
+			this.buttonDelayBrakeSet.Location = new System.Drawing.Point(160, 40);
+			this.buttonDelayBrakeSet.Name = "buttonDelayBrakeSet";
+			this.buttonDelayBrakeSet.Size = new System.Drawing.Size(48, 19);
+			this.buttonDelayBrakeSet.TabIndex = 35;
+			this.buttonDelayBrakeSet.Text = "Set...";
+			this.buttonDelayBrakeSet.UseVisualStyleBackColor = true;
+			this.buttonDelayBrakeSet.Click += new System.EventHandler(this.ButtonDelayBrakeSet_Click);
+			// 
+			// buttonDelayPowerSet
+			// 
+			this.buttonDelayPowerSet.Location = new System.Drawing.Point(160, 16);
+			this.buttonDelayPowerSet.Name = "buttonDelayPowerSet";
+			this.buttonDelayPowerSet.Size = new System.Drawing.Size(48, 19);
+			this.buttonDelayPowerSet.TabIndex = 33;
+			this.buttonDelayPowerSet.Text = "Set...";
+			this.buttonDelayPowerSet.UseVisualStyleBackColor = true;
+			this.buttonDelayPowerSet.Click += new System.EventHandler(this.ButtonDelayPowerSet_Click);
+			// 
+			// labelDelayLocoBrake
+			// 
+			this.labelDelayLocoBrake.Location = new System.Drawing.Point(8, 64);
+			this.labelDelayLocoBrake.Name = "labelDelayLocoBrake";
+			this.labelDelayLocoBrake.Size = new System.Drawing.Size(144, 16);
+			this.labelDelayLocoBrake.TabIndex = 6;
+			this.labelDelayLocoBrake.Text = "LocoBrake:";
+			this.labelDelayLocoBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDelayBrake
+			// 
+			this.labelDelayBrake.Location = new System.Drawing.Point(8, 40);
+			this.labelDelayBrake.Name = "labelDelayBrake";
+			this.labelDelayBrake.Size = new System.Drawing.Size(144, 16);
+			this.labelDelayBrake.TabIndex = 4;
+			this.labelDelayBrake.Text = "Brake:";
+			this.labelDelayBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDelayPower
+			// 
+			this.labelDelayPower.Location = new System.Drawing.Point(8, 16);
+			this.labelDelayPower.Name = "labelDelayPower";
+			this.labelDelayPower.Size = new System.Drawing.Size(144, 16);
+			this.labelDelayPower.TabIndex = 2;
+			this.labelDelayPower.Text = "Power:";
+			this.labelDelayPower.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxPerformance
+			// 
+			this.groupBoxPerformance.Controls.Add(this.textBoxAerodynamicDragCoefficient);
+			this.groupBoxPerformance.Controls.Add(this.textBoxCoefficientOfRollingResistance);
+			this.groupBoxPerformance.Controls.Add(this.textBoxCoefficientOfStaticFriction);
+			this.groupBoxPerformance.Controls.Add(this.labelDecelerationUnit);
+			this.groupBoxPerformance.Controls.Add(this.textBoxDeceleration);
+			this.groupBoxPerformance.Controls.Add(this.labelAerodynamicDragCoefficient);
+			this.groupBoxPerformance.Controls.Add(this.labelCoefficientOfStaticFriction);
+			this.groupBoxPerformance.Controls.Add(this.labelDeceleration);
+			this.groupBoxPerformance.Controls.Add(this.labelCoefficientOfRollingResistance);
+			this.groupBoxPerformance.Location = new System.Drawing.Point(288, 8);
+			this.groupBoxPerformance.Name = "groupBoxPerformance";
+			this.groupBoxPerformance.Size = new System.Drawing.Size(448, 120);
+			this.groupBoxPerformance.TabIndex = 1;
+			this.groupBoxPerformance.TabStop = false;
+			this.groupBoxPerformance.Text = "Performance";
+			// 
+			// textBoxAerodynamicDragCoefficient
+			// 
+			this.textBoxAerodynamicDragCoefficient.Location = new System.Drawing.Point(184, 88);
+			this.textBoxAerodynamicDragCoefficient.Name = "textBoxAerodynamicDragCoefficient";
+			this.textBoxAerodynamicDragCoefficient.Size = new System.Drawing.Size(184, 19);
+			this.textBoxAerodynamicDragCoefficient.TabIndex = 25;
+			// 
+			// textBoxCoefficientOfRollingResistance
+			// 
+			this.textBoxCoefficientOfRollingResistance.Location = new System.Drawing.Point(184, 64);
+			this.textBoxCoefficientOfRollingResistance.Name = "textBoxCoefficientOfRollingResistance";
+			this.textBoxCoefficientOfRollingResistance.Size = new System.Drawing.Size(184, 19);
+			this.textBoxCoefficientOfRollingResistance.TabIndex = 24;
+			// 
+			// textBoxCoefficientOfStaticFriction
+			// 
+			this.textBoxCoefficientOfStaticFriction.Location = new System.Drawing.Point(184, 40);
+			this.textBoxCoefficientOfStaticFriction.Name = "textBoxCoefficientOfStaticFriction";
+			this.textBoxCoefficientOfStaticFriction.Size = new System.Drawing.Size(184, 19);
+			this.textBoxCoefficientOfStaticFriction.TabIndex = 23;
+			// 
+			// labelDecelerationUnit
+			// 
+			this.labelDecelerationUnit.Location = new System.Drawing.Point(376, 16);
+			this.labelDecelerationUnit.Name = "labelDecelerationUnit";
+			this.labelDecelerationUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelDecelerationUnit.TabIndex = 22;
+			this.labelDecelerationUnit.Text = "km/h/s";
+			this.labelDecelerationUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxDeceleration
+			// 
+			this.textBoxDeceleration.Location = new System.Drawing.Point(184, 16);
+			this.textBoxDeceleration.Name = "textBoxDeceleration";
+			this.textBoxDeceleration.Size = new System.Drawing.Size(184, 19);
+			this.textBoxDeceleration.TabIndex = 20;
+			// 
+			// labelAerodynamicDragCoefficient
+			// 
+			this.labelAerodynamicDragCoefficient.Location = new System.Drawing.Point(8, 88);
+			this.labelAerodynamicDragCoefficient.Name = "labelAerodynamicDragCoefficient";
+			this.labelAerodynamicDragCoefficient.Size = new System.Drawing.Size(168, 16);
+			this.labelAerodynamicDragCoefficient.TabIndex = 5;
+			this.labelAerodynamicDragCoefficient.Text = "AerodynamicDragCoefficient:";
+			this.labelAerodynamicDragCoefficient.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCoefficientOfStaticFriction
+			// 
+			this.labelCoefficientOfStaticFriction.Location = new System.Drawing.Point(8, 40);
+			this.labelCoefficientOfStaticFriction.Name = "labelCoefficientOfStaticFriction";
+			this.labelCoefficientOfStaticFriction.Size = new System.Drawing.Size(168, 16);
+			this.labelCoefficientOfStaticFriction.TabIndex = 4;
+			this.labelCoefficientOfStaticFriction.Text = "CoefficientOfStaticFriction:";
+			this.labelCoefficientOfStaticFriction.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDeceleration
+			// 
+			this.labelDeceleration.Location = new System.Drawing.Point(8, 16);
+			this.labelDeceleration.Name = "labelDeceleration";
+			this.labelDeceleration.Size = new System.Drawing.Size(168, 16);
+			this.labelDeceleration.TabIndex = 3;
+			this.labelDeceleration.Text = "Deceleration:";
+			this.labelDeceleration.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCoefficientOfRollingResistance
+			// 
+			this.labelCoefficientOfRollingResistance.Location = new System.Drawing.Point(8, 64);
+			this.labelCoefficientOfRollingResistance.Name = "labelCoefficientOfRollingResistance";
+			this.labelCoefficientOfRollingResistance.Size = new System.Drawing.Size(168, 16);
+			this.labelCoefficientOfRollingResistance.TabIndex = 2;
+			this.labelCoefficientOfRollingResistance.Text = "CoefficientOfRollingResistance:";
+			this.labelCoefficientOfRollingResistance.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxCarGeneral
+			// 
+			this.groupBoxCarGeneral.Controls.Add(this.labelUnexposedFrontalAreaUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxUnexposedFrontalArea);
+			this.groupBoxCarGeneral.Controls.Add(this.labelUnexposedFrontalArea);
+			this.groupBoxCarGeneral.Controls.Add(this.labelRearBogie);
+			this.groupBoxCarGeneral.Controls.Add(this.labelFrontBogie);
+			this.groupBoxCarGeneral.Controls.Add(this.buttonRearBogieSet);
+			this.groupBoxCarGeneral.Controls.Add(this.buttonFrontBogieSet);
+			this.groupBoxCarGeneral.Controls.Add(this.checkBoxReversed);
+			this.groupBoxCarGeneral.Controls.Add(this.checkBoxLoadingSway);
+			this.groupBoxCarGeneral.Controls.Add(this.checkBoxDefinedAxles);
+			this.groupBoxCarGeneral.Controls.Add(this.checkBoxIsMotorCar);
+			this.groupBoxCarGeneral.Controls.Add(this.buttonObjectOpen);
+			this.groupBoxCarGeneral.Controls.Add(this.labelExposedFrontalAreaUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.labelCenterOfMassHeightUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.labelLoadingSway);
+			this.groupBoxCarGeneral.Controls.Add(this.labelHeightUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.labelWidthUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.labelLengthUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.labelMassUnit);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxMass);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxLength);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxWidth);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxHeight);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxCenterOfMassHeight);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxExposedFrontalArea);
+			this.groupBoxCarGeneral.Controls.Add(this.textBoxObject);
+			this.groupBoxCarGeneral.Controls.Add(this.labelObject);
+			this.groupBoxCarGeneral.Controls.Add(this.labelReversed);
+			this.groupBoxCarGeneral.Controls.Add(this.groupBoxAxles);
+			this.groupBoxCarGeneral.Controls.Add(this.labelDefinedAxles);
+			this.groupBoxCarGeneral.Controls.Add(this.labelExposedFrontalArea);
+			this.groupBoxCarGeneral.Controls.Add(this.labelCenterOfMassHeight);
+			this.groupBoxCarGeneral.Controls.Add(this.labelHeight);
+			this.groupBoxCarGeneral.Controls.Add(this.labelWidth);
+			this.groupBoxCarGeneral.Controls.Add(this.labelLength);
+			this.groupBoxCarGeneral.Controls.Add(this.labelMass);
+			this.groupBoxCarGeneral.Controls.Add(this.labelIsMotorCar);
+			this.groupBoxCarGeneral.Location = new System.Drawing.Point(8, 8);
+			this.groupBoxCarGeneral.Name = "groupBoxCarGeneral";
+			this.groupBoxCarGeneral.Size = new System.Drawing.Size(272, 464);
+			this.groupBoxCarGeneral.TabIndex = 0;
+			this.groupBoxCarGeneral.TabStop = false;
+			this.groupBoxCarGeneral.Text = "General";
+			// 
+			// labelUnexposedFrontalAreaUnit
+			// 
+			this.labelUnexposedFrontalAreaUnit.Location = new System.Drawing.Point(216, 184);
+			this.labelUnexposedFrontalAreaUnit.Name = "labelUnexposedFrontalAreaUnit";
+			this.labelUnexposedFrontalAreaUnit.Size = new System.Drawing.Size(40, 16);
+			this.labelUnexposedFrontalAreaUnit.TabIndex = 38;
+			this.labelUnexposedFrontalAreaUnit.Text = "m²";
+			this.labelUnexposedFrontalAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxUnexposedFrontalArea
+			// 
+			this.textBoxUnexposedFrontalArea.Location = new System.Drawing.Point(160, 184);
+			this.textBoxUnexposedFrontalArea.Name = "textBoxUnexposedFrontalArea";
+			this.textBoxUnexposedFrontalArea.Size = new System.Drawing.Size(48, 19);
+			this.textBoxUnexposedFrontalArea.TabIndex = 37;
+			// 
+			// labelUnexposedFrontalArea
+			// 
+			this.labelUnexposedFrontalArea.Location = new System.Drawing.Point(8, 184);
+			this.labelUnexposedFrontalArea.Name = "labelUnexposedFrontalArea";
+			this.labelUnexposedFrontalArea.Size = new System.Drawing.Size(144, 16);
+			this.labelUnexposedFrontalArea.TabIndex = 36;
+			this.labelUnexposedFrontalArea.Text = "UnexposedFrontalArea:";
+			this.labelUnexposedFrontalArea.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelRearBogie
+			// 
+			this.labelRearBogie.Location = new System.Drawing.Point(8, 336);
+			this.labelRearBogie.Name = "labelRearBogie";
+			this.labelRearBogie.Size = new System.Drawing.Size(144, 16);
+			this.labelRearBogie.TabIndex = 35;
+			this.labelRearBogie.Text = "RearBogie:";
+			this.labelRearBogie.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelFrontBogie
+			// 
+			this.labelFrontBogie.Location = new System.Drawing.Point(8, 312);
+			this.labelFrontBogie.Name = "labelFrontBogie";
+			this.labelFrontBogie.Size = new System.Drawing.Size(144, 16);
+			this.labelFrontBogie.TabIndex = 34;
+			this.labelFrontBogie.Text = "FrontBogie:";
+			this.labelFrontBogie.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// buttonRearBogieSet
+			// 
+			this.buttonRearBogieSet.Location = new System.Drawing.Point(160, 336);
+			this.buttonRearBogieSet.Name = "buttonRearBogieSet";
+			this.buttonRearBogieSet.Size = new System.Drawing.Size(48, 19);
+			this.buttonRearBogieSet.TabIndex = 33;
+			this.buttonRearBogieSet.Text = "Set...";
+			this.buttonRearBogieSet.UseVisualStyleBackColor = true;
+			this.buttonRearBogieSet.Click += new System.EventHandler(this.ButtonRearBogieSet_Click);
+			// 
+			// buttonFrontBogieSet
+			// 
+			this.buttonFrontBogieSet.Location = new System.Drawing.Point(160, 312);
+			this.buttonFrontBogieSet.Name = "buttonFrontBogieSet";
+			this.buttonFrontBogieSet.Size = new System.Drawing.Size(48, 19);
+			this.buttonFrontBogieSet.TabIndex = 32;
+			this.buttonFrontBogieSet.Text = "Set...";
+			this.buttonFrontBogieSet.UseVisualStyleBackColor = true;
+			this.buttonFrontBogieSet.Click += new System.EventHandler(this.ButtonFrontBogieSet_Click);
+			// 
+			// checkBoxReversed
+			// 
+			this.checkBoxReversed.Location = new System.Drawing.Point(160, 384);
+			this.checkBoxReversed.Name = "checkBoxReversed";
+			this.checkBoxReversed.Size = new System.Drawing.Size(48, 16);
+			this.checkBoxReversed.TabIndex = 31;
+			this.checkBoxReversed.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxLoadingSway
+			// 
+			this.checkBoxLoadingSway.Location = new System.Drawing.Point(160, 360);
+			this.checkBoxLoadingSway.Name = "checkBoxLoadingSway";
+			this.checkBoxLoadingSway.Size = new System.Drawing.Size(48, 16);
+			this.checkBoxLoadingSway.TabIndex = 30;
+			this.checkBoxLoadingSway.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxDefinedAxles
+			// 
+			this.checkBoxDefinedAxles.Location = new System.Drawing.Point(160, 208);
+			this.checkBoxDefinedAxles.Name = "checkBoxDefinedAxles";
+			this.checkBoxDefinedAxles.Size = new System.Drawing.Size(48, 16);
+			this.checkBoxDefinedAxles.TabIndex = 29;
+			this.checkBoxDefinedAxles.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxIsMotorCar
+			// 
+			this.checkBoxIsMotorCar.Location = new System.Drawing.Point(160, 16);
+			this.checkBoxIsMotorCar.Name = "checkBoxIsMotorCar";
+			this.checkBoxIsMotorCar.Size = new System.Drawing.Size(48, 16);
+			this.checkBoxIsMotorCar.TabIndex = 28;
+			this.checkBoxIsMotorCar.UseVisualStyleBackColor = true;
+			// 
+			// buttonObjectOpen
+			// 
+			this.buttonObjectOpen.Location = new System.Drawing.Point(208, 432);
+			this.buttonObjectOpen.Name = "buttonObjectOpen";
+			this.buttonObjectOpen.Size = new System.Drawing.Size(56, 19);
+			this.buttonObjectOpen.TabIndex = 3;
+			this.buttonObjectOpen.Text = "Open...";
+			this.buttonObjectOpen.UseVisualStyleBackColor = true;
+			this.buttonObjectOpen.Click += new System.EventHandler(this.ButtonObjectOpen_Click);
+			// 
+			// labelExposedFrontalAreaUnit
+			// 
+			this.labelExposedFrontalAreaUnit.Location = new System.Drawing.Point(216, 160);
+			this.labelExposedFrontalAreaUnit.Name = "labelExposedFrontalAreaUnit";
+			this.labelExposedFrontalAreaUnit.Size = new System.Drawing.Size(40, 16);
+			this.labelExposedFrontalAreaUnit.TabIndex = 27;
+			this.labelExposedFrontalAreaUnit.Text = "m²";
+			this.labelExposedFrontalAreaUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelCenterOfMassHeightUnit
+			// 
+			this.labelCenterOfMassHeightUnit.Location = new System.Drawing.Point(216, 136);
+			this.labelCenterOfMassHeightUnit.Name = "labelCenterOfMassHeightUnit";
+			this.labelCenterOfMassHeightUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelCenterOfMassHeightUnit.TabIndex = 24;
+			this.labelCenterOfMassHeightUnit.Text = "m";
+			this.labelCenterOfMassHeightUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelLoadingSway
+			// 
+			this.labelLoadingSway.Location = new System.Drawing.Point(8, 360);
+			this.labelLoadingSway.Name = "labelLoadingSway";
+			this.labelLoadingSway.Size = new System.Drawing.Size(144, 16);
+			this.labelLoadingSway.TabIndex = 11;
+			this.labelLoadingSway.Text = "LoadingSway:";
+			this.labelLoadingSway.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelHeightUnit
+			// 
+			this.labelHeightUnit.Location = new System.Drawing.Point(216, 112);
+			this.labelHeightUnit.Name = "labelHeightUnit";
+			this.labelHeightUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelHeightUnit.TabIndex = 23;
+			this.labelHeightUnit.Text = "m";
+			this.labelHeightUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelWidthUnit
+			// 
+			this.labelWidthUnit.Location = new System.Drawing.Point(216, 88);
+			this.labelWidthUnit.Name = "labelWidthUnit";
+			this.labelWidthUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelWidthUnit.TabIndex = 22;
+			this.labelWidthUnit.Text = "m";
+			this.labelWidthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelLengthUnit
+			// 
+			this.labelLengthUnit.Location = new System.Drawing.Point(216, 64);
+			this.labelLengthUnit.Name = "labelLengthUnit";
+			this.labelLengthUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelLengthUnit.TabIndex = 21;
+			this.labelLengthUnit.Text = "m";
+			this.labelLengthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelMassUnit
+			// 
+			this.labelMassUnit.Location = new System.Drawing.Point(216, 40);
+			this.labelMassUnit.Name = "labelMassUnit";
+			this.labelMassUnit.Size = new System.Drawing.Size(48, 16);
+			this.labelMassUnit.TabIndex = 20;
+			this.labelMassUnit.Text = "1000 kg";
+			this.labelMassUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxMass
+			// 
+			this.textBoxMass.Location = new System.Drawing.Point(160, 40);
+			this.textBoxMass.Name = "textBoxMass";
+			this.textBoxMass.Size = new System.Drawing.Size(48, 19);
+			this.textBoxMass.TabIndex = 19;
+			// 
+			// textBoxLength
+			// 
+			this.textBoxLength.Location = new System.Drawing.Point(160, 64);
+			this.textBoxLength.Name = "textBoxLength";
+			this.textBoxLength.Size = new System.Drawing.Size(48, 19);
+			this.textBoxLength.TabIndex = 18;
+			// 
+			// textBoxWidth
+			// 
+			this.textBoxWidth.Location = new System.Drawing.Point(160, 88);
+			this.textBoxWidth.Name = "textBoxWidth";
+			this.textBoxWidth.Size = new System.Drawing.Size(48, 19);
+			this.textBoxWidth.TabIndex = 17;
+			// 
+			// textBoxHeight
+			// 
+			this.textBoxHeight.Location = new System.Drawing.Point(160, 112);
+			this.textBoxHeight.Name = "textBoxHeight";
+			this.textBoxHeight.Size = new System.Drawing.Size(48, 19);
+			this.textBoxHeight.TabIndex = 16;
+			// 
+			// textBoxCenterOfMassHeight
+			// 
+			this.textBoxCenterOfMassHeight.Location = new System.Drawing.Point(160, 136);
+			this.textBoxCenterOfMassHeight.Name = "textBoxCenterOfMassHeight";
+			this.textBoxCenterOfMassHeight.Size = new System.Drawing.Size(48, 19);
+			this.textBoxCenterOfMassHeight.TabIndex = 15;
+			// 
+			// textBoxExposedFrontalArea
+			// 
+			this.textBoxExposedFrontalArea.Location = new System.Drawing.Point(160, 160);
+			this.textBoxExposedFrontalArea.Name = "textBoxExposedFrontalArea";
+			this.textBoxExposedFrontalArea.Size = new System.Drawing.Size(48, 19);
+			this.textBoxExposedFrontalArea.TabIndex = 14;
+			// 
+			// textBoxObject
+			// 
+			this.textBoxObject.Location = new System.Drawing.Point(160, 408);
+			this.textBoxObject.Name = "textBoxObject";
+			this.textBoxObject.Size = new System.Drawing.Size(104, 19);
+			this.textBoxObject.TabIndex = 13;
+			// 
+			// labelObject
+			// 
+			this.labelObject.Location = new System.Drawing.Point(8, 408);
+			this.labelObject.Name = "labelObject";
+			this.labelObject.Size = new System.Drawing.Size(144, 16);
+			this.labelObject.TabIndex = 10;
+			this.labelObject.Text = "Object:";
+			this.labelObject.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelReversed
+			// 
+			this.labelReversed.Location = new System.Drawing.Point(8, 384);
+			this.labelReversed.Name = "labelReversed";
+			this.labelReversed.Size = new System.Drawing.Size(144, 16);
+			this.labelReversed.TabIndex = 9;
+			this.labelReversed.Text = "Reversed:";
+			this.labelReversed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxAxles
+			// 
+			this.groupBoxAxles.Controls.Add(this.labelRearAxleUnit);
+			this.groupBoxAxles.Controls.Add(this.labelFrontAxleUnit);
+			this.groupBoxAxles.Controls.Add(this.textBoxRearAxle);
+			this.groupBoxAxles.Controls.Add(this.textBoxFrontAxle);
+			this.groupBoxAxles.Controls.Add(this.labelRearAxle);
+			this.groupBoxAxles.Controls.Add(this.labelFrontAxle);
+			this.groupBoxAxles.Location = new System.Drawing.Point(8, 232);
+			this.groupBoxAxles.Name = "groupBoxAxles";
+			this.groupBoxAxles.Size = new System.Drawing.Size(256, 72);
+			this.groupBoxAxles.TabIndex = 8;
+			this.groupBoxAxles.TabStop = false;
+			this.groupBoxAxles.Text = "Axles";
+			// 
+			// labelRearAxleUnit
+			// 
+			this.labelRearAxleUnit.Location = new System.Drawing.Point(208, 40);
+			this.labelRearAxleUnit.Name = "labelRearAxleUnit";
+			this.labelRearAxleUnit.Size = new System.Drawing.Size(40, 16);
+			this.labelRearAxleUnit.TabIndex = 26;
+			this.labelRearAxleUnit.Text = "m";
+			this.labelRearAxleUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// labelFrontAxleUnit
+			// 
+			this.labelFrontAxleUnit.Location = new System.Drawing.Point(208, 16);
+			this.labelFrontAxleUnit.Name = "labelFrontAxleUnit";
+			this.labelFrontAxleUnit.Size = new System.Drawing.Size(40, 16);
+			this.labelFrontAxleUnit.TabIndex = 25;
+			this.labelFrontAxleUnit.Text = "m";
+			this.labelFrontAxleUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxRearAxle
+			// 
+			this.textBoxRearAxle.Location = new System.Drawing.Point(152, 40);
+			this.textBoxRearAxle.Name = "textBoxRearAxle";
+			this.textBoxRearAxle.Size = new System.Drawing.Size(48, 19);
+			this.textBoxRearAxle.TabIndex = 12;
+			// 
+			// textBoxFrontAxle
+			// 
+			this.textBoxFrontAxle.Location = new System.Drawing.Point(152, 16);
+			this.textBoxFrontAxle.Name = "textBoxFrontAxle";
+			this.textBoxFrontAxle.Size = new System.Drawing.Size(48, 19);
+			this.textBoxFrontAxle.TabIndex = 11;
+			// 
+			// labelRearAxle
+			// 
+			this.labelRearAxle.Location = new System.Drawing.Point(8, 40);
+			this.labelRearAxle.Name = "labelRearAxle";
+			this.labelRearAxle.Size = new System.Drawing.Size(136, 16);
+			this.labelRearAxle.TabIndex = 10;
+			this.labelRearAxle.Text = "RearAxle:";
+			this.labelRearAxle.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelFrontAxle
+			// 
+			this.labelFrontAxle.Location = new System.Drawing.Point(8, 16);
+			this.labelFrontAxle.Name = "labelFrontAxle";
+			this.labelFrontAxle.Size = new System.Drawing.Size(136, 16);
+			this.labelFrontAxle.TabIndex = 9;
+			this.labelFrontAxle.Text = "FrontAxle:";
+			this.labelFrontAxle.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDefinedAxles
+			// 
+			this.labelDefinedAxles.Location = new System.Drawing.Point(8, 208);
+			this.labelDefinedAxles.Name = "labelDefinedAxles";
+			this.labelDefinedAxles.Size = new System.Drawing.Size(144, 16);
+			this.labelDefinedAxles.TabIndex = 7;
+			this.labelDefinedAxles.Text = "DefinedAxles:";
+			this.labelDefinedAxles.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelExposedFrontalArea
+			// 
+			this.labelExposedFrontalArea.Location = new System.Drawing.Point(8, 160);
+			this.labelExposedFrontalArea.Name = "labelExposedFrontalArea";
+			this.labelExposedFrontalArea.Size = new System.Drawing.Size(144, 16);
+			this.labelExposedFrontalArea.TabIndex = 6;
+			this.labelExposedFrontalArea.Text = "ExposedFrontalArea:";
+			this.labelExposedFrontalArea.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCenterOfMassHeight
+			// 
+			this.labelCenterOfMassHeight.Location = new System.Drawing.Point(8, 136);
+			this.labelCenterOfMassHeight.Name = "labelCenterOfMassHeight";
+			this.labelCenterOfMassHeight.Size = new System.Drawing.Size(144, 16);
+			this.labelCenterOfMassHeight.TabIndex = 5;
+			this.labelCenterOfMassHeight.Text = "CenterOfMassHeight:";
+			this.labelCenterOfMassHeight.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelHeight
+			// 
+			this.labelHeight.Location = new System.Drawing.Point(8, 112);
+			this.labelHeight.Name = "labelHeight";
+			this.labelHeight.Size = new System.Drawing.Size(144, 16);
+			this.labelHeight.TabIndex = 4;
+			this.labelHeight.Text = "Height:";
+			this.labelHeight.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelWidth
+			// 
+			this.labelWidth.Location = new System.Drawing.Point(8, 88);
+			this.labelWidth.Name = "labelWidth";
+			this.labelWidth.Size = new System.Drawing.Size(144, 16);
+			this.labelWidth.TabIndex = 3;
+			this.labelWidth.Text = "Width:";
+			this.labelWidth.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelLength
+			// 
+			this.labelLength.Location = new System.Drawing.Point(8, 64);
+			this.labelLength.Name = "labelLength";
+			this.labelLength.Size = new System.Drawing.Size(144, 16);
+			this.labelLength.TabIndex = 2;
+			this.labelLength.Text = "Length:";
+			this.labelLength.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelMass
+			// 
+			this.labelMass.Location = new System.Drawing.Point(8, 40);
+			this.labelMass.Name = "labelMass";
+			this.labelMass.Size = new System.Drawing.Size(144, 16);
+			this.labelMass.TabIndex = 1;
+			this.labelMass.Text = "Mass:";
+			this.labelMass.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelIsMotorCar
+			// 
+			this.labelIsMotorCar.Location = new System.Drawing.Point(8, 16);
+			this.labelIsMotorCar.Name = "labelIsMotorCar";
+			this.labelIsMotorCar.Size = new System.Drawing.Size(144, 16);
+			this.labelIsMotorCar.TabIndex = 0;
+			this.labelIsMotorCar.Text = "IsMotorCar:";
+			this.labelIsMotorCar.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// tabPageTrain
+			// 
+			this.tabPageTrain.Controls.Add(this.groupBoxDevice);
+			this.tabPageTrain.Controls.Add(this.groupBoxCab);
+			this.tabPageTrain.Controls.Add(this.groupBoxHandle);
+			this.tabPageTrain.Location = new System.Drawing.Point(4, 22);
+			this.tabPageTrain.Name = "tabPageTrain";
+			this.tabPageTrain.Size = new System.Drawing.Size(792, 670);
+			this.tabPageTrain.TabIndex = 3;
+			this.tabPageTrain.Text = "Train settings";
+			this.tabPageTrain.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxDevice
+			// 
+			this.groupBoxDevice.Controls.Add(this.labelDoorMaxToleranceUnit);
+			this.groupBoxDevice.Controls.Add(this.textBoxDoorMaxTolerance);
+			this.groupBoxDevice.Controls.Add(this.labelDoorWidthUnit);
+			this.groupBoxDevice.Controls.Add(this.textBoxDoorWidth);
+			this.groupBoxDevice.Controls.Add(this.comboBoxDoorCloseMode);
+			this.groupBoxDevice.Controls.Add(this.comboBoxDoorOpenMode);
+			this.groupBoxDevice.Controls.Add(this.comboBoxPassAlarm);
+			this.groupBoxDevice.Controls.Add(this.comboBoxReAdhesionDevice);
+			this.groupBoxDevice.Controls.Add(this.comboBoxAtc);
+			this.groupBoxDevice.Controls.Add(this.comboBoxAts);
+			this.groupBoxDevice.Controls.Add(this.checkBoxHoldBrake);
+			this.groupBoxDevice.Controls.Add(this.checkBoxEb);
+			this.groupBoxDevice.Controls.Add(this.checkBoxConstSpeed);
+			this.groupBoxDevice.Controls.Add(this.labelDoorMaxTolerance);
+			this.groupBoxDevice.Controls.Add(this.labelDoorWidth);
+			this.groupBoxDevice.Controls.Add(this.labelDoorCloseMode);
+			this.groupBoxDevice.Controls.Add(this.labelDoorOpenMode);
+			this.groupBoxDevice.Controls.Add(this.labelPassAlarm);
+			this.groupBoxDevice.Controls.Add(this.labelReAdhesionDevice);
+			this.groupBoxDevice.Controls.Add(this.labelHoldBrake);
+			this.groupBoxDevice.Controls.Add(this.labelConstSpeed);
+			this.groupBoxDevice.Controls.Add(this.labelEb);
+			this.groupBoxDevice.Controls.Add(this.labelAtc);
+			this.groupBoxDevice.Controls.Add(this.labelAts);
+			this.groupBoxDevice.Location = new System.Drawing.Point(432, 8);
+			this.groupBoxDevice.Name = "groupBoxDevice";
+			this.groupBoxDevice.Size = new System.Drawing.Size(336, 288);
+			this.groupBoxDevice.TabIndex = 2;
+			this.groupBoxDevice.TabStop = false;
+			this.groupBoxDevice.Text = "Device";
+			// 
+			// labelDoorMaxToleranceUnit
+			// 
+			this.labelDoorMaxToleranceUnit.Location = new System.Drawing.Point(304, 256);
+			this.labelDoorMaxToleranceUnit.Name = "labelDoorMaxToleranceUnit";
+			this.labelDoorMaxToleranceUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelDoorMaxToleranceUnit.TabIndex = 23;
+			this.labelDoorMaxToleranceUnit.Text = "mm";
+			this.labelDoorMaxToleranceUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxDoorMaxTolerance
+			// 
+			this.textBoxDoorMaxTolerance.Location = new System.Drawing.Point(128, 256);
+			this.textBoxDoorMaxTolerance.Name = "textBoxDoorMaxTolerance";
+			this.textBoxDoorMaxTolerance.Size = new System.Drawing.Size(168, 19);
+			this.textBoxDoorMaxTolerance.TabIndex = 22;
+			// 
+			// labelDoorWidthUnit
+			// 
+			this.labelDoorWidthUnit.Location = new System.Drawing.Point(304, 232);
+			this.labelDoorWidthUnit.Name = "labelDoorWidthUnit";
+			this.labelDoorWidthUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelDoorWidthUnit.TabIndex = 21;
+			this.labelDoorWidthUnit.Text = "mm";
+			this.labelDoorWidthUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxDoorWidth
+			// 
+			this.textBoxDoorWidth.Location = new System.Drawing.Point(128, 232);
+			this.textBoxDoorWidth.Name = "textBoxDoorWidth";
+			this.textBoxDoorWidth.Size = new System.Drawing.Size(168, 19);
+			this.textBoxDoorWidth.TabIndex = 20;
+			// 
+			// comboBoxDoorCloseMode
+			// 
+			this.comboBoxDoorCloseMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxDoorCloseMode.FormattingEnabled = true;
+			this.comboBoxDoorCloseMode.Items.AddRange(new object[] {
+            "Semi-automatic",
+            "Automatic",
+            "Manual"});
+			this.comboBoxDoorCloseMode.Location = new System.Drawing.Point(128, 208);
+			this.comboBoxDoorCloseMode.Name = "comboBoxDoorCloseMode";
+			this.comboBoxDoorCloseMode.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxDoorCloseMode.TabIndex = 19;
+			// 
+			// comboBoxDoorOpenMode
+			// 
+			this.comboBoxDoorOpenMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxDoorOpenMode.FormattingEnabled = true;
+			this.comboBoxDoorOpenMode.Items.AddRange(new object[] {
+            "Semi-automatic",
+            "Automatic",
+            "Manual"});
+			this.comboBoxDoorOpenMode.Location = new System.Drawing.Point(128, 184);
+			this.comboBoxDoorOpenMode.Name = "comboBoxDoorOpenMode";
+			this.comboBoxDoorOpenMode.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxDoorOpenMode.TabIndex = 18;
+			// 
+			// comboBoxPassAlarm
+			// 
+			this.comboBoxPassAlarm.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxPassAlarm.FormattingEnabled = true;
+			this.comboBoxPassAlarm.Items.AddRange(new object[] {
+            "None",
+            "Single",
+            "Looping"});
+			this.comboBoxPassAlarm.Location = new System.Drawing.Point(128, 160);
+			this.comboBoxPassAlarm.Name = "comboBoxPassAlarm";
+			this.comboBoxPassAlarm.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxPassAlarm.TabIndex = 17;
+			// 
+			// comboBoxReAdhesionDevice
+			// 
+			this.comboBoxReAdhesionDevice.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxReAdhesionDevice.FormattingEnabled = true;
+			this.comboBoxReAdhesionDevice.Items.AddRange(new object[] {
+            "None",
+            "Type A (instant)",
+            "Type B (slow)",
+            "Type C (medium)",
+            "Type D (fast)"});
+			this.comboBoxReAdhesionDevice.Location = new System.Drawing.Point(128, 136);
+			this.comboBoxReAdhesionDevice.Name = "comboBoxReAdhesionDevice";
+			this.comboBoxReAdhesionDevice.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxReAdhesionDevice.TabIndex = 16;
+			// 
+			// comboBoxAtc
+			// 
+			this.comboBoxAtc.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxAtc.FormattingEnabled = true;
+			this.comboBoxAtc.Items.AddRange(new object[] {
+            "None",
+            "Manual switching",
+            "Automatic switching"});
+			this.comboBoxAtc.Location = new System.Drawing.Point(128, 40);
+			this.comboBoxAtc.Name = "comboBoxAtc";
+			this.comboBoxAtc.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxAtc.TabIndex = 15;
+			// 
+			// comboBoxAts
+			// 
+			this.comboBoxAts.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxAts.FormattingEnabled = true;
+			this.comboBoxAts.Items.AddRange(new object[] {
+            "None",
+            "ATS-SN",
+            "ATS-SN / ATS-P"});
+			this.comboBoxAts.Location = new System.Drawing.Point(128, 16);
+			this.comboBoxAts.Name = "comboBoxAts";
+			this.comboBoxAts.Size = new System.Drawing.Size(168, 20);
+			this.comboBoxAts.TabIndex = 14;
+			// 
+			// checkBoxHoldBrake
+			// 
+			this.checkBoxHoldBrake.Location = new System.Drawing.Point(128, 112);
+			this.checkBoxHoldBrake.Name = "checkBoxHoldBrake";
+			this.checkBoxHoldBrake.Size = new System.Drawing.Size(168, 16);
+			this.checkBoxHoldBrake.TabIndex = 13;
+			this.checkBoxHoldBrake.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxEb
+			// 
+			this.checkBoxEb.Location = new System.Drawing.Point(128, 64);
+			this.checkBoxEb.Name = "checkBoxEb";
+			this.checkBoxEb.Size = new System.Drawing.Size(168, 16);
+			this.checkBoxEb.TabIndex = 12;
+			this.checkBoxEb.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxConstSpeed
+			// 
+			this.checkBoxConstSpeed.Location = new System.Drawing.Point(128, 88);
+			this.checkBoxConstSpeed.Name = "checkBoxConstSpeed";
+			this.checkBoxConstSpeed.Size = new System.Drawing.Size(168, 16);
+			this.checkBoxConstSpeed.TabIndex = 11;
+			this.checkBoxConstSpeed.UseVisualStyleBackColor = true;
+			// 
+			// labelDoorMaxTolerance
+			// 
+			this.labelDoorMaxTolerance.Location = new System.Drawing.Point(8, 256);
+			this.labelDoorMaxTolerance.Name = "labelDoorMaxTolerance";
+			this.labelDoorMaxTolerance.Size = new System.Drawing.Size(112, 16);
+			this.labelDoorMaxTolerance.TabIndex = 10;
+			this.labelDoorMaxTolerance.Text = "DoorMaxTolerance:";
+			this.labelDoorMaxTolerance.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDoorWidth
+			// 
+			this.labelDoorWidth.Location = new System.Drawing.Point(8, 232);
+			this.labelDoorWidth.Name = "labelDoorWidth";
+			this.labelDoorWidth.Size = new System.Drawing.Size(112, 16);
+			this.labelDoorWidth.TabIndex = 9;
+			this.labelDoorWidth.Text = "DoorWidth:";
+			this.labelDoorWidth.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDoorCloseMode
+			// 
+			this.labelDoorCloseMode.Location = new System.Drawing.Point(8, 208);
+			this.labelDoorCloseMode.Name = "labelDoorCloseMode";
+			this.labelDoorCloseMode.Size = new System.Drawing.Size(112, 16);
+			this.labelDoorCloseMode.TabIndex = 8;
+			this.labelDoorCloseMode.Text = "DoorCloseMode:";
+			this.labelDoorCloseMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelDoorOpenMode
+			// 
+			this.labelDoorOpenMode.Location = new System.Drawing.Point(8, 184);
+			this.labelDoorOpenMode.Name = "labelDoorOpenMode";
+			this.labelDoorOpenMode.Size = new System.Drawing.Size(112, 16);
+			this.labelDoorOpenMode.TabIndex = 7;
+			this.labelDoorOpenMode.Text = "DoorOpenMode:";
+			this.labelDoorOpenMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelPassAlarm
+			// 
+			this.labelPassAlarm.Location = new System.Drawing.Point(8, 160);
+			this.labelPassAlarm.Name = "labelPassAlarm";
+			this.labelPassAlarm.Size = new System.Drawing.Size(112, 16);
+			this.labelPassAlarm.TabIndex = 6;
+			this.labelPassAlarm.Text = "PassAlarm:";
+			this.labelPassAlarm.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelReAdhesionDevice
+			// 
+			this.labelReAdhesionDevice.Location = new System.Drawing.Point(8, 136);
+			this.labelReAdhesionDevice.Name = "labelReAdhesionDevice";
+			this.labelReAdhesionDevice.Size = new System.Drawing.Size(112, 16);
+			this.labelReAdhesionDevice.TabIndex = 5;
+			this.labelReAdhesionDevice.Text = "ReAdhesionDevice:";
+			this.labelReAdhesionDevice.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelHoldBrake
+			// 
+			this.labelHoldBrake.Location = new System.Drawing.Point(8, 112);
+			this.labelHoldBrake.Name = "labelHoldBrake";
+			this.labelHoldBrake.Size = new System.Drawing.Size(112, 16);
+			this.labelHoldBrake.TabIndex = 4;
+			this.labelHoldBrake.Text = "HoldBrake:";
+			this.labelHoldBrake.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelConstSpeed
+			// 
+			this.labelConstSpeed.Location = new System.Drawing.Point(8, 88);
+			this.labelConstSpeed.Name = "labelConstSpeed";
+			this.labelConstSpeed.Size = new System.Drawing.Size(112, 16);
+			this.labelConstSpeed.TabIndex = 3;
+			this.labelConstSpeed.Text = "ConstSpeed:";
+			this.labelConstSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelEb
+			// 
+			this.labelEb.Location = new System.Drawing.Point(8, 64);
+			this.labelEb.Name = "labelEb";
+			this.labelEb.Size = new System.Drawing.Size(112, 16);
+			this.labelEb.TabIndex = 2;
+			this.labelEb.Text = "Eb:";
+			this.labelEb.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAtc
+			// 
+			this.labelAtc.Location = new System.Drawing.Point(8, 40);
+			this.labelAtc.Name = "labelAtc";
+			this.labelAtc.Size = new System.Drawing.Size(112, 16);
+			this.labelAtc.TabIndex = 1;
+			this.labelAtc.Text = "Atc:";
+			this.labelAtc.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelAts
+			// 
+			this.labelAts.Location = new System.Drawing.Point(8, 16);
+			this.labelAts.Name = "labelAts";
+			this.labelAts.Size = new System.Drawing.Size(112, 16);
+			this.labelAts.TabIndex = 0;
+			this.labelAts.Text = "Ats:";
+			this.labelAts.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxCab
+			// 
+			this.groupBoxCab.Controls.Add(this.comboBoxDriverCar);
+			this.groupBoxCab.Controls.Add(this.labelCabZUnit);
+			this.groupBoxCab.Controls.Add(this.textBoxCabZ);
+			this.groupBoxCab.Controls.Add(this.labelCabYUnit);
+			this.groupBoxCab.Controls.Add(this.textBoxCabY);
+			this.groupBoxCab.Controls.Add(this.labelCabXUnit);
+			this.groupBoxCab.Controls.Add(this.textBoxCabX);
+			this.groupBoxCab.Controls.Add(this.labelDriverCar);
+			this.groupBoxCab.Controls.Add(this.labelCabZ);
+			this.groupBoxCab.Controls.Add(this.labelCabY);
+			this.groupBoxCab.Controls.Add(this.labelCabX);
+			this.groupBoxCab.Location = new System.Drawing.Point(8, 256);
+			this.groupBoxCab.Name = "groupBoxCab";
+			this.groupBoxCab.Size = new System.Drawing.Size(416, 120);
+			this.groupBoxCab.TabIndex = 1;
+			this.groupBoxCab.TabStop = false;
+			this.groupBoxCab.Text = "Cab";
+			// 
+			// comboBoxDriverCar
+			// 
+			this.comboBoxDriverCar.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxDriverCar.FormattingEnabled = true;
+			this.comboBoxDriverCar.Location = new System.Drawing.Point(192, 88);
+			this.comboBoxDriverCar.Name = "comboBoxDriverCar";
+			this.comboBoxDriverCar.Size = new System.Drawing.Size(184, 20);
+			this.comboBoxDriverCar.TabIndex = 10;
+			// 
+			// labelCabZUnit
+			// 
+			this.labelCabZUnit.Location = new System.Drawing.Point(384, 64);
+			this.labelCabZUnit.Name = "labelCabZUnit";
+			this.labelCabZUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelCabZUnit.TabIndex = 9;
+			this.labelCabZUnit.Text = "mm";
+			this.labelCabZUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxCabZ
+			// 
+			this.textBoxCabZ.Location = new System.Drawing.Point(192, 64);
+			this.textBoxCabZ.Name = "textBoxCabZ";
+			this.textBoxCabZ.Size = new System.Drawing.Size(184, 19);
+			this.textBoxCabZ.TabIndex = 8;
+			// 
+			// labelCabYUnit
+			// 
+			this.labelCabYUnit.Location = new System.Drawing.Point(384, 40);
+			this.labelCabYUnit.Name = "labelCabYUnit";
+			this.labelCabYUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelCabYUnit.TabIndex = 7;
+			this.labelCabYUnit.Text = "mm";
+			this.labelCabYUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxCabY
+			// 
+			this.textBoxCabY.Location = new System.Drawing.Point(192, 40);
+			this.textBoxCabY.Name = "textBoxCabY";
+			this.textBoxCabY.Size = new System.Drawing.Size(184, 19);
+			this.textBoxCabY.TabIndex = 6;
+			// 
+			// labelCabXUnit
+			// 
+			this.labelCabXUnit.Location = new System.Drawing.Point(384, 16);
+			this.labelCabXUnit.Name = "labelCabXUnit";
+			this.labelCabXUnit.Size = new System.Drawing.Size(24, 16);
+			this.labelCabXUnit.TabIndex = 5;
+			this.labelCabXUnit.Text = "mm";
+			this.labelCabXUnit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// textBoxCabX
+			// 
+			this.textBoxCabX.Location = new System.Drawing.Point(192, 16);
+			this.textBoxCabX.Name = "textBoxCabX";
+			this.textBoxCabX.Size = new System.Drawing.Size(184, 19);
+			this.textBoxCabX.TabIndex = 4;
+			// 
+			// labelDriverCar
+			// 
+			this.labelDriverCar.Location = new System.Drawing.Point(8, 88);
+			this.labelDriverCar.Name = "labelDriverCar";
+			this.labelDriverCar.Size = new System.Drawing.Size(176, 16);
+			this.labelDriverCar.TabIndex = 3;
+			this.labelDriverCar.Text = "DriverCar:";
+			this.labelDriverCar.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCabZ
+			// 
+			this.labelCabZ.Location = new System.Drawing.Point(8, 64);
+			this.labelCabZ.Name = "labelCabZ";
+			this.labelCabZ.Size = new System.Drawing.Size(176, 16);
+			this.labelCabZ.TabIndex = 2;
+			this.labelCabZ.Text = "Z:";
+			this.labelCabZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCabY
+			// 
+			this.labelCabY.Location = new System.Drawing.Point(8, 40);
+			this.labelCabY.Name = "labelCabY";
+			this.labelCabY.Size = new System.Drawing.Size(176, 16);
+			this.labelCabY.TabIndex = 1;
+			this.labelCabY.Text = "Y:";
+			this.labelCabY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelCabX
+			// 
+			this.labelCabX.Location = new System.Drawing.Point(8, 16);
+			this.labelCabX.Name = "labelCabX";
+			this.labelCabX.Size = new System.Drawing.Size(176, 16);
+			this.labelCabX.TabIndex = 0;
+			this.labelCabX.Text = "X:";
+			this.labelCabX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// groupBoxHandle
+			// 
+			this.groupBoxHandle.Controls.Add(this.numericUpDownLocoBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.labelLocoBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.comboBoxLocoBrakeHandleType);
+			this.groupBoxHandle.Controls.Add(this.labelLocoBrakeHandleType);
+			this.groupBoxHandle.Controls.Add(this.comboBoxEbHandleBehaviour);
+			this.groupBoxHandle.Controls.Add(this.labelEbHandleBehaviour);
+			this.groupBoxHandle.Controls.Add(this.numericUpDownDriverBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.labelDriverBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.numericUpDownDriverPowerNotches);
+			this.groupBoxHandle.Controls.Add(this.labelDriverPowerNotches);
+			this.groupBoxHandle.Controls.Add(this.numericUpDownPowerNotchReduceSteps);
+			this.groupBoxHandle.Controls.Add(this.labelPowerNotchReduceSteps);
+			this.groupBoxHandle.Controls.Add(this.numericUpDownBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.labelBrakeNotches);
+			this.groupBoxHandle.Controls.Add(this.numericUpDownPowerNotches);
+			this.groupBoxHandle.Controls.Add(this.labelPowerNotches);
+			this.groupBoxHandle.Controls.Add(this.comboBoxHandleType);
+			this.groupBoxHandle.Controls.Add(this.labelHandleType);
+			this.groupBoxHandle.Location = new System.Drawing.Point(8, 8);
+			this.groupBoxHandle.Name = "groupBoxHandle";
+			this.groupBoxHandle.Size = new System.Drawing.Size(416, 240);
+			this.groupBoxHandle.TabIndex = 0;
+			this.groupBoxHandle.TabStop = false;
+			this.groupBoxHandle.Text = "Handle";
+			// 
+			// numericUpDownLocoBrakeNotches
+			// 
+			this.numericUpDownLocoBrakeNotches.Location = new System.Drawing.Point(192, 208);
+			this.numericUpDownLocoBrakeNotches.Name = "numericUpDownLocoBrakeNotches";
+			this.numericUpDownLocoBrakeNotches.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownLocoBrakeNotches.TabIndex = 17;
+			// 
+			// labelLocoBrakeNotches
+			// 
+			this.labelLocoBrakeNotches.Location = new System.Drawing.Point(8, 208);
+			this.labelLocoBrakeNotches.Name = "labelLocoBrakeNotches";
+			this.labelLocoBrakeNotches.Size = new System.Drawing.Size(176, 16);
+			this.labelLocoBrakeNotches.TabIndex = 16;
+			this.labelLocoBrakeNotches.Text = "LocoBrakeNotches:";
+			this.labelLocoBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// comboBoxLocoBrakeHandleType
+			// 
+			this.comboBoxLocoBrakeHandleType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxLocoBrakeHandleType.FormattingEnabled = true;
+			this.comboBoxLocoBrakeHandleType.Items.AddRange(new object[] {
+            "Combined",
+            "Independant",
+            "Blocking"});
+			this.comboBoxLocoBrakeHandleType.Location = new System.Drawing.Point(192, 184);
+			this.comboBoxLocoBrakeHandleType.Name = "comboBoxLocoBrakeHandleType";
+			this.comboBoxLocoBrakeHandleType.Size = new System.Drawing.Size(216, 20);
+			this.comboBoxLocoBrakeHandleType.TabIndex = 15;
+			// 
+			// labelLocoBrakeHandleType
+			// 
+			this.labelLocoBrakeHandleType.Location = new System.Drawing.Point(8, 184);
+			this.labelLocoBrakeHandleType.Name = "labelLocoBrakeHandleType";
+			this.labelLocoBrakeHandleType.Size = new System.Drawing.Size(176, 16);
+			this.labelLocoBrakeHandleType.TabIndex = 14;
+			this.labelLocoBrakeHandleType.Text = "LocoBrakeHandleType:";
+			this.labelLocoBrakeHandleType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// comboBoxEbHandleBehaviour
+			// 
+			this.comboBoxEbHandleBehaviour.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxEbHandleBehaviour.FormattingEnabled = true;
+			this.comboBoxEbHandleBehaviour.Items.AddRange(new object[] {
+            "No action",
+            "Return power to neutral",
+            "Return reverser to neutral",
+            "Return power and reverser to neutral"});
+			this.comboBoxEbHandleBehaviour.Location = new System.Drawing.Point(192, 160);
+			this.comboBoxEbHandleBehaviour.Name = "comboBoxEbHandleBehaviour";
+			this.comboBoxEbHandleBehaviour.Size = new System.Drawing.Size(216, 20);
+			this.comboBoxEbHandleBehaviour.TabIndex = 13;
+			// 
+			// labelEbHandleBehaviour
+			// 
+			this.labelEbHandleBehaviour.Location = new System.Drawing.Point(8, 160);
+			this.labelEbHandleBehaviour.Name = "labelEbHandleBehaviour";
+			this.labelEbHandleBehaviour.Size = new System.Drawing.Size(176, 16);
+			this.labelEbHandleBehaviour.TabIndex = 12;
+			this.labelEbHandleBehaviour.Text = "EbHandleBehaviour:";
+			this.labelEbHandleBehaviour.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// numericUpDownDriverBrakeNotches
+			// 
+			this.numericUpDownDriverBrakeNotches.Location = new System.Drawing.Point(192, 136);
+			this.numericUpDownDriverBrakeNotches.Name = "numericUpDownDriverBrakeNotches";
+			this.numericUpDownDriverBrakeNotches.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownDriverBrakeNotches.TabIndex = 11;
+			// 
+			// labelDriverBrakeNotches
+			// 
+			this.labelDriverBrakeNotches.Location = new System.Drawing.Point(8, 136);
+			this.labelDriverBrakeNotches.Name = "labelDriverBrakeNotches";
+			this.labelDriverBrakeNotches.Size = new System.Drawing.Size(176, 16);
+			this.labelDriverBrakeNotches.TabIndex = 10;
+			this.labelDriverBrakeNotches.Text = "DriverBrakeNotches:";
+			this.labelDriverBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// numericUpDownDriverPowerNotches
+			// 
+			this.numericUpDownDriverPowerNotches.Location = new System.Drawing.Point(192, 112);
+			this.numericUpDownDriverPowerNotches.Name = "numericUpDownDriverPowerNotches";
+			this.numericUpDownDriverPowerNotches.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownDriverPowerNotches.TabIndex = 9;
+			// 
+			// labelDriverPowerNotches
+			// 
+			this.labelDriverPowerNotches.Location = new System.Drawing.Point(8, 112);
+			this.labelDriverPowerNotches.Name = "labelDriverPowerNotches";
+			this.labelDriverPowerNotches.Size = new System.Drawing.Size(176, 16);
+			this.labelDriverPowerNotches.TabIndex = 8;
+			this.labelDriverPowerNotches.Text = "DriverPowerNotches:";
+			this.labelDriverPowerNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// numericUpDownPowerNotchReduceSteps
+			// 
+			this.numericUpDownPowerNotchReduceSteps.Location = new System.Drawing.Point(192, 88);
+			this.numericUpDownPowerNotchReduceSteps.Name = "numericUpDownPowerNotchReduceSteps";
+			this.numericUpDownPowerNotchReduceSteps.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownPowerNotchReduceSteps.TabIndex = 7;
+			// 
+			// labelPowerNotchReduceSteps
+			// 
+			this.labelPowerNotchReduceSteps.Location = new System.Drawing.Point(8, 88);
+			this.labelPowerNotchReduceSteps.Name = "labelPowerNotchReduceSteps";
+			this.labelPowerNotchReduceSteps.Size = new System.Drawing.Size(176, 16);
+			this.labelPowerNotchReduceSteps.TabIndex = 6;
+			this.labelPowerNotchReduceSteps.Text = "PowerNotchReduceSteps:";
+			this.labelPowerNotchReduceSteps.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// numericUpDownBrakeNotches
+			// 
+			this.numericUpDownBrakeNotches.Location = new System.Drawing.Point(192, 64);
+			this.numericUpDownBrakeNotches.Name = "numericUpDownBrakeNotches";
+			this.numericUpDownBrakeNotches.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownBrakeNotches.TabIndex = 5;
+			// 
+			// labelBrakeNotches
+			// 
+			this.labelBrakeNotches.Location = new System.Drawing.Point(8, 64);
+			this.labelBrakeNotches.Name = "labelBrakeNotches";
+			this.labelBrakeNotches.Size = new System.Drawing.Size(176, 16);
+			this.labelBrakeNotches.TabIndex = 4;
+			this.labelBrakeNotches.Text = "BrakeNotches:";
+			this.labelBrakeNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// numericUpDownPowerNotches
+			// 
+			this.numericUpDownPowerNotches.Location = new System.Drawing.Point(192, 40);
+			this.numericUpDownPowerNotches.Name = "numericUpDownPowerNotches";
+			this.numericUpDownPowerNotches.Size = new System.Drawing.Size(216, 19);
+			this.numericUpDownPowerNotches.TabIndex = 3;
+			// 
+			// labelPowerNotches
+			// 
+			this.labelPowerNotches.Location = new System.Drawing.Point(8, 40);
+			this.labelPowerNotches.Name = "labelPowerNotches";
+			this.labelPowerNotches.Size = new System.Drawing.Size(176, 16);
+			this.labelPowerNotches.TabIndex = 2;
+			this.labelPowerNotches.Text = "PowerNotches:";
+			this.labelPowerNotches.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// comboBoxHandleType
+			// 
+			this.comboBoxHandleType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxHandleType.FormattingEnabled = true;
+			this.comboBoxHandleType.Items.AddRange(new object[] {
+            "Separated",
+            "Combined"});
+			this.comboBoxHandleType.Location = new System.Drawing.Point(192, 16);
+			this.comboBoxHandleType.Name = "comboBoxHandleType";
+			this.comboBoxHandleType.Size = new System.Drawing.Size(216, 20);
+			this.comboBoxHandleType.TabIndex = 1;
+			// 
+			// labelHandleType
+			// 
+			this.labelHandleType.Location = new System.Drawing.Point(8, 16);
+			this.labelHandleType.Name = "labelHandleType";
+			this.labelHandleType.Size = new System.Drawing.Size(176, 16);
+			this.labelHandleType.TabIndex = 0;
+			this.labelHandleType.Text = "HandleType:";
+			this.labelHandleType.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// tabControlEditor
+			// 
+			this.tabControlEditor.AllowDrop = true;
+			this.tabControlEditor.Controls.Add(this.tabPageTrain);
+			this.tabControlEditor.Controls.Add(this.tabPageCar);
+			this.tabControlEditor.Controls.Add(this.tabPageAccel);
+			this.tabControlEditor.Controls.Add(this.tabPageMotor);
+			this.tabControlEditor.Controls.Add(this.tabPageCoupler);
+			this.tabControlEditor.Controls.Add(this.tabPagePanel);
+			this.tabControlEditor.Controls.Add(this.tabPageSound);
+			this.tabControlEditor.Controls.Add(this.tabPageStatus);
+			this.tabControlEditor.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tabControlEditor.Location = new System.Drawing.Point(200, 24);
+			this.tabControlEditor.Name = "tabControlEditor";
+			this.tabControlEditor.SelectedIndex = 0;
+			this.tabControlEditor.Size = new System.Drawing.Size(800, 696);
+			this.tabControlEditor.TabIndex = 9;
+			// 
+			// numericUpDownTouchLayer
+			// 
+			this.numericUpDownTouchLayer.Location = new System.Drawing.Point(136, 216);
+			this.numericUpDownTouchLayer.Name = "numericUpDownTouchLayer";
+			this.numericUpDownTouchLayer.Size = new System.Drawing.Size(48, 19);
+			this.numericUpDownTouchLayer.TabIndex = 108;
+			// 
+			// labelTouchLayer
+			// 
+			this.labelTouchLayer.Location = new System.Drawing.Point(8, 216);
+			this.labelTouchLayer.Name = "labelTouchLayer";
+			this.labelTouchLayer.Size = new System.Drawing.Size(120, 16);
+			this.labelTouchLayer.TabIndex = 109;
+			this.labelTouchLayer.Text = "Layer:";
+			this.labelTouchLayer.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
 			// 
 			// FormEditor
 			// 
@@ -6557,69 +6527,30 @@ namespace TrainEditor2.Views
 			this.Load += new System.EventHandler(this.FormEditor_Load);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FormEditor_KeyDown);
 			this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.FormEditor_KeyUp);
-			this.tabControlEditor.ResumeLayout(false);
-			this.tabPageTrain.ResumeLayout(false);
-			this.groupBoxDevice.ResumeLayout(false);
-			this.groupBoxDevice.PerformLayout();
-			this.groupBoxCab.ResumeLayout(false);
-			this.groupBoxCab.PerformLayout();
-			this.groupBoxHandle.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownLocoBrakeNotches)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverBrakeNotches)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverPowerNotches)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotchReduceSteps)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).EndInit();
-			this.tabPageCar.ResumeLayout(false);
-			this.groupBoxPressure.ResumeLayout(false);
-			this.groupBoxPressure.PerformLayout();
-			this.groupBoxBrake.ResumeLayout(false);
-			this.groupBoxBrake.PerformLayout();
-			this.groupBoxMove.ResumeLayout(false);
-			this.groupBoxMove.PerformLayout();
-			this.groupBoxDelay.ResumeLayout(false);
-			this.groupBoxPerformance.ResumeLayout(false);
-			this.groupBoxPerformance.PerformLayout();
-			this.groupBoxCarGeneral.ResumeLayout(false);
-			this.groupBoxCarGeneral.PerformLayout();
-			this.groupBoxAxles.ResumeLayout(false);
-			this.groupBoxAxles.PerformLayout();
-			this.tabPageAccel.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.pictureBoxAccel)).EndInit();
-			this.panelAccel.ResumeLayout(false);
-			this.groupBoxPreview.ResumeLayout(false);
-			this.groupBoxPreview.PerformLayout();
-			this.groupBoxParameter.ResumeLayout(false);
-			this.groupBoxParameter.PerformLayout();
-			this.groupBoxNotch.ResumeLayout(false);
-			this.tabPageMotor.ResumeLayout(false);
-			this.panelMotorSound.ResumeLayout(false);
-			this.panelMotorSound.PerformLayout();
-			this.toolStripContainerDrawArea.ContentPanel.ResumeLayout(false);
-			this.toolStripContainerDrawArea.TopToolStripPanel.ResumeLayout(false);
-			this.toolStripContainerDrawArea.TopToolStripPanel.PerformLayout();
-			this.toolStripContainerDrawArea.ResumeLayout(false);
-			this.toolStripContainerDrawArea.PerformLayout();
-			this.toolStripToolBar.ResumeLayout(false);
-			this.toolStripToolBar.PerformLayout();
-			this.panelMotorSetting.ResumeLayout(false);
-			this.groupBoxDirect.ResumeLayout(false);
-			this.groupBoxDirect.PerformLayout();
-			this.groupBoxPlay.ResumeLayout(false);
-			this.groupBoxArea.ResumeLayout(false);
-			this.groupBoxArea.PerformLayout();
-			this.groupBoxSource.ResumeLayout(false);
-			this.groupBoxSource.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownRunIndex)).EndInit();
-			this.groupBoxView.ResumeLayout(false);
-			this.groupBoxView.PerformLayout();
-			this.statusStripStatus.ResumeLayout(false);
-			this.statusStripStatus.PerformLayout();
-			this.menuStripMotor.ResumeLayout(false);
-			this.menuStripMotor.PerformLayout();
-			this.tabPageCoupler.ResumeLayout(false);
-			this.groupBoxCouplerGeneral.ResumeLayout(false);
-			this.groupBoxCouplerGeneral.PerformLayout();
+			this.panelCars.ResumeLayout(false);
+			this.panelCarsNavi.ResumeLayout(false);
+			this.menuStripMenu.ResumeLayout(false);
+			this.menuStripMenu.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+			this.tabPageStatus.ResumeLayout(false);
+			this.tabPageStatus.PerformLayout();
+			this.panelStatusNavi.ResumeLayout(false);
+			this.menuStripStatus.ResumeLayout(false);
+			this.menuStripStatus.PerformLayout();
+			this.tabPageSound.ResumeLayout(false);
+			this.panelSoundSetting.ResumeLayout(false);
+			this.splitContainerSound.Panel1.ResumeLayout(false);
+			this.splitContainerSound.Panel2.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.splitContainerSound)).EndInit();
+			this.splitContainerSound.ResumeLayout(false);
+			this.panelSoundSettingEdit.ResumeLayout(false);
+			this.groupBoxSoundEntry.ResumeLayout(false);
+			this.groupBoxSoundKey.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownSoundKeyIndex)).EndInit();
+			this.groupBoxSoundValue.ResumeLayout(false);
+			this.groupBoxSoundValue.PerformLayout();
+			this.groupBoxSoundPosition.ResumeLayout(false);
+			this.groupBoxSoundPosition.PerformLayout();
 			this.tabPagePanel.ResumeLayout(false);
 			this.splitContainerPanel.Panel1.ResumeLayout(false);
 			this.splitContainerPanel.Panel2.ResumeLayout(false);
@@ -6675,570 +6606,81 @@ namespace TrainEditor2.Views
 			this.groupBoxTimetableLocation.ResumeLayout(false);
 			this.groupBoxTimetableLocation.PerformLayout();
 			this.tabPageTouch.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchCommandOption)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchSoundIndex)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchJumpScreen)).EndInit();
 			this.groupBoxTouchSize.ResumeLayout(false);
 			this.groupBoxTouchSize.PerformLayout();
 			this.groupBoxTouchLocation.ResumeLayout(false);
 			this.groupBoxTouchLocation.PerformLayout();
-			this.tabPageSound.ResumeLayout(false);
-			this.panelSoundSetting.ResumeLayout(false);
-			this.splitContainerSound.Panel1.ResumeLayout(false);
-			this.splitContainerSound.Panel2.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.splitContainerSound)).EndInit();
-			this.splitContainerSound.ResumeLayout(false);
-			this.panelSoundSettingEdit.ResumeLayout(false);
-			this.groupBoxSoundEntry.ResumeLayout(false);
-			this.groupBoxSoundKey.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.numericUpDownSoundKeyIndex)).EndInit();
-			this.groupBoxSoundValue.ResumeLayout(false);
-			this.groupBoxSoundValue.PerformLayout();
-			this.groupBoxSoundPosition.ResumeLayout(false);
-			this.groupBoxSoundPosition.PerformLayout();
-			this.tabPageStatus.ResumeLayout(false);
-			this.tabPageStatus.PerformLayout();
-			this.menuStripStatus.ResumeLayout(false);
-			this.menuStripStatus.PerformLayout();
-			this.panelCars.ResumeLayout(false);
-			this.panelCarsNavi.ResumeLayout(false);
-			this.menuStripMenu.ResumeLayout(false);
-			this.menuStripMenu.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
-			this.panelStatusNavi.ResumeLayout(false);
+			this.tabPageCoupler.ResumeLayout(false);
+			this.groupBoxCouplerGeneral.ResumeLayout(false);
+			this.groupBoxCouplerGeneral.PerformLayout();
+			this.tabPageMotor.ResumeLayout(false);
+			this.panelMotorSound.ResumeLayout(false);
+			this.panelMotorSound.PerformLayout();
+			this.toolStripContainerDrawArea.ContentPanel.ResumeLayout(false);
+			this.toolStripContainerDrawArea.TopToolStripPanel.ResumeLayout(false);
+			this.toolStripContainerDrawArea.TopToolStripPanel.PerformLayout();
+			this.toolStripContainerDrawArea.ResumeLayout(false);
+			this.toolStripContainerDrawArea.PerformLayout();
+			this.toolStripToolBar.ResumeLayout(false);
+			this.toolStripToolBar.PerformLayout();
+			this.panelMotorSetting.ResumeLayout(false);
+			this.groupBoxDirect.ResumeLayout(false);
+			this.groupBoxDirect.PerformLayout();
+			this.groupBoxPlay.ResumeLayout(false);
+			this.groupBoxArea.ResumeLayout(false);
+			this.groupBoxArea.PerformLayout();
+			this.groupBoxSource.ResumeLayout(false);
+			this.groupBoxSource.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownRunIndex)).EndInit();
+			this.groupBoxView.ResumeLayout(false);
+			this.groupBoxView.PerformLayout();
+			this.statusStripStatus.ResumeLayout(false);
+			this.statusStripStatus.PerformLayout();
+			this.menuStripMotor.ResumeLayout(false);
+			this.menuStripMotor.PerformLayout();
+			this.tabPageAccel.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.pictureBoxAccel)).EndInit();
+			this.panelAccel.ResumeLayout(false);
+			this.groupBoxPreview.ResumeLayout(false);
+			this.groupBoxPreview.PerformLayout();
+			this.groupBoxParameter.ResumeLayout(false);
+			this.groupBoxParameter.PerformLayout();
+			this.groupBoxNotch.ResumeLayout(false);
+			this.tabPageCar.ResumeLayout(false);
+			this.groupBoxPressure.ResumeLayout(false);
+			this.groupBoxPressure.PerformLayout();
+			this.groupBoxBrake.ResumeLayout(false);
+			this.groupBoxBrake.PerformLayout();
+			this.groupBoxMove.ResumeLayout(false);
+			this.groupBoxMove.PerformLayout();
+			this.groupBoxDelay.ResumeLayout(false);
+			this.groupBoxPerformance.ResumeLayout(false);
+			this.groupBoxPerformance.PerformLayout();
+			this.groupBoxCarGeneral.ResumeLayout(false);
+			this.groupBoxCarGeneral.PerformLayout();
+			this.groupBoxAxles.ResumeLayout(false);
+			this.groupBoxAxles.PerformLayout();
+			this.tabPageTrain.ResumeLayout(false);
+			this.groupBoxDevice.ResumeLayout(false);
+			this.groupBoxDevice.PerformLayout();
+			this.groupBoxCab.ResumeLayout(false);
+			this.groupBoxCab.PerformLayout();
+			this.groupBoxHandle.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownLocoBrakeNotches)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverBrakeNotches)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownDriverPowerNotches)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotchReduceSteps)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownBrakeNotches)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownPowerNotches)).EndInit();
+			this.tabControlEditor.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchLayer)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
 		}
 
 		#endregion
-
-		private System.Windows.Forms.TabControl tabControlEditor;
-		private System.Windows.Forms.TabPage tabPageTrain;
-		private System.Windows.Forms.GroupBox groupBoxDevice;
-		private System.Windows.Forms.Label labelDoorMaxToleranceUnit;
-		private System.Windows.Forms.TextBox textBoxDoorMaxTolerance;
-		private System.Windows.Forms.Label labelDoorWidthUnit;
-		private System.Windows.Forms.TextBox textBoxDoorWidth;
-		private System.Windows.Forms.ComboBox comboBoxDoorCloseMode;
-		private System.Windows.Forms.ComboBox comboBoxDoorOpenMode;
-		private System.Windows.Forms.ComboBox comboBoxPassAlarm;
-		private System.Windows.Forms.ComboBox comboBoxReAdhesionDevice;
-		private System.Windows.Forms.ComboBox comboBoxAtc;
-		private System.Windows.Forms.ComboBox comboBoxAts;
-		private System.Windows.Forms.CheckBox checkBoxHoldBrake;
-		private System.Windows.Forms.CheckBox checkBoxEb;
-		private System.Windows.Forms.CheckBox checkBoxConstSpeed;
-		private System.Windows.Forms.Label labelDoorMaxTolerance;
-		private System.Windows.Forms.Label labelDoorWidth;
-		private System.Windows.Forms.Label labelDoorCloseMode;
-		private System.Windows.Forms.Label labelDoorOpenMode;
-		private System.Windows.Forms.Label labelPassAlarm;
-		private System.Windows.Forms.Label labelReAdhesionDevice;
-		private System.Windows.Forms.Label labelHoldBrake;
-		private System.Windows.Forms.Label labelConstSpeed;
-		private System.Windows.Forms.Label labelEb;
-		private System.Windows.Forms.Label labelAtc;
-		private System.Windows.Forms.Label labelAts;
-		private System.Windows.Forms.GroupBox groupBoxCab;
-		private System.Windows.Forms.Label labelCabZUnit;
-		private System.Windows.Forms.TextBox textBoxCabZ;
-		private System.Windows.Forms.Label labelCabYUnit;
-		private System.Windows.Forms.TextBox textBoxCabY;
-		private System.Windows.Forms.Label labelCabXUnit;
-		private System.Windows.Forms.TextBox textBoxCabX;
-		private System.Windows.Forms.Label labelDriverCar;
-		private System.Windows.Forms.Label labelCabZ;
-		private System.Windows.Forms.Label labelCabY;
-		private System.Windows.Forms.Label labelCabX;
-		private System.Windows.Forms.GroupBox groupBoxHandle;
-		private System.Windows.Forms.NumericUpDown numericUpDownLocoBrakeNotches;
-		private System.Windows.Forms.Label labelLocoBrakeNotches;
-		private System.Windows.Forms.ComboBox comboBoxLocoBrakeHandleType;
-		private System.Windows.Forms.Label labelLocoBrakeHandleType;
-		private System.Windows.Forms.ComboBox comboBoxEbHandleBehaviour;
-		private System.Windows.Forms.Label labelEbHandleBehaviour;
-		private System.Windows.Forms.NumericUpDown numericUpDownDriverBrakeNotches;
-		private System.Windows.Forms.Label labelDriverBrakeNotches;
-		private System.Windows.Forms.NumericUpDown numericUpDownDriverPowerNotches;
-		private System.Windows.Forms.Label labelDriverPowerNotches;
-		private System.Windows.Forms.NumericUpDown numericUpDownPowerNotchReduceSteps;
-		private System.Windows.Forms.Label labelPowerNotchReduceSteps;
-		private System.Windows.Forms.NumericUpDown numericUpDownBrakeNotches;
-		private System.Windows.Forms.Label labelBrakeNotches;
-		private System.Windows.Forms.NumericUpDown numericUpDownPowerNotches;
-		private System.Windows.Forms.Label labelPowerNotches;
-		private System.Windows.Forms.ComboBox comboBoxHandleType;
-		private System.Windows.Forms.Label labelHandleType;
-		private System.Windows.Forms.TabPage tabPageCar;
-		private System.Windows.Forms.GroupBox groupBoxPressure;
-		private System.Windows.Forms.Label labelBrakeCylinderServiceMaximumPressureUnit;
-		private System.Windows.Forms.Label labelMainReservoirMaximumPressureUnit;
-		private System.Windows.Forms.Label labelMainReservoirMinimumPressureUnit;
-		private System.Windows.Forms.Label labelBrakeCylinderEmergencyMaximumPressureUnit;
-		private System.Windows.Forms.TextBox textBoxMainReservoirMaximumPressure;
-		private System.Windows.Forms.TextBox textBoxMainReservoirMinimumPressure;
-		private System.Windows.Forms.TextBox textBoxBrakeCylinderEmergencyMaximumPressure;
-		private System.Windows.Forms.TextBox textBoxBrakeCylinderServiceMaximumPressure;
-		private System.Windows.Forms.Label labelMainReservoirMaximumPressure;
-		private System.Windows.Forms.Label labelMainReservoirMinimumPressure;
-		private System.Windows.Forms.Label labelBrakeCylinderServiceMaximumPressure;
-		private System.Windows.Forms.Label labelBrakeCylinderEmergencyMaximumPressure;
-		private System.Windows.Forms.GroupBox groupBoxBrake;
-		private System.Windows.Forms.TextBox textBoxBrakeControlSpeed;
-		private System.Windows.Forms.Label labelBrakeControlSpeedUnit;
-		private System.Windows.Forms.ComboBox comboBoxBrakeControlSystem;
-		private System.Windows.Forms.ComboBox comboBoxLocoBrakeType;
-		private System.Windows.Forms.ComboBox comboBoxBrakeType;
-		private System.Windows.Forms.Label labelLocoBrakeType;
-		private System.Windows.Forms.Label labelBrakeType;
-		private System.Windows.Forms.Label labelBrakeControlSpeed;
-		private System.Windows.Forms.Label labelBrakeControlSystem;
-		private System.Windows.Forms.GroupBox groupBoxMove;
-		private System.Windows.Forms.Label labelBrakeCylinderDownUnit;
-		private System.Windows.Forms.TextBox textBoxBrakeCylinderDown;
-		private System.Windows.Forms.Label labelBrakeCylinderUpUnit;
-		private System.Windows.Forms.TextBox textBoxBrakeCylinderUp;
-		private System.Windows.Forms.Label labelJerkBrakeDownUnit;
-		private System.Windows.Forms.TextBox textBoxJerkBrakeDown;
-		private System.Windows.Forms.Label labelJerkBrakeUpUnit;
-		private System.Windows.Forms.TextBox textBoxJerkBrakeUp;
-		private System.Windows.Forms.Label labelJerkPowerDownUnit;
-		private System.Windows.Forms.TextBox textBoxJerkPowerDown;
-		private System.Windows.Forms.Label labelJerkPowerUpUnit;
-		private System.Windows.Forms.TextBox textBoxJerkPowerUp;
-		private System.Windows.Forms.Label labelJerkPowerUp;
-		private System.Windows.Forms.Label labelJerkPowerDown;
-		private System.Windows.Forms.Label labelJerkBrakeUp;
-		private System.Windows.Forms.Label labelJerkBrakeDown;
-		private System.Windows.Forms.Label labelBrakeCylinderUp;
-		private System.Windows.Forms.Label labelBrakeCylinderDown;
-		private System.Windows.Forms.GroupBox groupBoxDelay;
-		private System.Windows.Forms.Button buttonDelayLocoBrakeSet;
-		private System.Windows.Forms.Button buttonDelayBrakeSet;
-		private System.Windows.Forms.Button buttonDelayPowerSet;
-		private System.Windows.Forms.Label labelDelayLocoBrake;
-		private System.Windows.Forms.Label labelDelayBrake;
-		private System.Windows.Forms.Label labelDelayPower;
-		private System.Windows.Forms.GroupBox groupBoxPerformance;
-		private System.Windows.Forms.TextBox textBoxAerodynamicDragCoefficient;
-		private System.Windows.Forms.TextBox textBoxCoefficientOfRollingResistance;
-		private System.Windows.Forms.TextBox textBoxCoefficientOfStaticFriction;
-		private System.Windows.Forms.Label labelDecelerationUnit;
-		private System.Windows.Forms.TextBox textBoxDeceleration;
-		private System.Windows.Forms.Label labelAerodynamicDragCoefficient;
-		private System.Windows.Forms.Label labelCoefficientOfStaticFriction;
-		private System.Windows.Forms.Label labelDeceleration;
-		private System.Windows.Forms.Label labelCoefficientOfRollingResistance;
-		private System.Windows.Forms.GroupBox groupBoxCarGeneral;
-		private System.Windows.Forms.Label labelUnexposedFrontalAreaUnit;
-		private System.Windows.Forms.TextBox textBoxUnexposedFrontalArea;
-		private System.Windows.Forms.Label labelUnexposedFrontalArea;
-		private System.Windows.Forms.Label labelRearBogie;
-		private System.Windows.Forms.Label labelFrontBogie;
-		private System.Windows.Forms.Button buttonRearBogieSet;
-		private System.Windows.Forms.Button buttonFrontBogieSet;
-		private System.Windows.Forms.CheckBox checkBoxReversed;
-		private System.Windows.Forms.CheckBox checkBoxLoadingSway;
-		private System.Windows.Forms.CheckBox checkBoxDefinedAxles;
-		private System.Windows.Forms.CheckBox checkBoxIsMotorCar;
-		private System.Windows.Forms.Button buttonObjectOpen;
-		private System.Windows.Forms.Label labelExposedFrontalAreaUnit;
-		private System.Windows.Forms.Label labelCenterOfMassHeightUnit;
-		private System.Windows.Forms.Label labelLoadingSway;
-		private System.Windows.Forms.Label labelHeightUnit;
-		private System.Windows.Forms.Label labelWidthUnit;
-		private System.Windows.Forms.Label labelLengthUnit;
-		private System.Windows.Forms.Label labelMassUnit;
-		private System.Windows.Forms.TextBox textBoxMass;
-		private System.Windows.Forms.TextBox textBoxLength;
-		private System.Windows.Forms.TextBox textBoxWidth;
-		private System.Windows.Forms.TextBox textBoxHeight;
-		private System.Windows.Forms.TextBox textBoxCenterOfMassHeight;
-		private System.Windows.Forms.TextBox textBoxExposedFrontalArea;
-		private System.Windows.Forms.TextBox textBoxObject;
-		private System.Windows.Forms.Label labelObject;
-		private System.Windows.Forms.Label labelReversed;
-		private System.Windows.Forms.GroupBox groupBoxAxles;
-		private System.Windows.Forms.Label labelRearAxleUnit;
-		private System.Windows.Forms.Label labelFrontAxleUnit;
-		private System.Windows.Forms.TextBox textBoxRearAxle;
-		private System.Windows.Forms.TextBox textBoxFrontAxle;
-		private System.Windows.Forms.Label labelRearAxle;
-		private System.Windows.Forms.Label labelFrontAxle;
-		private System.Windows.Forms.Label labelDefinedAxles;
-		private System.Windows.Forms.Label labelExposedFrontalArea;
-		private System.Windows.Forms.Label labelCenterOfMassHeight;
-		private System.Windows.Forms.Label labelHeight;
-		private System.Windows.Forms.Label labelWidth;
-		private System.Windows.Forms.Label labelLength;
-		private System.Windows.Forms.Label labelMass;
-		private System.Windows.Forms.Label labelIsMotorCar;
-		private System.Windows.Forms.TabPage tabPageAccel;
-		private System.Windows.Forms.PictureBox pictureBoxAccel;
-		private System.Windows.Forms.Panel panelAccel;
-		private System.Windows.Forms.GroupBox groupBoxPreview;
-		private System.Windows.Forms.Button buttonAccelReset;
-		private System.Windows.Forms.Button buttonAccelZoomOut;
-		private System.Windows.Forms.Button buttonAccelZoomIn;
-		private System.Windows.Forms.Label labelAccelYValue;
-		private System.Windows.Forms.Label labelAccelXValue;
-		private System.Windows.Forms.Label labelAccelXmaxUnit;
-		private System.Windows.Forms.Label labelAccelXminUnit;
-		private System.Windows.Forms.Label labelAccelYmaxUnit;
-		private System.Windows.Forms.Label labelAccelYminUnit;
-		private System.Windows.Forms.TextBox textBoxAccelYmax;
-		private System.Windows.Forms.TextBox textBoxAccelYmin;
-		private System.Windows.Forms.TextBox textBoxAccelXmax;
-		private System.Windows.Forms.TextBox textBoxAccelXmin;
-		private System.Windows.Forms.Label labelAccelYmax;
-		private System.Windows.Forms.Label labelAccelYmin;
-		private System.Windows.Forms.Label labelAccelXmax;
-		private System.Windows.Forms.Label labelAccelXmin;
-		private System.Windows.Forms.Label labelAccelY;
-		private System.Windows.Forms.Label labelAccelX;
-		private System.Windows.Forms.CheckBox checkBoxSubtractDeceleration;
-		private System.Windows.Forms.GroupBox groupBoxParameter;
-		private System.Windows.Forms.Label labeAccelA0Unit;
-		private System.Windows.Forms.TextBox textBoxAccelA0;
-		private System.Windows.Forms.Label labelAccelA0;
-		private System.Windows.Forms.Label labelAccelA1Unit;
-		private System.Windows.Forms.TextBox textBoxAccelA1;
-		private System.Windows.Forms.Label labelAccelA1;
-		private System.Windows.Forms.Label labelAccelV1Unit;
-		private System.Windows.Forms.TextBox textBoxAccelV1;
-		private System.Windows.Forms.Label labelAccelV1;
-		private System.Windows.Forms.Label labelAccelV2Unit;
-		private System.Windows.Forms.TextBox textBoxAccelV2;
-		private System.Windows.Forms.Label labelAccelV2;
-		private System.Windows.Forms.TextBox textBoxAccelE;
-		private System.Windows.Forms.Label labelAccelE;
-		private System.Windows.Forms.GroupBox groupBoxNotch;
-		private System.Windows.Forms.ComboBox comboBoxNotch;
-		private System.Windows.Forms.TabPage tabPageMotor;
-		private System.Windows.Forms.Panel panelMotorSound;
-		private System.Windows.Forms.ToolStripContainer toolStripContainerDrawArea;
-		private System.Windows.Forms.ToolStrip toolStripToolBar;
-		private System.Windows.Forms.ToolStripButton toolStripButtonUndo;
-		private System.Windows.Forms.ToolStripButton toolStripButtonRedo;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparatorRedo;
-		private System.Windows.Forms.ToolStripButton toolStripButtonTearingOff;
-		private System.Windows.Forms.ToolStripButton toolStripButtonCopy;
-		private System.Windows.Forms.ToolStripButton toolStripButtonPaste;
-		private System.Windows.Forms.ToolStripButton toolStripButtonCleanup;
-		private System.Windows.Forms.ToolStripButton toolStripButtonDelete;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparatorEdit;
-		private System.Windows.Forms.ToolStripButton toolStripButtonSelect;
-		private System.Windows.Forms.ToolStripButton toolStripButtonMove;
-		private System.Windows.Forms.ToolStripButton toolStripButtonDot;
-		private System.Windows.Forms.ToolStripButton toolStripButtonLine;
-		private System.Windows.Forms.Panel panelMotorSetting;
-		private System.Windows.Forms.GroupBox groupBoxDirect;
-		private System.Windows.Forms.Button buttonDirectDot;
-		private System.Windows.Forms.Button buttonDirectMove;
-		private System.Windows.Forms.TextBox textBoxDirectY;
-		private System.Windows.Forms.Label labelDirectY;
-		private System.Windows.Forms.Label labelDirectXUnit;
-		private System.Windows.Forms.TextBox textBoxDirectX;
-		private System.Windows.Forms.Label labelDirectX;
-		private System.Windows.Forms.GroupBox groupBoxPlay;
-		private System.Windows.Forms.Button buttonStop;
-		private System.Windows.Forms.Button buttonPause;
-		private System.Windows.Forms.Button buttonPlay;
-		private System.Windows.Forms.GroupBox groupBoxArea;
-		private System.Windows.Forms.CheckBox checkBoxMotorConstant;
-		private System.Windows.Forms.CheckBox checkBoxMotorLoop;
-		private System.Windows.Forms.Button buttonMotorSwap;
-		private System.Windows.Forms.TextBox textBoxMotorAreaLeft;
-		private System.Windows.Forms.Label labelMotorAreaUnit;
-		private System.Windows.Forms.TextBox textBoxMotorAreaRight;
-		private System.Windows.Forms.Label labelMotorAccel;
-		private System.Windows.Forms.Label labelMotorAccelUnit;
-		private System.Windows.Forms.TextBox textBoxMotorAccel;
-		private System.Windows.Forms.GroupBox groupBoxSource;
-		private System.Windows.Forms.Label labelRun;
-		private System.Windows.Forms.CheckBox checkBoxTrack2;
-		private System.Windows.Forms.CheckBox checkBoxTrack1;
-		private System.Windows.Forms.GroupBox groupBoxView;
-		private System.Windows.Forms.Button buttonMotorReset;
-		private System.Windows.Forms.Button buttonMotorZoomOut;
-		private System.Windows.Forms.Button buttonMotorZoomIn;
-		private System.Windows.Forms.Label labelMotorMaxVolume;
-		private System.Windows.Forms.TextBox textBoxMotorMaxVolume;
-		private System.Windows.Forms.Label labelMotorMinVolume;
-		private System.Windows.Forms.TextBox textBoxMotorMinVolume;
-		private System.Windows.Forms.Label labelMotorMaxPitch;
-		private System.Windows.Forms.TextBox textBoxMotorMaxPitch;
-		private System.Windows.Forms.Label labelMotorMinPitch;
-		private System.Windows.Forms.TextBox textBoxMotorMinPitch;
-		private System.Windows.Forms.Label labelMotorMaxVelocityUnit;
-		private System.Windows.Forms.TextBox textBoxMotorMaxVelocity;
-		private System.Windows.Forms.Label labelMotorMaxVelocity;
-		private System.Windows.Forms.Label labelMotorMinVelocityUnit;
-		private System.Windows.Forms.TextBox textBoxMotorMinVelocity;
-		private System.Windows.Forms.Label labelMotorMinVelocity;
-		private System.Windows.Forms.StatusStrip statusStripStatus;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelY;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelX;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelTool;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelMode;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelTrack;
-		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelType;
-		private System.Windows.Forms.TabPage tabPageCoupler;
-		private System.Windows.Forms.GroupBox groupBoxCouplerGeneral;
-		private System.Windows.Forms.Label labelCouplerMaxUnit;
-		private System.Windows.Forms.TextBox textBoxCouplerMax;
-		private System.Windows.Forms.Label labelCouplerMax;
-		private System.Windows.Forms.Label labelCouplerMinUnit;
-		private System.Windows.Forms.TextBox textBoxCouplerMin;
-		private System.Windows.Forms.Label labelCouplerMin;
-		private System.Windows.Forms.TabPage tabPagePanel;
-		private System.Windows.Forms.SplitContainer splitContainerPanel;
-		private System.Windows.Forms.TreeView treeViewPanel;
-		private System.Windows.Forms.ListView listViewPanel;
-		private System.Windows.Forms.Panel panelPanelNavi;
-		private System.Windows.Forms.Button buttonPanelAdd;
-		private System.Windows.Forms.Button buttonPanelRemove;
-		private System.Windows.Forms.TabControl tabControlPanel;
-		private System.Windows.Forms.TabPage tabPageThis;
-		private System.Windows.Forms.Button buttonThisNighttimeImageOpen;
-		private System.Windows.Forms.Button buttonThisDaytimeImageOpen;
-		private System.Windows.Forms.GroupBox groupBoxThisOrigin;
-		private System.Windows.Forms.TextBox textBoxThisOriginY;
-		private System.Windows.Forms.TextBox textBoxThisOriginX;
-		private System.Windows.Forms.Label labelThisOriginY;
-		private System.Windows.Forms.Label labelThisOriginX;
-		private System.Windows.Forms.GroupBox groupBoxThisCenter;
-		private System.Windows.Forms.TextBox textBoxThisCenterY;
-		private System.Windows.Forms.TextBox textBoxThisCenterX;
-		private System.Windows.Forms.Label labelThisCenterY;
-		private System.Windows.Forms.Label labelThisCenterX;
-		private System.Windows.Forms.TextBox textBoxThisTransparentColor;
-		private System.Windows.Forms.TextBox textBoxThisNighttimeImage;
-		private System.Windows.Forms.TextBox textBoxThisDaytimeImage;
-		private System.Windows.Forms.TextBox textBoxThisBottom;
-		private System.Windows.Forms.TextBox textBoxThisTop;
-		private System.Windows.Forms.TextBox textBoxThisRight;
-		private System.Windows.Forms.TextBox textBoxThisLeft;
-		private System.Windows.Forms.TextBox textBoxThisResolution;
-		private System.Windows.Forms.Label labelThisResolution;
-		private System.Windows.Forms.Label labelThisLeft;
-		private System.Windows.Forms.Label labelThisRight;
-		private System.Windows.Forms.Label labelThisTop;
-		private System.Windows.Forms.Label labelThisBottom;
-		private System.Windows.Forms.Label labelThisDaytimeImage;
-		private System.Windows.Forms.Label labelThisNighttimeImage;
-		private System.Windows.Forms.Label labelThisTransparentColor;
-		private System.Windows.Forms.TabPage tabPageScreen;
-		private System.Windows.Forms.NumericUpDown numericUpDownScreenLayer;
-		private System.Windows.Forms.NumericUpDown numericUpDownScreenNumber;
-		private System.Windows.Forms.Label labelScreenLayer;
-		private System.Windows.Forms.Label labelScreenNumber;
-		private System.Windows.Forms.TabPage tabPagePilotLamp;
-		private System.Windows.Forms.NumericUpDown numericUpDownPilotLampLayer;
-		private System.Windows.Forms.GroupBox groupBoxPilotLampLocation;
-		private System.Windows.Forms.TextBox textBoxPilotLampLocationY;
-		private System.Windows.Forms.TextBox textBoxPilotLampLocationX;
-		private System.Windows.Forms.Label labelPilotLampLocationY;
-		private System.Windows.Forms.Label labelPilotLampLocationX;
-		private System.Windows.Forms.Button buttonPilotLampSubjectSet;
-		private System.Windows.Forms.Label labelPilotLampSubject;
-		private System.Windows.Forms.Label labelPilotLampLayer;
-		private System.Windows.Forms.Button buttonPilotLampNighttimeImageOpen;
-		private System.Windows.Forms.Button buttonPilotLampDaytimeImageOpen;
-		private System.Windows.Forms.TextBox textBoxPilotLampTransparentColor;
-		private System.Windows.Forms.TextBox textBoxPilotLampNighttimeImage;
-		private System.Windows.Forms.TextBox textBoxPilotLampDaytimeImage;
-		private System.Windows.Forms.Label labelPilotLampDaytimeImage;
-		private System.Windows.Forms.Label labelPilotLampNighttimeImage;
-		private System.Windows.Forms.Label labelPilotLampTransparentColor;
-		private System.Windows.Forms.TabPage tabPageNeedle;
-		private System.Windows.Forms.CheckBox checkBoxNeedleDefinedOrigin;
-		private System.Windows.Forms.Label labelNeedleDefinedOrigin;
-		private System.Windows.Forms.CheckBox checkBoxNeedleDefinedRadius;
-		private System.Windows.Forms.Label labelNeedleDefinedRadius;
-		private System.Windows.Forms.NumericUpDown numericUpDownNeedleLayer;
-		private System.Windows.Forms.CheckBox checkBoxNeedleSmoothed;
-		private System.Windows.Forms.Label labelNeedleSmoothed;
-		private System.Windows.Forms.CheckBox checkBoxNeedleBackstop;
-		private System.Windows.Forms.Label labelNeedleBackstop;
-		private System.Windows.Forms.TextBox textBoxNeedleDampingRatio;
-		private System.Windows.Forms.Label labelNeedleDampingRatio;
-		private System.Windows.Forms.TextBox textBoxNeedleNaturalFreq;
-		private System.Windows.Forms.Label labelNeedleNaturalFreq;
-		private System.Windows.Forms.TextBox textBoxNeedleMaximum;
-		private System.Windows.Forms.Label labelNeedleMaximum;
-		private System.Windows.Forms.TextBox textBoxNeedleMinimum;
-		private System.Windows.Forms.Label labelNeedleMinimum;
-		private System.Windows.Forms.TextBox textBoxNeedleLastAngle;
-		private System.Windows.Forms.Label labelNeedleLastAngle;
-		private System.Windows.Forms.TextBox textBoxNeedleInitialAngle;
-		private System.Windows.Forms.Label labelNeedleInitialAngle;
-		private System.Windows.Forms.GroupBox groupBoxNeedleOrigin;
-		private System.Windows.Forms.TextBox textBoxNeedleOriginY;
-		private System.Windows.Forms.TextBox textBoxNeedleOriginX;
-		private System.Windows.Forms.Label labelNeedleOriginY;
-		private System.Windows.Forms.Label labelNeedleOriginX;
-		private System.Windows.Forms.TextBox textBoxNeedleColor;
-		private System.Windows.Forms.Label labelNeedleColor;
-		private System.Windows.Forms.TextBox textBoxNeedleRadius;
-		private System.Windows.Forms.Label labelNeedleRadius;
-		private System.Windows.Forms.GroupBox groupBoxNeedleLocation;
-		private System.Windows.Forms.TextBox textBoxNeedleLocationY;
-		private System.Windows.Forms.TextBox textBoxNeedleLocationX;
-		private System.Windows.Forms.Label labelNeedleLocationY;
-		private System.Windows.Forms.Label labelNeedleLocationX;
-		private System.Windows.Forms.Button buttonNeedleSubjectSet;
-		private System.Windows.Forms.Label labelNeedleSubject;
-		private System.Windows.Forms.Label labelNeedleLayer;
-		private System.Windows.Forms.Button buttonNeedleNighttimeImageOpen;
-		private System.Windows.Forms.Button buttonNeedleDaytimeImageOpen;
-		private System.Windows.Forms.TextBox textBoxNeedleTransparentColor;
-		private System.Windows.Forms.TextBox textBoxNeedleNighttimeImage;
-		private System.Windows.Forms.TextBox textBoxNeedleDaytimeImage;
-		private System.Windows.Forms.Label labelNeedleDaytimeImage;
-		private System.Windows.Forms.Label labelNeedleNighttimeImage;
-		private System.Windows.Forms.Label labelNeedleTransparentColor;
-		private System.Windows.Forms.TabPage tabPageDigitalNumber;
-		private System.Windows.Forms.NumericUpDown numericUpDownDigitalNumberLayer;
-		private System.Windows.Forms.NumericUpDown numericUpDownDigitalNumberInterval;
-		private System.Windows.Forms.Label labelDigitalNumberInterval;
-		private System.Windows.Forms.GroupBox groupBoxDigitalNumberLocation;
-		private System.Windows.Forms.TextBox textBoxDigitalNumberLocationY;
-		private System.Windows.Forms.TextBox textBoxDigitalNumberLocationX;
-		private System.Windows.Forms.Label labelDigitalNumberLocationY;
-		private System.Windows.Forms.Label labelDigitalNumberLocationX;
-		private System.Windows.Forms.Button buttonDigitalNumberSubjectSet;
-		private System.Windows.Forms.Label labelDigitalNumberSubject;
-		private System.Windows.Forms.Label labelDigitalNumberLayer;
-		private System.Windows.Forms.Button buttonDigitalNumberNighttimeImageOpen;
-		private System.Windows.Forms.Button buttonDigitalNumberDaytimeImageOpen;
-		private System.Windows.Forms.TextBox textBoxDigitalNumberTransparentColor;
-		private System.Windows.Forms.TextBox textBoxDigitalNumberNighttimeImage;
-		private System.Windows.Forms.TextBox textBoxDigitalNumberDaytimeImage;
-		private System.Windows.Forms.Label labelDigitalNumberDaytimeImage;
-		private System.Windows.Forms.Label labelDigitalNumberNighttimeImage;
-		private System.Windows.Forms.Label labelDigitalNumberTransparentColor;
-		private System.Windows.Forms.TabPage tabPageDigitalGauge;
-		private System.Windows.Forms.NumericUpDown numericUpDownDigitalGaugeLayer;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeStep;
-		private System.Windows.Forms.Label labelDigitalGaugeStep;
-		private System.Windows.Forms.Label labelDigitalGaugeLayer;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeMaximum;
-		private System.Windows.Forms.Label labelDigitalGaugeMaximum;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeMinimum;
-		private System.Windows.Forms.Label labelDigitalGaugeMinimum;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeLastAngle;
-		private System.Windows.Forms.Label labelDigitalGaugeLastAngle;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeInitialAngle;
-		private System.Windows.Forms.Label labelDigitalGaugeInitialAngle;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeColor;
-		private System.Windows.Forms.Label labelDigitalGaugeColor;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeRadius;
-		private System.Windows.Forms.Label labelDigitalGaugeRadius;
-		private System.Windows.Forms.GroupBox groupBoxDigitalGaugeLocation;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeLocationY;
-		private System.Windows.Forms.TextBox textBoxDigitalGaugeLocationX;
-		private System.Windows.Forms.Label labelDigitalGaugeLocationY;
-		private System.Windows.Forms.Label labelDigitalGaugeLocationX;
-		private System.Windows.Forms.Button buttonDigitalGaugeSubjectSet;
-		private System.Windows.Forms.Label labelDigitalGaugeSubject;
-		private System.Windows.Forms.TabPage tabPageLinearGauge;
-		private System.Windows.Forms.Button buttonLinearGaugeNighttimeImageOpen;
-		private System.Windows.Forms.Button buttonLinearGaugeDaytimeImageOpen;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeTransparentColor;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeNighttimeImage;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeDaytimeImage;
-		private System.Windows.Forms.Label labelLinearGaugeDaytimeImage;
-		private System.Windows.Forms.Label labelLinearGaugeNighttimeImage;
-		private System.Windows.Forms.Label labelLinearGaugeTransparentColor;
-		private System.Windows.Forms.NumericUpDown numericUpDownLinearGaugeLayer;
-		private System.Windows.Forms.NumericUpDown numericUpDownLinearGaugeWidth;
-		private System.Windows.Forms.Label labelLinearGaugeWidth;
-		private System.Windows.Forms.GroupBox groupBoxLinearGaugeDirection;
-		private System.Windows.Forms.Label labelLinearGaugeDirectionY;
-		private System.Windows.Forms.Label labelLinearGaugeDirectionX;
-		private System.Windows.Forms.Label labelLinearGaugeLayer;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeMaximum;
-		private System.Windows.Forms.Label labelLinearGaugeMaximum;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeMinimum;
-		private System.Windows.Forms.Label labelLinearGaugeMinimum;
-		private System.Windows.Forms.GroupBox groupBoxLinearGaugeLocation;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeLocationY;
-		private System.Windows.Forms.TextBox textBoxLinearGaugeLocationX;
-		private System.Windows.Forms.Label labelLinearGaugeLocationY;
-		private System.Windows.Forms.Label labelLinearGaugeLocationX;
-		private System.Windows.Forms.Button buttonLinearGaugeSubjectSet;
-		private System.Windows.Forms.Label labelLinearGaugeSubject;
-		private System.Windows.Forms.TabPage tabPageTimetable;
-		private System.Windows.Forms.NumericUpDown numericUpDownTimetableLayer;
-		private System.Windows.Forms.Label labelTimetableLayer;
-		private System.Windows.Forms.TextBox textBoxTimetableTransparentColor;
-		private System.Windows.Forms.Label labelTimetableTransparentColor;
-		private System.Windows.Forms.TextBox textBoxTimetableHeight;
-		private System.Windows.Forms.Label labelTimetableHeight;
-		private System.Windows.Forms.TextBox textBoxTimetableWidth;
-		private System.Windows.Forms.Label labelTimetableWidth;
-		private System.Windows.Forms.GroupBox groupBoxTimetableLocation;
-		private System.Windows.Forms.TextBox textBoxTimetableLocationY;
-		private System.Windows.Forms.TextBox textBoxTimetableLocationX;
-		private System.Windows.Forms.Label labelTimetableLocationY;
-		private System.Windows.Forms.Label labelTimetableLocationX;
-		private System.Windows.Forms.TabPage tabPageTouch;
-		private System.Windows.Forms.ComboBox comboBoxTouchCommand;
-		private System.Windows.Forms.Label labelTouchCommand;
-		private System.Windows.Forms.NumericUpDown numericUpDownTouchCommandOption;
-		private System.Windows.Forms.Label labelTouchCommandOption;
-		private System.Windows.Forms.NumericUpDown numericUpDownTouchSoundIndex;
-		private System.Windows.Forms.Label labelTouchSoundIndex;
-		private System.Windows.Forms.NumericUpDown numericUpDownTouchJumpScreen;
-		private System.Windows.Forms.Label labelTouchJumpScreen;
-		private System.Windows.Forms.GroupBox groupBoxTouchSize;
-		private System.Windows.Forms.TextBox textBoxTouchSizeY;
-		private System.Windows.Forms.TextBox textBoxTouchSizeX;
-		private System.Windows.Forms.Label labelTouchSizeY;
-		private System.Windows.Forms.Label labelTouchSizeX;
-		private System.Windows.Forms.GroupBox groupBoxTouchLocation;
-		private System.Windows.Forms.TextBox textBoxTouchLocationY;
-		private System.Windows.Forms.TextBox textBoxTouchLocationX;
-		private System.Windows.Forms.Label labelTouchLocationY;
-		private System.Windows.Forms.Label labelTouchLocationX;
-		private System.Windows.Forms.TabPage tabPageSound;
-		private System.Windows.Forms.Panel panelSoundSetting;
-		private System.Windows.Forms.ListView listViewSound;
-		private System.Windows.Forms.Panel panelSoundSettingEdit;
-		private System.Windows.Forms.GroupBox groupBoxSoundEntry;
-		private System.Windows.Forms.Button buttonSoundRemove;
-		private System.Windows.Forms.GroupBox groupBoxSoundKey;
-		private System.Windows.Forms.NumericUpDown numericUpDownSoundKeyIndex;
-		private System.Windows.Forms.ComboBox comboBoxSoundKey;
-		private System.Windows.Forms.Button buttonSoundAdd;
-		private System.Windows.Forms.GroupBox groupBoxSoundValue;
-		private System.Windows.Forms.CheckBox checkBoxSoundRadius;
-		private System.Windows.Forms.CheckBox checkBoxSoundDefinedPosition;
-		private System.Windows.Forms.TextBox textBoxSoundRadius;
-		private System.Windows.Forms.GroupBox groupBoxSoundPosition;
-		private System.Windows.Forms.Label labelSoundPositionZUnit;
-		private System.Windows.Forms.TextBox textBoxSoundPositionZ;
-		private System.Windows.Forms.Label labelSoundPositionZ;
-		private System.Windows.Forms.Label labelSoundPositionYUnit;
-		private System.Windows.Forms.TextBox textBoxSoundPositionY;
-		private System.Windows.Forms.Label labelSoundPositionY;
-		private System.Windows.Forms.Label labelSoundPositionXUnit;
-		private System.Windows.Forms.TextBox textBoxSoundPositionX;
-		private System.Windows.Forms.Label labelSoundPositionX;
-		private System.Windows.Forms.Label labelSoundFileName;
-		private System.Windows.Forms.Button buttonSoundFileNameOpen;
-		private System.Windows.Forms.TextBox textBoxSoundFileName;
-		private System.Windows.Forms.TabPage tabPageStatus;
-		private System.Windows.Forms.ListView listViewStatus;
-		private System.Windows.Forms.ColumnHeader columnHeaderLevel;
-		private System.Windows.Forms.ColumnHeader columnHeaderText;
-		private System.Windows.Forms.MenuStrip menuStripStatus;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemError;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemWarning;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemInfo;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemClear;
 		private System.Windows.Forms.Panel panelCars;
 		private System.Windows.Forms.TreeView treeViewCars;
 		private System.Windows.Forms.Panel panelCarsNavi;
@@ -7258,65 +6700,589 @@ namespace TrainEditor2.Views
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemExit;
 		private System.Windows.Forms.ToolStripComboBox toolStripComboBoxLanguage;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelLanguage;
-		private System.Windows.Forms.ComboBox comboBoxDriverCar;
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImport;
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemExport;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparatorExport;
-		private System.Windows.Forms.MenuStrip menuStripMotor;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemEdit;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemUndo;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemRedo;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparatorUndo;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTearingOff;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemCopy;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemPaste;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemCleanup;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemDelete;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemView;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemPower;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemPowerTrack1;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemPowerTrack2;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemBrake;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemBrakeTrack1;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemBrakeTrack2;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemInput;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemPitch;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemVolume;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemIndex;
-		private System.Windows.Forms.ToolStripComboBox toolStripComboBoxIndex;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTool;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemSelect;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemMove;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemDot;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemLine;
-		private System.Windows.Forms.NumericUpDown numericUpDownRunIndex;
-		private System.Windows.Forms.Button buttonPanelCopy;
-		private System.Windows.Forms.Button buttonThisTransparentColorSet;
-		private System.Windows.Forms.Button buttonPilotLampTransparentColorSet;
-		private System.Windows.Forms.Button buttonNeedleTransparentColorSet;
-		private System.Windows.Forms.Button buttonNeedleColorSet;
-		private System.Windows.Forms.Label labelNeedleDefinedDampingRatio;
-		private System.Windows.Forms.Label labelNeedleDefinedNaturalFreq;
-		private System.Windows.Forms.CheckBox checkBoxNeedleDefinedDampingRatio;
-		private System.Windows.Forms.CheckBox checkBoxNeedleDefinedNaturalFreq;
-		private System.Windows.Forms.Button buttonDigitalNumberTransparentColorSet;
-		private System.Windows.Forms.Button buttonLinearGaugeTransparentColorSet;
-		private System.Windows.Forms.Button buttonDigitalGaugeColorSet;
-		private System.Windows.Forms.Button buttonTimetableTransparentColorSet;
-		private System.Windows.Forms.Panel panelPanelNaviCmd;
-		private System.Windows.Forms.NumericUpDown numericUpDownLinearGaugeDirectionY;
-		private System.Windows.Forms.NumericUpDown numericUpDownLinearGaugeDirectionX;
-		private System.Windows.Forms.Label labelBrakePipeNormalPressureUnit;
-		private System.Windows.Forms.TextBox textBoxBrakePipeNormalPressure;
-		private System.Windows.Forms.Label labelBrakePipeNormalPressure;
 		private System.Windows.Forms.ErrorProvider errorProvider;
-		private SplitContainer splitContainerSound;
-		private TreeView treeViewSound;
+		private TabControl tabControlEditor;
+		private TabPage tabPageTrain;
+		private GroupBox groupBoxDevice;
+		private Label labelDoorMaxToleranceUnit;
+		private TextBox textBoxDoorMaxTolerance;
+		private Label labelDoorWidthUnit;
+		private TextBox textBoxDoorWidth;
+		private ComboBox comboBoxDoorCloseMode;
+		private ComboBox comboBoxDoorOpenMode;
+		private ComboBox comboBoxPassAlarm;
+		private ComboBox comboBoxReAdhesionDevice;
+		private ComboBox comboBoxAtc;
+		private ComboBox comboBoxAts;
+		private CheckBox checkBoxHoldBrake;
+		private CheckBox checkBoxEb;
+		private CheckBox checkBoxConstSpeed;
+		private Label labelDoorMaxTolerance;
+		private Label labelDoorWidth;
+		private Label labelDoorCloseMode;
+		private Label labelDoorOpenMode;
+		private Label labelPassAlarm;
+		private Label labelReAdhesionDevice;
+		private Label labelHoldBrake;
+		private Label labelConstSpeed;
+		private Label labelEb;
+		private Label labelAtc;
+		private Label labelAts;
+		private GroupBox groupBoxCab;
+		private ComboBox comboBoxDriverCar;
+		private Label labelCabZUnit;
+		private TextBox textBoxCabZ;
+		private Label labelCabYUnit;
+		private TextBox textBoxCabY;
+		private Label labelCabXUnit;
+		private TextBox textBoxCabX;
+		private Label labelDriverCar;
+		private Label labelCabZ;
+		private Label labelCabY;
+		private Label labelCabX;
+		private GroupBox groupBoxHandle;
+		private NumericUpDown numericUpDownLocoBrakeNotches;
+		private Label labelLocoBrakeNotches;
+		private ComboBox comboBoxLocoBrakeHandleType;
+		private Label labelLocoBrakeHandleType;
+		private ComboBox comboBoxEbHandleBehaviour;
+		private Label labelEbHandleBehaviour;
+		private NumericUpDown numericUpDownDriverBrakeNotches;
+		private Label labelDriverBrakeNotches;
+		private NumericUpDown numericUpDownDriverPowerNotches;
+		private Label labelDriverPowerNotches;
+		private NumericUpDown numericUpDownPowerNotchReduceSteps;
+		private Label labelPowerNotchReduceSteps;
+		private NumericUpDown numericUpDownBrakeNotches;
+		private Label labelBrakeNotches;
+		private NumericUpDown numericUpDownPowerNotches;
+		private Label labelPowerNotches;
+		private ComboBox comboBoxHandleType;
+		private Label labelHandleType;
+		private TabPage tabPageCar;
+		private GroupBox groupBoxPressure;
+		private Label labelBrakePipeNormalPressureUnit;
+		private TextBox textBoxBrakePipeNormalPressure;
+		private Label labelBrakePipeNormalPressure;
+		private Label labelBrakeCylinderServiceMaximumPressureUnit;
+		private Label labelMainReservoirMaximumPressureUnit;
+		private Label labelMainReservoirMinimumPressureUnit;
+		private Label labelBrakeCylinderEmergencyMaximumPressureUnit;
+		private TextBox textBoxMainReservoirMaximumPressure;
+		private TextBox textBoxMainReservoirMinimumPressure;
+		private TextBox textBoxBrakeCylinderEmergencyMaximumPressure;
+		private TextBox textBoxBrakeCylinderServiceMaximumPressure;
+		private Label labelMainReservoirMaximumPressure;
+		private Label labelMainReservoirMinimumPressure;
+		private Label labelBrakeCylinderServiceMaximumPressure;
+		private Label labelBrakeCylinderEmergencyMaximumPressure;
+		private GroupBox groupBoxBrake;
+		private TextBox textBoxBrakeControlSpeed;
+		private Label labelBrakeControlSpeedUnit;
+		private ComboBox comboBoxBrakeControlSystem;
+		private ComboBox comboBoxLocoBrakeType;
+		private ComboBox comboBoxBrakeType;
+		private Label labelLocoBrakeType;
+		private Label labelBrakeType;
+		private Label labelBrakeControlSpeed;
+		private Label labelBrakeControlSystem;
+		private GroupBox groupBoxMove;
+		private Label labelBrakeCylinderDownUnit;
+		private TextBox textBoxBrakeCylinderDown;
+		private Label labelBrakeCylinderUpUnit;
+		private TextBox textBoxBrakeCylinderUp;
+		private Label labelJerkBrakeDownUnit;
+		private TextBox textBoxJerkBrakeDown;
+		private Label labelJerkBrakeUpUnit;
+		private TextBox textBoxJerkBrakeUp;
+		private Label labelJerkPowerDownUnit;
+		private TextBox textBoxJerkPowerDown;
+		private Label labelJerkPowerUpUnit;
+		private TextBox textBoxJerkPowerUp;
+		private Label labelJerkPowerUp;
+		private Label labelJerkPowerDown;
+		private Label labelJerkBrakeUp;
+		private Label labelJerkBrakeDown;
+		private Label labelBrakeCylinderUp;
+		private Label labelBrakeCylinderDown;
+		private GroupBox groupBoxDelay;
+		private Button buttonDelayLocoBrakeSet;
+		private Button buttonDelayBrakeSet;
+		private Button buttonDelayPowerSet;
+		private Label labelDelayLocoBrake;
+		private Label labelDelayBrake;
+		private Label labelDelayPower;
+		private GroupBox groupBoxPerformance;
+		private TextBox textBoxAerodynamicDragCoefficient;
+		private TextBox textBoxCoefficientOfRollingResistance;
+		private TextBox textBoxCoefficientOfStaticFriction;
+		private Label labelDecelerationUnit;
+		private TextBox textBoxDeceleration;
+		private Label labelAerodynamicDragCoefficient;
+		private Label labelCoefficientOfStaticFriction;
+		private Label labelDeceleration;
+		private Label labelCoefficientOfRollingResistance;
+		private GroupBox groupBoxCarGeneral;
+		private Label labelUnexposedFrontalAreaUnit;
+		private TextBox textBoxUnexposedFrontalArea;
+		private Label labelUnexposedFrontalArea;
+		private Label labelRearBogie;
+		private Label labelFrontBogie;
+		private Button buttonRearBogieSet;
+		private Button buttonFrontBogieSet;
+		private CheckBox checkBoxReversed;
+		private CheckBox checkBoxLoadingSway;
+		private CheckBox checkBoxDefinedAxles;
+		private CheckBox checkBoxIsMotorCar;
+		private Button buttonObjectOpen;
+		private Label labelExposedFrontalAreaUnit;
+		private Label labelCenterOfMassHeightUnit;
+		private Label labelLoadingSway;
+		private Label labelHeightUnit;
+		private Label labelWidthUnit;
+		private Label labelLengthUnit;
+		private Label labelMassUnit;
+		private TextBox textBoxMass;
+		private TextBox textBoxLength;
+		private TextBox textBoxWidth;
+		private TextBox textBoxHeight;
+		private TextBox textBoxCenterOfMassHeight;
+		private TextBox textBoxExposedFrontalArea;
+		private TextBox textBoxObject;
+		private Label labelObject;
+		private Label labelReversed;
+		private GroupBox groupBoxAxles;
+		private Label labelRearAxleUnit;
+		private Label labelFrontAxleUnit;
+		private TextBox textBoxRearAxle;
+		private TextBox textBoxFrontAxle;
+		private Label labelRearAxle;
+		private Label labelFrontAxle;
+		private Label labelDefinedAxles;
+		private Label labelExposedFrontalArea;
+		private Label labelCenterOfMassHeight;
+		private Label labelHeight;
+		private Label labelWidth;
+		private Label labelLength;
+		private Label labelMass;
+		private Label labelIsMotorCar;
+		private TabPage tabPageAccel;
+		private PictureBox pictureBoxAccel;
+		private Panel panelAccel;
+		private GroupBox groupBoxPreview;
+		private Button buttonAccelReset;
+		private Button buttonAccelZoomOut;
+		private Button buttonAccelZoomIn;
+		private Label labelAccelYValue;
+		private Label labelAccelXValue;
+		private Label labelAccelXmaxUnit;
+		private Label labelAccelXminUnit;
+		private Label labelAccelYmaxUnit;
+		private Label labelAccelYminUnit;
+		private TextBox textBoxAccelYmax;
+		private TextBox textBoxAccelYmin;
+		private TextBox textBoxAccelXmax;
+		private TextBox textBoxAccelXmin;
+		private Label labelAccelYmax;
+		private Label labelAccelYmin;
+		private Label labelAccelXmax;
+		private Label labelAccelXmin;
+		private Label labelAccelY;
+		private Label labelAccelX;
+		private CheckBox checkBoxSubtractDeceleration;
+		private GroupBox groupBoxParameter;
+		private Label labeAccelA0Unit;
+		private TextBox textBoxAccelA0;
+		private Label labelAccelA0;
+		private Label labelAccelA1Unit;
+		private TextBox textBoxAccelA1;
+		private Label labelAccelA1;
+		private Label labelAccelV1Unit;
+		private TextBox textBoxAccelV1;
+		private Label labelAccelV1;
+		private Label labelAccelV2Unit;
+		private TextBox textBoxAccelV2;
+		private Label labelAccelV2;
+		private TextBox textBoxAccelE;
+		private Label labelAccelE;
+		private GroupBox groupBoxNotch;
+		private ComboBox comboBoxNotch;
+		private TabPage tabPageMotor;
+		private Panel panelMotorSound;
+		private ToolStripContainer toolStripContainerDrawArea;
+		private OpenTK.GLControl glControlMotor;
+		private ToolStrip toolStripToolBar;
+		private ToolStripButton toolStripButtonUndo;
+		private ToolStripButton toolStripButtonRedo;
+		private ToolStripSeparator toolStripSeparatorRedo;
+		private ToolStripButton toolStripButtonTearingOff;
+		private ToolStripButton toolStripButtonCopy;
+		private ToolStripButton toolStripButtonPaste;
+		private ToolStripButton toolStripButtonCleanup;
+		private ToolStripButton toolStripButtonDelete;
+		private ToolStripSeparator toolStripSeparatorEdit;
+		private ToolStripButton toolStripButtonSelect;
+		private ToolStripButton toolStripButtonMove;
+		private ToolStripButton toolStripButtonDot;
+		private ToolStripButton toolStripButtonLine;
+		private Panel panelMotorSetting;
+		private GroupBox groupBoxDirect;
+		private Button buttonDirectDot;
+		private Button buttonDirectMove;
+		private TextBox textBoxDirectY;
+		private Label labelDirectY;
+		private Label labelDirectXUnit;
+		private TextBox textBoxDirectX;
+		private Label labelDirectX;
+		private GroupBox groupBoxPlay;
+		private Button buttonStop;
+		private Button buttonPause;
+		private Button buttonPlay;
+		private GroupBox groupBoxArea;
+		private CheckBox checkBoxMotorConstant;
+		private CheckBox checkBoxMotorLoop;
+		private Button buttonMotorSwap;
+		private TextBox textBoxMotorAreaLeft;
+		private Label labelMotorAreaUnit;
+		private TextBox textBoxMotorAreaRight;
+		private Label labelMotorAccel;
+		private Label labelMotorAccelUnit;
+		private TextBox textBoxMotorAccel;
+		private GroupBox groupBoxSource;
+		private NumericUpDown numericUpDownRunIndex;
+		private Label labelRun;
+		private CheckBox checkBoxTrack2;
+		private CheckBox checkBoxTrack1;
+		private GroupBox groupBoxView;
+		private Button buttonMotorReset;
+		private Button buttonMotorZoomOut;
+		private Button buttonMotorZoomIn;
+		private Label labelMotorMaxVolume;
+		private TextBox textBoxMotorMaxVolume;
+		private Label labelMotorMinVolume;
+		private TextBox textBoxMotorMinVolume;
+		private Label labelMotorMaxPitch;
+		private TextBox textBoxMotorMaxPitch;
+		private Label labelMotorMinPitch;
+		private TextBox textBoxMotorMinPitch;
+		private Label labelMotorMaxVelocityUnit;
+		private TextBox textBoxMotorMaxVelocity;
+		private Label labelMotorMaxVelocity;
+		private Label labelMotorMinVelocityUnit;
+		private TextBox textBoxMotorMinVelocity;
+		private Label labelMotorMinVelocity;
+		private StatusStrip statusStripStatus;
+		private ToolStripStatusLabel toolStripStatusLabelY;
+		private ToolStripStatusLabel toolStripStatusLabelX;
+		private ToolStripStatusLabel toolStripStatusLabelTool;
+		private ToolStripStatusLabel toolStripStatusLabelMode;
+		private ToolStripStatusLabel toolStripStatusLabelTrack;
+		private ToolStripStatusLabel toolStripStatusLabelType;
+		private MenuStrip menuStripMotor;
+		private ToolStripMenuItem toolStripMenuItemEdit;
+		private ToolStripMenuItem toolStripMenuItemUndo;
+		private ToolStripMenuItem toolStripMenuItemRedo;
+		private ToolStripSeparator toolStripSeparatorUndo;
+		private ToolStripMenuItem toolStripMenuItemTearingOff;
+		private ToolStripMenuItem toolStripMenuItemCopy;
+		private ToolStripMenuItem toolStripMenuItemPaste;
+		private ToolStripMenuItem toolStripMenuItemCleanup;
+		private ToolStripMenuItem toolStripMenuItemDelete;
+		private ToolStripMenuItem toolStripMenuItemView;
+		private ToolStripMenuItem toolStripMenuItemPower;
+		private ToolStripMenuItem toolStripMenuItemPowerTrack1;
+		private ToolStripMenuItem toolStripMenuItemPowerTrack2;
+		private ToolStripMenuItem toolStripMenuItemBrake;
+		private ToolStripMenuItem toolStripMenuItemBrakeTrack1;
+		private ToolStripMenuItem toolStripMenuItemBrakeTrack2;
+		private ToolStripMenuItem toolStripMenuItemInput;
+		private ToolStripMenuItem toolStripMenuItemPitch;
+		private ToolStripMenuItem toolStripMenuItemVolume;
+		private ToolStripMenuItem toolStripMenuItemIndex;
+		private ToolStripComboBox toolStripComboBoxIndex;
+		private ToolStripMenuItem toolStripMenuItemTool;
+		private ToolStripMenuItem toolStripMenuItemSelect;
+		private ToolStripMenuItem toolStripMenuItemMove;
+		private ToolStripMenuItem toolStripMenuItemDot;
+		private ToolStripMenuItem toolStripMenuItemLine;
+		private TabPage tabPageCoupler;
+		private GroupBox groupBoxCouplerGeneral;
+		private Button buttonCouplerObject;
 		private TextBox textBoxCouplerObject;
 		private Label labelCouplerObject;
-		private Button buttonCouplerObject;
-		private OpenTK.GLControl glControlMotor;
+		private Label labelCouplerMaxUnit;
+		private TextBox textBoxCouplerMax;
+		private Label labelCouplerMax;
+		private Label labelCouplerMinUnit;
+		private TextBox textBoxCouplerMin;
+		private Label labelCouplerMin;
+		private TabPage tabPagePanel;
+		private SplitContainer splitContainerPanel;
+		private TreeView treeViewPanel;
+		private ListView listViewPanel;
+		private Panel panelPanelNavi;
+		private Panel panelPanelNaviCmd;
+		private Button buttonPanelCopy;
+		private Button buttonPanelAdd;
+		private Button buttonPanelRemove;
+		private TabControl tabControlPanel;
+		private TabPage tabPageThis;
+		private Button buttonThisTransparentColorSet;
+		private Button buttonThisNighttimeImageOpen;
+		private Button buttonThisDaytimeImageOpen;
+		private GroupBox groupBoxThisOrigin;
+		private TextBox textBoxThisOriginY;
+		private TextBox textBoxThisOriginX;
+		private Label labelThisOriginY;
+		private Label labelThisOriginX;
+		private GroupBox groupBoxThisCenter;
+		private TextBox textBoxThisCenterY;
+		private TextBox textBoxThisCenterX;
+		private Label labelThisCenterY;
+		private Label labelThisCenterX;
+		private TextBox textBoxThisTransparentColor;
+		private TextBox textBoxThisNighttimeImage;
+		private TextBox textBoxThisDaytimeImage;
+		private TextBox textBoxThisBottom;
+		private TextBox textBoxThisTop;
+		private TextBox textBoxThisRight;
+		private TextBox textBoxThisLeft;
+		private TextBox textBoxThisResolution;
+		private Label labelThisResolution;
+		private Label labelThisLeft;
+		private Label labelThisRight;
+		private Label labelThisTop;
+		private Label labelThisBottom;
+		private Label labelThisDaytimeImage;
+		private Label labelThisNighttimeImage;
+		private Label labelThisTransparentColor;
+		private TabPage tabPageScreen;
+		private NumericUpDown numericUpDownScreenLayer;
+		private NumericUpDown numericUpDownScreenNumber;
+		private Label labelScreenLayer;
+		private Label labelScreenNumber;
+		private TabPage tabPagePilotLamp;
+		private Button buttonPilotLampTransparentColorSet;
+		private NumericUpDown numericUpDownPilotLampLayer;
+		private GroupBox groupBoxPilotLampLocation;
+		private TextBox textBoxPilotLampLocationY;
+		private TextBox textBoxPilotLampLocationX;
+		private Label labelPilotLampLocationY;
+		private Label labelPilotLampLocationX;
+		private Button buttonPilotLampSubjectSet;
+		private Label labelPilotLampSubject;
+		private Label labelPilotLampLayer;
+		private Button buttonPilotLampNighttimeImageOpen;
+		private Button buttonPilotLampDaytimeImageOpen;
+		private TextBox textBoxPilotLampTransparentColor;
+		private TextBox textBoxPilotLampNighttimeImage;
+		private TextBox textBoxPilotLampDaytimeImage;
+		private Label labelPilotLampDaytimeImage;
+		private Label labelPilotLampNighttimeImage;
+		private Label labelPilotLampTransparentColor;
+		private TabPage tabPageNeedle;
+		private CheckBox checkBoxNeedleDefinedDampingRatio;
+		private CheckBox checkBoxNeedleDefinedNaturalFreq;
+		private Label labelNeedleDefinedDampingRatio;
+		private Label labelNeedleDefinedNaturalFreq;
+		private Button buttonNeedleTransparentColorSet;
+		private Button buttonNeedleColorSet;
+		private CheckBox checkBoxNeedleDefinedOrigin;
+		private Label labelNeedleDefinedOrigin;
+		private CheckBox checkBoxNeedleDefinedRadius;
+		private Label labelNeedleDefinedRadius;
+		private NumericUpDown numericUpDownNeedleLayer;
+		private CheckBox checkBoxNeedleSmoothed;
+		private Label labelNeedleSmoothed;
+		private CheckBox checkBoxNeedleBackstop;
+		private Label labelNeedleBackstop;
+		private TextBox textBoxNeedleDampingRatio;
+		private Label labelNeedleDampingRatio;
+		private TextBox textBoxNeedleNaturalFreq;
+		private Label labelNeedleNaturalFreq;
+		private TextBox textBoxNeedleMaximum;
+		private Label labelNeedleMaximum;
+		private TextBox textBoxNeedleMinimum;
+		private Label labelNeedleMinimum;
+		private TextBox textBoxNeedleLastAngle;
+		private Label labelNeedleLastAngle;
+		private TextBox textBoxNeedleInitialAngle;
+		private Label labelNeedleInitialAngle;
+		private GroupBox groupBoxNeedleOrigin;
+		private TextBox textBoxNeedleOriginY;
+		private TextBox textBoxNeedleOriginX;
+		private Label labelNeedleOriginY;
+		private Label labelNeedleOriginX;
+		private TextBox textBoxNeedleColor;
+		private Label labelNeedleColor;
+		private TextBox textBoxNeedleRadius;
+		private Label labelNeedleRadius;
+		private GroupBox groupBoxNeedleLocation;
+		private TextBox textBoxNeedleLocationY;
+		private TextBox textBoxNeedleLocationX;
+		private Label labelNeedleLocationY;
+		private Label labelNeedleLocationX;
+		private Button buttonNeedleSubjectSet;
+		private Label labelNeedleSubject;
+		private Label labelNeedleLayer;
+		private Button buttonNeedleNighttimeImageOpen;
+		private Button buttonNeedleDaytimeImageOpen;
+		private TextBox textBoxNeedleTransparentColor;
+		private TextBox textBoxNeedleNighttimeImage;
+		private TextBox textBoxNeedleDaytimeImage;
+		private Label labelNeedleDaytimeImage;
+		private Label labelNeedleNighttimeImage;
+		private Label labelNeedleTransparentColor;
+		private TabPage tabPageDigitalNumber;
+		private Button buttonDigitalNumberTransparentColorSet;
+		private NumericUpDown numericUpDownDigitalNumberLayer;
+		private NumericUpDown numericUpDownDigitalNumberInterval;
+		private Label labelDigitalNumberInterval;
+		private GroupBox groupBoxDigitalNumberLocation;
+		private TextBox textBoxDigitalNumberLocationY;
+		private TextBox textBoxDigitalNumberLocationX;
+		private Label labelDigitalNumberLocationY;
+		private Label labelDigitalNumberLocationX;
+		private Button buttonDigitalNumberSubjectSet;
+		private Label labelDigitalNumberSubject;
+		private Label labelDigitalNumberLayer;
+		private Button buttonDigitalNumberNighttimeImageOpen;
+		private Button buttonDigitalNumberDaytimeImageOpen;
+		private TextBox textBoxDigitalNumberTransparentColor;
+		private TextBox textBoxDigitalNumberNighttimeImage;
+		private TextBox textBoxDigitalNumberDaytimeImage;
+		private Label labelDigitalNumberDaytimeImage;
+		private Label labelDigitalNumberNighttimeImage;
+		private Label labelDigitalNumberTransparentColor;
+		private TabPage tabPageDigitalGauge;
+		private Button buttonDigitalGaugeColorSet;
+		private NumericUpDown numericUpDownDigitalGaugeLayer;
+		private TextBox textBoxDigitalGaugeStep;
+		private Label labelDigitalGaugeStep;
+		private Label labelDigitalGaugeLayer;
+		private TextBox textBoxDigitalGaugeMaximum;
+		private Label labelDigitalGaugeMaximum;
+		private TextBox textBoxDigitalGaugeMinimum;
+		private Label labelDigitalGaugeMinimum;
+		private TextBox textBoxDigitalGaugeLastAngle;
+		private Label labelDigitalGaugeLastAngle;
+		private TextBox textBoxDigitalGaugeInitialAngle;
+		private Label labelDigitalGaugeInitialAngle;
+		private TextBox textBoxDigitalGaugeColor;
+		private Label labelDigitalGaugeColor;
+		private TextBox textBoxDigitalGaugeRadius;
+		private Label labelDigitalGaugeRadius;
+		private GroupBox groupBoxDigitalGaugeLocation;
+		private TextBox textBoxDigitalGaugeLocationY;
+		private TextBox textBoxDigitalGaugeLocationX;
+		private Label labelDigitalGaugeLocationY;
+		private Label labelDigitalGaugeLocationX;
+		private Button buttonDigitalGaugeSubjectSet;
+		private Label labelDigitalGaugeSubject;
+		private TabPage tabPageLinearGauge;
+		private Button buttonLinearGaugeTransparentColorSet;
+		private Button buttonLinearGaugeNighttimeImageOpen;
+		private Button buttonLinearGaugeDaytimeImageOpen;
+		private TextBox textBoxLinearGaugeTransparentColor;
+		private TextBox textBoxLinearGaugeNighttimeImage;
+		private TextBox textBoxLinearGaugeDaytimeImage;
+		private Label labelLinearGaugeDaytimeImage;
+		private Label labelLinearGaugeNighttimeImage;
+		private Label labelLinearGaugeTransparentColor;
+		private NumericUpDown numericUpDownLinearGaugeLayer;
+		private NumericUpDown numericUpDownLinearGaugeWidth;
+		private Label labelLinearGaugeWidth;
+		private GroupBox groupBoxLinearGaugeDirection;
+		private NumericUpDown numericUpDownLinearGaugeDirectionY;
+		private NumericUpDown numericUpDownLinearGaugeDirectionX;
+		private Label labelLinearGaugeDirectionY;
+		private Label labelLinearGaugeDirectionX;
+		private Label labelLinearGaugeLayer;
+		private TextBox textBoxLinearGaugeMaximum;
+		private Label labelLinearGaugeMaximum;
+		private TextBox textBoxLinearGaugeMinimum;
+		private Label labelLinearGaugeMinimum;
+		private GroupBox groupBoxLinearGaugeLocation;
+		private TextBox textBoxLinearGaugeLocationY;
+		private TextBox textBoxLinearGaugeLocationX;
+		private Label labelLinearGaugeLocationY;
+		private Label labelLinearGaugeLocationX;
+		private Button buttonLinearGaugeSubjectSet;
+		private Label labelLinearGaugeSubject;
+		private TabPage tabPageTimetable;
+		private Button buttonTimetableTransparentColorSet;
+		private NumericUpDown numericUpDownTimetableLayer;
+		private Label labelTimetableLayer;
+		private TextBox textBoxTimetableTransparentColor;
+		private Label labelTimetableTransparentColor;
+		private TextBox textBoxTimetableHeight;
+		private Label labelTimetableHeight;
+		private TextBox textBoxTimetableWidth;
+		private Label labelTimetableWidth;
+		private GroupBox groupBoxTimetableLocation;
+		private TextBox textBoxTimetableLocationY;
+		private TextBox textBoxTimetableLocationX;
+		private Label labelTimetableLocationY;
+		private Label labelTimetableLocationX;
+		private TabPage tabPageTouch;
+		private Button buttonTouchSoundCommand;
+		private Label labelTouchSoundCommand;
+		private NumericUpDown numericUpDownTouchJumpScreen;
+		private Label labelTouchJumpScreen;
+		private GroupBox groupBoxTouchSize;
+		private TextBox textBoxTouchSizeY;
+		private TextBox textBoxTouchSizeX;
+		private Label labelTouchSizeY;
+		private Label labelTouchSizeX;
+		private GroupBox groupBoxTouchLocation;
+		private TextBox textBoxTouchLocationY;
+		private TextBox textBoxTouchLocationX;
+		private Label labelTouchLocationY;
+		private Label labelTouchLocationX;
+		private TabPage tabPageSound;
+		private Panel panelSoundSetting;
+		private SplitContainer splitContainerSound;
+		private TreeView treeViewSound;
+		private ListView listViewSound;
+		private Panel panelSoundSettingEdit;
+		private GroupBox groupBoxSoundEntry;
+		private Button buttonSoundRemove;
+		private GroupBox groupBoxSoundKey;
+		private NumericUpDown numericUpDownSoundKeyIndex;
+		private ComboBox comboBoxSoundKey;
+		private Button buttonSoundAdd;
+		private GroupBox groupBoxSoundValue;
+		private CheckBox checkBoxSoundRadius;
+		private CheckBox checkBoxSoundDefinedPosition;
+		private TextBox textBoxSoundRadius;
+		private GroupBox groupBoxSoundPosition;
+		private Label labelSoundPositionZUnit;
+		private TextBox textBoxSoundPositionZ;
+		private Label labelSoundPositionZ;
+		private Label labelSoundPositionYUnit;
+		private TextBox textBoxSoundPositionY;
+		private Label labelSoundPositionY;
+		private Label labelSoundPositionXUnit;
+		private TextBox textBoxSoundPositionX;
+		private Label labelSoundPositionX;
+		private Label labelSoundFileName;
+		private Button buttonSoundFileNameOpen;
+		private TextBox textBoxSoundFileName;
+		private TabPage tabPageStatus;
+		private ListView listViewStatus;
+		private ColumnHeader columnHeaderLevel;
+		private ColumnHeader columnHeaderText;
 		private Panel panelStatusNavi;
 		private Button buttonOutputLogs;
+		private MenuStrip menuStripStatus;
+		private ToolStripMenuItem toolStripMenuItemError;
+		private ToolStripMenuItem toolStripMenuItemWarning;
+		private ToolStripMenuItem toolStripMenuItemInfo;
+		private ToolStripMenuItem toolStripMenuItemClear;
+		private NumericUpDown numericUpDownTouchLayer;
+		private Label labelTouchLayer;
 	}
 }

--- a/source/TrainEditor2/Views/FormEditor.Functions.cs
+++ b/source/TrainEditor2/Views/FormEditor.Functions.cs
@@ -14,27 +14,27 @@ namespace TrainEditor2.Views
 {
 	public partial class FormEditor
 	{
-		private TreeNode TreeViewItemViewModelToTreeNode(TreeViewItemViewModel item)
+		internal static TreeNode TreeViewItemViewModelToTreeNode(TreeViewItemViewModel item)
 		{
 			return new TreeNode(item.Title.Value, item.Children.Select(TreeViewItemViewModelToTreeNode).ToArray()) { Tag = item };
 		}
 
-		private TreeNode SearchTreeNode(TreeViewItemViewModel item, TreeNode node)
+		internal static TreeNode SearchTreeNode(TreeViewItemViewModel item, TreeNode node)
 		{
 			return node.Tag == item ? node : node.Nodes.OfType<TreeNode>().Select(x => SearchTreeNode(item, x)).FirstOrDefault(x => x != null);
 		}
 
-		private ColumnHeader ListViewColumnHeaderViewModelToColumnHeader(ListViewColumnHeaderViewModel column)
+		internal static ColumnHeader ListViewColumnHeaderViewModelToColumnHeader(ListViewColumnHeaderViewModel column)
 		{
 			return new ColumnHeader { Text = column.Text.Value, Tag = column };
 		}
 
-		private ListViewItem ListViewItemViewModelToListViewItem(ListViewItemViewModel item)
+		internal static ListViewItem ListViewItemViewModelToListViewItem(ListViewItemViewModel item)
 		{
 			return new ListViewItem(item.Texts.ToArray()) { ImageIndex = item.ImageIndex.Value, Tag = item };
 		}
 
-		private void UpdateListViewItem(ListViewItem item, ListViewItemViewModel viewModel)
+		internal static void UpdateListViewItem(ListViewItem item, ListViewItemViewModel viewModel)
 		{
 			for (int i = 0; i < viewModel.Texts.Count; i++)
 			{

--- a/source/TrainEditor2/Views/FormEditor.Panel.cs
+++ b/source/TrainEditor2/Views/FormEditor.Panel.cs
@@ -105,6 +105,15 @@ namespace TrainEditor2.Views
 				})
 				.AddTo(panelDisposable);
 
+			x.ListColumns
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewPanel.Columns.Clear();
+					listViewPanel.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(panelDisposable);
+
 			x.ListItems
 				.ObserveAddChanged()
 				.Subscribe(y =>
@@ -123,6 +132,15 @@ namespace TrainEditor2.Views
 						listViewPanel.Items.Remove(item);
 					}
 
+					listViewPanel.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(panelDisposable);
+
+			x.ListItems
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewPanel.Items.Clear();
 					listViewPanel.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
 				})
 				.AddTo(panelDisposable);

--- a/source/TrainEditor2/Views/FormEditor.Sound.cs
+++ b/source/TrainEditor2/Views/FormEditor.Sound.cs
@@ -78,6 +78,15 @@ namespace TrainEditor2.Views
 				})
 				.AddTo(soundDisposable);
 
+			x.ListColumns
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewSound.Columns.Clear();
+					listViewSound.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(soundDisposable);
+
 			x.ListItems
 				.ObserveAddChanged()
 				.Subscribe(y =>
@@ -96,6 +105,15 @@ namespace TrainEditor2.Views
 						listViewSound.Items.Remove(item);
 					}
 
+					listViewSound.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(soundDisposable);
+
+			x.ListItems
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewSound.Items.Clear();
 					listViewSound.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
 				})
 				.AddTo(soundDisposable);

--- a/source/TrainEditor2/Views/FormEditor.Touch.cs
+++ b/source/TrainEditor2/Views/FormEditor.Touch.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using OpenBveApi.Interface;
 using Reactive.Bindings.Binding;
 using Reactive.Bindings.Extensions;
 using TrainEditor2.Extensions;
@@ -55,6 +54,22 @@ namespace TrainEditor2.Views
 				.BindToErrorProvider(errorProvider, textBoxTouchLocationY)
 				.AddTo(touchDisposable);
 
+			y.Layer
+				.BindTo(
+					numericUpDownTouchLayer,
+					z => z.Value,
+					BindingMode.TwoWay,
+					null,
+					z => (int)z,
+					Observable.FromEvent<EventHandler, EventArgs>(
+							h => (s, e) => h(e),
+							h => numericUpDownTouchLayer.ValueChanged += h,
+							h => numericUpDownTouchLayer.ValueChanged -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(touchDisposable);
+
 			y.SizeX
 				.BindTo(
 					textBoxTouchSizeX,
@@ -106,54 +121,6 @@ namespace TrainEditor2.Views
 							h => (s, e) => h(e),
 							h => numericUpDownTouchJumpScreen.ValueChanged += h,
 							h => numericUpDownTouchJumpScreen.ValueChanged -= h
-						)
-						.ToUnit()
-				)
-				.AddTo(touchDisposable);
-
-			y.SoundIndex
-				.BindTo(
-					numericUpDownTouchSoundIndex,
-					z => z.Value,
-					BindingMode.TwoWay,
-					null,
-					z => (int)z,
-					Observable.FromEvent<EventHandler, EventArgs>(
-							h => (s, e) => h(e),
-							h => numericUpDownTouchSoundIndex.ValueChanged += h,
-							h => numericUpDownTouchSoundIndex.ValueChanged -= h
-						)
-						.ToUnit()
-				)
-				.AddTo(touchDisposable);
-
-			y.CommandInfo
-				.BindTo(
-					comboBoxTouchCommand,
-					z => z.SelectedIndex,
-					BindingMode.TwoWay,
-					z => (int)z.Command,
-					z => Translations.CommandInfos.TryGetInfo((Translations.Command)z),
-					Observable.FromEvent<EventHandler, EventArgs>(
-							h => (s, e) => h(e),
-							h => comboBoxTouchCommand.SelectedIndexChanged += h,
-							h => comboBoxTouchCommand.SelectedIndexChanged -= h
-						)
-						.ToUnit()
-				)
-				.AddTo(touchDisposable);
-
-			y.CommandOption
-				.BindTo(
-					numericUpDownTouchCommandOption,
-					z => z.Value,
-					BindingMode.TwoWay,
-					null,
-					z => (int)z,
-					Observable.FromEvent<EventHandler, EventArgs>(
-							h => (s, e) => h(e),
-							h => numericUpDownTouchCommandOption.ValueChanged += h,
-							h => numericUpDownTouchCommandOption.ValueChanged -= h
 						)
 						.ToUnit()
 				)

--- a/source/TrainEditor2/Views/FormEditor.cs
+++ b/source/TrainEditor2/Views/FormEditor.cs
@@ -467,15 +467,6 @@ namespace TrainEditor2.Views
 				comboBox.DrawItem += ToolStripComboBoxIndex_DrawItem;
 			}
 
-			comboBoxTouchCommand.Items
-				.AddRange(
-					Enum.GetValues(typeof(Translations.Command))
-						.OfType<Translations.Command>()
-						.Select(c => Translations.CommandInfos.TryGetInfo(c).Name)
-						.OfType<object>()
-						.ToArray()
-				);
-
 			Icon = GetIcon();
 
 			toolStripMenuItemError.Image = Bitmap.FromHicon(SystemIcons.Error.Handle);
@@ -736,6 +727,12 @@ namespace TrainEditor2.Views
 			e.Graphics.DrawString(toolStripComboBoxIndex.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), e.Bounds.X + e.Bounds.Height + 10, e.Bounds.Y);
 		}
 
+		private void GlControlMotor_Load(object sender, EventArgs e)
+		{
+			glControlMotor.MakeCurrent();
+			Program.Renderer.Initialize(Program.CurrentHost, Interface.CurrentOptions);
+		}
+
 		private void GlControlMotor_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
 		{
 			switch (e.KeyCode)
@@ -813,6 +810,11 @@ namespace TrainEditor2.Views
 			}
 
 			glControlMotor.SwapBuffers();
+		}
+
+		private void ButtonCouplerObject_Click(object sender, EventArgs e)
+		{
+			OpenFileDialog(textBoxCouplerObject);
 		}
 
 		private void ButtonThisDaytimeImageOpen_Click(object sender, EventArgs e)
@@ -945,20 +947,17 @@ namespace TrainEditor2.Views
 			OpenColorDialog(textBoxTimetableTransparentColor);
 		}
 
+		private void ButtonTouchSoundCommand_Click(object sender, EventArgs e)
+		{
+			using (FormTouch form = new FormTouch(app.Panel.Value.SelectedTouch.Value))
+			{
+				form.ShowDialog(this);
+			}
+		}
+
 		private void ButtonSoundFileNameOpen_Click(object sender, EventArgs e)
 		{
 			OpenFileDialog(textBoxSoundFileName);
-		}
-
-		private void buttonCouplerObject_Click(object sender, EventArgs e)
-		{
-			OpenFileDialog(textBoxCouplerObject);
-		}
-
-		private void glControlMotor_Load(object sender, EventArgs e)
-		{
-			glControlMotor.MakeCurrent();
-			Program.Renderer.Initialize(Program.CurrentHost, Interface.CurrentOptions);
 		}
 	}
 }

--- a/source/TrainEditor2/Views/FormTouch.Designer.cs
+++ b/source/TrainEditor2/Views/FormTouch.Designer.cs
@@ -1,0 +1,305 @@
+namespace TrainEditor2.Views
+{
+	partial class FormTouch
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			disposable.Dispose();
+
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.panelTouch = new System.Windows.Forms.Panel();
+			this.groupBoxTouch = new System.Windows.Forms.GroupBox();
+			this.groupBoxTouchSound = new System.Windows.Forms.GroupBox();
+			this.numericUpDownTouchSoundIndex = new System.Windows.Forms.NumericUpDown();
+			this.labelTouchSoundIndex = new System.Windows.Forms.Label();
+			this.buttonTouchCopy = new System.Windows.Forms.Button();
+			this.groupBoxTouchCommand = new System.Windows.Forms.GroupBox();
+			this.comboBoxTouchCommandName = new System.Windows.Forms.ComboBox();
+			this.numericUpDownTouchCommandOption = new System.Windows.Forms.NumericUpDown();
+			this.labelTouchCommandOption = new System.Windows.Forms.Label();
+			this.labelTouchCommandName = new System.Windows.Forms.Label();
+			this.buttonTouchAdd = new System.Windows.Forms.Button();
+			this.buttonTouchRemove = new System.Windows.Forms.Button();
+			this.splitContainerTouch = new System.Windows.Forms.SplitContainer();
+			this.treeViewTouch = new System.Windows.Forms.TreeView();
+			this.listViewTouch = new System.Windows.Forms.ListView();
+			this.panelTouchNavi = new System.Windows.Forms.Panel();
+			this.buttonOK = new System.Windows.Forms.Button();
+			this.panelTouch.SuspendLayout();
+			this.groupBoxTouch.SuspendLayout();
+			this.groupBoxTouchSound.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchSoundIndex)).BeginInit();
+			this.groupBoxTouchCommand.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchCommandOption)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.splitContainerTouch)).BeginInit();
+			this.splitContainerTouch.Panel1.SuspendLayout();
+			this.splitContainerTouch.Panel2.SuspendLayout();
+			this.splitContainerTouch.SuspendLayout();
+			this.panelTouchNavi.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// panelTouch
+			// 
+			this.panelTouch.Controls.Add(this.groupBoxTouch);
+			this.panelTouch.Dock = System.Windows.Forms.DockStyle.Right;
+			this.panelTouch.Location = new System.Drawing.Point(496, 0);
+			this.panelTouch.Name = "panelTouch";
+			this.panelTouch.Size = new System.Drawing.Size(216, 408);
+			this.panelTouch.TabIndex = 0;
+			// 
+			// groupBoxTouch
+			// 
+			this.groupBoxTouch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBoxTouch.Controls.Add(this.groupBoxTouchSound);
+			this.groupBoxTouch.Controls.Add(this.buttonTouchCopy);
+			this.groupBoxTouch.Controls.Add(this.groupBoxTouchCommand);
+			this.groupBoxTouch.Controls.Add(this.buttonTouchAdd);
+			this.groupBoxTouch.Controls.Add(this.buttonTouchRemove);
+			this.groupBoxTouch.Location = new System.Drawing.Point(8, 224);
+			this.groupBoxTouch.Name = "groupBoxTouch";
+			this.groupBoxTouch.Size = new System.Drawing.Size(200, 184);
+			this.groupBoxTouch.TabIndex = 110;
+			this.groupBoxTouch.TabStop = false;
+			this.groupBoxTouch.Text = "Edit entry";
+			// 
+			// groupBoxTouchSound
+			// 
+			this.groupBoxTouchSound.Controls.Add(this.numericUpDownTouchSoundIndex);
+			this.groupBoxTouchSound.Controls.Add(this.labelTouchSoundIndex);
+			this.groupBoxTouchSound.Location = new System.Drawing.Point(8, 16);
+			this.groupBoxTouchSound.Name = "groupBoxTouchSound";
+			this.groupBoxTouchSound.Size = new System.Drawing.Size(184, 48);
+			this.groupBoxTouchSound.TabIndex = 90;
+			this.groupBoxTouchSound.TabStop = false;
+			this.groupBoxTouchSound.Text = "Sound";
+			// 
+			// numericUpDownTouchSoundIndex
+			// 
+			this.numericUpDownTouchSoundIndex.Location = new System.Drawing.Point(72, 16);
+			this.numericUpDownTouchSoundIndex.Maximum = new decimal(new int[] {
+            256,
+            0,
+            0,
+            0});
+			this.numericUpDownTouchSoundIndex.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+			this.numericUpDownTouchSoundIndex.Name = "numericUpDownTouchSoundIndex";
+			this.numericUpDownTouchSoundIndex.Size = new System.Drawing.Size(48, 19);
+			this.numericUpDownTouchSoundIndex.TabIndex = 108;
+			// 
+			// labelTouchSoundIndex
+			// 
+			this.labelTouchSoundIndex.Location = new System.Drawing.Point(8, 16);
+			this.labelTouchSoundIndex.Name = "labelTouchSoundIndex";
+			this.labelTouchSoundIndex.Size = new System.Drawing.Size(56, 16);
+			this.labelTouchSoundIndex.TabIndex = 9;
+			this.labelTouchSoundIndex.Text = "Index:";
+			this.labelTouchSoundIndex.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// buttonTouchCopy
+			// 
+			this.buttonTouchCopy.Location = new System.Drawing.Point(72, 152);
+			this.buttonTouchCopy.Name = "buttonTouchCopy";
+			this.buttonTouchCopy.Size = new System.Drawing.Size(56, 24);
+			this.buttonTouchCopy.TabIndex = 93;
+			this.buttonTouchCopy.Text = "Copy";
+			this.buttonTouchCopy.UseVisualStyleBackColor = true;
+			// 
+			// groupBoxTouchCommand
+			// 
+			this.groupBoxTouchCommand.Controls.Add(this.comboBoxTouchCommandName);
+			this.groupBoxTouchCommand.Controls.Add(this.numericUpDownTouchCommandOption);
+			this.groupBoxTouchCommand.Controls.Add(this.labelTouchCommandOption);
+			this.groupBoxTouchCommand.Controls.Add(this.labelTouchCommandName);
+			this.groupBoxTouchCommand.Location = new System.Drawing.Point(8, 72);
+			this.groupBoxTouchCommand.Name = "groupBoxTouchCommand";
+			this.groupBoxTouchCommand.Size = new System.Drawing.Size(184, 72);
+			this.groupBoxTouchCommand.TabIndex = 109;
+			this.groupBoxTouchCommand.TabStop = false;
+			this.groupBoxTouchCommand.Text = "Command";
+			// 
+			// comboBoxTouchCommandName
+			// 
+			this.comboBoxTouchCommandName.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxTouchCommandName.FormattingEnabled = true;
+			this.comboBoxTouchCommandName.Location = new System.Drawing.Point(72, 16);
+			this.comboBoxTouchCommandName.Name = "comboBoxTouchCommandName";
+			this.comboBoxTouchCommandName.Size = new System.Drawing.Size(104, 20);
+			this.comboBoxTouchCommandName.TabIndex = 112;
+			// 
+			// numericUpDownTouchCommandOption
+			// 
+			this.numericUpDownTouchCommandOption.Location = new System.Drawing.Point(72, 40);
+			this.numericUpDownTouchCommandOption.Name = "numericUpDownTouchCommandOption";
+			this.numericUpDownTouchCommandOption.Size = new System.Drawing.Size(48, 19);
+			this.numericUpDownTouchCommandOption.TabIndex = 111;
+			// 
+			// labelTouchCommandOption
+			// 
+			this.labelTouchCommandOption.Location = new System.Drawing.Point(8, 40);
+			this.labelTouchCommandOption.Name = "labelTouchCommandOption";
+			this.labelTouchCommandOption.Size = new System.Drawing.Size(56, 16);
+			this.labelTouchCommandOption.TabIndex = 109;
+			this.labelTouchCommandOption.Text = "Option:";
+			this.labelTouchCommandOption.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// labelTouchCommandName
+			// 
+			this.labelTouchCommandName.Location = new System.Drawing.Point(8, 16);
+			this.labelTouchCommandName.Name = "labelTouchCommandName";
+			this.labelTouchCommandName.Size = new System.Drawing.Size(56, 16);
+			this.labelTouchCommandName.TabIndex = 9;
+			this.labelTouchCommandName.Text = "Name:";
+			this.labelTouchCommandName.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// buttonTouchAdd
+			// 
+			this.buttonTouchAdd.Location = new System.Drawing.Point(8, 152);
+			this.buttonTouchAdd.Name = "buttonTouchAdd";
+			this.buttonTouchAdd.Size = new System.Drawing.Size(56, 24);
+			this.buttonTouchAdd.TabIndex = 92;
+			this.buttonTouchAdd.Text = "Add";
+			this.buttonTouchAdd.UseVisualStyleBackColor = true;
+			// 
+			// buttonTouchRemove
+			// 
+			this.buttonTouchRemove.Location = new System.Drawing.Point(136, 152);
+			this.buttonTouchRemove.Name = "buttonTouchRemove";
+			this.buttonTouchRemove.Size = new System.Drawing.Size(56, 24);
+			this.buttonTouchRemove.TabIndex = 91;
+			this.buttonTouchRemove.Text = "Remove";
+			this.buttonTouchRemove.UseVisualStyleBackColor = true;
+			// 
+			// splitContainerTouch
+			// 
+			this.splitContainerTouch.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.splitContainerTouch.Location = new System.Drawing.Point(0, 0);
+			this.splitContainerTouch.Name = "splitContainerTouch";
+			// 
+			// splitContainerTouch.Panel1
+			// 
+			this.splitContainerTouch.Panel1.Controls.Add(this.treeViewTouch);
+			// 
+			// splitContainerTouch.Panel2
+			// 
+			this.splitContainerTouch.Panel2.Controls.Add(this.listViewTouch);
+			this.splitContainerTouch.Size = new System.Drawing.Size(496, 408);
+			this.splitContainerTouch.SplitterDistance = 155;
+			this.splitContainerTouch.TabIndex = 1;
+			// 
+			// treeViewTouch
+			// 
+			this.treeViewTouch.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.treeViewTouch.HideSelection = false;
+			this.treeViewTouch.Location = new System.Drawing.Point(0, 0);
+			this.treeViewTouch.Name = "treeViewTouch";
+			this.treeViewTouch.Size = new System.Drawing.Size(155, 408);
+			this.treeViewTouch.TabIndex = 0;
+			// 
+			// listViewTouch
+			// 
+			this.listViewTouch.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.listViewTouch.FullRowSelect = true;
+			this.listViewTouch.HideSelection = false;
+			this.listViewTouch.Location = new System.Drawing.Point(0, 0);
+			this.listViewTouch.MultiSelect = false;
+			this.listViewTouch.Name = "listViewTouch";
+			this.listViewTouch.Size = new System.Drawing.Size(337, 408);
+			this.listViewTouch.TabIndex = 0;
+			this.listViewTouch.UseCompatibleStateImageBehavior = false;
+			this.listViewTouch.View = System.Windows.Forms.View.Details;
+			// 
+			// panelTouchNavi
+			// 
+			this.panelTouchNavi.Controls.Add(this.buttonOK);
+			this.panelTouchNavi.Dock = System.Windows.Forms.DockStyle.Bottom;
+			this.panelTouchNavi.Location = new System.Drawing.Point(0, 408);
+			this.panelTouchNavi.Name = "panelTouchNavi";
+			this.panelTouchNavi.Size = new System.Drawing.Size(712, 42);
+			this.panelTouchNavi.TabIndex = 2;
+			// 
+			// buttonOK
+			// 
+			this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.buttonOK.Location = new System.Drawing.Point(648, 8);
+			this.buttonOK.Name = "buttonOK";
+			this.buttonOK.Size = new System.Drawing.Size(56, 24);
+			this.buttonOK.TabIndex = 41;
+			this.buttonOK.Text = "OK";
+			this.buttonOK.UseVisualStyleBackColor = true;
+			this.buttonOK.Click += new System.EventHandler(this.ButtonOK_Click);
+			// 
+			// FormTouch
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(712, 450);
+			this.Controls.Add(this.splitContainerTouch);
+			this.Controls.Add(this.panelTouch);
+			this.Controls.Add(this.panelTouchNavi);
+			this.Name = "FormTouch";
+			this.Text = "TouchElement";
+			this.Load += new System.EventHandler(this.FormTouch_Load);
+			this.panelTouch.ResumeLayout(false);
+			this.groupBoxTouch.ResumeLayout(false);
+			this.groupBoxTouchSound.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchSoundIndex)).EndInit();
+			this.groupBoxTouchCommand.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownTouchCommandOption)).EndInit();
+			this.splitContainerTouch.Panel1.ResumeLayout(false);
+			this.splitContainerTouch.Panel2.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.splitContainerTouch)).EndInit();
+			this.splitContainerTouch.ResumeLayout(false);
+			this.panelTouchNavi.ResumeLayout(false);
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.Panel panelTouch;
+		private System.Windows.Forms.SplitContainer splitContainerTouch;
+		private System.Windows.Forms.TreeView treeViewTouch;
+		private System.Windows.Forms.ListView listViewTouch;
+		private System.Windows.Forms.GroupBox groupBoxTouchSound;
+		private System.Windows.Forms.Label labelTouchSoundIndex;
+		private System.Windows.Forms.Button buttonTouchCopy;
+		private System.Windows.Forms.Button buttonTouchAdd;
+		private System.Windows.Forms.Button buttonTouchRemove;
+		private System.Windows.Forms.GroupBox groupBoxTouchCommand;
+		private System.Windows.Forms.Label labelTouchCommandOption;
+		private System.Windows.Forms.Label labelTouchCommandName;
+		private System.Windows.Forms.NumericUpDown numericUpDownTouchSoundIndex;
+		private System.Windows.Forms.NumericUpDown numericUpDownTouchCommandOption;
+		private System.Windows.Forms.ComboBox comboBoxTouchCommandName;
+		private System.Windows.Forms.GroupBox groupBoxTouch;
+		private System.Windows.Forms.Panel panelTouchNavi;
+		private System.Windows.Forms.Button buttonOK;
+	}
+}

--- a/source/TrainEditor2/Views/FormTouch.cs
+++ b/source/TrainEditor2/Views/FormTouch.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using OpenBveApi.Interface;
+using Reactive.Bindings.Binding;
+using Reactive.Bindings.Extensions;
+using TrainEditor2.Extensions;
+using TrainEditor2.ViewModels.Others;
+using TrainEditor2.ViewModels.Panels;
+
+namespace TrainEditor2.Views
+{
+	public partial class FormTouch : Form
+	{
+		private readonly CompositeDisposable disposable;
+
+		private readonly TouchElementViewModel touch;
+
+		private TreeNode TreeViewTouchTopNode
+		{
+			get
+			{
+				if (treeViewTouch.Nodes.Count == 0)
+				{
+					treeViewTouch.Nodes.Add(new TreeNode());
+				}
+
+				return treeViewTouch.Nodes[0];
+			}
+			// ReSharper disable once UnusedMember.Local
+			set
+			{
+				treeViewTouch.Nodes.Clear();
+				treeViewTouch.Nodes.Add(value);
+				treeViewTouch.ExpandAll();
+				treeViewTouch.SelectedNode = treeViewTouch.Nodes
+					.OfType<TreeNode>()
+					.Select(z => FormEditor.SearchTreeNode(touch.SelectedTreeItem.Value, z))
+					.FirstOrDefault(z => z != null);
+				touch.SelectedTreeItem.ForceNotify();
+			}
+		}
+
+		private ListViewItem ListViewTouchSelectedItem
+		{
+			get
+			{
+				if (listViewTouch.SelectedItems.Count == 1)
+				{
+					return listViewTouch.SelectedItems[0];
+				}
+
+				return null;
+			}
+			// ReSharper disable once UnusedMember.Local
+			set
+			{
+				foreach (ListViewItem item in listViewTouch.Items.OfType<ListViewItem>().Where(x => x.Selected))
+				{
+					item.Selected = false;
+				}
+
+				if (value != null)
+				{
+					value.Selected = true;
+				}
+			}
+		}
+
+		internal FormTouch(TouchElementViewModel touch)
+		{
+			disposable = new CompositeDisposable();
+			CompositeDisposable listItemDisposable = new CompositeDisposable().AddTo(disposable);
+			CompositeDisposable entryDisposable = new CompositeDisposable().AddTo(disposable);
+
+			this.touch = touch;
+
+			InitializeComponent();
+
+			touch.TreeItem
+				.BindTo(
+					this,
+					x => x.TreeViewTouchTopNode,
+					BindingMode.OneWay,
+					FormEditor.TreeViewItemViewModelToTreeNode
+				)
+				.AddTo(disposable);
+
+			touch.SelectedTreeItem
+				.BindTo(
+					treeViewTouch,
+					x => x.SelectedNode,
+					BindingMode.TwoWay,
+					x => treeViewTouch.Nodes.OfType<TreeNode>().Select(y => FormEditor.SearchTreeNode(x, y)).FirstOrDefault(y => y != null),
+					x => (TreeViewItemViewModel)x.Tag,
+					Observable.FromEvent<TreeViewEventHandler, TreeViewEventArgs>(
+							h => (s, e) => h(e),
+							h => treeViewTouch.AfterSelect += h,
+							h => treeViewTouch.AfterSelect -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(disposable);
+
+			touch.SelectedTreeItem
+				.BindTo(
+					listViewTouch,
+					x => x.Enabled,
+					BindingMode.OneWay,
+					x => touch.TreeItem.Value.Children.Contains(x)
+				)
+				.AddTo(disposable);
+
+			touch.ListColumns
+				.ObserveAddChanged()
+				.Subscribe(x =>
+				{
+					listViewTouch.Columns.Add(FormEditor.ListViewColumnHeaderViewModelToColumnHeader(x));
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.ListColumns
+				.ObserveRemoveChanged()
+				.Subscribe(y =>
+				{
+					foreach (ColumnHeader column in listViewTouch.Columns.OfType<ColumnHeader>().Where(z => z.Tag == y).ToArray())
+					{
+						listViewTouch.Columns.Remove(column);
+					}
+
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.ListColumns
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewTouch.Columns.Clear();
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.ListItems
+				.ObserveAddChanged()
+				.Subscribe(x =>
+				{
+					listViewTouch.Items.Add(FormEditor.ListViewItemViewModelToListViewItem(x));
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.ListItems
+				.ObserveRemoveChanged()
+				.Subscribe(x =>
+				{
+					foreach (ListViewItem item in listViewTouch.Items.OfType<ListViewItem>().Where(y => y.Tag == x).ToArray())
+					{
+						listViewTouch.Items.Remove(item);
+					}
+
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.ListItems
+				.ObserveResetChanged()
+				.Subscribe(_ =>
+				{
+					listViewTouch.Items.Clear();
+					listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+				})
+				.AddTo(disposable);
+
+			touch.SelectedListItem
+				.BindTo(
+					this,
+					x => x.ListViewTouchSelectedItem,
+					BindingMode.TwoWay,
+					x => listViewTouch.Items.OfType<ListViewItem>().FirstOrDefault(y => y.Tag == x),
+					x => (ListViewItemViewModel)x?.Tag,
+					Observable.FromEvent<EventHandler, EventArgs>(
+							h => (s, e) => h(e),
+							h => listViewTouch.SelectedIndexChanged += h,
+							h => listViewTouch.SelectedIndexChanged -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(disposable);
+
+			touch.SelectedListItem
+				.Where(x => x != null)
+				.Subscribe(x =>
+				{
+					listItemDisposable.Dispose();
+					listItemDisposable = new CompositeDisposable().AddTo(disposable);
+
+					x.Texts
+						.ObserveReplaceChanged()
+						.Subscribe(_ =>
+						{
+							FormEditor.UpdateListViewItem(ListViewTouchSelectedItem, touch.SelectedListItem.Value);
+							listViewTouch.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+						})
+						.AddTo(listItemDisposable);
+				})
+				.AddTo(disposable);
+
+			touch.SelectedSoundEntry
+				.BindTo(
+					groupBoxTouchSound,
+					x => x.Enabled,
+					x => x != null
+				)
+				.AddTo(disposable);
+
+			touch.SelectedSoundEntry
+				.Where(x => x != null)
+				.Subscribe(x =>
+				{
+					entryDisposable.Dispose();
+					entryDisposable = new CompositeDisposable().AddTo(disposable);
+
+					BindToSoundEntry(x).AddTo(entryDisposable);
+				})
+				.AddTo(disposable);
+
+			touch.SelectedCommandEntry
+				.BindTo(
+					groupBoxTouchCommand,
+					x => x.Enabled,
+					x => x != null
+				)
+				.AddTo(disposable);
+
+			touch.SelectedCommandEntry
+				.Where(x => x != null)
+				.Subscribe(x =>
+				{
+					entryDisposable.Dispose();
+					entryDisposable = new CompositeDisposable().AddTo(disposable);
+
+					BindToCommandEntry(x).AddTo(entryDisposable);
+				})
+				.AddTo(disposable);
+
+			comboBoxTouchCommandName.Items
+				.AddRange(
+					Enum.GetValues(typeof(Translations.Command))
+						.OfType<Translations.Command>()
+						.Select(c => Translations.CommandInfos.TryGetInfo(c).Name)
+						.OfType<object>()
+						.ToArray()
+				);
+
+			new[] { touch.AddSoundEntry, touch.AddCommandEntry }
+				.BindToButton(buttonTouchAdd)
+				.AddTo(disposable);
+
+			new[] { touch.CopySoundEntry, touch.CopyCommandEntry }
+				.BindToButton(buttonTouchCopy)
+				.AddTo(disposable);
+
+			new[] { touch.RemoveSoundEntry, touch.RemoveCommandEntry }
+				.BindToButton(buttonTouchRemove)
+				.AddTo(disposable);
+		}
+
+		private void FormTouch_Load(object sender, EventArgs e)
+		{
+			Icon = FormEditor.GetIcon();
+		}
+
+		private void ButtonOK_Click(object sender, EventArgs e)
+		{
+			ListViewTouchSelectedItem = null;
+			treeViewTouch.SelectedNode = TreeViewTouchTopNode;
+
+			Close();
+		}
+
+		private IDisposable BindToSoundEntry(TouchElementViewModel.SoundEntryViewModel entry)
+		{
+			CompositeDisposable entryDisposable = new CompositeDisposable();
+
+			entry.Index
+				.BindTo(
+					numericUpDownTouchSoundIndex,
+					x => x.Value,
+					BindingMode.TwoWay,
+					null,
+					x => (int)x,
+					Observable.FromEvent<EventHandler, EventArgs>(
+							h => (s, e) => h(e),
+							h => numericUpDownTouchSoundIndex.ValueChanged += h,
+							h => numericUpDownTouchSoundIndex.ValueChanged -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(entryDisposable);
+
+			return entryDisposable;
+		}
+
+		private IDisposable BindToCommandEntry(TouchElementViewModel.CommandEntryViewModel entry)
+		{
+			CompositeDisposable entryDisposable = new CompositeDisposable();
+
+			entry.Info
+				.BindTo(
+					comboBoxTouchCommandName,
+					x => x.SelectedIndex,
+					BindingMode.TwoWay,
+					x => (int)x.Command,
+					x => Translations.CommandInfos.TryGetInfo((Translations.Command)x),
+					Observable.FromEvent<EventHandler, EventArgs>(
+							h => (s, e) => h(e),
+							h => comboBoxTouchCommandName.SelectedIndexChanged += h,
+							h => comboBoxTouchCommandName.SelectedIndexChanged -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(entryDisposable);
+
+			entry.Option
+				.BindTo(
+					numericUpDownTouchCommandOption,
+					x => x.Value,
+					BindingMode.TwoWay,
+					null,
+					x => (int)x,
+					Observable.FromEvent<EventHandler, EventArgs>(
+							h => (s, e) => h(e),
+							h => numericUpDownTouchCommandOption.ValueChanged += h,
+							h => numericUpDownTouchCommandOption.ValueChanged -= h
+						)
+						.ToUnit()
+				)
+				.AddTo(entryDisposable);
+
+			return entryDisposable;
+		}
+	}
+}

--- a/source/TrainEditor2/Views/FormTouch.resx
+++ b/source/TrainEditor2/Views/FormTouch.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,22 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStripMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>569, 17</value>
-  </metadata>
-  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>701, 17</value>
-  </metadata>
-  <metadata name="toolStripToolBar.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>154, 17</value>
-  </metadata>
-  <metadata name="menuStripMotor.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>297, 17</value>
-  </metadata>
-  <metadata name="menuStripStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>431, 17</value>
-  </metadata>
 </root>


### PR DESCRIPTION
This PR add multiple sounds and commands to one touch element on the panel.

Use the following format:

```
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<openBVE xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <Panel>
    <Screen>
      <Touch>
        <SoundEntries>
          <Entry>
            <Index>-1</Index>
          </Entry>
        </SoundEntries>
        <CommandEntries>
          <Entry>
            <Name>N/A</Name>
            <Option>0</Option>
          </Entry>
        </CommandEntries>
      </Touch>
    </Screen>
  </Panel>
</openBVE>
```

In addition, several bugs in TrainEditor2 were fixed.