### PR TITLE
Improvements to TFOs

### DIFF
--- a/assets/Languages/ca-ES.xlf
+++ b/assets/Languages/ca-ES.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Codificació:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Previsualització:</target>

--- a/assets/Languages/cs-CZ.xlf
+++ b/assets/Languages/cs-CZ.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Kódování:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Náhled:</target>

--- a/assets/Languages/de-CH.xlf
+++ b/assets/Languages/de-CH.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Kodierung:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Vorschau:</target>

--- a/assets/Languages/de-DE.xlf
+++ b/assets/Languages/de-DE.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Kodierung:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Vorschau:</target>

--- a/assets/Languages/en-GB.xlf
+++ b/assets/Languages/en-GB.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Encoding:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Preview:</target>

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -227,6 +227,9 @@
 					<trans-unit id="train_settings_encoding">
 						<source>Encoding:</source>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 					</trans-unit>

--- a/assets/Languages/es-ES.xlf
+++ b/assets/Languages/es-ES.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Codificación:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Vista previa:</target>

--- a/assets/Languages/fi-FI.xlf
+++ b/assets/Languages/fi-FI.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Koodaus:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Esikatselu:</target>

--- a/assets/Languages/fr-FR.xlf
+++ b/assets/Languages/fr-FR.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Encodage :</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Prévisualisation :</target>

--- a/assets/Languages/hu-HU.xlf
+++ b/assets/Languages/hu-HU.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Kódolás:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Előnézet:</target>

--- a/assets/Languages/id-ID.xlf
+++ b/assets/Languages/id-ID.xlf
@@ -296,6 +296,9 @@
 						<source>Encoding:</source>
 						<target>Enkode</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Tampilan</target>

--- a/assets/Languages/it-IT.xlf
+++ b/assets/Languages/it-IT.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Codifica:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Anteprima:</target>

--- a/assets/Languages/ja-JP.xlf
+++ b/assets/Languages/ja-JP.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>エンコード:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>プレビュー:</target>

--- a/assets/Languages/ko-KR.xlf
+++ b/assets/Languages/ko-KR.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>인코딩:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>미리 보기:</target>

--- a/assets/Languages/nl-NL.xlf
+++ b/assets/Languages/nl-NL.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Codering:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Voorbeeld:</target>

--- a/assets/Languages/pl-PL.xlf
+++ b/assets/Languages/pl-PL.xlf
@@ -299,6 +299,9 @@
 						<source>Encoding:</source>
 						<target>Kodowanie:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Podgląd:</target>

--- a/assets/Languages/pt-BR.xlf
+++ b/assets/Languages/pt-BR.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Codificação:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Pré-visualização:</target>

--- a/assets/Languages/pt-PT.xlf
+++ b/assets/Languages/pt-PT.xlf
@@ -299,6 +299,9 @@
 						<source>Encoding:</source>
 						<target>Codificação:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Pré-visualização:</target>

--- a/assets/Languages/ro-RO.xlf
+++ b/assets/Languages/ro-RO.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>Codificare:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Previzualizare:</target>

--- a/assets/Languages/ru-RU.xlf
+++ b/assets/Languages/ru-RU.xlf
@@ -297,6 +297,9 @@
 						<source>Encoding:</source>
 						<target>Выбрать:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Предпросмотр:</target>

--- a/assets/Languages/uk-UA.xlf
+++ b/assets/Languages/uk-UA.xlf
@@ -299,6 +299,9 @@
 						<source>Encoding:</source>
 						<target>Кодування:</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Попередній перегляд:</target>

--- a/assets/Languages/zh-CN.xlf
+++ b/assets/Languages/zh-CN.xlf
@@ -299,6 +299,9 @@
 						<source>Encoding:</source>
 						<target>字符编码: </target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>预览: </target>

--- a/assets/Languages/zh-HK.xlf
+++ b/assets/Languages/zh-HK.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>編碼：</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>預覽：</target>

--- a/assets/Languages/zh-TW.xlf
+++ b/assets/Languages/zh-TW.xlf
@@ -298,6 +298,9 @@
 						<source>Encoding:</source>
 						<target>編碼：</target>
 					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>預覽：</target>

