### PR TITLE
Fix: issues with changing speed and rail index while driving at TFO

### DIFF
--- a/source/OpenBVE/Game/AI/AI.TrackFollowingObject.cs
+++ b/source/OpenBVE/Game/AI/AI.TrackFollowingObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
+using OpenBveApi.Routes;
 using OpenBveApi.Trains;
 
 namespace OpenBve
@@ -13,28 +14,78 @@ namespace OpenBve
 		}
 
 		/// <summary>Travel plan of the train moving to a certain point</summary>
-		internal class TravelData
+		internal abstract class TravelData
 		{
 			// Parameters from XML
 			internal double Decelerate;
-			internal double StopPosition;
-			internal double StopTime;
-			internal bool OpenLeftDoors;
-			internal bool OpenRightDoors;
+			internal double Position;
+			internal virtual double PassingSpeed
+			{
+				get;
+				set;
+			}
 			internal double Accelerate;
 			internal double TargetSpeed;
-			internal TravelDirection Direction;
 			internal int RailIndex;
 
 			// Parameters calculated by the SetupTravelData function
 			internal double DecelerationStartPosition;
 			internal double DecelerationStartTime;
-			internal double ArrivalTime;
-			internal double OpeningDoorsEndTime;
-			internal double ClosingDoorsStartTime;
-			internal double DepartureTime;
+			internal virtual double ArrivalTime
+			{
+				get;
+				set;
+			}
+			internal double Mileage;
+			internal virtual double DepartureTime
+			{
+				get;
+				set;
+			}
 			internal double AccelerationEndPosition;
 			internal double AccelerationEndTime;
+		}
+
+		internal class TravelPointData : TravelData
+		{
+			// Parameters calculated by the SetupTravelData function
+			private double PassingTime;
+			internal override double ArrivalTime
+			{
+				get
+				{
+					return PassingTime;
+				}
+				set
+				{
+					PassingTime = value;
+				}
+			}
+			internal override double DepartureTime
+			{
+				get
+				{
+					return PassingTime;
+				}
+				set
+				{
+					PassingTime = value;
+				}
+			}
+		}
+
+		internal class TravelStopData : TravelData
+		{
+			// Parameters from XML
+			internal override double PassingSpeed => 0.0;
+			internal double StopTime;
+			internal bool OpenLeftDoors;
+			internal bool OpenRightDoors;
+			internal TravelDirection Direction;
+
+			// Parameters calculated by the SetupTravelData function
+			internal double OpeningDoorsEndTime;
+			internal double ClosingDoorsStartTime;
 		}
 
 		internal class TrackFollowingObjectAI : GeneralAI
@@ -42,14 +93,14 @@ namespace OpenBve
 			private readonly TrainManager.TrackFollowingObject Train;
 
 			/// <summary>Travel plan of train</summary>
-			private readonly List<TravelData> Data;
+			private readonly TravelData[] Data;
 
 			private double TimeLastProcessed;
 			private double CurrentPosition;
 			internal double AppearanceTime;
 			internal double LeaveTime;
 
-			internal TrackFollowingObjectAI(TrainManager.TrackFollowingObject train, List<TravelData> data)
+			internal TrackFollowingObjectAI(TrainManager.TrackFollowingObject train, TravelData[] data)
 			{
 				Train = train;
 				Data = data;
@@ -58,8 +109,7 @@ namespace OpenBve
 
 			public override void Trigger(double TimeElapsed)
 			{
-				// Trains need to stop more than 2 points.
-				if (Data == null || Data.Count < 2 || Program.CurrentRoute.SecondsSinceMidnight == TimeLastProcessed)
+				if (Program.CurrentRoute.SecondsSinceMidnight == TimeLastProcessed)
 				{
 					return;
 				}
@@ -69,109 +119,35 @@ namespace OpenBve
 				{
 					SetupTravelData(Program.CurrentRoute.SecondsSinceMidnight);
 					CheckTravelData(Program.CurrentRoute.SecondsSinceMidnight);
-					CurrentPosition = Data[0].StopPosition;
+					CurrentPosition = Data[0].Position;
 				}
 
 				TimeLastProcessed = Program.CurrentRoute.SecondsSinceMidnight;
 
+				// Dispose the train if it is past the leave time of the train
+				if (LeaveTime > AppearanceTime && Program.CurrentRoute.SecondsSinceMidnight >= LeaveTime)
+				{
+					Train.Dispose();
+					return;
+				}
+
 				// Calculate the position where the train is at the present time.
-				double DeltaT;
-				double Position = Data[0].StopPosition;
-				int RailIndex = Data[0].RailIndex;
-				bool OpenLeftDoors = false;
-				bool OpenRightDoors = false;
-
-				if (Program.CurrentRoute.SecondsSinceMidnight >= Data[0].ArrivalTime)
-				{
-					OpenLeftDoors = Data[0].OpenLeftDoors;
-					OpenRightDoors = Data[0].OpenRightDoors;
-				}
-
-				if (Program.CurrentRoute.SecondsSinceMidnight >= Data[0].ClosingDoorsStartTime)
-				{
-					OpenLeftDoors = false;
-					OpenRightDoors = false;
-				}
-
-				// The start point does not slow down. Acceleration only.
-				if (Program.CurrentRoute.SecondsSinceMidnight >= Data[0].DepartureTime)
-				{
-					if (Program.CurrentRoute.SecondsSinceMidnight < Data[0].AccelerationEndTime)
-					{
-						DeltaT = Program.CurrentRoute.SecondsSinceMidnight - Data[0].DepartureTime;
-					}
-					else
-					{
-						DeltaT = Data[0].AccelerationEndTime - Data[0].DepartureTime;
-					}
-					Position += (int)Data[0].Direction * (0.5 * Data[0].Accelerate * Math.Pow(DeltaT, 2.0));
-				}
-
-				for (int i = 1; i < Data.Count; i++)
-				{
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Data[i - 1].AccelerationEndTime)
-					{
-						if (Program.CurrentRoute.SecondsSinceMidnight < Data[i].DecelerationStartTime)
-						{
-							DeltaT = Program.CurrentRoute.SecondsSinceMidnight - Data[i - 1].AccelerationEndTime;
-						}
-						else
-						{
-							DeltaT = Data[i].DecelerationStartTime - Data[i - 1].AccelerationEndTime;
-						}
-						Position += (int)Data[i - 1].Direction * (Data[i - 1].TargetSpeed * DeltaT);
-					}
-
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Data[i].DecelerationStartTime)
-					{
-						if (Program.CurrentRoute.SecondsSinceMidnight < Data[i].ArrivalTime)
-						{
-							DeltaT = Program.CurrentRoute.SecondsSinceMidnight - Data[i].DecelerationStartTime;
-						}
-						else
-						{
-							DeltaT = Data[i].ArrivalTime - Data[i].DecelerationStartTime;
-						}
-						Position += (int)Data[i - 1].Direction * (Data[i - 1].TargetSpeed * DeltaT - 0.5 * Data[i].Decelerate * Math.Pow(DeltaT, 2.0));
-					}
-
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Data[i].ArrivalTime)
-					{
-						OpenLeftDoors = Data[i].OpenLeftDoors;
-						OpenRightDoors = Data[i].OpenRightDoors;
-					}
-
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Data[i].ClosingDoorsStartTime)
-					{
-						OpenLeftDoors = false;
-						OpenRightDoors = false;
-					}
-
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Data[i].DepartureTime)
-					{
-						if (Program.CurrentRoute.SecondsSinceMidnight < Data[i].AccelerationEndTime)
-						{
-							DeltaT = Program.CurrentRoute.SecondsSinceMidnight - Data[i].DepartureTime;
-						}
-						else
-						{
-							DeltaT = Data[i].AccelerationEndTime - Data[i].DepartureTime;
-						}
-						Position += (int)Data[i].Direction * (0.5 * Data[i].Accelerate * Math.Pow(DeltaT, 2.0));
-						RailIndex = Data[i].RailIndex;
-					}
-				}
+				double NewMileage;
+				double NewPosition;
+				TravelDirection NewDirection;
+				bool OpenLeftDoors;
+				bool OpenRightDoors;
+				GetNewState(Program.CurrentRoute.SecondsSinceMidnight, out NewMileage, out NewPosition, out NewDirection, out OpenLeftDoors, out OpenRightDoors);
 
 				// Calculate the travel distance of the train.
