### PR TITLE
Change: Move to an abstract cargo type

### DIFF
--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -454,6 +454,8 @@ namespace CarXmlConvertor
 				newLines.Add("<MotorCar>False</MotorCar>");
 				newLines.Add("<Mass>" + ConvertTrainDat.TrailerCarMass + "</Mass>");
 			}
+			// BVE has all cars as passenger carrying by default
+			newLines.Add("<Cargo>Passengers</Cargo>");
 			if (CarInfos[i].AxlesDefined)
 			{
 				newLines.Add("<FrontAxle>" + CarInfos[i].FrontAxle + "</FrontAxle>");

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -113,11 +113,11 @@ namespace LibRender2
 		protected List<Matrix4D> projectionMatrixList;
 		protected List<Matrix4D> viewMatrixList;
 
-#pragma warning disable 0219
+#pragma warning disable 0219, CS0169
 		/// <summary>Holds the last openGL error</summary>
 		/// <remarks>Is only used in debug builds, hence the pragma</remarks>
 		private ErrorCode lastError;
-#pragma warning restore 0219
+#pragma warning restore 0219, CS0169
 
 		/// <summary>The current shader in use</summary>
 		protected internal Shader CurrentShader;

--- a/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
+++ b/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
@@ -33,6 +33,8 @@ namespace OpenBve
 			}
 		}
 
+		/// <summary>Updates any TFOs within the world after a jump</summary>
+		/// <param name="Train">The train which has jumped</param>
 		public static void ProcessJump(AbstractTrain Train)
 		{
 			if (Train.IsPlayerTrain)

--- a/source/OpenBVE/Game/Score/Score.cs
+++ b/source/OpenBVE/Game/Score/Score.cs
@@ -336,7 +336,21 @@ namespace OpenBve
 					}
 				}
 				// passengers
