### PR TITLE
Fix: the issue that an exception occurred in legacy OpenGL (again...)

### DIFF
--- a/source/LibRender2/Backgrounds/Background.cs
+++ b/source/LibRender2/Backgrounds/Background.cs
@@ -114,7 +114,7 @@ namespace LibRender2.Backgrounds
 		/// <param name="scale">The scale</param>
 		private void RenderStaticBackground(StaticBackground data, float alpha, float scale)
 		{
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				RenderStaticBackgroundRetained(data, alpha, scale);
 			}
@@ -329,7 +329,7 @@ namespace LibRender2.Backgrounds
 		/// <param name="data">The background object</param>
 		private void RenderBackgroundObject(BackgroundObject data)
 		{
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				renderer.DefaultShader.Activate();
 				renderer.DefaultShader.SetCurrentProjectionMatrix(renderer.CurrentProjectionMatrix);
@@ -365,7 +365,7 @@ namespace LibRender2.Backgrounds
 					}
 				}
 
-				if (renderer.currentOptions.IsUseNewRenderer)
+				if (renderer.AvailableNewRenderer)
 				{
 					renderer.RenderFace(renderer.DefaultShader, new ObjectState { Prototype = data.Object }, face, Matrix4D.NoTransformation, Matrix4D.Scale(1.0) * renderer.CurrentViewMatrix);
 				}
@@ -375,7 +375,7 @@ namespace LibRender2.Backgrounds
 				}
 			}
 
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				renderer.DefaultShader.Deactivate();
 			}

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -142,6 +142,10 @@ namespace LibRender2
 
 		internal int lastVAO;
 
+		protected bool ForceLegacyOpenGL;
+
+		public bool AvailableNewRenderer => currentOptions != null && currentOptions.IsUseNewRenderer && !ForceLegacyOpenGL;
+
 		protected BaseRenderer()
 		{
 			Screen = new Screen();
@@ -171,6 +175,7 @@ namespace LibRender2
 			{
 				CurrentHost.AddMessage(MessageType.Error, false, "Initializing the default shaders failed- Falling back to legacy openGL.");
 				CurrentOptions.IsUseNewRenderer = false;
+				ForceLegacyOpenGL = true;
 			}
 
 			Background = new Background(this);

--- a/source/LibRender2/Objects/ObjectLibrary.cs
+++ b/source/LibRender2/Objects/ObjectLibrary.cs
@@ -87,7 +87,7 @@ namespace LibRender2.Objects
 		{
 			bool result = AddObject(State);
 
-			if (currentOptions.IsUseNewRenderer && State.Prototype.Mesh.VAO == null)
+			if (renderer.AvailableNewRenderer && State.Prototype.Mesh.VAO == null)
 			{
 				VAOExtensions.CreateVAO(ref State.Prototype.Mesh, State.Prototype.Dynamic, renderer.DefaultShader.VertexLayout);
 			}

--- a/source/LibRender2/Primitives/Cube.cs
+++ b/source/LibRender2/Primitives/Cube.cs
@@ -177,7 +177,7 @@ namespace LibRender2.Primitives
 				}
 			};
 
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				defaultVAO = new VertexArrayObject();
 				defaultVAO.Bind();
@@ -198,7 +198,7 @@ namespace LibRender2.Primitives
 		/// <param name="TextureIndex">The texture to apply</param>
 		public void Draw(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double Size, Vector3 Camera, Texture TextureIndex)
 		{
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				Draw(Position, Direction, Up, Side, new Vector3(Size, Size, Size), Camera, TextureIndex);
 			}