-				double Delta = Position - CurrentPosition;
-				CurrentPosition = Position;
+				double DeltaPosition = NewPosition - CurrentPosition;
 
 				// Set the state quantity of the train.
-				if (Delta < 0)
+				if (DeltaPosition < 0)
 				{
 					Train.Handles.Reverser.Driver = TrainManager.ReverserPosition.Reverse;
 				}
-				else if (Delta > 0)
+				else if (DeltaPosition > 0)
 				{
 					Train.Handles.Reverser.Driver = TrainManager.ReverserPosition.Forwards;
 				}
@@ -180,74 +156,78 @@ namespace OpenBve
 				TrainManager.OpenTrainDoors(Train, OpenLeftDoors, OpenRightDoors);
 				TrainManager.CloseTrainDoors(Train, !OpenLeftDoors, !OpenRightDoors);
 
+				if (TimeElapsed != 0.0)
+				{
+					Train.CurrentSpeed = DeltaPosition / TimeElapsed;
+					Train.Specs.CurrentAverageAcceleration = Math.Sign(Train.CurrentSpeed) * Train.CurrentSpeed / TimeElapsed;
+				}
+				else
+				{
+					Train.CurrentSpeed = 0.0;
+					Train.Specs.CurrentAverageAcceleration = 0.0;
+				}
+
 				foreach (var Car in Train.Cars)
 				{
-					Car.FrontAxle.Follower.TrackIndex = RailIndex;
-					Car.RearAxle.Follower.TrackIndex = RailIndex;
-					Car.FrontBogie.FrontAxle.Follower.TrackIndex = RailIndex;
-					Car.FrontBogie.RearAxle.Follower.TrackIndex = RailIndex;
-					Car.RearBogie.FrontAxle.Follower.TrackIndex = RailIndex;
-					Car.RearBogie.RearAxle.Follower.TrackIndex = RailIndex;
-					Car.Move(Delta);
-					if (TimeElapsed != 0.0)
-					{
-						Car.CurrentSpeed = Delta / TimeElapsed;
-						Car.Specs.CurrentPerceivedSpeed = Car.CurrentSpeed;
-						if (Car.Specs.CurrentPerceivedSpeed < 0)
-						{
-							Car.Specs.CurrentAcceleration = -(Car.CurrentSpeed / TimeElapsed);
-						}
-						else
-						{
-							Car.Specs.CurrentAcceleration = Car.CurrentSpeed / TimeElapsed;
-						}
-						Car.Specs.CurrentAccelerationOutput = Car.Specs.CurrentAcceleration;
-					}
-					else
-					{
-						Car.CurrentSpeed = 0.0;
-						Car.Specs.CurrentPerceivedSpeed = 0.0;
-						Car.Specs.CurrentAcceleration = 0.0;
-						Car.Specs.CurrentAccelerationOutput = 0.0;
-					}
+					SetRailIndex(NewMileage, NewDirection, Car.FrontAxle.Follower);
+					SetRailIndex(NewMileage, NewDirection, Car.RearAxle.Follower);
+					SetRailIndex(NewMileage, NewDirection, Car.FrontBogie.FrontAxle.Follower);
+					SetRailIndex(NewMileage, NewDirection, Car.FrontBogie.RearAxle.Follower);
+					SetRailIndex(NewMileage, NewDirection, Car.RearBogie.FrontAxle.Follower);
+					SetRailIndex(NewMileage, NewDirection, Car.RearBogie.RearAxle.Follower);
+
+					Car.Move(DeltaPosition);
+
+					Car.CurrentSpeed = Train.CurrentSpeed;
+					Car.Specs.CurrentPerceivedSpeed = Train.CurrentSpeed;
+					Car.Specs.CurrentAcceleration = Train.Specs.CurrentAverageAcceleration;
+					Car.Specs.CurrentAccelerationOutput = Train.Specs.CurrentAverageAcceleration;
 				}
 