--- a/source/LibRender2/Objects/ObjectLibrary.cs
+++ b/source/LibRender2/Objects/ObjectLibrary.cs
@@ -85,6 +85,10 @@ namespace LibRender2.Objects
 
 		public void ShowObject(ObjectState State, ObjectType Type)
 		{
+			if (renderer.DefaultShader == null)
+			{
+				throw new Exception();
+			}
 			bool result = AddObject(State);
 
 			if (State.Prototype.Mesh.VAO == null)

--- a/source/OpenBVE/Game/AI/AI.cs
+++ b/source/OpenBVE/Game/AI/AI.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenBve
+namespace OpenBve
 {
     internal static partial class Game
     {
@@ -9,8 +9,8 @@
         }
 
 	    internal static bool InitialAIDriver;
+	    internal static bool InitialReversedConsist;
 
-       
 
         // bogus pretrain
         

--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -57,6 +57,7 @@ namespace OpenBve
 		{
 			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
 			string TrainDirectory = string.Empty;
+			bool consistReversed = false;
 			List<Game.TravelData> Data = new List<Game.TravelData>();
 
 			foreach (XElement SectionElement in Element.Elements())
@@ -101,6 +102,14 @@ namespace OpenBve
 										{
 											TrainDirectory = trainDirectory;
 										}
+									}
+									break;
+								case "reversed":
+									int n;
+									NumberFormats.TryParseIntVb6(Value, out n);
+									if (n == 1 || Value.ToLowerInvariant() == "true")
+									{
+										consistReversed = true;
 									}
 									break;
 							}
@@ -296,6 +305,10 @@ namespace OpenBve
 				Car.RearBogie.RearAxle.Follower.TrackIndex = Data[0].RailIndex;
 			}
 
+			if (consistReversed)
+			{
+				Train.Reverse();
+			}
 			Train.PlaceCars(Data[0].StopPosition);
 		}
 

--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -150,8 +150,16 @@ namespace OpenBve
 				return;
 			}
 
-			// Initial setting
-			string TrainData = OpenBveApi.Path.CombineFile(TrainDirectory, "train.dat");
+			/*
+			 * First check for a train.ai file- Functionally identical, but allows for differently configured AI
+			 * trains not to show up as driveable
+			 */
+			string TrainData = OpenBveApi.Path.CombineFile(TrainDirectory, "train.ai");
+			if (!System.IO.File.Exists(TrainData))
+			{
+				// Check for the standard driveable train.dat
+				TrainData = OpenBveApi.Path.CombineFile(TrainDirectory, "train.dat");
+			}
 			string ExteriorFile = OpenBveApi.Path.CombineFile(TrainDirectory, "extensions.cfg");
 			if (!System.IO.File.Exists(TrainData) || !System.IO.File.Exists(ExteriorFile))
 			{

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.Bogie.cs
@@ -19,9 +19,9 @@ namespace OpenBve
 			internal double Length;
 #pragma warning restore 0649
 			/// <summary>Front axle about which the bogie pivots</summary>
-			internal Axle FrontAxle;
+			internal readonly Axle FrontAxle;
 			/// <summary>Rear axle about which the bogie pivots</summary>
-			internal Axle RearAxle;
+			internal readonly Axle RearAxle;
 			internal Vector3 Up;
 			/// <summary>The car sections (objects) attached to the bogie</summary>
 			internal CarSection[] CarSections;
@@ -111,6 +111,37 @@ namespace OpenBve
 							}
 						}
 					}
+				}
+			}
+
+			internal void Reverse()
+			{
+				// reverse axle positions
+				double temp = FrontAxle.Position;
+				FrontAxle.Position = -RearAxle.Position;
+				RearAxle.Position = -temp;
+				if (CarSections.Length == 0 || CarSections == null)
+				{
+					return;
+				}
+				int idxToReverse = 0; //cannot have an interior view
+				
+				for (int i = 0; i < CarSections[idxToReverse].Groups[0].Elements.Length; i++)
+				{
+					for (int h = 0; h < CarSections[idxToReverse].Groups[0].Elements[i].States.Length; h++)
+					{
+						CarSections[idxToReverse].Groups[0].Elements[i].States[h].Prototype.ApplyScale(-1.0, 1.0, -1.0);
+						Matrix4D t = CarSections[idxToReverse].Groups[0].Elements[i].States[h].Translation;
+						t.Row3.X *= -1.0f;
+						t.Row3.Z *= -1.0f;
+						CarSections[idxToReverse].Groups[0].Elements[i].States[h].Translation = t;
+					}
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateXDirection.X *= -1.0;
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateXDirection.Z *= -1.0;
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateYDirection.X *= -1.0;
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateYDirection.Z *= -1.0;
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateZDirection.X *= -1.0;
+					CarSections[idxToReverse].Groups[0].Elements[i].TranslateZDirection.Z *= -1.0;
 				}
 			}
 

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -753,6 +753,17 @@ namespace OpenBve
 				}
 			}
 