-				if (TrainManager.PlayerTrain.Passengers.FallenOver & PassengerTimer == 0.0)
+				bool fallenOver = false;
+				for (int i = 0; i < TrainManager.PlayerTrain.Cars.Length; i++)
+				{
+					/*
+					 * NOTE: This should currently break on the first car.
+					 * When other cargo types are implemented, it may not
+					 */
+
+					if (TrainManager.PlayerTrain.Cars[i].Cargo.Damaged)
+					{
+						fallenOver = true;
+						break;
+					}
+				}
+				if (fallenOver & PassengerTimer == 0.0)
 				{
 					int x = ScoreValuePassengerDiscomfort;
 					this.CurrentValue += x;
@@ -348,7 +362,7 @@ namespace OpenBve
 					PassengerTimer -= TimeElapsed;
 					if (PassengerTimer <= 0.0)
 					{
-						if (TrainManager.PlayerTrain.Passengers.FallenOver)
+						if (fallenOver)
 						{
 							PassengerTimer = 5.0;
 						}

--- a/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
@@ -155,7 +155,7 @@ namespace OpenBve.Graphics.Renderers
 				"air pressure: " + (0.001 * airPressure).ToString("0.00", Culture) + " kPa",
 				"air density: " + airDensity.ToString("0.0000", Culture) + " kg/m³",
 				"speed of sound: " + (Program.CurrentRoute.Atmosphere.GetSpeedOfSound(airDensity) * 3.6).ToString("0.00", Culture) + " km/h",
-				"passenger ratio: " + TrainManager.PlayerTrain.Passengers.PassengerRatio.ToString("0.00"),
+				"passenger ratio: " + TrainManager.PlayerTrain.CargoRatio.ToString("0.00"),
 				"total mass: " + mass.ToString("0.00", Culture) + " kg",
 				"",
 				"=route",

--- a/source/OpenBVE/OldCode/TrainManager.cs
+++ b/source/OpenBVE/OldCode/TrainManager.cs
@@ -12,6 +12,7 @@ namespace OpenBve
 	/// <summary>The TrainManager is the root class containing functions to load and manage trains within the simulation world.</summary>
 	public class TrainManager : TrainManagerBase
 	{
+		/// <inheritdoc/>
 		public TrainManager(HostInterface host, BaseRenderer renderer, BaseOptions options, FileSystem fileSystem) : base(host, renderer, options, fileSystem)
 		{
 		}

--- a/source/OpenBVE/UserInterface/formImageExport.cs
+++ b/source/OpenBVE/UserInterface/formImageExport.cs
@@ -7,11 +7,11 @@ using RouteManager2;
 
 namespace OpenBve
 {
-	public partial class formImageExport : Form
+	internal partial class formImageExport : Form
 	{
 		private readonly bool IsMap;
 		private readonly string routeFileName;
-		public formImageExport(bool isMap, string fileName)
+		internal formImageExport(bool isMap, string fileName)
 		{
 			InitializeComponent();
 			IsMap = isMap;

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -142,6 +142,8 @@ namespace OpenBve
 
 		/// <summary>Populates the route display list from the selected folder</summary>
 		/// <param name="Folder">The folder containing route files</param>
+		/// <param name="listView">The list view to populate</param>
+		/// <param name="packages">Whether this is a packaged content folder</param>
 		private void populateRouteList(string Folder, ListView listView, bool packages)
 		{
 			try
@@ -664,6 +666,8 @@ namespace OpenBve
 
 		/// <summary>Populates the train display list from the selected folder</summary>
 		/// <param name="Folder">The folder containing train folders</param>
+		/// <param name="listView">The list view to populate</param>
+		/// <param name="packages">Whether this is a packaged content folder</param>
 		private void populateTrainList(string Folder, ListView listView, bool packages)
 		{
 			try

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -11,6 +11,7 @@ using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using TrainManager.BrakeSystems;
 using TrainManager.Car;
+using TrainManager.Cargo;
 using TrainManager.Power;
 using TrainManager.Trains;
 
@@ -490,6 +491,17 @@ namespace Train.OpenBve
 						doorTolerance *= 1000.0;
 						Train.Cars[Car].Doors[0] = new Door(-1, doorWidth, doorTolerance);
 						Train.Cars[Car].Doors[0] = new Door(1, doorWidth, doorTolerance);
+						break;
+					case "cargo":
+						switch (c.InnerText.ToLowerInvariant())
+						{
+							case "passengers":
+								Train.Cars[Car].Cargo = new Passengers(Train.Cars[Car]);
+								break;
+							case "none":
+								Train.Cars[Car].Cargo = new CargoBase();
+								break;
+						}
 						break;
 				}
 			}

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -499,7 +499,7 @@ namespace Train.OpenBve
 								Train.Cars[Car].Cargo = new Passengers(Train.Cars[Car]);
 								break;
 							case "none":
-								Train.Cars[Car].Cargo = new CargoBase();
+								Train.Cars[Car].Cargo = new EmptyLoad();
 								break;
 						}
 						break;

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -498,6 +498,9 @@ namespace Train.OpenBve
 							case "passengers":
 								Train.Cars[Car].Cargo = new Passengers(Train.Cars[Car]);
 								break;
+							case "freight":
+								Train.Cars[Car].Cargo = new RobustFreight(Train.Cars[Car]);
+								break;
 							case "none":
 								Train.Cars[Car].Cargo = new EmptyLoad();
 								break;

--- a/source/TrainEditor2/IO/Trains/TrainDat/Parser.cs
+++ b/source/TrainEditor2/IO/Trains/TrainDat/Parser.cs
@@ -40,7 +40,7 @@ namespace TrainEditor2.IO.Trains.TrainDat
 			}
 
 			bool ver1220000 = false;
-
+			int version = 0;
 			foreach (string line in lines)
 			{
 				if (line.Length != 0)
@@ -62,11 +62,10 @@ namespace TrainEditor2.IO.Trains.TrainDat
 							if (s.ToLowerInvariant().StartsWith("openbve"))
 							{
 								string tt = s.Substring(7, s.Length - 7);
-								int v;
 
-								if (int.TryParse(tt, NumberStyles.Float, culture, out v))
+								if (int.TryParse(tt, NumberStyles.Float, culture, out version))
 								{
-									if (v > currentVersion)
+									if (version > currentVersion)
 									{
 										Interface.AddMessage(MessageType.Warning, false, $"The train.dat {fileName} was created with a newer version of openBVE. Please check for an update.");
 									}
@@ -297,7 +296,7 @@ namespace TrainEditor2.IO.Trains.TrainDat
 										}
 										break;
 									case 4:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayElectricBrakeUp = new[] { a };
 										}
@@ -307,7 +306,7 @@ namespace TrainEditor2.IO.Trains.TrainDat
 										}
 										break;
 									case 5:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayElectricBrakeDown = new[] { a };
 										}
@@ -317,13 +316,13 @@ namespace TrainEditor2.IO.Trains.TrainDat
 										}
 										break;
 									case 6:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayLocoBrakeUp = new[] { a };
 										}
 										break;
 									case 7:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayLocoBrakeDown = new[] { a };
 										}