-				Train.CurrentSpeed = Train.Cars[0].CurrentSpeed;
-				Train.Specs.CurrentAverageAcceleration = Train.Cars[0].Specs.CurrentAcceleration;
-
-				// Dispose the train if it is past the leave time of the train
-				if (LeaveTime > AppearanceTime && Program.CurrentRoute.SecondsSinceMidnight >= LeaveTime)
-				{
-					Train.Dispose();
-				}
+				CurrentPosition = NewPosition;
 			}
 
 			/// <summary>Create a train operation plan.</summary>
 			internal void SetupTravelData(double InitializeTime)
 			{
-				// The start point does not slow down. Acceleration only.
-				double DeltaPosition = 0.0;
-				if (Data[0].Accelerate != 0.0)
-				{
-					DeltaPosition = Math.Pow(Data[0].TargetSpeed, 2.0) / (2.0 * Data[0].Accelerate);
-				}
-				Data[0].AccelerationEndPosition = Data[0].StopPosition + (int)Data[0].Direction * DeltaPosition;
+				// The first point must be TravelStopData.
+				TravelStopData FirstData = (TravelStopData)Data[0];
 
-				for (int i = 1; i < Data.Count; i++)
+				// Calculate the end point of acceleration and the start point of deceleration.
 				{
-					DeltaPosition = 0.0;
-					if (Data[i].Decelerate != 0.0)
-					{
-						DeltaPosition = Math.Pow(Data[i - 1].TargetSpeed, 2.0) / (2.0 * Data[i].Decelerate);
-					}
-					Data[i].DecelerationStartPosition = Data[i].StopPosition - (int)Data[i - 1].Direction * DeltaPosition;
+					TravelDirection LastDirection;
+					double DeltaPosition;
 
-					DeltaPosition = 0.0;
-					if (Data[i].Accelerate != 0.0)
+					// The start point does not slow down. Acceleration only.
 					{
-						DeltaPosition = Math.Pow(Data[i].TargetSpeed, 2.0) / (2.0 * Data[i].Accelerate);
+						FirstData.Mileage = 0.0;
+						LastDirection = FirstData.Direction;
+						DeltaPosition = 0.0;
+						if (FirstData.Accelerate != 0.0)
+						{
+							DeltaPosition = Math.Pow(FirstData.TargetSpeed, 2.0) / (2.0 * FirstData.Accelerate);
+						}
+						FirstData.AccelerationEndPosition = FirstData.Position + (int)LastDirection * DeltaPosition;
 					}
-					Data[i].AccelerationEndPosition = Data[i].StopPosition + (int)Data[i].Direction * DeltaPosition;
+
+					for (int i = 1; i < Data.Length; i++)
+					{
+						DeltaPosition = 0.0;
+						if (Data[i].Decelerate != 0.0)
+						{
+							DeltaPosition = (Math.Pow(Data[i].PassingSpeed, 2.0) - Math.Pow(Data[i - 1].TargetSpeed, 2.0)) / (2.0 * Data[i].Decelerate);
+						}
+						Data[i].DecelerationStartPosition = Data[i].Position - (int)LastDirection * DeltaPosition;
+
+						Data[i].Mileage = Data[i - 1].Mileage + Math.Abs(Data[i].Position - Data[i - 1].Position);
+						LastDirection = (Data[i] as TravelStopData)?.Direction ?? LastDirection;
+						DeltaPosition = 0.0;
+						if (Data[i].Accelerate != 0.0)
+						{
+							DeltaPosition = (Math.Pow(Data[i].TargetSpeed, 2.0) - Math.Pow(Data[i].PassingSpeed, 2.0)) / (2.0 * Data[i].Accelerate);
+						}
+						Data[i].AccelerationEndPosition = Data[i].Position + (int)LastDirection * DeltaPosition;
+					}
 				}
 
 				// Time to operate the door
@@ -263,65 +243,79 @@ namespace OpenBve
 					ClosingDoorsTime = 1.0 / Train.Cars[0].Specs.DoorCloseFrequency;
 				}
 
-				// Delay
-				Data[0].ArrivalTime = InitializeTime;
-				AppearanceTime = InitializeTime;
-				LeaveTime = Train.LeaveTime + InitializeTime;
-
-				Data[0].OpeningDoorsEndTime = Data[0].ArrivalTime;
-				if (Data[0].OpenLeftDoors || Data[0].OpenRightDoors)
+				// Reflect the delay until the TFO becomes effective at the first point.
 				{
-					Data[0].OpeningDoorsEndTime += OpeningDoorsTime;
+					FirstData.ArrivalTime = InitializeTime;
+					AppearanceTime = InitializeTime;
+					LeaveTime = Train.LeaveTime + InitializeTime;
+
+					FirstData.OpeningDoorsEndTime = FirstData.ArrivalTime;
+					if (FirstData.OpenLeftDoors || FirstData.OpenRightDoors)
+					{
+						FirstData.OpeningDoorsEndTime += OpeningDoorsTime;
+					}
+					FirstData.ClosingDoorsStartTime = FirstData.OpeningDoorsEndTime + FirstData.StopTime;
+					FirstData.DepartureTime = FirstData.ClosingDoorsStartTime;
+					if (FirstData.OpenLeftDoors || FirstData.OpenRightDoors)
+					{
+						FirstData.DepartureTime += ClosingDoorsTime;
+					}
 				}
-				Data[0].ClosingDoorsStartTime = Data[0].OpeningDoorsEndTime + Data[0].StopTime;
-				Data[0].DepartureTime = Data[0].ClosingDoorsStartTime;
-				if (Data[0].OpenLeftDoors || Data[0].OpenRightDoors)
+
+				// Calculate the time of each point.
 				{
-					Data[0].DepartureTime += ClosingDoorsTime;
-				}
+					double DeltaT;
 
-				// The start point does not slow down. Acceleration only.
-				double DeltaT = 0.0;
-				if (Data[0].Accelerate != 0.0)
-				{
-					DeltaT = Data[0].TargetSpeed / Data[0].Accelerate;
-				}
-				Data[0].AccelerationEndTime = Data[0].DepartureTime + DeltaT;
-
-				for (int i = 1; i < Data.Count; i++)
-				{
-					DeltaT = 0.0;
-					if (Data[i - 1].TargetSpeed != 0.0)
+					// The start point does not slow down. Acceleration only.
 					{
-						DeltaT = Math.Abs(Data[i].DecelerationStartPosition - Data[i - 1].AccelerationEndPosition) / Data[i - 1].TargetSpeed;
-					}
-					Data[i].DecelerationStartTime = Data[i - 1].AccelerationEndTime + DeltaT;
-
-					DeltaT = 0.0;
-					if (Data[i].Decelerate != 0.0)
-					{
-						DeltaT = Data[i - 1].TargetSpeed / Data[i].Decelerate;
-					}
-					Data[i].ArrivalTime = Data[i].DecelerationStartTime + DeltaT;
-
-					Data[i].OpeningDoorsEndTime = Data[i].ArrivalTime;
-					if (Data[i].OpenLeftDoors || Data[i].OpenRightDoors)
-					{
-						Data[i].OpeningDoorsEndTime += OpeningDoorsTime;
-					}
-					Data[i].ClosingDoorsStartTime = Data[i].OpeningDoorsEndTime + Data[i].StopTime;
-					Data[i].DepartureTime = Data[i].ClosingDoorsStartTime;
-					if (Data[i].OpenLeftDoors || Data[i].OpenRightDoors)
-					{
-						Data[i].DepartureTime += ClosingDoorsTime;
+						DeltaT = 0.0;
+						if (FirstData.Accelerate != 0.0)
+						{
+							DeltaT = FirstData.TargetSpeed / FirstData.Accelerate;
+						}
+						FirstData.AccelerationEndTime = FirstData.DepartureTime + DeltaT;
 					}
 
-					DeltaT = 0.0;
-					if (Data[i].Accelerate != 0.0)
+					for (int i = 1; i < Data.Length; i++)
 					{
-						DeltaT = Data[i].TargetSpeed / Data[i].Accelerate;
+						DeltaT = 0.0;
+						if (Data[i - 1].TargetSpeed != 0.0)
+						{
+							DeltaT = Math.Abs(Data[i].DecelerationStartPosition - Data[i - 1].AccelerationEndPosition) / Data[i - 1].TargetSpeed;
+						}
+						Data[i].DecelerationStartTime = Data[i - 1].AccelerationEndTime + DeltaT;
+
+						DeltaT = 0.0;
+						if (Data[i].Decelerate != 0.0)
+						{
+							DeltaT = (Data[i].PassingSpeed - Data[i - 1].TargetSpeed) / Data[i].Decelerate;
+						}
+						Data[i].ArrivalTime = Data[i].DecelerationStartTime + DeltaT;
+
+						TravelStopData StopData = Data[i] as TravelStopData;
+
+						if (StopData != null)
+						{
+							StopData.OpeningDoorsEndTime = StopData.ArrivalTime;
+							if (StopData.OpenLeftDoors || StopData.OpenRightDoors)
+							{
+								StopData.OpeningDoorsEndTime += OpeningDoorsTime;
+							}
+							StopData.ClosingDoorsStartTime = StopData.OpeningDoorsEndTime + StopData.StopTime;
+							StopData.DepartureTime = StopData.ClosingDoorsStartTime;
+							if (StopData.OpenLeftDoors || StopData.OpenRightDoors)
+							{
+								StopData.DepartureTime += ClosingDoorsTime;
+							}
+						}
+
+						DeltaT = 0.0;
+						if (Data[i].Accelerate != 0.0)
+						{
+							DeltaT = (Data[i].TargetSpeed - Data[i].PassingSpeed) / Data[i].Accelerate;
+						}
+						Data[i].AccelerationEndTime = Data[i].DepartureTime + DeltaT;
 					}
-					Data[i].AccelerationEndTime = Data[i].DepartureTime + DeltaT;
 				}
 			}
 