+			public override void Reverse()
+			{
+				double trackPosition = Cars[0].TrackPosition;
+				Cars = Cars.Reverse().ToArray();
+				for (int i = 0; i < Cars.Length; i++)
+				{
+					Cars[i].Reverse();
+				}
+				PlaceCars(trackPosition);
+			}
+
 			/// <summary>Call this method to topple a car</summary>
 			/// <param name="CarIndex">The car index to derail</param>
 			/// <param name="ElapsedTime">The elapsed time for this frame (Used for logging)</param>

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -762,6 +762,8 @@ namespace OpenBve
 					Cars[i].Reverse();
 				}
 				PlaceCars(trackPosition);
+				DriverCar = Cars.Length - 1 - DriverCar;
+				UpdateCabObjects();
 			}
 
 			/// <summary>Call this method to topple a car</summary>

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -855,6 +855,16 @@ namespace OpenBve
 			Loading.SimulationSetup = true;
 			switch (Game.InitialViewpoint)
 			{
+				case 0:
+					if (Game.InitialReversedConsist)
+					{
+						/*
+						 * HACK: The cab view has been created using the position of the initial driver car.
+						 * Trigger a forced change to ensure that it is now correctly positioned in the consist
+						 */
+						TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].ChangeCarSection(TrainManager.CarSectionType.Interior);
+					}
+					break;
 				case 1:
 					//Switch camera to exterior
 					MainLoop.SaveCameraSettings();

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -398,10 +398,16 @@ namespace OpenBve {
 				}
 				// place cars
 				TrainManager.Trains[k].PlaceCars(0.0);
-				
-				// configure ai / timetable
+
+				// configure other properties
 				if (TrainManager.Trains[k].IsPlayerTrain) {
 					TrainManager.Trains[k].TimetableDelta = 0.0;
+					if (Game.InitialReversedConsist)
+					{
+						TrainManager.Trains[k].Reverse();
+						World.CameraCar = TrainManager.Trains[k].DriverCar;
+						Program.Renderer.Camera.CurrentRestriction = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].CameraRestrictionMode;
+					}
 				} else if (TrainManager.Trains[k].State != TrainState.Bogus) {
 					TrainManager.Trains[k].AI = new Game.SimpleHumanDriverAI(TrainManager.Trains[k]);
 					TrainManager.Trains[k].TimetableDelta = Game.PrecedingTrainTimeDeltas[k];

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -57,10 +57,9 @@ namespace OpenBve
 			{
 				Game.InitialStationTime = result.StartTime;
 			}
-			if (result.AIDriver == true)
-			{
-				Game.InitialAIDriver = true;
-			}
+
+			Game.InitialAIDriver = result.AIDriver;
+			Game.InitialReversedConsist = result.ReverseConsist;
 			if (result.FullScreen == true)
 			{
 				Interface.CurrentOptions.FullscreenMode = true;

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -46,6 +46,8 @@
 			this.textboxTrainDescription = new System.Windows.Forms.TextBox();
 			this.pictureboxTrainImage = new System.Windows.Forms.PictureBox();
 			this.tabpageTrainSettings = new System.Windows.Forms.TabPage();
+			this.checkBoxReverseConsist = new System.Windows.Forms.CheckBox();
+			this.labelReverseConsist = new System.Windows.Forms.Label();
 			this.panelTrainEncoding = new System.Windows.Forms.Panel();
 			this.labelTrainEncoding = new System.Windows.Forms.Label();
 			this.buttonTrainEncodingBig5 = new System.Windows.Forms.Button();
@@ -103,19 +105,19 @@
 			this.checkBoxInputDeviceEnable = new System.Windows.Forms.CheckBox();
 			this.buttonInputDeviceConfig = new System.Windows.Forms.Button();
 			this.groupBoxObjectParser = new System.Windows.Forms.GroupBox();
-			this.labelXparser = new System.Windows.Forms.Label();
-			this.comboBoxXparser = new System.Windows.Forms.ComboBox();
 			this.labelObjparser = new System.Windows.Forms.Label();
 			this.comboBoxObjparser = new System.Windows.Forms.ComboBox();
+			this.labelXparser = new System.Windows.Forms.Label();
+			this.comboBoxXparser = new System.Windows.Forms.ComboBox();
 			this.groupBoxKioskMode = new System.Windows.Forms.GroupBox();
 			this.labelKioskTimeout = new System.Windows.Forms.Label();
 			this.numericUpDownKioskTimeout = new System.Windows.Forms.NumericUpDown();
 			this.checkBoxEnableKiosk = new System.Windows.Forms.CheckBox();
 			this.groupBoxAdvancedOptions = new System.Windows.Forms.GroupBox();
+			this.checkBoxPanel2Extended = new System.Windows.Forms.CheckBox();
 			this.pictureboxCursor = new System.Windows.Forms.PictureBox();
 			this.labelCursor = new System.Windows.Forms.Label();
 			this.comboboxCursor = new System.Windows.Forms.ComboBox();
-			this.checkBoxPanel2Extended = new System.Windows.Forms.CheckBox();
 			this.checkBoxHacks = new System.Windows.Forms.CheckBox();
 			this.checkBoxTransparencyFix = new System.Windows.Forms.CheckBox();
 			this.checkBoxUnloadTextures = new System.Windows.Forms.CheckBox();
@@ -475,11 +477,12 @@
 			this.panelOptions.SuspendLayout();
 			this.panelOptionsPage2.SuspendLayout();
 			this.groupBoxInputDevice.SuspendLayout();
+			this.groupBoxObjectParser.SuspendLayout();
 			this.groupBoxKioskMode.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownKioskTimeout)).BeginInit();
 			this.groupBoxAdvancedOptions.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.updownTimeAccelerationFactor)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.pictureboxCursor)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.updownTimeAccelerationFactor)).BeginInit();
 			this.groupBoxPackageOptions.SuspendLayout();
 			this.panelOptionsLeft.SuspendLayout();
 			this.groupboxDisplayMode.SuspendLayout();
