### PR TITLE
Change: use API functions to determine encoding

### DIFF
--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -211,48 +211,22 @@ namespace OpenBve {
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			TextEncoding.Encoding newEncoding = TextEncoding.GetEncodingFromFile(path);
-			if (newEncoding != TextEncoding.Encoding.Unknown)
+			if (string.IsNullOrEmpty(path))
 			{
-				switch (newEncoding)
-				{
-					case TextEncoding.Encoding.Utf7:
-						Encoding = System.Text.Encoding.UTF7;
-						break;
-					case TextEncoding.Encoding.Utf8:
-						Encoding = System.Text.Encoding.UTF8;
-						break;
-					case TextEncoding.Encoding.Utf16Le:
-						Encoding = System.Text.Encoding.Unicode;
-						break;
-					case TextEncoding.Encoding.Utf16Be:
-						Encoding = System.Text.Encoding.BigEndianUnicode;
-						break;
-					case TextEncoding.Encoding.Utf32Le:
-						Encoding = System.Text.Encoding.UTF32;
-						break;
-					case TextEncoding.Encoding.Utf32Be:
-						Encoding = System.Text.Encoding.GetEncoding(12001);
-						break;
-					case TextEncoding.Encoding.Shift_JIS:
-						Encoding = System.Text.Encoding.GetEncoding(932);
-						break;
-					case TextEncoding.Encoding.ASCII:
-					case TextEncoding.Encoding.Windows1252:
-						Encoding = System.Text.Encoding.GetEncoding(1252);
-						break;
-					case TextEncoding.Encoding.Big5:
-						Encoding = System.Text.Encoding.GetEncoding(950);
-						break;
-					case TextEncoding.Encoding.EUC_KR:
-						Encoding = System.Text.Encoding.GetEncoding(949);
-						break;
-					case TextEncoding.Encoding.OEM866:
-						Encoding = System.Text.Encoding.GetEncoding(866);
-						break;
-				}
+				Object = null;
+				return false;
 			}
+
+			if (!DetermineObjectExtension(ref path))
+			{
+				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
+				Object = null;
+				return false;
+			}
+
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
+				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
+
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {
 						try {

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -211,19 +211,6 @@ namespace OpenBve {
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			if (string.IsNullOrEmpty(path))
-			{
-				Object = null;
-				return false;
-			}
-
-			if (!DetermineObjectExtension(ref path))
-			{
-				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
-				Object = null;
-				return false;
-			}
-
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
 				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
 

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Preprocess.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.Preprocess.cs
@@ -452,11 +452,11 @@ namespace OpenBve
 									{
 										int x;
 										if (NumberFormats.TryParseIntVb6(s, out x)) {
-											if (x < 0)
+											if (x < 0 || x > 0x10FFFF)
 											{
-												//Must be non-negative
+												// UTF-8 characters from 0-0x10FFFF
 												continueWithNextExpression = true;
-												Program.CurrentHost.AddMessage(MessageType.Error, false, "Index must be a non-negative character in " + t + Epilog);
+												Program.CurrentHost.AddMessage(MessageType.Error, false, $"Index does not correspond to a valid Unicode character in {t}{Epilog}");
 											}
 											else
 											{
@@ -473,9 +473,9 @@ namespace OpenBve
 									int x;
 									if (NumberFormats.TryParseIntVb6(s, out x))
 									{
-										if (x < 0 || x > 128)
+										if (x < 0 || x > 127)
 										{
-											//Standard ASCII characters from 0-128
+											//Standard ASCII characters from 0-127
 											continueWithNextExpression = true;
 											Program.CurrentHost.AddMessage(MessageType.Error, false, "Index does not correspond to a valid ASCII character in " + t + Epilog);
 										}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.PreprocessOptions.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.PreprocessOptions.cs
@@ -266,7 +266,7 @@ namespace OpenBve
 									}
 								}
 									break;
-								case "options.enablehacks":
+								case "options.enablebvetshacks":
 								{
 									//Whether to apply various hacks to fix BVE2 / BVE4 routes
 									//Whilst this is harmless, it should be DISABLED on openBVE content

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -569,6 +569,9 @@ namespace OpenBve {
 											Data.FogTransitionMode = a == 1;
 										}
 									} break;
+								case "options.compatibletransparencymode":
+								case "options.enablebvetshacks":
+										break;
 									// route
 								case "route.comment":
 									if (Arguments.Length < 1) {
@@ -1755,7 +1758,20 @@ namespace OpenBve {
 														string f = Arguments[0];
 														try
 														{
-															LocateObject(ref f, ObjectPath);
+															if (!LocateObject(ref f, ObjectPath))
+															{
+																string testPath = Path.CombineFile(ObjectPath, f);
+
+																if (Program.CurrentHost.DetermineStaticObjectExtension(ref testPath))
+																{
+																	f = testPath;
+																}
+																else
+																{
+																	Program.CurrentHost.AddMessage(MessageType.Error, false, "SignalFileWithoutExtension does not exist in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+																	break;
+																}
+															}
 														}
 														catch
 														{
@@ -1763,39 +1779,6 @@ namespace OpenBve {
 															//Really needs commenting fixing, rather than hacks like this.....
 															Program.CurrentHost.AddMessage(MessageType.Error, false, "SignalFileWithoutExtension does not contain a valid path in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 															break;
-														}
-														if (!System.IO.File.Exists(f) && !System.IO.Path.HasExtension(f))
-														{
-															string ff;
-															bool notFound = false;
-															while (true)
-															{
-																ff = Path.CombineFile(ObjectPath, f + ".x");
-																if (System.IO.File.Exists(ff))
-																{
-																	f = ff;
-																	break;
-																}
-																ff = Path.CombineFile(ObjectPath, f + ".csv");
-																if (System.IO.File.Exists(ff))
-																{
-																	f = ff;
-																	break;
-																}
-																ff = Path.CombineFile(ObjectPath, f + ".b3d");
-																if (System.IO.File.Exists(ff))
-																{
-																	f = ff;
-																	break;
-																}
-																Program.CurrentHost.AddMessage(MessageType.Error, false, "SignalFileWithoutExtension does not exist in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																notFound = true;
-																break;
-															}
-															if (notFound)
-															{
-																break;
-															}
 														}
 														Bve4SignalData Signal = new Bve4SignalData
 														{
@@ -1818,51 +1801,33 @@ namespace OpenBve {
 																	if (!System.IO.File.Exists(f) && System.IO.Path.HasExtension(f))
 																	{
 																		string ext = System.IO.Path.GetExtension(f);
-																		switch (ext.ToLowerInvariant())
+
+																		if (Program.CurrentHost.SupportedStaticObjectExtensions.Contains(ext.ToLowerInvariant()))
 																		{
-																			case ".csv":
-																			case ".b3d":
-																			case ".x":
-																				Program.CurrentHost.AddMessage(MessageType.Warning, false, "GlowFileWithoutExtension should not supply a file extension in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																				f = Path.CombineFile(ObjectPath, f);
-																				glowFileFound = true;
-																				break;
-																			case ".animated":
-																			case ".s":
-																				Program.CurrentHost.AddMessage(MessageType.Error, false, "GlowFileWithoutExtension must be a static object in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																				break;
-																			default:
-																				Program.CurrentHost.AddMessage(MessageType.Error, false, "GlowFileWithoutExtension is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																				break;
+																			Program.CurrentHost.AddMessage(MessageType.Warning, false, "GlowFileWithoutExtension should not supply a file extension in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+																			f = Path.CombineFile(ObjectPath, f);
+																			glowFileFound = true;
 																		}
-																		
+																		else if (Program.CurrentHost.SupportedAnimatedObjectExtensions.Contains(ext.ToLowerInvariant()))
+																		{
+																			Program.CurrentHost.AddMessage(MessageType.Error, false, "GlowFileWithoutExtension must be a static object in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+																		}
+																		else
+																		{
+																			Program.CurrentHost.AddMessage(MessageType.Error, false, "GlowFileWithoutExtension is invalid in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
+																		}
 																	}
 																	if (!System.IO.File.Exists(f) && !System.IO.Path.HasExtension(f))
 																	{
-																		string ff;
-																		while (true)
+																		string testPath = Path.CombineFile(ObjectPath, f);
+
+																		if (Program.CurrentHost.DetermineStaticObjectExtension(ref testPath))
 																		{
-																			ff = Path.CombineFile(ObjectPath, f + ".x");
-																			if (System.IO.File.Exists(ff))
-																			{
-																				f = ff;
-																				glowFileFound = true;
-																				break;
-																			}
-																			ff = Path.CombineFile(ObjectPath, f + ".csv");
-																			if (System.IO.File.Exists(ff))
-																			{
-																				f = ff;
-																				glowFileFound = true;
-																				break;
-																			}
-																			ff = Path.CombineFile(ObjectPath, f + ".b3d");
-																			if (System.IO.File.Exists(ff))
-																			{
-																				f = ff;
-																				glowFileFound = true;
-																				break;
-																			}
+																			f = testPath;
+																			glowFileFound = true;
+																		}
+																		else
+																		{
 																			Program.CurrentHost.AddMessage(MessageType.Error, false, "GlowFileWithoutExtension does not exist in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 																			break;
 																		}

--- a/source/OpenBVE/Parsers/Train/ExtensionsCfgParser.cs
+++ b/source/OpenBVE/Parsers/Train/ExtensionsCfgParser.cs
@@ -19,34 +19,7 @@ namespace OpenBve {
 			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
 			string FileName = OpenBveApi.Path.CombineFile(TrainPath, "extensions.cfg");
 			if (System.IO.File.Exists(FileName)) {
-				TextEncoding.Encoding newEncoding = TextEncoding.GetEncodingFromFile(FileName);
-				if (newEncoding != TextEncoding.Encoding.Unknown)
-				{
-					switch (newEncoding)
-					{
-						case TextEncoding.Encoding.Utf7:
-							Encoding = System.Text.Encoding.UTF7;
-							break;
-						case TextEncoding.Encoding.Utf8:
-							Encoding = System.Text.Encoding.UTF8;
-							break;
-						case TextEncoding.Encoding.Utf16Le:
-							Encoding = System.Text.Encoding.Unicode;
-							break;
-						case TextEncoding.Encoding.Utf16Be:
-							Encoding = System.Text.Encoding.BigEndianUnicode;
-							break;
-						case TextEncoding.Encoding.Utf32Le:
-							Encoding = System.Text.Encoding.UTF32;
-							break;
-						case TextEncoding.Encoding.Utf32Be:
-							Encoding = System.Text.Encoding.GetEncoding(12001);
-							break;
-						case TextEncoding.Encoding.Shift_JIS:
-							Encoding = System.Text.Encoding.GetEncoding(932);
-							break;
-					}
-				}
+				Encoding = TextEncoding.GetSystemEncodingFromFile(FileName, Encoding);
 
 				string[] Lines = System.IO.File.ReadAllLines(FileName, Encoding);
 				for (int i = 0; i < Lines.Length; i++) {

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -238,19 +238,6 @@ namespace OpenBve {
 
 		public override bool LoadStaticObject(string path, System.Text.Encoding Encoding, bool PreserveVertices, out StaticObject Object)
 		{
-			if (string.IsNullOrEmpty(path))
-			{
-				Object = null;
-				return false;
-			}
-
-			if (!DetermineStaticObjectExtension(ref path))
-			{
-				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
-				Object = null;
-				return false;
-			}
-
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
 				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
 
@@ -290,19 +277,6 @@ namespace OpenBve {
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			if (string.IsNullOrEmpty(path))
-			{
-				Object = null;
-				return false;
-			}
-
-			if (!DetermineObjectExtension(ref path))
-			{
-				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
-				Object = null;
-				return false;
-			}
-
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
 				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
 

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -238,48 +238,22 @@ namespace OpenBve {
 
 		public override bool LoadStaticObject(string path, System.Text.Encoding Encoding, bool PreserveVertices, out StaticObject Object)
 		{
-			TextEncoding.Encoding newEncoding = TextEncoding.GetEncodingFromFile(path);
-			if (newEncoding != TextEncoding.Encoding.Unknown)
+			if (string.IsNullOrEmpty(path))
 			{
-				switch (newEncoding)
-				{
-					case TextEncoding.Encoding.Utf7:
-						Encoding = System.Text.Encoding.UTF7;
-						break;
-					case TextEncoding.Encoding.Utf8:
-						Encoding = System.Text.Encoding.UTF8;
-						break;
-					case TextEncoding.Encoding.Utf16Le:
-						Encoding = System.Text.Encoding.Unicode;
-						break;
-					case TextEncoding.Encoding.Utf16Be:
-						Encoding = System.Text.Encoding.BigEndianUnicode;
-						break;
-					case TextEncoding.Encoding.Utf32Le:
-						Encoding = System.Text.Encoding.UTF32;
-						break;
-					case TextEncoding.Encoding.Utf32Be:
-						Encoding = System.Text.Encoding.GetEncoding(12001);
-						break;
-					case TextEncoding.Encoding.Shift_JIS:
-						Encoding = System.Text.Encoding.GetEncoding(932);
-						break;
-					case TextEncoding.Encoding.ASCII:
-					case TextEncoding.Encoding.Windows1252:
-						Encoding = System.Text.Encoding.GetEncoding(1252);
-						break;
-					case TextEncoding.Encoding.Big5:
-						Encoding = System.Text.Encoding.GetEncoding(950);
-						break;
-					case TextEncoding.Encoding.EUC_KR:
-						Encoding = System.Text.Encoding.GetEncoding(949);
-						break;
-					case TextEncoding.Encoding.OEM866:
-						Encoding = System.Text.Encoding.GetEncoding(866);
-						break;
-				}
+				Object = null;
+				return false;
 			}
+
+			if (!DetermineStaticObjectExtension(ref path))
+			{
+				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
+				Object = null;
+				return false;
+			}
+
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
+				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
+
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {
 						try {
@@ -316,48 +290,22 @@ namespace OpenBve {
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			TextEncoding.Encoding newEncoding = TextEncoding.GetEncodingFromFile(path);
-			if (newEncoding != TextEncoding.Encoding.Unknown)
+			if (string.IsNullOrEmpty(path))
 			{
-				switch (newEncoding)
-				{
-					case TextEncoding.Encoding.Utf7:
-						Encoding = System.Text.Encoding.UTF7;
-						break;
-					case TextEncoding.Encoding.Utf8:
-						Encoding = System.Text.Encoding.UTF8;
-						break;
-					case TextEncoding.Encoding.Utf16Le:
-						Encoding = System.Text.Encoding.Unicode;
-						break;
-					case TextEncoding.Encoding.Utf16Be:
-						Encoding = System.Text.Encoding.BigEndianUnicode;
-						break;
-					case TextEncoding.Encoding.Utf32Le:
-						Encoding = System.Text.Encoding.UTF32;
-						break;
-					case TextEncoding.Encoding.Utf32Be:
-						Encoding = System.Text.Encoding.GetEncoding(12001);
-						break;
-					case TextEncoding.Encoding.Shift_JIS:
-						Encoding = System.Text.Encoding.GetEncoding(932);
-						break;
-					case TextEncoding.Encoding.ASCII:
-					case TextEncoding.Encoding.Windows1252:
-						Encoding = System.Text.Encoding.GetEncoding(1252);
-						break;
-					case TextEncoding.Encoding.Big5:
-						Encoding = System.Text.Encoding.GetEncoding(950);
-						break;
-					case TextEncoding.Encoding.EUC_KR:
-						Encoding = System.Text.Encoding.GetEncoding(949);
-						break;
-					case TextEncoding.Encoding.OEM866:
-						Encoding = System.Text.Encoding.GetEncoding(866);
-						break;
-				}
+				Object = null;
+				return false;
 			}
+
+			if (!DetermineObjectExtension(ref path))
+			{
+				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
+				Object = null;
+				return false;
+			}
+
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
+				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
+
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {
 						try {

--- a/source/OpenBVE/System/Program/CommandLine.cs
+++ b/source/OpenBVE/System/Program/CommandLine.cs
@@ -27,86 +27,11 @@ namespace OpenBve
 					{
 						case "/route":
 							Result.RouteFile = value;
-							switch (TextEncoding.GetEncodingFromFile(Result.RouteFile))
-							{
-								case TextEncoding.Encoding.Utf7:
-									Result.RouteEncoding = System.Text.Encoding.UTF7;
-									break;
-								case TextEncoding.Encoding.Utf8:
-									Result.RouteEncoding = System.Text.Encoding.UTF8;
-									break;
-								case TextEncoding.Encoding.Utf16Le:
-									Result.RouteEncoding = System.Text.Encoding.Unicode;
-									break;
-								case TextEncoding.Encoding.Utf16Be:
-									Result.RouteEncoding = System.Text.Encoding.BigEndianUnicode;
-									break;
-								case TextEncoding.Encoding.Utf32Le:
-									Result.RouteEncoding = System.Text.Encoding.UTF32;
-									break;
-								case TextEncoding.Encoding.Utf32Be:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(12001);
-									break;
-								case TextEncoding.Encoding.Shift_JIS:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(932);
-									break;
-								case TextEncoding.Encoding.ASCII:
-								case TextEncoding.Encoding.Windows1252:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(1252);
-									break;
-								case TextEncoding.Encoding.Big5:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(950);
-									break;
-								case TextEncoding.Encoding.EUC_KR:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(949);
-									break;
-								case TextEncoding.Encoding.OEM866:
-									Result.RouteEncoding = System.Text.Encoding.GetEncoding(866);
-									break;
-								default:
-									Result.RouteEncoding = Encoding.Default;
-									break;
-							}
+							Result.RouteEncoding = TextEncoding.GetSystemEncodingFromFile(Result.RouteFile);
 							break;
 						case "/train":
 							Result.TrainFolder = value;
-							switch (TextEncoding.GetEncodingFromFile(Result.TrainFolder, "train.txt"))
-							{
-								case TextEncoding.Encoding.Utf8:
-									Result.TrainEncoding = System.Text.Encoding.UTF8;
-									break;
-								case TextEncoding.Encoding.Utf16Le:
-									Result.TrainEncoding = System.Text.Encoding.Unicode;
-									break;
-								case TextEncoding.Encoding.Utf16Be:
-									Result.TrainEncoding = System.Text.Encoding.BigEndianUnicode;
-									break;
-								case TextEncoding.Encoding.Utf32Le:
-									Result.TrainEncoding = System.Text.Encoding.UTF32;
-									break;
-								case TextEncoding.Encoding.Utf32Be:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(12001);
-									break;
-								case TextEncoding.Encoding.Shift_JIS:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(932);
-									break;
-								case TextEncoding.Encoding.ASCII:
-								case TextEncoding.Encoding.Windows1252:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(1252);
-									break;
-								case TextEncoding.Encoding.Big5:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(950);
-									break;
-								case TextEncoding.Encoding.EUC_KR:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(949);
-									break;
-								case TextEncoding.Encoding.OEM866:
-									Result.TrainEncoding = System.Text.Encoding.GetEncoding(866);
-									break;
-								default:
-									Result.TrainEncoding = Encoding.Default;
-									break;
-							}
+							Result.TrainEncoding = TextEncoding.GetSystemEncodingFromFile(Result.TrainFolder, "train.txt");
 							break;
 						case "/station":
 							Result.InitialStation = value;

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -867,83 +867,13 @@ namespace OpenBve
 
 				// determine encoding
 				if (!UserSelectedEncoding) {
+					Result.RouteEncoding = TextEncoding.GetSystemEncodingFromFile(Result.RouteFile);
 					comboboxRouteEncoding.Tag = new object();
 					comboboxRouteEncoding.SelectedIndex = 0;
-					comboboxRouteEncoding.Items[0] = "(UTF-8)";
+					comboboxRouteEncoding.Items[0] = $"{Result.RouteEncoding.EncodingName} - {Result.RouteEncoding.CodePage}";
 					comboboxRouteEncoding.Tag = null;
-					Result.RouteEncoding = System.Text.Encoding.Default;
-					switch (TextEncoding.GetEncodingFromFile(Result.RouteFile)) {
-						case TextEncoding.Encoding.Utf7:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-7)";
-							Result.RouteEncoding = System.Text.Encoding.UTF7;
-							break;
-						case TextEncoding.Encoding.Utf8:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-8)";
-							Result.RouteEncoding = System.Text.Encoding.UTF8;
-							break;
-						case TextEncoding.Encoding.Utf16Le:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-16 little endian)";
-							Result.RouteEncoding = System.Text.Encoding.Unicode;
-							break;
-						case TextEncoding.Encoding.Utf16Be:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-16 big endian)";
-							Result.RouteEncoding = System.Text.Encoding.BigEndianUnicode;
-							break;
-						case TextEncoding.Encoding.Utf32Le:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-32 little endian)";
-							Result.RouteEncoding = System.Text.Encoding.UTF32;
-							break;
-						case TextEncoding.Encoding.Utf32Be:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(UTF-32 big endian)";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(12001);
-							break;
-						case TextEncoding.Encoding.Shift_JIS:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "(SHIFT_JIS)";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(932);
-							break;
-						case TextEncoding.Encoding.ASCII:
-						case TextEncoding.Encoding.Windows1252:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "Western European (Windows) 1252";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(1252);
-							break;
-						case TextEncoding.Encoding.Big5:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "Chinese Traditional (Big5) 950";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(950);
-							break;
-						case TextEncoding.Encoding.EUC_KR:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "Korean - 949";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(949);
-							break;
-						case TextEncoding.Encoding.OEM866:
-							panelRouteEncoding.Enabled = false;
-							comboboxRouteEncoding.SelectedIndex = 0;
-							comboboxRouteEncoding.Items[0] = "Legacy Cyrillic - 866";
-							Result.RouteEncoding = System.Text.Encoding.GetEncoding(866);
-							break;
-					}
-					panelRouteEncoding.Enabled = true;
+
 					comboboxRouteEncoding.Tag = new object();
-					
 					int i;
 					for (i = 0; i < Interface.CurrentOptions.RouteEncodings.Length; i++) {
 						if (Interface.CurrentOptions.RouteEncodings[i].Value == Result.RouteFile) {
@@ -976,59 +906,12 @@ namespace OpenBve
 		// show train
 		private void ShowTrain(bool UserSelectedEncoding) {
 			if (!UserSelectedEncoding) {
+				Result.TrainEncoding = TextEncoding.GetSystemEncodingFromFile(Result.TrainFolder, "train.txt");
 				comboboxTrainEncoding.Tag = new object();
 				comboboxTrainEncoding.SelectedIndex = 0;
-				comboboxTrainEncoding.Items[0] = "(UTF-8)";
+				comboboxTrainEncoding.Items[0] = $"{Result.TrainEncoding.EncodingName} - {Result.TrainEncoding.CodePage}";
+
 				comboboxTrainEncoding.Tag = null;
-				Result.TrainEncoding = System.Text.Encoding.Default;
-				switch (TextEncoding.GetEncodingFromFile(Result.TrainFolder, "train.txt")) {
-					case TextEncoding.Encoding.Utf8:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(UTF-8)";
-						Result.TrainEncoding = System.Text.Encoding.UTF8;
-						break;
-					case TextEncoding.Encoding.Utf16Le:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(UTF-16 little endian)";
-						Result.TrainEncoding = System.Text.Encoding.Unicode;
-						break;
-					case TextEncoding.Encoding.Utf16Be:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(UTF-16 big endian)";
-						Result.TrainEncoding = System.Text.Encoding.BigEndianUnicode;
-						break;
-					case TextEncoding.Encoding.Utf32Le:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(UTF-32 little endian)";
-						Result.TrainEncoding = System.Text.Encoding.UTF32;
-						break;
-					case TextEncoding.Encoding.Utf32Be:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(UTF-32 big endian)";
-						Result.TrainEncoding = System.Text.Encoding.GetEncoding(12001);
-						break;
-					case TextEncoding.Encoding.Shift_JIS:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "(SHIFT_JIS)";
-						Result.TrainEncoding = System.Text.Encoding.GetEncoding(932);
-						break;
-					case TextEncoding.Encoding.ASCII:
-					case TextEncoding.Encoding.Windows1252:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "Western European (Windows) 1252";
-						Result.TrainEncoding = System.Text.Encoding.GetEncoding(1252);
-						break;
-					case TextEncoding.Encoding.Big5:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "Chinese Traditional (Big5) 950";
-						Result.TrainEncoding = System.Text.Encoding.GetEncoding(950);
-						break;
-					case TextEncoding.Encoding.EUC_KR:
-						comboboxTrainEncoding.SelectedIndex = 0;
-						comboboxTrainEncoding.Items[0] = "Korean - 949";
-						Result.TrainEncoding = System.Text.Encoding.GetEncoding(949);
-						break;
-				}
 				int i;
 				for (i = 0; i < Interface.CurrentOptions.TrainEncodings.Length; i++) {
 					if (Interface.CurrentOptions.TrainEncodings[i].Value == Result.TrainFolder) {

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -246,7 +246,7 @@ namespace OpenBve {
 				EncodingCodepages = new int[Info.Length + 1];
 				string[] EncodingDescriptions = new string[Info.Length + 1];
 				EncodingCodepages[0] = System.Text.Encoding.UTF8.CodePage;
-				EncodingDescriptions[0] = "(UTF-8)";
+				EncodingDescriptions[0] = $"{System.Text.Encoding.UTF8.EncodingName} - {System.Text.Encoding.UTF8.CodePage}";
 				for (int i = 0; i < Info.Length; i++)
 				{
 					EncodingCodepages[i + 1] = Info[i].CodePage;

--- a/source/OpenBveApi/Objects/ObjectInterface.cs
+++ b/source/OpenBveApi/Objects/ObjectInterface.cs
@@ -3,6 +3,16 @@
 	/// <summary>Represents the interface for loading objects. Plugins must implement this interface if they wish to expose objects.</summary>
 	public abstract class ObjectInterface
 	{
+		/// <summary>
+		/// Array of supported animated object extensions.
+		/// </summary>
+		public virtual string[] SupportedAnimatedObjectExtensions => new string[0];
+
+		/// <summary>
+		/// Array of supported static object extensions.
+		/// </summary>
+		public virtual string[] SupportedStaticObjectExtensions => new string[0];
+
 		/// <summary>Called when the plugin is loaded.</summary>
 		/// <param name="host">The host that loaded the plugin.</param>
 		/// <param name="fileSystem">The program filesystem object</param>

--- a/source/OpenBveApi/System/Hosts.cs
+++ b/source/OpenBveApi/System/Hosts.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -203,7 +204,8 @@ namespace OpenBveApi.Hosts {
 				return true;
 			}
 
-			foreach (string extension in SupportedStaticObjectExtensions)
+			// Search in the order of .x, .csv, .b3d, etc.
+			foreach (string extension in SupportedStaticObjectExtensions.OrderByDescending(x => Array.IndexOf(new[] { ".b3d", ".csv", ".x" }, x)))
 			{
 				string testPath = Path.CombineFile(System.IO.Path.GetDirectoryName(FilePath), $"{System.IO.Path.GetFileName(FilePath)}{extension}");
 

--- a/source/OpenBveApi/System/Hosts.cs
+++ b/source/OpenBveApi/System/Hosts.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
@@ -156,6 +157,63 @@ namespace OpenBveApi.Hosts {
 		/// <returns>Whether loading the sound was successful.</returns>
 		public virtual bool RegisterSound(Sounds.Sound sound, out SoundHandle handle) {
 			handle = null;
+			return false;
+		}
+
+		/// <summary>
+		/// Add an extension to the path of the object file that is missing the extension and no file.
+		/// </summary>
+		/// <param name="FilePath">The absolute on-disk path to the object</param>
+		/// <returns>Whether the extension could be determined</returns>
+		public bool DetermineObjectExtension(ref string FilePath)
+		{
+			if (System.IO.File.Exists(FilePath) || System.IO.Path.HasExtension(FilePath))
+			{
+				return true;
+			}
+
+			if (DetermineStaticObjectExtension(ref FilePath))
+			{
+				return true;
+			}
+
+			foreach (string extension in SupportedAnimatedObjectExtensions)
+			{
+				string testPath = Path.CombineFile(System.IO.Path.GetDirectoryName(FilePath), $"{System.IO.Path.GetFileName(FilePath)}{extension}");
+
+				if (System.IO.File.Exists(testPath))
+				{
+					FilePath = testPath;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Add an extension to the path of the static object file that is missing the extension and no file.
+		/// </summary>
+		/// <param name="FilePath">The absolute on-disk path to the object</param>
+		/// <returns>Whether the extension could be determined</returns>
+		public bool DetermineStaticObjectExtension(ref string FilePath)
+		{
+			if (System.IO.File.Exists(FilePath) || System.IO.Path.HasExtension(FilePath))
+			{
+				return true;
+			}
+
+			foreach (string extension in SupportedStaticObjectExtensions)
+			{
+				string testPath = Path.CombineFile(System.IO.Path.GetDirectoryName(FilePath), $"{System.IO.Path.GetFileName(FilePath)}{extension}");
+
+				if (System.IO.File.Exists(testPath))
+				{
+					FilePath = testPath;
+					return true;
+				}
+			}
+
 			return false;
 		}
 
@@ -360,6 +418,15 @@ namespace OpenBveApi.Hosts {
 
 		/// <summary>The list of available content loading plugins</summary>
 		public ContentLoadingPlugin[] Plugins;
+
+		/// <summary>
+		/// Array of supported animated object extensions.
+		/// </summary>
+		public string[] SupportedAnimatedObjectExtensions => Plugins.Where(x => x.Object != null).SelectMany(x => x.Object.SupportedAnimatedObjectExtensions).ToArray();
+
+		/// <summary>
+		/// Array of supported static object extensions.
+		/// </summary>
+		public string[] SupportedStaticObjectExtensions => Plugins.Where(x => x.Object != null).SelectMany(x => x.Object.SupportedStaticObjectExtensions).ToArray();
 	}
-	
 }

--- a/source/OpenBveApi/System/TextEncoding.cs
+++ b/source/OpenBveApi/System/TextEncoding.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Ude;
+﻿using Ude;
 
 namespace OpenBveApi
 {
@@ -20,91 +19,120 @@ namespace OpenBveApi
 		public enum Encoding
 		{
 			/// <summary>The character encoding is unknown</summary>
-			Unknown = 0,
+			Unknown,
 
-			/// <summary>UTF-7</summary>
-			Utf7 = 1,
+			/// <summary>IBM855 (OEM Cyrillic)</summary>
+			IBM855 = 855,
 
-			/// <summary>UTF-8</summary>
-			Utf8 = 2,
+			/// <summary>IBM866 (Legacy Cyrillic)</summary>
+			IBM866 = 866,
+
+			/// <summary>Shift_JIS</summary>
+			SHIFT_JIS = 932,
+
+			/// <summary>EUC-KR (EUC-KR is a subset of KS_C_5601-1987 and Legacy Korean)</summary>
+			EUC_KR = 949,
+
+			/// <summary>BIG5 (Traditional Chinese)</summary>
+			BIG5 = 950,
 
 			/// <summary>UTF-16LE</summary>
-			Utf16Le = 3,
+			UTF16_LE = 1200,
 
 			/// <summary>UTF-16BE</summary>
-			Utf16Be = 4,
+			UTF16_BE = 1201,
 
-			/// <summary>UTF-32LE</summary>
-			Utf32Le = 5,
+			/// <summary>Windows-1251 (Legacy Microsoft Cyrillic)</summary>
+			WIN1251 = 1251,
 
-			/// <summary>UTF-32BE</summary>
-			Utf32Be = 6,
+			/// <summary>Windows-1252 (Legacy Microsoft Western European)</summary>
+			WIN1252 = 1252,
 
-			/// <summary>SHIFT_JIS</summary>
-			Shift_JIS = 7,
-
-			/// <summary>Basic ASCII</summary>
-			ASCII,
-
-			/// <summary>Windows-1252 (Legacy Microsoft)</summary>
-			Windows1252,
+			/// <summary>Windows-1253 (Legacy Microsoft Greek)</summary>
+			WIN1253 = 1253,
 
 			/// <summary>Windows-1255 (Legacy Microsoft Hebrew)</summary>
-			Windows1255,
+			WIN1255 = 1255,
 
-			/// <summary>BIG5</summary>
-			Big5,
+			/// <summary>x-mac-cyrillic (Legacy Mac Cyrillic)</summary>
+			MAC_CYRILLIC = 10007,
 
-			/// <summary>Legacy Korean</summary>
-			EUC_KR,
+			/// <summary>UTF-32LE</summary>
+			UTF32_LE = 12000,
 
-			/// <summary>Legacy Cyrillic</summary>
-			OEM866			
+			/// <summary>UTF-32BE</summary>
+			UTF32_BE = 12001,
+
+			/// <summary>Basic ASCII</summary>
+			ASCII = 20127,
+
+			/// <summary>KOI8-R (Legacy Cyrillic)</summary>
+			KOI8_R = 20866,
+
+			/// <summary>EUC-JP</summary>
+			EUC_JP = 20932,
+
+			/// <summary>ISO-8859-2 (ISO 8859 Central European)</summary>
+			ISO8859_2 = 28592,
+
+			/// <summary>ISO-8859-5 (ISO 8859 Cyrillic)</summary>
+			ISO8859_5 = 28595,
+
+			/// <summary>ISO-8859-7 (ISO 8859 Greek)</summary>
+			ISO8859_7 = 28597,
+
+			/// <summary>ISO-8859-8 (ISO 8859 Visual Hebrew)</summary>
+			ISO8859_8 = 28598,
+
+			/// <summary>ISO-2022-JP (ISO 2022 Japanese)</summary>
+			ISO2022_JP = 50220,
+
+			/// <summary>ISO-2022-KR (ISO 2022 Korean)</summary>
+			ISO2022_KR = 50225,
+
+			/// <summary>ISO-2022-CN (ISO 2022 Chinese)</summary>
+			ISO2022_CN = 50227,
+
+			/// <summary>HZ_GB_2312 (Simplified Chinese)</summary>
+			HZ_GB_2312 = 52936,
+
+			/// <summary>GB18030 (Simplified Chinese)</summary>
+			GB18030 = 54936,
+
+			/// <summary>UTF-7</summary>
+			UTF7 = 65000,
+
+			/// <summary>UTF-8</summary>
+			UTF8 = 65001
 		}
 
-		/// <summary>Gets the character endcoding of a file</summary>
+		/// <summary>Gets the character system encoding of a file</summary>
 		/// <param name="File">The absolute path to a file</param>
-		/// <returns>The character encoding, or the system default encoding if unknown</returns>
-		public static System.Text.Encoding GetSystemEncodingFromFile(string File)
+		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
+		/// <returns>The character system encoding, or default encoding if unknown</returns>
+		public static System.Text.Encoding GetSystemEncodingFromFile(string File, System.Text.Encoding DefaultEncoding = null)
 		{
 			Encoding e = GetEncodingFromFile(File);
 
-			switch (e)
+			if (e == Encoding.Unknown)
 			{
-				case Encoding.Unknown:
-					return System.Text.Encoding.Default;
-				case Encoding.Utf7:
-					return System.Text.Encoding.UTF7;
-				case Encoding.Utf8:
-					return System.Text.Encoding.UTF8;
-				case Encoding.Utf16Le:
-					return System.Text.Encoding.Unicode;
-				case Encoding.Utf16Be:
-					return System.Text.Encoding.BigEndianUnicode;
-				case Encoding.Utf32Le:
-					return System.Text.Encoding.UTF32;
-				case Encoding.Utf32Be:
-					return System.Text.Encoding.GetEncoding(12001);
-				case Encoding.Shift_JIS:
-					return System.Text.Encoding.GetEncoding(932);
-				case Encoding.ASCII:
-					return System.Text.Encoding.ASCII;
-				case Encoding.Windows1252:
-					return System.Text.Encoding.GetEncoding(1252);
-				case Encoding.Windows1255:
-					return System.Text.Encoding.GetEncoding(1255);
-				case Encoding.Big5:
-					return System.Text.Encoding.GetEncoding(950);
-				case Encoding.EUC_KR:
-					return System.Text.Encoding.GetEncoding(51949);
-				case Encoding.OEM866:
-					return System.Text.Encoding.GetEncoding(866);
-				default:
-					throw new ArgumentOutOfRangeException();
+				return DefaultEncoding ?? System.Text.Encoding.Default;
 			}
+
+			return System.Text.Encoding.GetEncoding((int)e);
 		}
 
-		/// <summary>Gets the character endcoding of a file</summary>
+		/// <summary>Gets the character system encoding of a file within a folder</summary>
+		/// <param name="Folder">The absolute path to the folder containing the file</param>
+		/// <param name="File">The filename</param>
+		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
+		/// <returns>The character system encoding, or default encoding if unknown</returns>
+		public static System.Text.Encoding GetSystemEncodingFromFile(string Folder, string File, System.Text.Encoding DefaultEncoding = null)
+		{
+			return GetSystemEncodingFromFile(Path.CombineFile(Folder, File), DefaultEncoding);
+		}
+
+		/// <summary>Gets the character encoding of a file</summary>
 		/// <param name="File">The absolute path to a file</param>
 		/// <returns>The character encoding, or unknown</returns>
 		public static Encoding GetEncodingFromFile(string File)
@@ -123,12 +151,12 @@ namespace OpenBveApi
 				{
 					if (Data[0] == 0xEF & Data[1] == 0xBB & Data[2] == 0xBF)
 					{
-						return Encoding.Utf8;
+						return Encoding.UTF8;
 					}
 
 					if (Data[0] == 0x2b & Data[1] == 0x2f & Data[2] == 0x76)
 					{
-						return Encoding.Utf7;
+						return Encoding.UTF7;
 					}
 				}
 
@@ -136,12 +164,12 @@ namespace OpenBveApi
 				{
 					if (Data[0] == 0xFE & Data[1] == 0xFF)
 					{
-						return Encoding.Utf16Be;
+						return Encoding.UTF16_BE;
 					}
 
 					if (Data[0] == 0xFF & Data[1] == 0xFE)
 					{
-						return Encoding.Utf16Le;
+						return Encoding.UTF16_LE;
 					}
 				}
 
@@ -149,12 +177,12 @@ namespace OpenBveApi
 				{
 					if (Data[0] == 0x00 & Data[1] == 0x00 & Data[2] == 0xFE & Data[3] == 0xFF)
 					{
-						return Encoding.Utf32Be;
+						return Encoding.UTF32_BE;
 					}
 
 					if (Data[0] == 0xFF & Data[1] == 0xFE & Data[2] == 0x00 & Data[3] == 0x00)
 					{
-						return Encoding.Utf32Le;
+						return Encoding.UTF32_LE;
 					}
 				}
 
@@ -167,70 +195,104 @@ namespace OpenBveApi
 					return Encoding.Unknown;
 				}
 				
-				switch (Det.Charset.ToUpperInvariant())
+				switch (Det.Charset)
 				{
-					case "SHIFT-JIS":
-					case "SHIFT_JIS":
-						return Encoding.Shift_JIS;
-					case "UTF-8":
-						return Encoding.Utf8;
-					case "UTF-7":
-						return Encoding.Utf7;
-					case "WINDOWS-1251":
-						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "585tc1.csv" && fInfo.Length == 37302)
-						{
-							return Encoding.Shift_JIS;
-						}
-						return Encoding.Windows1252;
-					case "WINDOWS-1252":
-						if (fInfo.Length == 62861)
-						{
-							//HK tram route. Comes in a non-unicode zip, so filename may be subject to mangling
-							return Encoding.Big5;
-						}
-						return Encoding.Windows1252;
-					case "WINDOWS-1255":
-						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "xdbetulasmall.csv" && fInfo.Length == 406)
-						{
-							//Hungarian birch tree; Actually loads OK with 1255, but use the correct one
-							return Encoding.Windows1252;
-						}
-						return Encoding.Big5;
-					case "BIG5":
+					case Charsets.IBM855:
+						return Encoding.IBM855;
+					case Charsets.IBM866:
+						return Encoding.IBM866;
+					case Charsets.SHIFT_JIS:
+						return Encoding.SHIFT_JIS;
+					case Charsets.EUCKR:
+						return Encoding.EUC_KR;
+					case Charsets.BIG5:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "stoklosy.b3d" && fInfo.Length == 18256)
 						{
 							//Polish Warsaw metro object file uses diacritics in filenames
-							return Encoding.Windows1252;
+							return Encoding.WIN1252;
 						}
-						return Encoding.Big5;
-					case "EUC-KR":
-						return Encoding.EUC_KR;
-					case "ASCII":
-						return Encoding.ASCII;
-					case "IBM866":
-						return Encoding.OEM866;
-					case "X-MAC-CYRILLIC":
+
+						return Encoding.BIG5;
+					case Charsets.UTF16_LE:
+						return Encoding.UTF16_LE;
+					case Charsets.UTF16_BE:
+						return Encoding.UTF16_BE;
+					case Charsets.WIN1251:
+						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "585tc1.csv" && fInfo.Length == 37302)
+						{
+							return Encoding.SHIFT_JIS;
+						}
+
+						return Encoding.WIN1251;
+					case Charsets.WIN1252:
+						if (fInfo.Length == 62861)
+						{
+							//HK tram route. Comes in a non-unicode zip, so filename may be subject to mangling
+							return Encoding.BIG5;
+						}
+
+						return Encoding.WIN1252;
+					case Charsets.WIN1253:
+						return Encoding.WIN1253;
+					case Charsets.WIN1255:
+						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "xdbetulasmall.csv" && fInfo.Length == 406)
+						{
+							//Hungarian birch tree; Actually loads OK with 1255, but use the correct one
+							return Encoding.WIN1252;
+						}
+
+						return Encoding.WIN1255;
+					case Charsets.MAC_CYRILLIC:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "exit01.csv" && fInfo.Length == 752)
 						{
 							//hira2
-							return Encoding.Shift_JIS;
+							return Encoding.SHIFT_JIS;
 						}
-						break;
-					case "GB18030":
-						//Extended new Chinese charset
-						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "people6.b3d" && fInfo.Length == 377)
-						{
-							//Polish Warsaw metro object file uses diacritics in filenames
-							return Encoding.Windows1252;
-						}
-						break;
-					case "EUC-JP":
+
+						return Encoding.MAC_CYRILLIC;
+					case Charsets.UTF32_LE:
+						return Encoding.UTF32_LE;
+					case Charsets.UTF32_BE:
+						return Encoding.UTF32_BE;
+					case Charsets.ASCII:
+						return Encoding.ASCII;
+					case Charsets.KOI8R:
+						return Encoding.KOI8_R;
+					case Charsets.EUCJP:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "xsara.b3d" && fInfo.Length == 3429)
 						{
 							//Uses an odd character in the comments, ASCII works just fine
 							return Encoding.ASCII;
 						}
-						break;
+
+						return Encoding.EUC_JP;
+					case Charsets.ISO8859_2:
+						return Encoding.ISO8859_2;
+					case Charsets.ISO8859_5:
+						return Encoding.ISO8859_5;
+					case Charsets.ISO_8859_7:
+						return Encoding.ISO8859_7;
+					case Charsets.ISO8859_8:
+						return Encoding.ISO8859_8;
+					case Charsets.ISO2022_JP:
+						return Encoding.ISO2022_JP;
+					case Charsets.ISO2022_KR:
+						return Encoding.ISO2022_KR;
+					case Charsets.ISO2022_CN:
+						return Encoding.ISO2022_CN;
+					case Charsets.HZ_GB_2312:
+						return Encoding.HZ_GB_2312;
+					case Charsets.GB18030:
+						//Extended new Chinese charset
+						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "people6.b3d" && fInfo.Length == 377)
+						{
+							//Polish Warsaw metro object file uses diacritics in filenames
+							return Encoding.GB18030;
+						}
+
+						return Encoding.GB18030;
+					case Charsets.UTF8:
+						return Encoding.UTF8;
 				}
 
 				Det.Reset();
@@ -242,7 +304,7 @@ namespace OpenBveApi
 			}
 		}
 
-		/// <summary>Gets the character endcoding of a file within a folder</summary>
+		/// <summary>Gets the character encoding of a file within a folder</summary>
 		/// <param name="Folder">The absolute path to the folder containing the file</param>
 		/// <param name="File">The filename</param>
 		/// <returns>The character encoding, or unknown</returns>

--- a/source/Plugins/Object.Animated/Plugin.cs
+++ b/source/Plugins/Object.Animated/Plugin.cs
@@ -12,6 +12,8 @@ namespace Plugin
 
 		private static string currentSoundFolder;
 
+		public override string[] SupportedAnimatedObjectExtensions => new[] { ".animated" };
+
 		public override void Load(HostInterface host, FileSystem fileSystem)
 		{
 			currentHost = host;

--- a/source/Plugins/Object.CsvB3d/Plugin.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.cs
@@ -12,6 +12,8 @@ namespace Plugin
 	    private static bool BveTsHacks = false;
 	    private static string CompatibilityFolder;
 
+	    public override string[] SupportedStaticObjectExtensions => new[] { ".b3d", ".csv" };
+
 	    public override void Load(HostInterface host, FileSystem fileSystem) {
 		    currentHost = host;
 		    CompatibilityFolder = fileSystem.GetDataFolder("Compatibility");

--- a/source/Plugins/Object.DirectX/Plugin.cs
+++ b/source/Plugins/Object.DirectX/Plugin.cs
@@ -11,6 +11,8 @@ namespace Plugin
 	    internal static HostInterface currentHost;
 	    private static XParsers currentXParser = XParsers.Original;
 
+	    public override string[] SupportedStaticObjectExtensions => new[] { ".x" };
+
 	    public override void Load(HostInterface host, FileSystem fileSystem) {
 		    currentHost = host;
 	    }

--- a/source/Plugins/Object.LokSim/Plugin.cs
+++ b/source/Plugins/Object.LokSim/Plugin.cs
@@ -13,6 +13,9 @@ namespace Plugin
 
 		internal static string LoksimPackageFolder;
 
+		public override string[] SupportedAnimatedObjectExtensions => new[] { ".l3dgrp" };
+		public override string[] SupportedStaticObjectExtensions => new[] { ".l3dobj" };
+
 		public override void Load(HostInterface host, FileSystem fileSystem)
 		{
 			currentHost = host;

--- a/source/Plugins/Object.Msts/Plugin.cs
+++ b/source/Plugins/Object.Msts/Plugin.cs
@@ -16,6 +16,8 @@ namespace Plugin
 
 		internal static string LoksimPackageFolder;
 
+		public override string[] SupportedAnimatedObjectExtensions => new[] { ".s" };
+
 		public override void Load(HostInterface host, FileSystem fileSystem)
 		{
 			currentHost = host;

--- a/source/Plugins/Object.Wavefront/Plugin.cs
+++ b/source/Plugins/Object.Wavefront/Plugin.cs
@@ -11,6 +11,8 @@ namespace Plugin
 	    internal static HostInterface currentHost;
 	    private static ObjParsers currentObjParser = ObjParsers.Original;
 
+	    public override string[] SupportedStaticObjectExtensions => new[] { ".obj" };
+
 	    public override void Load(HostInterface host, FileSystem fileSystem) {
 		    currentHost = host;
 	    }

--- a/source/RouteViewer/Parsers/CsvRwRouteParser.cs
+++ b/source/RouteViewer/Parsers/CsvRwRouteParser.cs
@@ -2714,30 +2714,15 @@ namespace OpenBve
 														string f = System.IO.Path.Combine(ObjectPath, Arguments[0]);
 														if (!System.IO.File.Exists(f))
 														{
-															bool notFound = false;
-															while (true)
+															string testPath = Path.CombineFile(ObjectPath, f);
+
+															if (Program.CurrentHost.DetermineStaticObjectExtension(ref testPath))
 															{
-																f = Path.CombineFile(System.IO.Path.GetDirectoryName(f), System.IO.Path.GetFileName(f) + ".x");
-																if (System.IO.File.Exists(f))
-																{
-																	break;
-																}
-																f = Path.CombineFile(System.IO.Path.GetDirectoryName(f), System.IO.Path.GetFileName(f) + ".csv");
-																if (System.IO.File.Exists(f))
-																{
-																	break;
-																}
-																f = Path.CombineFile(System.IO.Path.GetDirectoryName(f), System.IO.Path.GetFileName(f) + ".b3d");
-																if (System.IO.File.Exists(f))
-																{
-																	break;
-																}
-																Interface.AddMessage(MessageType.Error, false, "SignalFileWithoutExtension does not exist in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
-																notFound = true;
-																break;
+																f = testPath;
 															}
-															if (notFound)
+															else
 															{
+																Program.CurrentHost.AddMessage(MessageType.Error, false, "SignalFileWithoutExtension does not exist in " + Command + " at line " + Expressions[j].Line.ToString(Culture) + ", column " + Expressions[j].Column.ToString(Culture) + " in file " + Expressions[j].File);
 																break;
 															}
 														}

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -281,47 +281,19 @@ namespace OpenBve
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			TextEncoding.Encoding newEncoding = TextEncoding.GetEncodingFromFile(path);
-			if (newEncoding != TextEncoding.Encoding.Unknown)
+			if (string.IsNullOrEmpty(path))
 			{
-				switch (newEncoding)
-				{
-					case TextEncoding.Encoding.Utf7:
-						Encoding = System.Text.Encoding.UTF7;
-						break;
-					case TextEncoding.Encoding.Utf8:
-						Encoding = System.Text.Encoding.UTF8;
-						break;
-					case TextEncoding.Encoding.Utf16Le:
-						Encoding = System.Text.Encoding.Unicode;
-						break;
-					case TextEncoding.Encoding.Utf16Be:
-						Encoding = System.Text.Encoding.BigEndianUnicode;
-						break;
-					case TextEncoding.Encoding.Utf32Le:
-						Encoding = System.Text.Encoding.UTF32;
-						break;
-					case TextEncoding.Encoding.Utf32Be:
-						Encoding = System.Text.Encoding.GetEncoding(12001);
-						break;
-					case TextEncoding.Encoding.Shift_JIS:
-						Encoding = System.Text.Encoding.GetEncoding(932);
-						break;
-					case TextEncoding.Encoding.ASCII:
-					case TextEncoding.Encoding.Windows1252:
-						Encoding = System.Text.Encoding.GetEncoding(1252);
-						break;
-					case TextEncoding.Encoding.Big5:
-						Encoding = System.Text.Encoding.GetEncoding(950);
-						break;
-					case TextEncoding.Encoding.EUC_KR:
-						Encoding = System.Text.Encoding.GetEncoding(949);
-						break;
-					case TextEncoding.Encoding.OEM866:
-						Encoding = System.Text.Encoding.GetEncoding(866);
-						break;
-				}
+				Object = null;
+				return false;
 			}
+
+			if (!DetermineObjectExtension(ref path))
+			{
+				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
+				Object = null;
+				return false;
+			}
+
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -282,6 +282,8 @@ namespace OpenBve
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
+				Encoding = TextEncoding.GetSystemEncodingFromFile(path, Encoding);
+
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {
 						try {

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -281,19 +281,6 @@ namespace OpenBve
 
 		public override bool LoadObject(string path, System.Text.Encoding Encoding, out UnifiedObject Object)
 		{
-			if (string.IsNullOrEmpty(path))
-			{
-				Object = null;
-				return false;
-			}
-
-			if (!DetermineObjectExtension(ref path))
-			{
-				Interface.AddMessage(MessageType.Error, true, $"The file {path} does not have a recognized extension.");
-				Object = null;
-				return false;
-			}
-
 			if (System.IO.File.Exists(path) || System.IO.Directory.Exists(path)) {
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++) {
 					if (Program.CurrentHost.Plugins[i].Object != null) {


### PR DESCRIPTION
This PR contains the following changes in addition to the title.
- Move: the function that determines the extension of the object file to the API
- Fix: the range of $Char and $CharAscii argument
- Fix: typo in CsvRwRouteParser.PreprocessOptions.cs