@@ -329,21 +323,24 @@ namespace OpenBve
 			private void CheckTravelData(double InitializeTime)
 			{
 				bool Recalculation = false;
+				TravelDirection LastDirection = ((TravelStopData)Data[0]).Direction;
 
-				for (int i = 1; i < Data.Count; i++)
+				for (int i = 1; i < Data.Length; i++)
 				{
 					// The deceleration start point must appear after the acceleration end point.
-					if ((Data[i - 1].AccelerationEndPosition - Data[i].DecelerationStartPosition) * (int)Data[i - 1].Direction > 0)
+					if ((Data[i - 1].AccelerationEndPosition - Data[i].DecelerationStartPosition) * (int)LastDirection > 0)
 					{
 						// Reset acceleration and deceleration.
-						double Delta = Math.Abs(Data[i].StopPosition - Data[i - 1].StopPosition);
+						double Delta = Math.Abs(Data[i].Position - Data[i - 1].Position);
 						if (Delta != 0.0)
 						{
-							Data[i - 1].Accelerate = Math.Pow(Data[i - 1].TargetSpeed, 2.0) / Delta;
-							Data[i].Decelerate = Data[i - 1].Accelerate;
+							Data[i - 1].Accelerate = (Math.Pow(Data[i - 1].TargetSpeed, 2.0) - Math.Pow(Data[i - 1].PassingSpeed, 2.0)) / Delta;
+							Data[i].Decelerate = (Math.Pow(Data[i].PassingSpeed, 2.0) - Math.Pow(Data[i - 1].TargetSpeed, 2.0)) / Delta;
 							Recalculation = true;
 						}
 					}
+
+					LastDirection = (Data[i] as TravelStopData)?.Direction ?? LastDirection;
 				}
 
 				// Recreate the operation plan of the train.
@@ -351,6 +348,118 @@ namespace OpenBve
 				{
 					SetupTravelData(InitializeTime);
 				}
+			}
+
+			private void GetNewState(double Time, out double NewMileage, out double NewPosition, out TravelDirection NewDirection, out bool OpenLeftDoors, out bool OpenRightDoors)
+			{
+				double DeltaT;
+				double DeltaPosition;
+				OpenLeftDoors = false;
+				OpenRightDoors = false;
+
+				{
+					// The first point must be TravelStopData.
+					TravelStopData FirstData = (TravelStopData)Data[0];
+
+					NewMileage = FirstData.Mileage;
+					NewPosition = FirstData.Position;
+					NewDirection = FirstData.Direction;
+
+					if (Time <= FirstData.ArrivalTime)
+					{
+						return;
+					}
+
+					if (Time <= FirstData.ClosingDoorsStartTime)
+					{
+						OpenLeftDoors = FirstData.OpenLeftDoors;
+						OpenRightDoors = FirstData.OpenRightDoors;
+						return;
+					}
+
+					if (Time <= FirstData.DepartureTime)
+					{
+						return;
+					}
+
+					// The start point does not slow down. Acceleration only.
+					if (Time <= FirstData.AccelerationEndTime)
+					{
+						DeltaT = Time - FirstData.DepartureTime;
+						DeltaPosition = 0.5 * FirstData.Accelerate * Math.Pow(DeltaT, 2.0);
+						NewMileage += DeltaPosition;
+						NewPosition += (int)NewDirection * DeltaPosition;
+						return;
+					}
+
+					NewMileage += Math.Abs(FirstData.AccelerationEndPosition - NewPosition);
+					NewPosition = FirstData.AccelerationEndPosition;
+				}
+
+				for (int i = 1; i < Data.Length; i++)
+				{
+					if (Time <= Data[i].DecelerationStartTime)
+					{
+						DeltaT = Time - Data[i - 1].AccelerationEndTime;
+						DeltaPosition = Data[i - 1].TargetSpeed * DeltaT;
+						NewMileage += DeltaPosition;
+						NewPosition += (int)NewDirection * DeltaPosition;
+						return;
+					}
+
+					NewMileage += Math.Abs(Data[i].DecelerationStartPosition - NewPosition);
+					NewPosition = Data[i].DecelerationStartPosition;
+
+					if (Time <= Data[i].ArrivalTime)
+					{
+						DeltaT = Time - Data[i].DecelerationStartTime;
+						DeltaPosition = Data[i - 1].TargetSpeed * DeltaT + 0.5 * Data[i].Decelerate * Math.Pow(DeltaT, 2.0);
+						NewMileage += DeltaPosition;
+						NewPosition += (int)NewDirection * DeltaPosition;
+						return;
+					}
+
+					TravelStopData StopData = Data[i] as TravelStopData;
+
+					NewMileage = Data[i].Mileage;
+					NewPosition = Data[i].Position;
+					NewDirection = StopData?.Direction ?? NewDirection;
+
+					if (Time <= Data[i].ArrivalTime)
+					{
+						return;
+					}
+
+					if (Time <= StopData?.ClosingDoorsStartTime)
+					{
+						OpenLeftDoors = StopData.OpenLeftDoors;
+						OpenRightDoors = StopData.OpenRightDoors;
+						return;
+					}
+
+					// The end point does not accelerate.
+					if (Time <= Data[i].DepartureTime || i == Data.Length - 1)
+					{
+						return;
+					}
+
+					if (Time <= Data[i].AccelerationEndTime)
+					{
+						DeltaT = Time - Data[i].ArrivalTime;
+						DeltaPosition = Data[i].PassingSpeed * DeltaT + 0.5 * Data[i].Accelerate * Math.Pow(DeltaT, 2.0);
+						NewMileage += DeltaPosition;
+						NewPosition += (int)NewDirection * DeltaPosition;
+						return;
+					}
+
+					NewMileage += Math.Abs(Data[i].AccelerationEndPosition - NewPosition);
+					NewPosition = Data[i].AccelerationEndPosition;
+				}
+			}
+
+			private void SetRailIndex(double Mileage, TravelDirection Direction, TrackFollower TrackFollower)
+			{
+				TrackFollower.TrackIndex = Data.LastOrDefault(x => x.Mileage <= Mileage + (int)Direction * (TrackFollower.TrackPosition - CurrentPosition))?.RailIndex ?? Data[0].RailIndex;
 			}
 		}
 	}

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.ApplyRouteData.cs
@@ -636,7 +636,11 @@ namespace OpenBve
 					for (int jj = 0; jj < Data.Blocks[i].Rails.Count; jj++)
 					{
 						int j = Data.Blocks[i].Rails.ElementAt(jj).Key;
-						if (j > 0 && !Data.Blocks[i].Rails[j].RailStarted) continue;
+						if (j > 0 && !Data.Blocks[i].Rails[j].RailStarted)
+						{
+							Program.CurrentRoute.Tracks[j].Elements[n].InvalidElement = true;
+							continue;
+						}
 						// rail
 						Vector3 pos;
 						Transformation RailTransformation = new Transformation();

--- a/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
+++ b/source/OpenBVE/Parsers/Route/BVE/CsvRwRouteParser.cs
@@ -1004,7 +1004,7 @@ namespace OpenBve {
 										}
 										int n = TrainManager.TFOs.Length;
 										Array.Resize(ref TrainManager.TFOs, n + 1);
-										TrainManager.TFOs[n] = TrackFollowingObjectParser.ParseTrackFollowingObject(tfoFile, ObjectPath);
+										TrainManager.TFOs[n] = TrackFollowingObjectParser.ParseTrackFollowingObject(ObjectPath, tfoFile);
 									}
 									break;
 									// train