@@ -829,6 +832,8 @@
 			// 
 			// tabpageTrainSettings
 			// 
+			this.tabpageTrainSettings.Controls.Add(this.checkBoxReverseConsist);
+			this.tabpageTrainSettings.Controls.Add(this.labelReverseConsist);
 			this.tabpageTrainSettings.Controls.Add(this.panelTrainEncoding);
 			this.tabpageTrainSettings.Controls.Add(this.labelTrainEncodingPreview);
 			this.tabpageTrainSettings.Controls.Add(this.textboxTrainEncodingPreview);
@@ -839,6 +844,27 @@
 			this.tabpageTrainSettings.TabIndex = 3;
 			this.tabpageTrainSettings.Text = "Settings";
 			this.tabpageTrainSettings.UseVisualStyleBackColor = true;
+			// 
+			// checkBoxReverseConsist
+			// 
+			this.checkBoxReverseConsist.AutoSize = true;
+			this.checkBoxReverseConsist.Location = new System.Drawing.Point(269, 61);
+			this.checkBoxReverseConsist.Name = "checkBoxReverseConsist";
+			this.checkBoxReverseConsist.Size = new System.Drawing.Size(15, 14);
+			this.checkBoxReverseConsist.TabIndex = 12;
+			this.checkBoxReverseConsist.UseVisualStyleBackColor = true;
+			this.checkBoxReverseConsist.CheckedChanged += new System.EventHandler(this.checkBoxReverseConsist_CheckedChanged);
+			// 
+			// labelReverseConsist
+			// 
+			this.labelReverseConsist.AutoEllipsis = true;
+			this.labelReverseConsist.ForeColor = System.Drawing.SystemColors.ControlText;
+			this.labelReverseConsist.Location = new System.Drawing.Point(8, 59);
+			this.labelReverseConsist.Name = "labelReverseConsist";
+			this.labelReverseConsist.Size = new System.Drawing.Size(96, 16);
+			this.labelReverseConsist.TabIndex = 11;
+			this.labelReverseConsist.Text = "Reverse Consist:";
+			this.labelReverseConsist.TextAlign = System.Drawing.ContentAlignment.TopRight;
 			// 
 			// panelTrainEncoding
 			// 
@@ -917,7 +943,7 @@
 			// 
 			this.labelTrainEncodingPreview.AutoEllipsis = true;
 			this.labelTrainEncodingPreview.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.labelTrainEncodingPreview.Location = new System.Drawing.Point(8, 64);