@@ -219,7 +219,7 @@ namespace LibRender2.Primitives
 		/// <param name="TextureIndex">The texture to apply</param>
 		public void Draw(Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, Vector3 Size, Vector3 Camera, Texture TextureIndex)
 		{
-			if (renderer.currentOptions.IsUseNewRenderer)
+			if (renderer.AvailableNewRenderer)
 			{
 				DrawRetained(defaultVAO, Position, Direction, Up, Side, Size, Camera, TextureIndex);
 			}

--- a/source/ObjectViewer/NewRendererS.cs
+++ b/source/ObjectViewer/NewRendererS.cs
@@ -35,9 +35,12 @@ namespace OpenBve
 		{
 			base.Initialize(CurrentHost, CurrentOptions);
 
-			redAxisVAO = RegisterBox(Color128.Red);
-			greenAxisVAO = RegisterBox(Color128.Green);
-			blueAxisVAO = RegisterBox(Color128.Blue);
+			if (AvailableNewRenderer)
+			{
+				redAxisVAO = RegisterBox(Color128.Red);
+				greenAxisVAO = RegisterBox(Color128.Green);
+				blueAxisVAO = RegisterBox(Color128.Blue);
+			}
 		}
 
 		internal string GetBackgroundColorName()
@@ -168,7 +171,7 @@ namespace OpenBve
 			{
 				UnsetAlphaFunc();
 
-				if (Interface.CurrentOptions.IsUseNewRenderer)
+				if (AvailableNewRenderer)
 				{
 					Cube.DrawRetained(redAxisVAO, Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(100.0, 0.01, 0.01), Camera.AbsolutePosition, null);
 					Cube.DrawRetained(greenAxisVAO, Vector3.Zero, Vector3.Forward, Vector3.Down, Vector3.Right, new Vector3(0.01, 100.0, 0.01), Camera.AbsolutePosition, null);
@@ -186,7 +189,7 @@ namespace OpenBve
 			}
 
 			// opaque face
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				//Setup the shader for rendering the scene
 				DefaultShader.Activate();
@@ -204,7 +207,7 @@ namespace OpenBve
 			ResetOpenGlState();
 			foreach (FaceState face in VisibleObjects.OpaqueFaces)
 			{
-				if (Interface.CurrentOptions.IsUseNewRenderer)
+				if (AvailableNewRenderer)
 				{
 					RenderFace(DefaultShader, face);
 				}
@@ -226,7 +229,7 @@ namespace OpenBve
 
 				foreach (FaceState face in VisibleObjects.AlphaFaces)
 				{
-					if (Interface.CurrentOptions.IsUseNewRenderer)
+					if (AvailableNewRenderer)
 					{
 						RenderFace(DefaultShader, face);
 					}
@@ -248,7 +251,7 @@ namespace OpenBve
 					{
 						if (face.Object.Prototype.Mesh.Materials[face.Face.Material].Color.A == 255)
 						{
-							if (Interface.CurrentOptions.IsUseNewRenderer)
+							if (AvailableNewRenderer)
 							{
 								RenderFace(DefaultShader, face);
 							}
@@ -275,7 +278,7 @@ namespace OpenBve
 							additive = true;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -292,7 +295,7 @@ namespace OpenBve
 							additive = false;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -304,7 +307,7 @@ namespace OpenBve
 				}
 			}
 
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				DefaultShader.Deactivate();
 			}

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -306,7 +306,7 @@ namespace OpenBve.Graphics
 
 			// world layer
 			// opaque face
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				//Setup the shader for rendering the scene
 				DefaultShader.Activate();
@@ -331,7 +331,7 @@ namespace OpenBve.Graphics
 			ResetOpenGlState();
 			foreach (FaceState face in VisibleObjects.OpaqueFaces)
 			{
-				if (Interface.CurrentOptions.IsUseNewRenderer)
+				if (AvailableNewRenderer)
 				{
 					RenderFace(DefaultShader, face);
 				}
@@ -352,7 +352,7 @@ namespace OpenBve.Graphics
 
 				foreach (FaceState face in VisibleObjects.AlphaFaces)
 				{
-					if (Interface.CurrentOptions.IsUseNewRenderer)
+					if (AvailableNewRenderer)
 					{
 						RenderFace(DefaultShader, face);
 					}
@@ -374,7 +374,7 @@ namespace OpenBve.Graphics
 					{
 						if (face.Object.Prototype.Mesh.Materials[face.Face.Material].Color.A == 255)
 						{
-							if (Interface.CurrentOptions.IsUseNewRenderer)
+							if (AvailableNewRenderer)
 							{
 								RenderFace(DefaultShader, face);
 							}
@@ -401,7 +401,7 @@ namespace OpenBve.Graphics
 							additive = true;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -418,7 +418,7 @@ namespace OpenBve.Graphics
 							additive = false;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -442,7 +442,7 @@ namespace OpenBve.Graphics
 				DefaultShader.Deactivate();
 				MotionBlur.RenderFullscreen(Interface.CurrentOptions.MotionBlur, FrameRate, Math.Abs(Camera.CurrentSpeed));
 			}
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				DefaultShader.Activate();
 				ResetShader(DefaultShader); //Must reset shader between overlay and world layers for correct lighting results
@@ -467,7 +467,7 @@ namespace OpenBve.Graphics
 				// overlay opaque face
 				foreach (FaceState face in VisibleObjects.OverlayOpaqueFaces)
 				{
-					if (Interface.CurrentOptions.IsUseNewRenderer)
+					if (AvailableNewRenderer)
 					{
 						RenderFace(DefaultShader, face);
 					}
@@ -489,7 +489,7 @@ namespace OpenBve.Graphics
 
 					foreach (FaceState face in VisibleObjects.OverlayAlphaFaces)
 					{
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -511,7 +511,7 @@ namespace OpenBve.Graphics
 						{
 							if (face.Object.Prototype.Mesh.Materials[face.Face.Material].Color.A == 255)
 							{
-								if (Interface.CurrentOptions.IsUseNewRenderer)
+								if (AvailableNewRenderer)
 								{
 									RenderFace(DefaultShader, face);
 								}
@@ -538,7 +538,7 @@ namespace OpenBve.Graphics
 								additive = true;
 							}
 
-							if (Interface.CurrentOptions.IsUseNewRenderer)
+							if (AvailableNewRenderer)
 							{
 								RenderFace(DefaultShader, face);
 							}
@@ -555,7 +555,7 @@ namespace OpenBve.Graphics
 								additive = false;
 							}
 
-							if (Interface.CurrentOptions.IsUseNewRenderer)
+							if (AvailableNewRenderer)
 							{
 								RenderFace(DefaultShader, face);
 							}
@@ -586,7 +586,7 @@ namespace OpenBve.Graphics
 				VisibleObjects.SortPolygonsInOverlayAlphaFaces();
 				foreach (FaceState face in VisibleObjects.OverlayAlphaFaces)
 				{
-					if (Interface.CurrentOptions.IsUseNewRenderer)
+					if (AvailableNewRenderer)
 					{
 						RenderFace(DefaultShader, face);
 					}
@@ -596,7 +596,7 @@ namespace OpenBve.Graphics
 					}
 				}
 			}
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				/*
 				 * Must remember to de-activate at the end of the render sequence if in GL3 mode.

--- a/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
@@ -162,7 +162,7 @@ namespace OpenBve.Graphics.Renderers
 				"total animated objects: " + ObjectManager.AnimatedWorldObjectsUsed.ToString(Culture),
 				"",
 				"=renderer",
-				"renderer type: " + (Interface.CurrentOptions.IsUseNewRenderer ? "openGL 3.0 (new)" : "openGL 1.2 (old)"),
+				"renderer type: " + (Program.Renderer.AvailableNewRenderer ? "openGL 3.0 (new)" : "openGL 1.2 (old)"),
 				"opaque faces: " + Program.Renderer.VisibleObjects.OpaqueFaces.Count.ToString(Culture),
 				"alpha faces: " + Program.Renderer.VisibleObjects.AlphaFaces.Count.ToString(Culture),
 				"overlay opaque faces: " + Program.Renderer.VisibleObjects.OverlayOpaqueFaces.Count.ToString(Culture),

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1599,7 +1599,7 @@ namespace OpenBve
 										break;
 									case Translations.Command.DebugRendererMode:
 										Interface.CurrentOptions.IsUseNewRenderer = !Interface.CurrentOptions.IsUseNewRenderer;
-										Game.AddMessage($"Renderer mode: {(Interface.CurrentOptions.IsUseNewRenderer ? "New renderer" : "Original renderer")}", MessageDependency.None, GameMode.Expert, MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+										Game.AddMessage($"Renderer mode: {(Program.Renderer.AvailableNewRenderer ? "New renderer" : "Original renderer")}", MessageDependency.None, GameMode.Expert, MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
 										break;
 									case Translations.Command.MiscAI:
 										// option: AI

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -78,7 +78,7 @@ namespace OpenBve
 					Interface.CurrentOptions.WindowHeight = result.Height;
 				}
 			}
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (Program.Renderer.AvailableNewRenderer)
 			{
 				Program.FileSystem.AppendToLogFile("Using openGL 3.0 (new) renderer");
 			}

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -311,7 +311,7 @@ namespace OpenBve
 
 			// world layer
 			// opaque face
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				//Setup the shader for rendering the scene
 				DefaultShader.Activate();
@@ -337,7 +337,7 @@ namespace OpenBve
 
 			foreach (FaceState face in VisibleObjects.OpaqueFaces)
 			{
-				if (Interface.CurrentOptions.IsUseNewRenderer)
+				if (AvailableNewRenderer)
 				{
 					RenderFace(DefaultShader, face);
 				}
@@ -359,7 +359,7 @@ namespace OpenBve
 
 				foreach (FaceState face in VisibleObjects.AlphaFaces)
 				{
-					if (Interface.CurrentOptions.IsUseNewRenderer)
+					if (AvailableNewRenderer)
 					{
 						RenderFace(DefaultShader, face);
 					}
@@ -381,7 +381,7 @@ namespace OpenBve
 					{
 						if (face.Object.Prototype.Mesh.Materials[face.Face.Material].Color.A == 255)
 						{
-							if (Interface.CurrentOptions.IsUseNewRenderer)
+							if (AvailableNewRenderer)
 							{
 								RenderFace(DefaultShader, face);
 							}
@@ -408,7 +408,7 @@ namespace OpenBve
 							additive = true;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -425,7 +425,7 @@ namespace OpenBve
 							additive = false;
 						}
 
-						if (Interface.CurrentOptions.IsUseNewRenderer)
+						if (AvailableNewRenderer)
 						{
 							RenderFace(DefaultShader, face);
 						}
@@ -438,7 +438,7 @@ namespace OpenBve
 			}
 
 			// render overlays
-			if (Interface.CurrentOptions.IsUseNewRenderer)
+			if (AvailableNewRenderer)
 			{
 				DefaultShader.Deactivate();
 			}


### PR DESCRIPTION
#433 fix was flawed.
This PR re-correct it.

This fix prevents switching to a new renderer if the creation of the default shader fails.