@@ -347,7 +346,7 @@ namespace TrainEditor2.IO.Trains.TrainDat
 										delayBrakeDown = lines[i].Split(',').Select(x => double.Parse(x, culture)).ToArray();
 										break;
 									case 4:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayElectricBrakeUp = lines[i].Split(',').Select(x => double.Parse(x, culture)).ToArray();
 										}
@@ -357,7 +356,7 @@ namespace TrainEditor2.IO.Trains.TrainDat
 										}
 										break;
 									case 5:
-										if (currentVersion >= 18320)
+										if (version >= 18320)
 										{
 											delayElectricBrakeDown = lines[i].Split(',').Select(x => double.Parse(x, culture)).ToArray();
 										}

--- a/source/TrainEditor2/Simulation/TrainManager/TrainManager.cs
+++ b/source/TrainEditor2/Simulation/TrainManager/TrainManager.cs
@@ -11,7 +11,7 @@ namespace TrainEditor2.Simulation.TrainManager
 	public partial class TrainManager : TrainManagerBase
 	{
 		/// <summary>A reference to the train of the Trains element that corresponds to the player's train.</summary>
-		internal static Train PlayerTrain = null;
+		internal new static Train PlayerTrain = null;
 
 		internal static List<RunElement> RunSounds = new List<RunElement>();
 		internal static List<MotorElement> MotorSounds = new List<MotorElement>();

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -13,6 +13,7 @@ using OpenBveApi.Trains;
 using OpenBveApi.World;
 using SoundManager;
 using TrainManager.BrakeSystems;
+using TrainManager.Cargo;
 using TrainManager.Motor;
 using TrainManager.Power;
 using TrainManager.Trains;
@@ -82,6 +83,8 @@ namespace TrainManager.Car
 		public bool HasInteriorView = false;
 		/// <summary>Contains the generic sounds attached to the car</summary>
 		public CarSounds Sounds;
+		/// <summary>The cargo carried by the car</summary>
+		public CargoBase Cargo;
 
 		public CarBase(TrainBase train, int index, double CoefficientOfFriction, double CoefficientOfRollingResistance, double AerodynamicDragCoefficient)
 		{
@@ -109,6 +112,7 @@ namespace TrainManager.Car
 			ChangeCarSection(CarSectionType.NotVisible);
 			FrontBogie.ChangeSection(-1);
 			RearBogie.ChangeSection(-1);
+			Cargo = new Passengers(this);
 		}
 
 		public CarBase(TrainBase train, int index)
@@ -129,6 +133,7 @@ namespace TrainManager.Car
 				new Horn(this)
 			};
 			Brightness = new Brightness(this);
+			Cargo = new Passengers(this);
 		}
 
 		/// <summary>Moves the car</summary>

--- a/source/TrainManager/Cargo/CargoBase.cs
+++ b/source/TrainManager/Cargo/CargoBase.cs
@@ -1,0 +1,31 @@
+﻿namespace TrainManager.Cargo
+{
+	/// <summary>Represents the base cargo type to be carried by a car</summary>
+	public class CargoBase
+	{
+		/// <summary>The current cargo ratio</summary>
+		/// <remarks>Must be a number between 0 and 250, where 100 represents a nominal loading</remarks>
+		public double Ratio = 100.0;
+
+		/// <summary>Whether the cargo is being damaged by excessive acceleration etc.</summary>
+		/// <remarks>Used for scoring purposes</remarks>
+		public bool Damaged = false;
+
+		/// <summary>Returns the total mass of the cargo</summary>
+		public virtual double Mass => 0.0;
+
+		/// <summary>Called once a frame to update the cargo</summary>
+		/// <param name="Acceleration">The current acceleration of the train</param>
+		/// <param name="TimeElapsed">The elapsed time</param>
+		public virtual void Update(double Acceleration, double TimeElapsed)
+		{
+
+		}
+
+		/// <summary>Updates the mass of the cargo from a new loading ratio</summary>
+		public virtual void UpdateLoading(double ratio)
+		{
+
+		}
+	}
+}