+			this.labelTrainEncodingPreview.Location = new System.Drawing.Point(7, 80);
 			this.labelTrainEncodingPreview.Name = "labelTrainEncodingPreview";
 			this.labelTrainEncodingPreview.Size = new System.Drawing.Size(96, 16);
 			this.labelTrainEncodingPreview.TabIndex = 4;
@@ -930,12 +956,12 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.textboxTrainEncodingPreview.BackColor = System.Drawing.SystemColors.Window;
-			this.textboxTrainEncodingPreview.Location = new System.Drawing.Point(104, 64);
+			this.textboxTrainEncodingPreview.Location = new System.Drawing.Point(104, 81);
 			this.textboxTrainEncodingPreview.Multiline = true;
 			this.textboxTrainEncodingPreview.Name = "textboxTrainEncodingPreview";
 			this.textboxTrainEncodingPreview.ReadOnly = true;
 			this.textboxTrainEncodingPreview.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-			this.textboxTrainEncodingPreview.Size = new System.Drawing.Size(180, 80);
+			this.textboxTrainEncodingPreview.Size = new System.Drawing.Size(180, 63);
 			this.textboxTrainEncodingPreview.TabIndex = 5;
 			// 
 			// buttonStart
@@ -1543,6 +1569,27 @@
 			this.groupBoxObjectParser.TabStop = false;
 			this.groupBoxObjectParser.Text = "Object Parser";
 			// 
+			// labelObjparser
+			// 
+			this.labelObjparser.AutoSize = true;
+			this.labelObjparser.Location = new System.Drawing.Point(7, 48);
+			this.labelObjparser.Name = "labelObjparser";
+			this.labelObjparser.Size = new System.Drawing.Size(93, 13);
+			this.labelObjparser.TabIndex = 0;
+			this.labelObjparser.Text = "Obj Object Parser:";
+			// 
+			// comboBoxObjparser
+			// 
+			this.comboBoxObjparser.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.comboBoxObjparser.FormattingEnabled = true;
+			this.comboBoxObjparser.Items.AddRange(new object[] {
+            "Original",
+            "Assimp"});
+			this.comboBoxObjparser.Location = new System.Drawing.Point(107, 44);
+			this.comboBoxObjparser.Name = "comboBoxObjparser";
+			this.comboBoxObjparser.Size = new System.Drawing.Size(190, 21);
+			this.comboBoxObjparser.TabIndex = 1;
+			// 
 			// labelXparser
 			// 
 			this.labelXparser.AutoSize = true;
@@ -1564,27 +1611,6 @@
 			this.comboBoxXparser.Name = "comboBoxXparser";
 			this.comboBoxXparser.Size = new System.Drawing.Size(190, 21);
 			this.comboBoxXparser.TabIndex = 1;
-			// 
-			// labelObjparser
-			// 
-			this.labelObjparser.AutoSize = true;
-			this.labelObjparser.Location = new System.Drawing.Point(7, 48);
-			this.labelObjparser.Name = "labelObjparser";
-			this.labelObjparser.Size = new System.Drawing.Size(84, 13);
-			this.labelObjparser.TabIndex = 0;
-			this.labelObjparser.Text = "Obj Object Parser:";
-			// 
-			// comboBoxObjparser
-			// 
-			this.comboBoxObjparser.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxObjparser.FormattingEnabled = true;
-			this.comboBoxObjparser.Items.AddRange(new object[] {
-            "Original",
-            "Assimp"});
-			this.comboBoxObjparser.Location = new System.Drawing.Point(107, 44);
-			this.comboBoxObjparser.Name = "comboBoxObjparser";
-			this.comboBoxObjparser.Size = new System.Drawing.Size(190, 21);
-			this.comboBoxObjparser.TabIndex = 1;
 			// 
 			// groupBoxKioskMode
 			// 
@@ -1655,7 +1681,7 @@
 			this.checkBoxPanel2Extended.AutoSize = true;
 			this.checkBoxPanel2Extended.Location = new System.Drawing.Point(8, 183);
 			this.checkBoxPanel2Extended.Name = "checkBoxPanel2Extended";
-			this.checkBoxPanel2Extended.Size = new System.Drawing.Size(203, 17);
+			this.checkBoxPanel2Extended.Size = new System.Drawing.Size(159, 17);
 			this.checkBoxPanel2Extended.TabIndex = 17;
 			this.checkBoxPanel2Extended.Text = "Enable Panel2 extend mode";
 			this.checkBoxPanel2Extended.UseVisualStyleBackColor = true;
