### PR TITLE
Change: Shift rails to a dictionary accessor.

### DIFF
--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using OpenBveApi.Hosts;
 using OpenBveApi.Interface;
@@ -300,7 +301,7 @@ namespace OpenBve {
 			}
 		}
 
-		public override Track[] Tracks
+		public override Dictionary<int, Track> Tracks
 		{
 			get
 			{

--- a/source/OpenBVE/Game/Game.cs
+++ b/source/OpenBVE/Game/Game.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using OpenBveApi.Colors;
 using OpenBveApi.Textures;
 using OpenBveApi.Trains;
@@ -49,9 +50,10 @@ namespace OpenBve {
 		/// <param name="ResetRenderer">Whether the renderer should be reset</param>
 		internal static void Reset(bool ResetLogs, bool ResetRenderer) {
 			// track manager
-			for (int i = 0; i < Program.CurrentRoute.Tracks.Length; i++)
+			for (int i = 0; i < Program.CurrentRoute.Tracks.Count; i++)
 			{
-				Program.CurrentRoute.Tracks[i] = new Track();
+				int key = Program.CurrentRoute.Tracks.ElementAt(i).Key;
+				Program.CurrentRoute.Tracks[key] = new Track();
 			}
 			// train manager
 			TrainManager.Trains = new TrainManager.Train[] { };

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -378,13 +378,13 @@ namespace OpenBve
 						for (int jj = 0; jj < Data.Blocks[i].Rails.Count; jj++)
 						{
 							int j = Data.Blocks[i].Rails.ElementAt(jj).Key;
-							if (Data.Blocks[i].Rails[j].RailStarted & !Data.Blocks[i + 1].Rails.ContainsKey(j))
+							if (Data.Blocks[i].Rails[j].RailStarted & Data.Blocks[i + 1].Rails.ContainsKey(j))
 							{
 								bool q = false;
 								for (int kk = 0; kk < Data.Blocks[i].Rails.Count; kk++)
 								{
 									int k = Data.Blocks[i].Rails.ElementAt(kk).Key;
-									if (Data.Blocks[i].Rails[k].RailStarted & !Data.Blocks[i + 1].Rails.ContainsKey(k))
+									if (Data.Blocks[i].Rails[k].RailStarted & Data.Blocks[i + 1].Rails.ContainsKey(k))
 									{
 										bool qx = Math.Sign(Data.Blocks[i].Rails[k].RailStart.X - Data.Blocks[i].Rails[j].RailStart.X) != Math.Sign(Data.Blocks[i + 1].Rails[k].RailEnd.X - Data.Blocks[i + 1].Rails[j].RailEnd.X);
 										bool qy = (Data.Blocks[i].Rails[k].RailStart.Y - Data.Blocks[i].Rails[j].RailStart.Y) * (Data.Blocks[i + 1].Rails[k].RailEnd.Y - Data.Blocks[i + 1].Rails[j].RailEnd.Y) <= 0.0;
@@ -652,7 +652,7 @@ namespace OpenBve
 							double y = Data.Blocks[i].Rails[j].RailStart.Y;
 							Vector3 offset = new Vector3(Direction.Y * x, y, -Direction.X * x);
 							pos = Position + offset;
-							if (i < Data.Blocks.Length - 1 && !Data.Blocks[i + 1].Rails.ContainsKey(j))
+							if (i < Data.Blocks.Length - 1 && Data.Blocks[i + 1].Rails.ContainsKey(j))
 							{
 								// take orientation of upcoming block into account
 								Vector2 Direction2 = Direction;
@@ -759,7 +759,7 @@ namespace OpenBve
 								int m = Program.CurrentRoute.PointsOfInterest.Length;
 								Array.Resize(ref Program.CurrentRoute.PointsOfInterest, m + 1);
 								Program.CurrentRoute.PointsOfInterest[m].TrackPosition = Data.Blocks[i].PointsOfInterest[k].TrackPosition;
-								if (i < Data.Blocks.Length - 1 && !Data.Blocks[i + 1].Rails.ContainsKey(j))
+								if (i < Data.Blocks.Length - 1 && Data.Blocks[i + 1].Rails.ContainsKey(j))
 								{
 									double dx = Data.Blocks[i + 1].Rails[j].RailEnd.X - Data.Blocks[i].Rails[j].RailStart.X;
 									double dy = Data.Blocks[i + 1].Rails[j].RailEnd.Y - Data.Blocks[i].Rails[j].RailStart.Y;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenBveApi.Colors;
@@ -154,20 +155,17 @@ namespace OpenBve
 			Fog CurrentFog = new Fog(Program.CurrentRoute.NoFogStart, Program.CurrentRoute.NoFogEnd, Color24.Grey, 0.0);
 			for (int i = Data.FirstUsedBlock; i < Data.Blocks.Length; i++)
 			{
-				if (Data.Blocks[i].Rails.Length > Program.CurrentRoute.Tracks.Length)
+				if (Data.Blocks[i].Rails.Count > Program.CurrentRoute.Tracks.Count)
 				{
-					Array.Resize(ref Program.CurrentRoute.Tracks, Data.Blocks[i].Rails.Length);
-				}
-			}
-			for (int i = 0; i < Program.CurrentRoute.Tracks.Length; i++)
-			{
-				if (Program.CurrentRoute.Tracks[i] == null)
-				{
-					Program.CurrentRoute.Tracks[i] = new Track();
-				}
-				if (Program.CurrentRoute.Tracks[i].Elements == null)
-				{
-					Program.CurrentRoute.Tracks[i].Elements = new TrackElement[256];
+					for (int d = 0; d < Data.Blocks[i].Rails.Count; d++)
+					{
+						var item = Data.Blocks[i].Rails.ElementAt(d);
+						if (!Program.CurrentRoute.Tracks.ContainsKey(item.Key))
+						{
+							Program.CurrentRoute.Tracks.Add(item.Key, new Track());
+							Program.CurrentRoute.Tracks[item.Key].Elements = new TrackElement[256];
+						}
+					}
 				}
 			}
 			// process blocks
@@ -201,11 +199,16 @@ namespace OpenBve
 				}
 				TrackElement WorldTrackElement = Data.Blocks[i].CurrentTrackState;
 				int n = CurrentTrackLength;
-				for (int j = 0; j < Program.CurrentRoute.Tracks.Length; j++)
+				for (int j = 0; j < Program.CurrentRoute.Tracks.Count; j++)
 				{
-					if (n >= Program.CurrentRoute.Tracks[j].Elements.Length)
+					var key = Program.CurrentRoute.Tracks.ElementAt(j).Key;
+					if (Program.CurrentRoute.Tracks[key].Elements == null)
 					{
-						Array.Resize(ref Program.CurrentRoute.Tracks[j].Elements, Program.CurrentRoute.Tracks[j].Elements.Length << 1);
+						Program.CurrentRoute.Tracks[key].Elements = new TrackElement[256];
+					}
+					if (n >= Program.CurrentRoute.Tracks[key].Elements.Length)
+					{
+						Array.Resize(ref Program.CurrentRoute.Tracks[key].Elements, Program.CurrentRoute.Tracks[key].Elements.Length << 1);
 					}
 				}
 				CurrentTrackLength++;
@@ -217,9 +220,10 @@ namespace OpenBve
 				Program.CurrentRoute.Tracks[0].Elements[n].StartingTrackPosition = StartingDistance;
 				Program.CurrentRoute.Tracks[0].Elements[n].AdhesionMultiplier = Data.Blocks[i].AdhesionMultiplier;
 				Program.CurrentRoute.Tracks[0].Elements[n].CsvRwAccuracyLevel = Data.Blocks[i].Accuracy;
-				for (int j = 0; j < Program.CurrentRoute.Tracks.Length; j++)
+				for (int j = 0; j < Program.CurrentRoute.Tracks.Count; j++)
 				{
-					Program.CurrentRoute.Tracks[j].Elements[n].Events = new GeneralEvent[] { };
+					var key = Program.CurrentRoute.Tracks.ElementAt(j).Key;
+					Program.CurrentRoute.Tracks[key].Elements[n].Events = new GeneralEvent[] { };
 				}
 				// background
 				if (!PreviewOnly)
@@ -259,8 +263,9 @@ namespace OpenBve
 						/*
 						 * Legacy brightness: This applies equally to all tracks in a block
 						 */
-						for (int t = 0; t < Program.CurrentRoute.Tracks.Length; t++)
+						for (int tt = 0; tt < Program.CurrentRoute.Tracks.Count; tt++)
 						{
+							int t = Program.CurrentRoute.Tracks.ElementAt(tt).Key;
 							int m = Program.CurrentRoute.Tracks[t].Elements[n].Events.Length;
 							Array.Resize(ref Program.CurrentRoute.Tracks[t].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].BrightnessChanges[j].TrackPosition - StartingDistance;
@@ -370,14 +375,16 @@ namespace OpenBve
 				{
 					if (i < Data.Blocks.Length - 1)
 					{
-						for (int j = 0; j < Data.Blocks[i].Rails.Length; j++)
+						for (int jj = 0; jj < Data.Blocks[i].Rails.Count; jj++)
 						{
-							if (Data.Blocks[i].Rails[j].RailStarted & Data.Blocks[i + 1].Rails.Length > j)
+							int j = Data.Blocks[i].Rails.ElementAt(jj).Key;
+							if (Data.Blocks[i].Rails[j].RailStarted & !Data.Blocks[i + 1].Rails.ContainsKey(j))
 							{
 								bool q = false;
-								for (int k = 0; k < Data.Blocks[i].Rails.Length; k++)
+								for (int kk = 0; kk < Data.Blocks[i].Rails.Count; kk++)
 								{
-									if (Data.Blocks[i].Rails[k].RailStarted & Data.Blocks[i + 1].Rails.Length > k)
+									int k = Data.Blocks[i].Rails.ElementAt(kk).Key;
+									if (Data.Blocks[i].Rails[k].RailStarted & !Data.Blocks[i + 1].Rails.ContainsKey(k))
 									{
 										bool qx = Math.Sign(Data.Blocks[i].Rails[k].RailStart.X - Data.Blocks[i].Rails[j].RailStart.X) != Math.Sign(Data.Blocks[i + 1].Rails[k].RailEnd.X - Data.Blocks[i + 1].Rails[j].RailEnd.X);
 										bool qy = (Data.Blocks[i].Rails[k].RailStart.Y - Data.Blocks[i].Rails[j].RailStart.Y) * (Data.Blocks[i + 1].Rails[k].RailEnd.Y - Data.Blocks[i + 1].Rails[j].RailEnd.Y) <= 0.0;
@@ -622,8 +629,9 @@ namespace OpenBve
 				// rail-aligned objects
 				if (!PreviewOnly)
 				{
-					for (int j = 0; j < Data.Blocks[i].Rails.Length; j++)
+					for (int jj = 0; jj < Data.Blocks[i].Rails.Count; jj++)
 					{
+						int j = Data.Blocks[i].Rails.ElementAt(jj).Key;
 						if (j > 0 && !Data.Blocks[i].Rails[j].RailStarted) continue;
 						// rail
 						Vector3 pos;
@@ -644,7 +652,7 @@ namespace OpenBve
 							double y = Data.Blocks[i].Rails[j].RailStart.Y;
 							Vector3 offset = new Vector3(Direction.Y * x, y, -Direction.X * x);
 							pos = Position + offset;
-							if (i < Data.Blocks.Length - 1 && Data.Blocks[i + 1].Rails.Length > j)
+							if (i < Data.Blocks.Length - 1 && !Data.Blocks[i + 1].Rails.ContainsKey(j))
 							{
 								// take orientation of upcoming block into account
 								Vector2 Direction2 = Direction;
@@ -751,7 +759,7 @@ namespace OpenBve
 								int m = Program.CurrentRoute.PointsOfInterest.Length;
 								Array.Resize(ref Program.CurrentRoute.PointsOfInterest, m + 1);
 								Program.CurrentRoute.PointsOfInterest[m].TrackPosition = Data.Blocks[i].PointsOfInterest[k].TrackPosition;
-								if (i < Data.Blocks.Length - 1 && Data.Blocks[i + 1].Rails.Length > j)
+								if (i < Data.Blocks.Length - 1 && !Data.Blocks[i + 1].Rails.ContainsKey(j))
 								{
 									double dx = Data.Blocks[i + 1].Rails[j].RailEnd.X - Data.Blocks[i].Rails[j].RailStart.X;
 									double dy = Data.Blocks[i + 1].Rails[j].RailEnd.Y - Data.Blocks[i].Rails[j].RailStart.Y;
@@ -971,7 +979,7 @@ namespace OpenBve
 									double px0 = p > 0 ? Data.Blocks[i].Rails[p].RailStart.X : 0.0;
 									double px1 = p > 0 ? Data.Blocks[i + 1].Rails[p].RailEnd.X : 0.0;
 									int s = Data.Blocks[i].Forms[k].SecondaryRail;
-									if (s < 0 || s >= Data.Blocks[i].Rails.Length || !Data.Blocks[i].Rails[s].RailStarted)
+									if (s < 0 || !Data.Blocks[i].Rails.ContainsKey(s) || !Data.Blocks[i].Rails[s].RailStarted)
 									{
 										Interface.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName);
 									}
@@ -1127,7 +1135,7 @@ namespace OpenBve
 								double px0 = p > 0 ? Data.Blocks[i].Rails[p].RailStart.X : 0.0;
 								double px1 = p > 0 ? Data.Blocks[i + 1].Rails[p].RailEnd.X : 0.0;
 								int s = Data.Blocks[i].Cracks[k].SecondaryRail;
-								if (s < 0 || s >= Data.Blocks[i].Rails.Length || !Data.Blocks[i].Rails[s].RailStarted)
+								if (s < 0 || !Data.Blocks[i].Rails.ContainsKey(s) || !Data.Blocks[i].Rails[s].RailStarted)
 								{
 									Interface.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Crack at track position " + StartingDistance.ToString(Culture) + " in file " + FileName);
 								}
@@ -1649,8 +1657,9 @@ namespace OpenBve
 				Array.Resize(ref Program.CurrentRoute.PointsOfInterest, n);
 			}
 			// convert block-based cant into point-based cant
-			for (int i = 0; i < Program.CurrentRoute.Tracks.Length; i++)
+			for (int ii = 0; ii < Program.CurrentRoute.Tracks.Count; ii++)
 			{
+				int i = Program.CurrentRoute.Tracks.ElementAt(ii).Key;
 				for (int j = CurrentTrackLength - 1; j >= 1; j--)
 				{
 					if (Program.CurrentRoute.Tracks[i].Elements[j].CurveCant == 0.0)
@@ -1674,8 +1683,9 @@ namespace OpenBve
 				}
 			}
 			// finalize
-			for (int i = 0; i < Program.CurrentRoute.Tracks.Length; i++)
+			for (int ii = 0; ii < Program.CurrentRoute.Tracks.Count; ii++)
 			{
+				int i = Program.CurrentRoute.Tracks.ElementAt(ii).Key;
 				Array.Resize(ref Program.CurrentRoute.Tracks[i].Elements, CurrentTrackLength);
 			}
 			for (int i = 0; i < Program.CurrentRoute.Stations.Length; i++)
@@ -1836,8 +1846,9 @@ namespace OpenBve
 		// compute cant tangents
 		private static void ComputeCantTangents()
 		{
-			for (int i = 0; i < Program.CurrentRoute.Tracks.Length; i++)
+			for (int ii = 0; ii < Program.CurrentRoute.Tracks.Count; ii++)
 			{
+				int i = Program.CurrentRoute.Tracks.ElementAt(ii).Key;
 				if (Program.CurrentRoute.Tracks[i].Elements.Length == 1)
 				{
 					Program.CurrentRoute.Tracks[i].Elements[0].CurveCantTangent = 0.0;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using OpenBveApi.Math;
 using OpenBveApi.Textures;
 
 namespace OpenBve
@@ -89,16 +91,18 @@ namespace OpenBve
 								}
 							}
 						}
-						Blocks[i].Rails = new Rail[Blocks[i - 1].Rails.Length];
-						for (int j = 0; j < Blocks[i].Rails.Length; j++)
+						
+						for (int j = 0; j < Blocks[i - 1].Rails.Count; j++)
 						{
-							Blocks[i].Rails[j].RailStarted = Blocks[i - 1].Rails[j].RailStarted;
-							Blocks[i].Rails[j].RailStart.X = Blocks[i - 1].Rails[j].RailStart.X;
-							Blocks[i].Rails[j].RailStart.Y = Blocks[i - 1].Rails[j].RailStart.Y;
-							Blocks[i].Rails[j].RailStartRefreshed = false;
-							Blocks[i].Rails[j].RailEnded = false;
-							Blocks[i].Rails[j].RailEnd.X = Blocks[i - 1].Rails[j].RailStart.X;
-							Blocks[i].Rails[j].RailEnd.Y = Blocks[i - 1].Rails[j].RailStart.Y;
+							int key = Blocks[i - 1].Rails.ElementAt(j).Key;
+							Rail rail = new Rail
+							{
+								RailStarted = Blocks[i -1].Rails[key].RailStarted,
+								RailStart = new Vector2(Blocks[i -1].Rails[key].RailStart),
+								RailStartRefreshed = false,
+								RailEnd = new Vector2(Blocks[i - 1].Rails[key].RailStart)
+							};
+							Blocks[i].Rails.Add(key, rail);
 						}
 						if (!PreviewOnly)
 						{

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.RouteData.cs
@@ -100,6 +100,7 @@ namespace OpenBve
 								RailStarted = Blocks[i -1].Rails[key].RailStarted,
 								RailStart = new Vector2(Blocks[i -1].Rails[key].RailStart),
 								RailStartRefreshed = false,
+								RailEnded = false,
 								RailEnd = new Vector2(Blocks[i - 1].Rails[key].RailStart)
 							};
 							Blocks[i].Rails.Add(key, rail);

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Structures.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Math;
+﻿using System.Collections.Generic;
+using OpenBveApi.Math;
 using OpenBveApi.Routes;
 using OpenBveApi.Trains;
 using RouteManager2.Climate;
@@ -200,7 +201,7 @@ namespace OpenBve
 			internal int[] Cycle;
 			internal RailCycle[] RailCycles;
 			internal double Height;
-			internal Rail[] Rails;
+			internal Dictionary<int, Rail> Rails;
 			internal int[] RailType;
 			internal WallDike[] RailWall;
 			internal WallDike[] RailDike;
@@ -224,6 +225,11 @@ namespace OpenBve
 			internal bool StationPassAlarm;
 			internal double Accuracy;
 			internal double AdhesionMultiplier;
+
+			internal Block()
+			{
+				Rails = new Dictionary<int, Rail>();
+			}
 		}
 
 		/// <summary>Holds the base structures for a route: These are cloned and transformed for final world placement</summary>

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using SoundManager;
 using Path = OpenBveApi.Path;
 using OpenBveApi.Colors;
@@ -64,8 +65,8 @@ namespace OpenBve {
 				Blocks = new Block[1]
 			};
 			Data.Blocks[0] = new Block();
-			Data.Blocks[0].Rails = new Rail[1];
-			Data.Blocks[0].Rails[0].RailStarted = true;
+			Data.Blocks[0].Rails = new Dictionary<int, Rail>();
+			Data.Blocks[0].Rails.Add(0, new Rail { RailStarted =  true });
 			Data.Blocks[0].RailType = new int[] { 0 };
 			Data.Blocks[0].Limits = new Limit[] { };
 			Data.Blocks[0].StopPositions = new Stop[] { };
@@ -619,8 +620,9 @@ namespace OpenBve {
 										} else if (a <= 0.0) {
 											Interface.AddMessage(MessageType.Error, false, "ValueInMillimeters is expected to be positive in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 										} else {
-											for (int t = 0; t < Program.CurrentRoute.Tracks.Length; t++)
+											for (int tt = 0; tt < Program.CurrentRoute.Tracks.Count; tt++)
 											{
+												int t = Program.CurrentRoute.Tracks.ElementAt(tt).Key;
 												Program.CurrentRoute.Tracks[t].RailGauge = 0.001 * a;
 											}
 										}
@@ -2290,27 +2292,34 @@ namespace OpenBve {
 										}
 										if (string.Compare(Command, "track.railstart", StringComparison.OrdinalIgnoreCase) == 0)
 										{
-											if (idx < Data.Blocks[BlockIndex].Rails.Length && Data.Blocks[BlockIndex].Rails[idx].RailStarted)
+											if (Data.Blocks[BlockIndex].Rails.ContainsKey(idx) && Data.Blocks[BlockIndex].Rails[idx].RailStarted)
 											{
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " is required to reference a non-existing rail in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											}
 										}
-										if (Data.Blocks[BlockIndex].Rails.Length <= idx)
+										if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx))
 										{
-											Array.Resize<Rail>(ref Data.Blocks[BlockIndex].Rails, idx + 1);
-											int ol = Data.Blocks[BlockIndex].RailCycles.Length;
-											Array.Resize<RailCycle>(ref Data.Blocks[BlockIndex].RailCycles, idx + 1);
-											for (int rc = ol; rc < Data.Blocks[BlockIndex].RailCycles.Length; rc++)
+											Data.Blocks[BlockIndex].Rails.Add(idx, new Rail());
+
+											if (idx >= Data.Blocks[BlockIndex].RailCycles.Length)
 											{
-												Data.Blocks[BlockIndex].RailCycles[rc].RailCycleIndex = -1;
+												int ol = Data.Blocks[BlockIndex].RailCycles.Length;
+												Array.Resize<RailCycle>(ref Data.Blocks[BlockIndex].RailCycles, idx + 1);
+												for (int rc = ol; rc < Data.Blocks[BlockIndex].RailCycles.Length; rc++)
+												{
+													Data.Blocks[BlockIndex].RailCycles[rc].RailCycleIndex = -1;
+												}
 											}
+												
 										}
+
+										Rail currentRail = Data.Blocks[BlockIndex].Rails[idx];
 										if (Data.Blocks[BlockIndex].Rails[idx].RailStartRefreshed)
 										{
-											Data.Blocks[BlockIndex].Rails[idx].RailEnded = true;
+											currentRail.RailEnded = true;
 										}
-										Data.Blocks[BlockIndex].Rails[idx].RailStarted = true;
-										Data.Blocks[BlockIndex].Rails[idx].RailStartRefreshed = true;
+										currentRail.RailStarted = true;
+										currentRail.RailStartRefreshed = true;
 										if (Arguments.Length >= 2)
 										{
 											if (Arguments[1].Length > 0)
@@ -2321,11 +2330,11 @@ namespace OpenBve {
 													Interface.AddMessage(MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													x = 0.0;
 												}
-												Data.Blocks[BlockIndex].Rails[idx].RailStart.X = x;
+												currentRail.RailStart.X = x;
 											}
 											if (!Data.Blocks[BlockIndex].Rails[idx].RailEnded)
 											{
-												Data.Blocks[BlockIndex].Rails[idx].RailEnd.X = Data.Blocks[BlockIndex].Rails[idx].RailStart.X;
+												currentRail.RailEnd.X = Data.Blocks[BlockIndex].Rails[idx].RailStart.X;
 											}
 										}
 										if (Arguments.Length >= 3)
@@ -2338,11 +2347,11 @@ namespace OpenBve {
 													Interface.AddMessage(MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													y = 0.0;
 												}
-												Data.Blocks[BlockIndex].Rails[idx].RailStart.Y = y;
+												currentRail.RailStart.Y = y;
 											}
 											if (!Data.Blocks[BlockIndex].Rails[idx].RailEnded)
 											{
-												Data.Blocks[BlockIndex].Rails[idx].RailEnd.Y = Data.Blocks[BlockIndex].Rails[idx].RailStart.Y;
+												currentRail.RailEnd.Y = Data.Blocks[BlockIndex].Rails[idx].RailStart.Y;
 											}
 										}
 										if (Data.Blocks[BlockIndex].RailType.Length <= idx)
@@ -2394,7 +2403,8 @@ namespace OpenBve {
 										{
 											cant *= 0.001;
 										}
-										Data.Blocks[BlockIndex].Rails[idx].CurveCant = cant;
+										currentRail.CurveCant = cant;
+										Data.Blocks[BlockIndex].Rails[idx] = currentRail;
 									}
 									break;
 								case "track.railend":
@@ -2407,18 +2417,20 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												break;
 											}
-											if (idx < 0 || idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)
+											if (idx < 0 || !Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)
 											{
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " references a non-existing rail in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												break;
 											}
-											if (Data.Blocks[BlockIndex].RailType.Length <= idx)
+											if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx))
 											{
-												Array.Resize<Rail>(ref Data.Blocks[BlockIndex].Rails, idx + 1);
+												Data.Blocks[BlockIndex].Rails.Add(idx, new Rail());
 											}
-											Data.Blocks[BlockIndex].Rails[idx].RailStarted = false;
-											Data.Blocks[BlockIndex].Rails[idx].RailStartRefreshed = false;
-											Data.Blocks[BlockIndex].Rails[idx].RailEnded = true;
+
+											Rail currentRail = Data.Blocks[BlockIndex].Rails[idx];
+											currentRail.RailStarted = false;
+											currentRail.RailStartRefreshed = false;
+											currentRail.RailEnded = true;
 											if (Arguments.Length >= 2 && Arguments[1].Length > 0)
 											{
 												double x;
@@ -2427,7 +2439,7 @@ namespace OpenBve {
 													Interface.AddMessage(MessageType.Error, false, "X is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													x = 0.0;
 												}
-												Data.Blocks[BlockIndex].Rails[idx].RailEnd.X = x;
+												currentRail.RailEnd.X = x;
 											}
 											if (Arguments.Length >= 3 && Arguments[2].Length > 0)
 											{
@@ -2437,8 +2449,10 @@ namespace OpenBve {
 													Interface.AddMessage(MessageType.Error, false, "Y is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													y = 0.0;
 												}
-												Data.Blocks[BlockIndex].Rails[idx].RailEnd.Y = y;
+												currentRail.RailEnd.Y = y;
 											}
+
+											Data.Blocks[BlockIndex].Rails[idx] = currentRail;
 										}
 									} break;
 								case "track.railtype":
@@ -2457,7 +2471,7 @@ namespace OpenBve {
 											if (idx < 0) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												if (sttype < 0) {
@@ -3689,10 +3703,10 @@ namespace OpenBve {
 											} else if (idx2 < 0 & idx2 != Form.SecondaryRailStub & idx2 != Form.SecondaryRailL & idx2 != Form.SecondaryRailR) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex2 is expected to be greater or equal to -2 in Track.Form at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx1 >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx1].RailStarted) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx1) || !Data.Blocks[BlockIndex].Rails[idx1].RailStarted) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex1 could be out of range in Track.Form at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
-												if (idx2 != Form.SecondaryRailStub & idx2 != Form.SecondaryRailL & idx2 != Form.SecondaryRailR && (idx2 >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx2].RailStarted)) {
+												if (idx2 != Form.SecondaryRailStub & idx2 != Form.SecondaryRailL & idx2 != Form.SecondaryRailR && (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx2) || !Data.Blocks[BlockIndex].Rails[idx2].RailStarted)) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex2 could be out of range in Track.Form at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												int roof = 0, pf = 0;
@@ -3731,7 +3745,7 @@ namespace OpenBve {
 											if (idx < 0) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex is expected to be non-negative in Track.Pole at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx +" could be out of range in Track.Pole at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												if (idx >= Data.Blocks[BlockIndex].RailPole.Length) {
@@ -3794,7 +3808,7 @@ namespace OpenBve {
 											if (idx < 0 | idx >= Data.Blocks[BlockIndex].RailPole.Length) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " does not reference an existing pole in Track.PoleEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= Data.Blocks[BlockIndex].Rails.Length || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.PoleEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												Data.Blocks[BlockIndex].RailPole[idx].Exists = false;
@@ -3877,7 +3891,7 @@ namespace OpenBve {
 															dir = -1;
 														}
 													}
-													if (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
+													if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
 														Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.Wall at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													}
 													if (idx >= Data.Blocks[BlockIndex].RailWall.Length) {
@@ -3901,7 +3915,7 @@ namespace OpenBve {
 											if (idx < 0 | idx >= Data.Blocks[BlockIndex].RailWall.Length) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " does not reference an existing wall in Track.WallEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= Data.Blocks[BlockIndex].Rails.Length || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.WallEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												Data.Blocks[BlockIndex].RailWall[idx].Exists = false;
@@ -3985,7 +3999,7 @@ namespace OpenBve {
 															dir = -1;
 														}
 													}
-													if (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
+													if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted) {
 														Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.Dike at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													}
 													if (idx >= Data.Blocks[BlockIndex].RailDike.Length) {
@@ -4009,7 +4023,7 @@ namespace OpenBve {
 											if (idx < 0 | idx >= Data.Blocks[BlockIndex].RailDike.Length) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx +" does not reference an existing dike in Track.DikeEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= Data.Blocks[BlockIndex].Rails.Length || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
+												if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || (!Data.Blocks[BlockIndex].Rails[idx].RailStarted & !Data.Blocks[BlockIndex].Rails[idx].RailEnded)) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.DikeEnd at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												Data.Blocks[BlockIndex].RailDike[idx].Exists = false;
@@ -4179,10 +4193,10 @@ namespace OpenBve {
 												} else if (idx1 == idx2) {
 													Interface.AddMessage(MessageType.Error, false, "RailIndex1 is expected to be unequal to Index2 in Track.Crack at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												} else {
-													if (idx1 >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx1].RailStarted) {
+													if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx1) || !Data.Blocks[BlockIndex].Rails[idx1].RailStarted) {
 														Interface.AddMessage(MessageType.Warning, false, "RailIndex1 " + idx1 + " could be out of range in Track.Crack at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													}
-													if (idx2 >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx2].RailStarted) {
+													if (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx2) || !Data.Blocks[BlockIndex].Rails[idx2].RailStarted) {
 														Interface.AddMessage(MessageType.Warning, false, "RailIndex2 " + idx2 + " could be out of range in Track.Crack at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 													}
 													int n = Data.Blocks[BlockIndex].Cracks.Length;
@@ -4222,7 +4236,7 @@ namespace OpenBve {
 											} else if (sttype < 0) {
 												Interface.AddMessage(MessageType.Error, false, "FreeObjStructureIndex is expected to be non-negative in Track.FreeObj at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											} else {
-												if (idx >= 0 && (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)) {
+												if (idx >= 0 && (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)) {
 													Interface.AddMessage(MessageType.Warning, false, "RailIndex " + idx + " could be out of range in Track.FreeObj at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												}
 												if (!Data.Structure.FreeObjects.ContainsKey(sttype)) {
@@ -4480,7 +4494,7 @@ namespace OpenBve {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex is expected to be non-negative in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 												idx = 0;
 											}
-											if (idx >= 0 && (idx >= Data.Blocks[BlockIndex].Rails.Length || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)) {
+											if (idx >= 0 && (!Data.Blocks[BlockIndex].Rails.ContainsKey(idx) || !Data.Blocks[BlockIndex].Rails[idx].RailStarted)) {
 												Interface.AddMessage(MessageType.Error, false, "RailIndex " + idx + " references a non-existing rail in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 											}
 											double x = 0.0, y = 0.0;

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -2334,7 +2334,7 @@ namespace OpenBve {
 											}
 											if (!Data.Blocks[BlockIndex].Rails[idx].RailEnded)
 											{
-												currentRail.RailEnd.X = Data.Blocks[BlockIndex].Rails[idx].RailStart.X;
+												currentRail.RailEnd.X = currentRail.RailStart.X;
 											}
 										}
 										if (Arguments.Length >= 3)
@@ -2351,7 +2351,7 @@ namespace OpenBve {
 											}
 											if (!Data.Blocks[BlockIndex].Rails[idx].RailEnded)
 											{
-												currentRail.RailEnd.Y = Data.Blocks[BlockIndex].Rails[idx].RailStart.Y;
+												currentRail.RailEnd.Y = currentRail.RailStart.Y;
 											}
 										}
 										if (Data.Blocks[BlockIndex].RailType.Length <= idx)

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using OpenBveApi.Hosts;
 using OpenBveApi.Interface;
@@ -355,7 +356,7 @@ namespace OpenBve {
 			}
 		}
 
-		public override Track[] Tracks
+		public override Dictionary<int, Track> Tracks
 		{
 			get
 			{

--- a/source/OpenBveApi/Routes/Track.TrackFollower.cs
+++ b/source/OpenBveApi/Routes/Track.TrackFollower.cs
@@ -53,6 +53,7 @@ namespace OpenBveApi.Routes
 			t.WorldUp = new Vector3(WorldUp);
 			t.WorldSide = new Vector3(WorldSide);
 			t.TriggerType = TriggerType;
+			t.TrackIndex = TrackIndex;
 			return t;
 		}
 

--- a/source/OpenBveApi/Routes/Track.TrackFollower.cs
+++ b/source/OpenBveApi/Routes/Track.TrackFollower.cs
@@ -109,7 +109,7 @@ namespace OpenBveApi.Routes
 		/// <param name="AddTrackInaccuracy">Whether to add track innacuracy</param>
 		public void UpdateAbsolute(double NewTrackPosition, bool UpdateWorldCoordinates, bool AddTrackInaccuracy)
 		{
-			if (TrackIndex >= currentHost.Tracks.Length || currentHost.Tracks[TrackIndex].Elements.Length == 0) return;
+			if (!currentHost.Tracks.ContainsKey(TrackIndex) || currentHost.Tracks[TrackIndex].Elements.Length == 0) return;
 			int i = LastTrackElement;
 			while (i >= 0 && NewTrackPosition < currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition)
 			{

--- a/source/OpenBveApi/System/Hosts.cs
+++ b/source/OpenBveApi/System/Hosts.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Drawing;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
@@ -324,7 +325,7 @@ namespace OpenBveApi.Hosts {
 		}
 
 		/// <summary>Gets or sets the tracks array within the host application</summary>
-		public virtual Track[] Tracks
+		public virtual Dictionary<int, Track> Tracks
 		{
 			get
 			{

--- a/source/RouteManager2/CurrentRoute.cs
+++ b/source/RouteManager2/CurrentRoute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using LibRender2;
 using OpenBveApi.Colors;
@@ -22,7 +23,7 @@ namespace RouteManager2
 		public string Image = "";
 
 		/// <summary>The list of tracks available in the simulation.</summary>
-		public Track[] Tracks;
+		public Dictionary<int, Track> Tracks;
 
 		/// <summary>Holds a reference to the base TrainManager.Trains array</summary>
 		public AbstractTrain[] Trains;
@@ -75,8 +76,13 @@ namespace RouteManager2
 		public CurrentRoute(BaseRenderer renderer)
 		{
 			this.renderer = renderer;
-
-			Tracks = new[] { new Track { Elements = new TrackElement[0] } };
+			
+			Tracks = new Dictionary<int, Track>();
+			Track t = new Track()
+			{
+				Elements = new TrackElement[0]
+			};
+			Tracks.Add(0, t);
 			Trains = new AbstractTrain[0];
 			Sections = new Section[0];
 			Stations = new RouteStation[0];

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -6,6 +6,7 @@
 // ╚═════════════════════════════════════════════════════════════╝
 
 using System;
+using System.Collections.Generic;
 using OpenBveApi.Colors;
 using OpenBveApi.Textures;
 using OpenBveApi.Trains;
@@ -38,7 +39,12 @@ namespace OpenBve {
 
 		internal static void Reset() {
 			// track manager
-			Program.CurrentRoute.Tracks = new Track[] { new Track() };
+			Program.CurrentRoute.Tracks = new Dictionary<int, Track>();
+			Track t = new Track
+			{
+				Elements = new TrackElement[0]
+			};
+			Program.CurrentRoute.Tracks.Add(0, t);
 			// train manager
 			TrainManager.Trains = new TrainManager.Train[] { };
 			// game

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using OpenBveApi;
@@ -5599,8 +5600,9 @@ namespace OpenBve
 						/*
 						 * Legacy brightness: This applies equally to all tracks in a block
 						 */
-						for (int t = 0; t < Program.CurrentRoute.Tracks.Length; t++)
+						for (int tt = 0; tt < Program.CurrentRoute.Tracks.Count; tt++)
 						{
+							int t = Program.CurrentRoute.Tracks.ElementAt(tt).Key;
 							int m = Program.CurrentRoute.Tracks[t].Elements[n].Events.Length;
 							Array.Resize(ref Program.CurrentRoute.Tracks[t].Elements[n].Events, m + 1);
 							double d = Data.Blocks[i].BrightnessChanges[j].TrackPosition - StartingDistance;

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using OpenBveApi.Hosts;
 using OpenBveApi.Interface;
@@ -370,7 +371,7 @@ namespace OpenBve
 			}
 		}
 
-		public override Track[] Tracks
+		public override Dictionary<int, Track> Tracks
 		{
 			get
 			{


### PR DESCRIPTION
This changes rails to use a dictionary type accessor, as opposed to a single array.
This drastically reduces memory usage in the route parser and sim where an author has used mega high rail numbers.

### Issues:
* ~~Curve calculation for trains running on secondary tracks seems broken. (Probably using a for loop somewhere we shouldn't now...)~~ Fixed.
* ~~Not implemented in Route Viewer / Object Viewer, these are broken in this PR at the minute.~~ Route Viewer doesn't implement the parser changes, but implements the backend changes. Should be enough, and hopefully will move the route loading code to a plugin soon.

cc @s520 - Multiple rail running is primarily your code.