--- a/source/TrainManager/Cargo/CargoBase.cs
+++ b/source/TrainManager/Cargo/CargoBase.cs
@@ -1,7 +1,7 @@
 ﻿namespace TrainManager.Cargo
 {
 	/// <summary>Represents the base cargo type to be carried by a car</summary>
-	public class CargoBase
+	public abstract class CargoBase
 	{
 		/// <summary>The current cargo ratio</summary>
 		/// <remarks>Must be a number between 0 and 250, where 100 represents a nominal loading</remarks>

--- a/source/TrainManager/Cargo/NoLoad.cs
+++ b/source/TrainManager/Cargo/NoLoad.cs
@@ -1,0 +1,9 @@
+﻿
+namespace TrainManager.Cargo
+{
+	/// <summary>Represents an empty load</summary>
+	public class EmptyLoad : CargoBase
+	{
+		// No unique properties required, but the base is abstract
+	}
+}

--- a/source/TrainManager/Cargo/RobustFreight.cs
+++ b/source/TrainManager/Cargo/RobustFreight.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using TrainManager.Car;
+
+namespace TrainManager.Cargo
+{
+	/// <summary>Represents a robust freight cargo, e.g. steel coils</summary>
+	/// <remarks>This cargo type changes weight with station loadings, but does not damage</remarks>
+	public class RobustFreight : CargoBase
+	{
+		private readonly CarBase baseCar;
+
+		private double freightMass;
+
+		public override double Mass
+		{
+			get
+			{
+				return freightMass;
+			}
+		}
+
+		public RobustFreight(CarBase car)
+		{
+			baseCar = car;
+		}
+		
+		public override void UpdateLoading(double ratio)
+		{
+			// NOTE: This is the same calculation as the passenger mass at present for backwards compatability
+			Ratio = ratio;
+			double area = baseCar.Width * baseCar.Length;
+			const double freightPerArea = 1.0; //Nominal 1 freight unit per meter of interior space
+			double randomFactor = 0.9 + 0.2 * TrainManagerBase.RandomNumberGenerator.NextDouble();
+			double freight = Math.Round(randomFactor * Ratio * freightPerArea * area);
+			const double massPerFreight = 70.0; //70kg mass per freight unit
+			freightMass = freight * massPerFreight;
+		}
+	}
+}

--- a/source/TrainManager/Train/Station.cs
+++ b/source/TrainManager/Train/Station.cs
@@ -188,8 +188,10 @@ namespace TrainManager.Trains
 									StationDepartureTime = TrainManagerBase.CurrentRoute.SecondsSinceMidnight + TrainManagerBase.CurrentRoute.Stations[i].StopTime;
 								}
 
-								Passengers.PassengerRatio = TrainManagerBase.CurrentRoute.Stations[i].PassengerRatio;
-								TrainManagerBase.UpdateTrainMassFromPassengerRatio(this);
+								for (int j = 0; j < Cars.Length; j++)
+								{
+									Cars[j].Cargo.UpdateLoading(TrainManagerBase.CurrentRoute.Stations[i].PassengerRatio);
+								}
 								if (IsPlayerTrain)
 								{
 									double early = 0.0;

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -27,8 +27,6 @@ namespace TrainManager.Trains
 		public TrainSpecs Specs;
 		/// <summary>The cab handles</summary>
 		public CabHandles Handles;
-		/// <summary>Holds the passengers</summary>
-		public TrainPassengers Passengers;
 		/// <summary>Holds the safety systems for the train</summary>
 		public TrainSafetySystems SafetySystems;
 		/// <summary>Holds the cars</summary>
@@ -64,6 +62,22 @@ namespace TrainManager.Trains
 
 		/// <inheritdoc/>
 		public override int NumberOfCars => this.Cars.Length;
+
+		/// <summary>Gets the average cargo loading ratio for this train</summary>
+		public double CargoRatio
+		{
+			get
+			{
+				double r = 0;
+				for (int i = 0; i < Cars.Length; i++)
+				{
+					r += Cars[i].Cargo.Ratio;
+				}
+
+				r /= Cars.Length;
+				return r;
+			}
+		}
 
 		public TrainBase(TrainState state)
 		{
@@ -423,14 +437,17 @@ namespace TrainManager.Trains
 				return;
 			}
 
-			// move cars
+			// Car level inital processing
 			for (int i = 0; i < Cars.Length; i++)
 			{
+				// move cars
 				Cars[i].Move(Cars[i].CurrentSpeed * TimeElapsed);
 				if (State == TrainState.Disposed)
 				{
 					return;
 				}
+				// update cargo and related score
+				Cars[i].Cargo.Update(Specs.CurrentAverageAcceleration, TimeElapsed);
 			}
 
 			// update station and doors
@@ -478,8 +495,6 @@ namespace TrainManager.Trains
 
 				Cars[DriverCar].Breaker.Update(breaker);
 			}
-			// passengers
-			Passengers.Update(Specs.CurrentAverageAcceleration, TimeElapsed);
 			// signals
 			if (CurrentSectionLimit == 0.0)
 			{

--- a/source/TrainManager/TrainManager.cs
+++ b/source/TrainManager/TrainManager.cs
@@ -78,23 +78,7 @@ namespace TrainManager
 				Train.UpdateObjects(TimeElapsed, ForceUpdate);
 			}
 		}