--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.XPath;
 using OpenBveApi;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
@@ -12,172 +15,109 @@ using OpenBveApi.Trains;
 
 namespace OpenBve
 {
-	class TrackFollowingObjectParser
+	internal static class TrackFollowingObjectParser
 	{
+		private static readonly CultureInfo culture = CultureInfo.InvariantCulture;
+
 		/// <summary>Parses a track following object</summary>
+		/// <param name="ObjectPath">Absolute path to the object folder of route data</param>
 		/// <param name="FileName">The XML file to parse</param>
-		internal static TrainManager.TrackFollowingObject ParseTrackFollowingObject(string FileName, string ObjectPath)
+		internal static TrainManager.TrackFollowingObject ParseTrackFollowingObject(string ObjectPath, string FileName)
 		{
 			// The current XML file to load
 			XDocument CurrentXML = XDocument.Load(FileName, LoadOptions.SetLineInfo);
-			string Path = System.IO.Path.GetDirectoryName(FileName);
-
-			// Check for null
-			if (CurrentXML.Root == null)
-			{
-				// We couldn't find any valid XML, so return false
-				throw new System.IO.InvalidDataException();
-			}
-
-			IEnumerable<XElement> DocumentElements = CurrentXML.Root.Elements("TrackFollowingObject");
+			List<XElement> TfoElements = CurrentXML.XPathSelectElements("/openBVE/TrackFollowingObject").ToList();
 
 			// Check this file actually contains OpenBVE other train definition elements
-			if (DocumentElements == null || !DocumentElements.Any())
+			if (!TfoElements.Any())
 			{
 				// We couldn't find any valid XML, so return false
-				throw new System.IO.InvalidDataException();
+				throw new InvalidDataException();
 			}
 
 			TrainManager.TrackFollowingObject Train = new TrainManager.TrackFollowingObject(TrainState.Pending);
 
-			foreach (XElement Element in DocumentElements)
+			foreach (XElement Element in TfoElements)
 			{
-				ParseTrackFollowingObjectNode(Element, FileName, Path, ObjectPath, Train);
+				ParseTrackFollowingObjectNode(ObjectPath, FileName, Element, Train);
 			}
 
 			return Train;
 		}
 
 		/// <summary>Parses a base track following object node</summary>
-		/// <param name="Element">The XElement to parse</param>
+		/// <param name="ObjectPath">Absolute path to the object folder of route data</param>
 		/// <param name="FileName">The filename of the containing XML file</param>
-		/// <param name="Path">The path of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
 		/// <param name="Train">The track following object to parse this node into</param>
-		private static void ParseTrackFollowingObjectNode(XElement Element, string FileName, string Path, string ObjectPath, TrainManager.TrackFollowingObject Train)
+		private static void ParseTrackFollowingObjectNode(string ObjectPath, string FileName, XElement SectionElement, TrainManager.TrackFollowingObject Train)
 		{
-			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
+			string Section = SectionElement.Name.LocalName;
+
 			string TrainDirectory = string.Empty;
-			bool consistReversed = false;
+			bool ConsistReversed = false;
 			List<Game.TravelData> Data = new List<Game.TravelData>();
 
-			foreach (XElement SectionElement in Element.Elements())
+			foreach (XElement KeyNode in SectionElement.Elements())
 			{
-				string Section = SectionElement.Name.LocalName;
+				string Key = KeyNode.Name.LocalName;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
 
-				switch (SectionElement.Name.LocalName.ToLowerInvariant())
+				switch (Key.ToLowerInvariant())
 				{
-					case "stops":
-						ParseStopNode(SectionElement, FileName, Data);
+					case "definition":
+						ParseDefinitionNode(FileName, KeyNode, Train);
 						break;
 					case "train":
-						foreach (XElement KeyNode in SectionElement.Elements())
-						{
-							string Key = KeyNode.Name.LocalName;
-							string Value = KeyNode.Value;
-							int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-							switch (Key.ToLowerInvariant())
-							{
-								case "directory":
-									{
-										string trainDirectory = OpenBveApi.Path.CombineDirectory(Path, Value);
-										if (!System.IO.Directory.Exists(trainDirectory))
-										{
-											trainDirectory = OpenBveApi.Path.CombineFile(Program.FileSystem.InitialTrainFolder, Value);
-										}
-										if (!System.IO.Directory.Exists(trainDirectory))
-										{
-											trainDirectory = OpenBveApi.Path.CombineFile(Program.FileSystem.TrainInstallationDirectory, Value);
-										}
-										if (!System.IO.Directory.Exists(trainDirectory))
-										{
-											trainDirectory = OpenBveApi.Path.CombineFile(ObjectPath, Value);
-										}
-
-										if(!System.IO.Directory.Exists(trainDirectory))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Directory was not found in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										else
-										{
-											TrainDirectory = trainDirectory;
-										}
-									}
-									break;
-								case "reversed":
-									int n;
-									NumberFormats.TryParseIntVb6(Value, out n);
-									if (n == 1 || Value.ToLowerInvariant() == "true")
-									{
-										consistReversed = true;
-									}
-									break;
-							}
-						}
+						ParseTrainNode(ObjectPath, FileName, KeyNode, ref TrainDirectory, ref ConsistReversed);
 						break;
-					case "definition":
-						foreach (XElement KeyNode in SectionElement.Elements())
-						{
-							string Key = KeyNode.Name.LocalName;
-							string Value = KeyNode.Value;
-							int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-							switch (Key.ToLowerInvariant())
-							{
-								case "appearancetime":
-									if (Value.Length != 0 && !Interface.TryParseTime(Value, out Train.AppearanceTime))
-									{
-										Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-									}
-									break;
-								case "appearancestartposition":
-									if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Train.AppearanceStartPosition))
-									{
-										Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-									}
-									break;
-								case "appearanceendposition":
-									if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Train.AppearanceEndPosition))
-									{
-										Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-									}
-									break;
-								case "leavetime":
-									if (Value.Length != 0 && !Interface.TryParseTime(Value, out Train.LeaveTime))
-									{
-										Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-									}
-									break;
-							}
-						}
+					case "points":
+					case "stops":
+						ParseTravelDataNodes(FileName, KeyNode, Data);
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
 						break;
 				}
 			}
 