@@ -1674,7 +1700,7 @@
 			this.labelCursor.AutoSize = true;
 			this.labelCursor.Location = new System.Drawing.Point(48, 145);
 			this.labelCursor.Name = "labelCursor";
-			this.labelCursor.Size = new System.Drawing.Size(13, 13);
+			this.labelCursor.Size = new System.Drawing.Size(37, 13);
 			this.labelCursor.TabIndex = 17;
 			this.labelCursor.Text = "Cursor";
 			// 
@@ -1683,7 +1709,7 @@
 			this.comboboxCursor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.comboboxCursor.FormattingEnabled = true;
 			this.comboboxCursor.Location = new System.Drawing.Point(48, 158);
-			this.comboboxCursor.Name = "comboboxLanguages";
+			this.comboboxCursor.Name = "comboboxCursor";
 			this.comboboxCursor.Size = new System.Drawing.Size(108, 21);
 			this.comboboxCursor.TabIndex = 18;
 			this.comboboxCursor.SelectedIndexChanged += new System.EventHandler(this.comboboxCursor_SelectedIndexChanged);
@@ -1724,24 +1750,28 @@
 			this.labelTimeAcceleration.AutoSize = true;
 			this.labelTimeAcceleration.Location = new System.Drawing.Point(8, 125);
 			this.labelTimeAcceleration.Name = "labelTimeAcceleration";
-			this.labelTimeAcceleration.Size = new System.Drawing.Size(179, 17);
+			this.labelTimeAcceleration.Size = new System.Drawing.Size(126, 13);
 			this.labelTimeAcceleration.TabIndex = 10;
 			this.labelTimeAcceleration.Text = "Accelerated Time Factor:";
 			// 
 			// updownTimeAccelerationFactor
 			// 
 			this.updownTimeAccelerationFactor.Location = new System.Drawing.Point(150, 122);
+			this.updownTimeAccelerationFactor.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
 			this.updownTimeAccelerationFactor.Name = "updownTimeAccelerationFactor";
 			this.updownTimeAccelerationFactor.Size = new System.Drawing.Size(52, 20);
 			this.updownTimeAccelerationFactor.TabIndex = 3;
-			this.updownTimeAccelerationFactor.Maximum = 5;
 			this.updownTimeAccelerationFactor.ValueChanged += new System.EventHandler(this.updownTimeAccelerationFactor_ValueChanged);
 			// 
-			// checkBoxDisableDisplayLists
+			// checkBoxIsUseNewRenderer
 			// 
 			this.checkBoxIsUseNewRenderer.AutoSize = true;
 			this.checkBoxIsUseNewRenderer.Location = new System.Drawing.Point(8, 43);
-			this.checkBoxIsUseNewRenderer.Name = "checkBoxDisableDisplayLists";
+			this.checkBoxIsUseNewRenderer.Name = "checkBoxIsUseNewRenderer";
 			this.checkBoxIsUseNewRenderer.Size = new System.Drawing.Size(159, 17);
 			this.checkBoxIsUseNewRenderer.TabIndex = 2;
 			this.checkBoxIsUseNewRenderer.Text = "Disable OpenGL display lists";
@@ -5602,9 +5632,9 @@
 			this.Controls.Add(this.labelFillerOne);
 			this.Controls.Add(this.labelFillerTwo);
 			this.Controls.Add(this.labelFillerThree);
+			this.Controls.Add(this.panelStart);
 			this.Controls.Add(this.panelOptions);
 			this.Controls.Add(this.panelControls);
-			this.Controls.Add(this.panelStart);
 			this.Controls.Add(this.panelPackages);
 			this.Controls.Add(this.panelReview);
 			this.KeyPreview = true;
@@ -5652,13 +5682,15 @@
 			this.panelOptionsPage2.ResumeLayout(false);
 			this.groupBoxInputDevice.ResumeLayout(false);
 			this.groupBoxInputDevice.PerformLayout();