-
-		/// <summary>Called after passengers have finished boarding, in order to update the train's mass from the new passenger ratio</summary>
-		/// <param name="Train">The train</param>
-		internal static void UpdateTrainMassFromPassengerRatio(TrainBase Train)
-		{
-			for (int i = 0; i < Train.Cars.Length; i++)
-			{
-				double area = Train.Cars[i].Width * Train.Cars[i].Length;
-				const double passengersPerArea = 1.0;
-				double randomFactor = 0.9 + 0.2 * RandomNumberGenerator.NextDouble();
-				double passengers = Math.Round(randomFactor * Train.Passengers.PassengerRatio * passengersPerArea * area);
-				const double massPerPassenger = 70.0;
-				double passengerMass = passengers * massPerPassenger;
-				Train.Cars[i].CargoMass = passengerMass;
-			}
-		}
-
+		
 		/// <summary>Performs the jump for all TFOs</summary>
 		public void JumpTFO()
 		{

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Cargo\CargoBase.cs" />
     <Compile Include="Cargo\NoLoad.cs" />
     <Compile Include="Cargo\Passengers.cs" />
+    <Compile Include="Cargo\RobustFreight.cs" />
     <Compile Include="Car\Bogie\Bogie.cs" />
     <Compile Include="Car\CarBase.cs" />
     <Compile Include="Car\CarSounds.cs" />

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Brake\CarBrake.BrakeType.cs" />
     <Compile Include="Brake\CarBrake.cs" />
     <Compile Include="Brake\ElectroPneumaticBrakeType.cs" />
+    <Compile Include="Cargo\CargoBase.cs" />
+    <Compile Include="Cargo\Passengers.cs" />
     <Compile Include="Car\Bogie\Bogie.cs" />
     <Compile Include="Car\CarBase.cs" />
     <Compile Include="Car\CarSounds.cs" />
@@ -121,7 +123,6 @@
     <Compile Include="Train\Doors.cs" />
     <Compile Include="Train\DriverBody.cs" />
     <Compile Include="Train\Horn.cs" />
-    <Compile Include="Train\Passengers.cs" />
     <Compile Include="Train\RequestStop.cs" />
     <Compile Include="Train\Station.cs" />
     <Compile Include="Train\TrainBase.cs" />

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Brake\CarBrake.cs" />
     <Compile Include="Brake\ElectroPneumaticBrakeType.cs" />
     <Compile Include="Cargo\CargoBase.cs" />
+    <Compile Include="Cargo\NoLoad.cs" />
     <Compile Include="Cargo\Passengers.cs" />
     <Compile Include="Car\Bogie\Bogie.cs" />
     <Compile Include="Car\CarBase.cs" />


### PR DESCRIPTION
### Significant Changes:
* Moves cargo to be an abstract type on a per-car as opposed to per-train basis.
* Implements cars which carry no cargo.

### Rationale
BVE assumes that all cars carry passengers, and hence thier mass is updated according to the passenger ratio when stopping at a station.
This isn't valid for locomotives, and isn't really helpful if we're trying to move beyond our current bounds (for example, later we might want station specific cargo)

Small baby steps at the minute- Fuel usage needs to be implemented for motor cars (if appropriate), but that will feed into another modification of the mass figure, and should not be done as a cargo type; otherwise we'd need far more subtypes.