-			if (!Data.Any() || string.IsNullOrEmpty(TrainDirectory))
+			if (Data.Count < 2)
 			{
+				Interface.AddMessage(MessageType.Error, false, $"There must be at least two points to go through in {FileName}");
+				return;
+			}
+
+			if (!(Data.First() is Game.TravelStopData) || !(Data.Last() is Game.TravelStopData))
+			{
+				Interface.AddMessage(MessageType.Error, false, $"The first and the last point to go through must be the \"Stop\" node in {FileName}");
+				return;
+			}
+
+			if (string.IsNullOrEmpty(TrainDirectory))
+			{
+				Interface.AddMessage(MessageType.Error, false, $"No train has been specified in {FileName}");
 				return;
 			}
 
 			/*
 			 * First check for a train.ai file- Functionally identical, but allows for differently configured AI
-			 * trains not to show up as driveable
+			 * trains not to show up as drivable
 			 */
 			string TrainData = OpenBveApi.Path.CombineFile(TrainDirectory, "train.ai");
-			if (!System.IO.File.Exists(TrainData))
+			if (!File.Exists(TrainData))
 			{
-				// Check for the standard driveable train.dat
+				// Check for the standard drivable train.dat
 				TrainData = OpenBveApi.Path.CombineFile(TrainDirectory, "train.dat");
 			}
 			string ExteriorFile = OpenBveApi.Path.CombineFile(TrainDirectory, "extensions.cfg");
-			if (!System.IO.File.Exists(TrainData) || !System.IO.File.Exists(ExteriorFile))
+			if (!File.Exists(TrainData) || !File.Exists(ExteriorFile))
 			{
-				Interface.AddMessage(MessageType.Error, true, "The supplied train folder in TrackFollowingObject " + FileName + " did not contain a complete set of data.");
+				Interface.AddMessage(MessageType.Error, true, $"The supplied train folder in TrackFollowingObject {FileName} did not contain a complete set of data.");
 				return;
 			}
 			TrainDatParser.ParseTrainData(TrainData, TextEncoding.GetSystemEncodingFromFile(TrainData), Train);
 			SoundCfgParser.ParseSoundConfig(TrainDirectory, Train);
-			Train.AI = new Game.TrackFollowingObjectAI(Train, Data);
+			Train.AI = new Game.TrackFollowingObjectAI(Train, Data.ToArray());
 
 			UnifiedObject[] CarObjects = new UnifiedObject[Train.Cars.Length];
 			UnifiedObject[] BogieObjects = new UnifiedObject[Train.Cars.Length * 2];
@@ -192,7 +132,7 @@ namespace OpenBve
 					// load default exterior object
 					string file = OpenBveApi.Path.CombineFile(Program.FileSystem.GetDataFolder("Compatibility"), "exterior.csv");
 					StaticObject so;
-					Program.CurrentHost.LoadStaticObject(file, System.Text.Encoding.UTF8, false, out so);
+					Program.CurrentHost.LoadStaticObject(file, Encoding.UTF8, false, out so);
 					if (so == null)
 					{
 						CarObjects[i] = null;
@@ -306,150 +246,384 @@ namespace OpenBve
 				Car.RearBogie.RearAxle.Follower.TrackIndex = Data[0].RailIndex;
 			}
 
-			if (consistReversed)
+			if (ConsistReversed)
 			{
 				Train.Reverse();
 			}
-			Train.PlaceCars(Data[0].StopPosition);
+			Train.PlaceCars(Data[0].Position);
 		}
 
-		/// <summary>Parses a train travel stop node</summary>
-		/// <param name="Element">The XElement to parse</param>
+		/// <summary>
+		/// Function to parse TFO definition
+		/// </summary>
 		/// <param name="FileName">The filename of the containing XML file</param>
-		/// <param name="Data">The list of travel data to add this to</param>
-		private static void ParseStopNode(XElement Element, string FileName, List<Game.TravelData> Data)
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <param name="Train">The track following object to parse this node into</param>
+		private static void ParseDefinitionNode(string FileName, XElement SectionElement, TrainManager.TrackFollowingObject Train)
 		{
-			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
+			string Section = SectionElement.Name.LocalName;
 
-			foreach (XElement SectionElement in Element.Elements())
+			foreach (XElement KeyNode in SectionElement.Elements())
 			{
-				string Section = SectionElement.Name.LocalName;
+				string Key = KeyNode.Name.LocalName;
+				string Value = KeyNode.Value;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
 
-				switch (SectionElement.Name.LocalName.ToLowerInvariant())
+				switch (Key.ToLowerInvariant())
 				{
-					case "stop":
+					case "appearancetime":
+						if (Value.Any() && !Interface.TryParseTime(Value, out Train.AppearanceTime))
 						{
-							Game.TravelData NewData = new Game.TravelData();
-							double Decelerate = 0.0;
-							double Accelerate = 0.0;
-							double TargetSpeed = 0.0;
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "appearancestartposition":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out Train.AppearanceStartPosition))
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "appearanceendposition":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out Train.AppearanceEndPosition))
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "leavetime":
+						if (Value.Any() && !Interface.TryParseTime(Value, out Train.LeaveTime))
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						break;
+				}
+			}
+		}
 