+			this.groupBoxObjectParser.ResumeLayout(false);
+			this.groupBoxObjectParser.PerformLayout();
 			this.groupBoxKioskMode.ResumeLayout(false);
 			this.groupBoxKioskMode.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownKioskTimeout)).EndInit();
 			this.groupBoxAdvancedOptions.ResumeLayout(false);
 			this.groupBoxAdvancedOptions.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.updownTimeAccelerationFactor)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.pictureboxCursor)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.updownTimeAccelerationFactor)).EndInit();
 			this.groupBoxPackageOptions.ResumeLayout(false);
 			this.groupBoxPackageOptions.PerformLayout();
 			this.panelOptionsLeft.ResumeLayout(false);
@@ -6183,5 +6215,7 @@
 		private System.Windows.Forms.ComboBox comboBoxXparser;
 		private System.Windows.Forms.Label labelObjparser;
 		private System.Windows.Forms.ComboBox comboBoxObjparser;
+		private System.Windows.Forms.CheckBox checkBoxReverseConsist;
+		private System.Windows.Forms.Label labelReverseConsist;
 	}
 }

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -45,6 +45,8 @@ namespace OpenBve {
 			internal string TrainFolder;
 			/// <summary>The text encoding of the selected train</summary>
 			internal System.Text.Encoding TrainEncoding;
+			/// <summary>Whether the consist of the train is to be reversed on start</summary>
+			internal bool ReverseConsist;
 			internal string InitialStation;
 			internal double StartTime;
 			internal bool AIDriver;
@@ -635,7 +637,8 @@ namespace OpenBve {
 			groupboxTrainDetails.Text = Translations.GetInterfaceString("start_train_details");
 			tabpageTrainDescription.Text = Translations.GetInterfaceString("start_train_description");
 			tabpageTrainSettings.Text = Translations.GetInterfaceString("start_train_settings");
-			labelTrainEncoding.Text = Translations.GetInterfaceString("start_train_settings_encoding");
+			labelTrainEncoding.Text = Translations.GetInterfaceString("start_train_settings_reverseconsist");
+			labelReverseConsist.Text = Translations.GetInterfaceString("start_train_settings_encoding");
 			comboboxTrainEncoding.Items[0] = Translations.GetInterfaceString("(UTF-8)");
 			labelTrainEncodingPreview.Text = Translations.GetInterfaceString("start_train_settings_encoding_preview");
 			labelStart.Text = @" " + Translations.GetInterfaceString("start_start");
@@ -1768,6 +1771,11 @@ namespace OpenBve {
 			{
 				f.ShowDialog();
 			}
+		}
+
+		private void checkBoxReverseConsist_CheckedChanged(object sender, EventArgs e)
+		{
+			Result.ReverseConsist = checkBoxReverseConsist.Checked;
 		}
 	}
 }

--- a/source/OpenBveApi/Train/AbstractCar.cs
+++ b/source/OpenBveApi/Train/AbstractCar.cs
@@ -7,18 +7,23 @@ namespace OpenBveApi.Trains
 	{
 		/// <summary>The width of the car in meters</summary>
 		public double Width;
+
 		/// <summary>The height of the car in meters</summary>
 		public double Height;
+
 		/// <summary>The length of the car in meters</summary>
 		public double Length;
+
 		/// <summary>The Up vector</summary>
 		public Vector3 Up;
+
 		/// <summary>The current speed of this car</summary>
 		/// <remarks>Default units are km/h</remarks>
 		public double CurrentSpeed;
+
 		/// <summary>Contains the current brightness values</summary>
 		public Brightness Brightness;
-		
+
 		/// <summary>Creates the in-world co-ordinates for a sound attached to this car</summary>
 		public virtual void CreateWorldCoordinates(Vector3 Car, out Vector3 Position, out Vector3 Direction)
 		{
@@ -34,5 +39,11 @@ namespace OpenBveApi.Trains
 				return 0.0;
 			}
 		}
-}
+
+		/// <summary>Call this method to reverse (flip) the car</summary>
+		public virtual void Reverse()
+		{
+
+		}
+	}
 }

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -78,6 +78,12 @@ namespace OpenBveApi.Trains
 
 		}
 
+		/// <summary>Call this method to reverse (flip) the entire train</summary>
+		public virtual void Reverse()
+		{
+
+		}
+
 		/// <summary>Disposes of the train and releases all resources</summary>
 		public virtual void Dispose()
 		{


### PR DESCRIPTION
* Allow consists to be reversed with a tag in the file. (Important for locomotive hauled stuff)
* Use train.ai instead of train.dat to signify that a consist is not intended for driving and should not be displayed as such in the main menu.
* Allow a consist to be flipped from the main menu before starting a game. (Added to the advanced tab)