-							foreach (XElement KeyNode in SectionElement.Elements())
+		/// <summary>
+		/// Function to parse train definition
+		/// </summary>
+		/// <param name="ObjectPath">Absolute path to the object folder of route data</param>
+		/// <param name="FileName">The filename of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <param name="TrainDirectory">Absolute path to the train directory</param>
+		/// <param name="ConsistReversed">Whether to reverse the train composition.</param>
+		private static void ParseTrainNode(string ObjectPath, string FileName, XElement SectionElement, ref string TrainDirectory, ref bool ConsistReversed)
+		{
+			string Section = SectionElement.Name.LocalName;
+
+			foreach (XElement KeyNode in SectionElement.Elements())
+			{
+				string Key = KeyNode.Name.LocalName;
+				string Value = KeyNode.Value;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+
+				switch (Key.ToLowerInvariant())
+				{
+					case "directory":
+						{
+							string TmpPath = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), Value);
+							if (!Directory.Exists(TmpPath))
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
-								{
-									case "decelerate":
-										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Decelerate))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-									case "stopposition":
-										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out NewData.StopPosition))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-									case "stoptime":
-										if (Value.Length != 0 && !Interface.TryParseTime(Value, out NewData.StopTime))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-									case "doors":
-										{
-											int door = 0;
-											bool doorboth = false;
-
-											switch (Value.ToLowerInvariant())
-											{
-												case "l":
-												case "left":
-													door = -1;
-													break;
-												case "r":
-												case "right":
-													door = 1;
-													break;
-												case "n":
-												case "none":
-												case "neither":
-													door = 0;
-													break;
-												case "b":
-												case "both":
-													doorboth = true;
-													break;
-												default:
-													if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out door))
-													{
-														Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-														door = 0;
-													}
-													break;
-											}
-
-											NewData.OpenLeftDoors = door < 0.0 | doorboth;
-											NewData.OpenRightDoors = door > 0.0 | doorboth;
-										}
-										break;
-									case "accelerate":
-										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Accelerate))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-									case "targetspeed":
-										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out TargetSpeed))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-									case "direction":
-										{
-											int d = 0;
-											switch (Value.ToLowerInvariant())
-											{
-												case "f":
-													d = 1;
-													break;
-												case "r":
-													d = -1;
-													break;
-												default:
-													if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out d))
-													{
-														Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-													}
-													break;
-											}
-											if (d == 1 || d == -1)
-											{
-												NewData.Direction = (Game.TravelDirection)d;
-											}
-										}
-										break;
-									case "rail":
-										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out NewData.RailIndex))
-										{
-											Interface.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-										}
-										break;
-								}
+								TmpPath = OpenBveApi.Path.CombineFile(Program.FileSystem.InitialTrainFolder, Value);
+							}
+							if (!Directory.Exists(TmpPath))
+							{
+								TmpPath = OpenBveApi.Path.CombineFile(Program.FileSystem.TrainInstallationDirectory, Value);
+							}
+							if (!Directory.Exists(TmpPath))
+							{
+								TmpPath = OpenBveApi.Path.CombineFile(ObjectPath, Value);
 							}
 
-							NewData.Decelerate = Decelerate / 3.6;
-							NewData.Accelerate = Accelerate / 3.6;
-							NewData.TargetSpeed = TargetSpeed / 3.6;
-							Data.Add(NewData);
+							if (!Directory.Exists(TmpPath))
+							{
+								Interface.AddMessage(MessageType.Error, false, $"Directory was not found in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+							}
+							else
+							{
+								TrainDirectory = TmpPath;
+							}
+						}
+						break;
+					case "reversed":
+						if (Value.Any())
+						{
+							switch (Value.ToLowerInvariant())
+							{
+								case "true":
+									ConsistReversed = true;
+									break;
+								case "false":
+									ConsistReversed = false;
+									break;
+								default:
+									{
+										int n;
+
+										if (!NumberFormats.TryParseIntVb6(Value, out n))
+										{
+											Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+										}
+										else
+										{
+											ConsistReversed = Convert.ToBoolean(n);
+										}
+									}
+									break;
+							}
+						}
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						break;
+				}
+			}
+		}
+
+		/// <summary>Parses a train travel data node</summary>
+		/// <param name="FileName">The filename of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <param name="Data">The list of travel data to add this to</param>
+		private static void ParseTravelDataNodes(string FileName, XElement SectionElement, ICollection<Game.TravelData> Data)
+		{
+			string Section = SectionElement.Name.LocalName;
+
+			foreach (XElement KeyNode in SectionElement.Elements())
+			{
+				string Key = KeyNode.Name.LocalName;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+
+				switch (Key.ToLowerInvariant())
+				{
+					case "stop":
+						Data.Add(ParseTravelStopNode(FileName, KeyNode));
+						break;
+					case "point":
+						Data.Add(ParseTravelPointNode(FileName, KeyNode));
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Function to parse the contents of TravelData class
+		/// </summary>
+		/// <param name="FileName">The filename of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <param name="Data">Travel data to which the parse results apply</param>
+		private static void ParseTravelDataNode(string FileName, XElement SectionElement, Game.TravelData Data)
+		{
+			string Section = SectionElement.Name.LocalName;
+
+			double Decelerate = 0.0;
+			double Accelerate = 0.0;
+			double TargetSpeed = 0.0;
+
+			foreach (XElement KeyNode in SectionElement.Elements())
+			{
+				string Key = KeyNode.Name.LocalName;
+				string Value = KeyNode.Value;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+
+				switch (Key.ToLowerInvariant())
+				{
+					case "decelerate":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out Decelerate) || Decelerate < 0.0)
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is expected to be a non-negative floating-point number in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "position":
+					case "stopposition":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out Data.Position))
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "accelerate":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out Accelerate) || Accelerate < 0.0)
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is expected to be a non-negative floating-point number in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "targetspeed":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out TargetSpeed) || TargetSpeed < 0.0)
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is expected to be a non-negative floating-point number in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "rail":
+						if (Value.Any() && !NumberFormats.TryParseIntVb6(Value, out Data.RailIndex) || Data.RailIndex < 0)
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is expected to be a non-negative integer number in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+							Data.RailIndex = 0;
 						}
 						break;
 				}
 			}
+
+			Data.Decelerate = -Decelerate / 3.6;
+			Data.Accelerate = Accelerate / 3.6;
+			Data.TargetSpeed = TargetSpeed / 3.6;
+		}
+
+		/// <summary>
+		/// Function to parse the contents of TravelStopData class
+		/// </summary>
+		/// <param name="FileName">The filename of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <returns>An instance of the new TravelStopData class with the parse result applied</returns>
+		private static Game.TravelStopData ParseTravelStopNode(string FileName, XElement SectionElement)
+		{
+			string Section = SectionElement.Name.LocalName;
+
+			Game.TravelStopData Data = new Game.TravelStopData();
+
+			ParseTravelDataNode(FileName, SectionElement, Data);
+
+			foreach (XElement KeyNode in SectionElement.Elements())
+			{
+				string Key = KeyNode.Name.LocalName;
+				string Value = KeyNode.Value;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+
+				switch (Key.ToLowerInvariant())
+				{
+					case "stoptime":
+						if (Value.Any() && !Interface.TryParseTime(Value, out Data.StopTime))
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "doors":
+						{
+							int Door = 0;
+							bool DoorBoth = false;
+
+							switch (Value.ToLowerInvariant())
+							{
+								case "l":
+								case "left":
+									Door = -1;
+									break;
+								case "r":
+								case "right":
+									Door = 1;
+									break;
+								case "n":
+								case "none":
+								case "neither":
+									Door = 0;
+									break;
+								case "b":
+								case "both":
+									DoorBoth = true;
+									break;
+								default:
+									if (Value.Any() && !NumberFormats.TryParseIntVb6(Value, out Door))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+									}
+									break;
+							}
+
+							Data.OpenLeftDoors = Door < 0.0 | DoorBoth;
+							Data.OpenRightDoors = Door > 0.0 | DoorBoth;
+						}
+						break;
+					case "direction":
+						{
+							int d = 0;
+							switch (Value.ToLowerInvariant())
+							{
+								case "f":
+									d = 1;
+									break;
+								case "r":
+									d = -1;
+									break;
+								default:
+									if (Value.Any() && (!NumberFormats.TryParseIntVb6(Value, out d) || !Enum.IsDefined(typeof(Game.TravelDirection), d)))
+									{
+										Interface.AddMessage(MessageType.Error, false, $"Value is invalid in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+										d = 1;
+									}
+									break;
+							}
+
+							Data.Direction = (Game.TravelDirection)d;
+						}
+						break;
+					case "decelerate":
+					case "position":
+					case "stopposition":
+					case "accelerate":
+					case "targetspeed":
+					case "rail":
+						// Already parsed
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						break;
+				}
+			}
+
+			return Data;
+		}
+
+		/// <summary>
+		/// Function to parse the contents of TravelPointData class
+		/// </summary>
+		/// <param name="FileName">The filename of the containing XML file</param>
+		/// <param name="SectionElement">The XElement to parse</param>
+		/// <returns>An instance of the new TravelPointData class with the parse result applied</returns>
+		private static Game.TravelPointData ParseTravelPointNode(string FileName, XElement SectionElement)
+		{
+			string Section = SectionElement.Name.LocalName;
+
+			Game.TravelPointData Data = new Game.TravelPointData();
+
+			ParseTravelDataNode(FileName, SectionElement, Data);
+
+			double PassingSpeed = 0.0;
+
+			foreach (XElement KeyNode in SectionElement.Elements())
+			{
+				string Key = KeyNode.Name.LocalName;
+				string Value = KeyNode.Value;
+				int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+
+				switch (Key.ToLowerInvariant())
+				{
+					case "passingspeed":
+						if (Value.Any() && !NumberFormats.TryParseDoubleVb6(Value, out PassingSpeed) || PassingSpeed < 0.0)
+						{
+							Interface.AddMessage(MessageType.Error, false, $"Value is expected to be a non-negative floating-point number in {Key} in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						}
+						break;
+					case "decelerate":
+					case "position":
+					case "stopposition":
+					case "accelerate":
+					case "targetspeed":
+					case "rail":
+						// Already parsed
+						break;
+					default:
+						Interface.AddMessage(MessageType.Warning, false, $"Unsupported key {Key} encountered in {Section} at line {LineNumber.ToString(culture)} in {FileName}");
+						break;
+				}
+			}
+
+			Data.PassingSpeed = PassingSpeed / 3.6;
+
+			return Data;
 		}
 	}
 }

--- a/source/OpenBveApi/Routes/Track.TrackElement.cs
+++ b/source/OpenBveApi/Routes/Track.TrackElement.cs
@@ -5,6 +5,8 @@ namespace OpenBveApi.Routes
 	/// <summary>Defines a single track element (cell)</summary>
 	public struct TrackElement
 	{
+		/// <summary>Whether the element is invalid</summary>
+		public bool InvalidElement;
 		/// <summary>The starting linear track position of this element</summary>
 		public double StartingTrackPosition;
 		/// <summary>The curve radius applying to this element</summary>
@@ -34,6 +36,7 @@ namespace OpenBveApi.Routes
 		/// <param name="StartingTrackPosition">The starting position (relative to zero)</param>
 		public TrackElement(double StartingTrackPosition)
 		{
+			this.InvalidElement = false;
 			this.StartingTrackPosition = StartingTrackPosition;
 			this.Pitch = 0.0;
 			this.CurveRadius = 0.0;

--- a/source/OpenBveApi/Routes/Track.TrackFollower.cs
+++ b/source/OpenBveApi/Routes/Track.TrackFollower.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Math;
+﻿using System.Linq;
+using OpenBveApi.Math;
 using OpenBveApi.Trains;
 
 namespace OpenBveApi.Routes
@@ -124,6 +125,23 @@ namespace OpenBveApi.Routes
 			{
 				while (i < currentHost.Tracks[TrackIndex].Elements.Length - 1)
 				{
+					if (currentHost.Tracks[TrackIndex].Elements[i + 1].InvalidElement)
+					{
+						var nextTrackStarted = currentHost.Tracks[TrackIndex].Elements.Select((x, j) => new { Index = j, Element = x }).Skip(i + 1).FirstOrDefault(x => !x.Element.InvalidElement);
+
+						if (nextTrackStarted == null)
+						{
+							break;
+						}
+
+						i = nextTrackStarted.Index;
+
+						if (i == currentHost.Tracks[TrackIndex].Elements.Length - 1)
+						{
+							break;
+						}
+					}
+
 					if (NewTrackPosition < currentHost.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition) break;
 					double ta = TrackPosition - currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
 					double tb = currentHost.Tracks[TrackIndex].Elements[i + 1].StartingTrackPosition - currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition + 0.01;


### PR DESCRIPTION
## An issue with changing speed
If you specify the deceleration or acceleration as shown below, TFO will stop for a moment.
```xml
<Stop>
  <Decelerate>1.62</Decelerate>
  <StopPosition>400</StopPosition>
  <StopTime>00.0000</StopTime>
  <Accelerate>0</Accelerate>
  <TargetSpeed>60</TargetSpeed>
  <Direction>1</Direction>
  <Rail>2</Rail>
</Stop>
```
I made the following changes to fix this problem.
- Add `<Point>`
This element can specify the passing speed of the point.
However, it has no stop-related elements. (`<Doors>`, `<StopTime>`, `<Direction>`)
```xml
<Point>
  <Decelerate>1.62</Decelerate>
  <Position>400</Position>
  <PassingSpeed>60</PassingSpeed>
  <Accelerate>0</Accelerate>
  <TargetSpeed>60</TargetSpeed>
  <Rail>2</Rail>
</Point>
```
- Add `<Points>` to `<Stops>` aliases.
- Add `<Position>` to `<StopPosition>` aliases.

Also, the first and last elements of `<Points>` (or `<Stops>`) must be `<Stop>`.

## An issue with changing rail index
Here, the top is defined as the far side of the route, and the last is defined as the front of the route.
When the beginning of the TFO passes the point where the rail index changes, the rail index changes for all axles.
Therefore, if the rail after the change does not overlap the rail before the change by the length of the train, the axle position will be incorrect.
This PR change will change the axle rail index when the axle passes the point where the rail index changes.