### PR TITLE
Update: Building.md [ci skip]

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -14,12 +14,12 @@ This file is a WIP set of instructions for building openBVE from source.
 #### When to use Mono
 
 - Mono 5.20.1 or later, x86 or x64
-- NuGet 2.16 or later
+- NuGet client 2.16 or later
 
 ### Linux
 
 - Mono 5.20.1 or later, x86 or x64
-- NuGet 2.16 or later
+- NuGet client 2.16 or later
 - OpenAL
 - debhelper (Debian and compatibles only)
 
@@ -39,10 +39,20 @@ NOTE: You need to get Mono from [the Mono project repository](https://www.mono-p
 sudo dnf install mono-devel mono-locale-extras nuget openal-soft
 ```
 
+#### Reference information
+
+You can install the latest NuGet client using the command below.
+
+```bash
+sudo curl -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+echo -e '#!/bin/sh\nexec /usr/bin/cli /usr/local/bin/nuget.exe "$@"' | sudo tee /usr/local/bin/nuget
+sudo chmod 755 /usr/local/bin/nuget
+```
+
 ### Mac
 
 - Mono 5.20.1 or later, x86 only
-- NuGet 2.16 or later
+- NuGet client 2.16 or later
 - OpenAL
 
 ## Building

--- a/Building.md
+++ b/Building.md
@@ -1,44 +1,74 @@
 # Building openBVE from source
 
 This file is a WIP set of instructions for building openBVE from source.
-Note that as NuGet packages are used, the first-time build requires an internet connection.
 
 ## Prerequisites
 
 ### Windows
-Either .NET Framework 4.7.2 or Mono 5.20.1 or later, x86 or x64
+
+#### When to use .NET Framework
+
+- Visual Studio 2017 or later, x86 or x64
+- .NET Framework 4.7.2 or later, x86 or x64
+
+#### When to use Mono
+
+- Mono 5.20.1 or later, x86 or x64
+- NuGet 2.16 or later
 
 ### Linux
-Mono 5.20.1 or later, x86 or x64, and the following packages:
 
-- mono-runtime
-- libmono-corlib4.5-cil
-- libmono-system-drawing4.0-cil
-- libmono-system-windows-forms4.0-cil
-- libmono-system4.0-cil
-- libmono-system-xml-linq4.0-cil
-- libmono-i18n4.0-all
-- libmono-microsoft-csharp4.0-cil
+- Mono 5.20.1 or later, x86 or x64
+- NuGet 2.16 or later
+- OpenAL
 - debhelper (Debian and compatibles only)
-- libopenal1
+
+#### Debian and compatibles
+
+NOTE: You need to get Mono from [the Mono project repository](https://www.mono-project.com/download/stable/#download-lin), not the distribution repository.
+
+```bash
+sudo apt install mono-devel libmono-i18n4.0-all nuget libopenal1 debhelper
+```
+
+#### RHEL and compatibles
+
+NOTE: You need to get Mono from [the Mono project repository](https://www.mono-project.com/download/stable/#download-lin), not the distribution repository.
+
+```bash
+sudo dnf install mono-devel mono-locale-extras nuget openal-soft
+```
 
 ### Mac
-Mono 5.20.1 or later, x86 only.
 
+- Mono 5.20.1 or later, x86 only
+- NuGet 2.16 or later
+- OpenAL
 
 ## Building
 
+**Note that as NuGet packages are used, the first-time build requires an internet connection.**
+
 ### Windows
-Open the main OpenBVE.sln file with Visual Studio.
-Build the required project, allowing NuGet to restore the packages as required.
+
+#### When to use .NET Framework
+
+1. Open the main OpenBVE.sln file with Visual Studio.
+2. Build the required project, allowing NuGet to restore the packages as required.
+
+#### When to use Mono
+
+1. Start "Open Mono Command Prompt" from the start menu.
+2. Open the main openBVE source directory in this terminal.
+3. Restore the packages as required. `nuget restore OpenBVE.sln`
+4. Build the solution. `msbuild OpenBve.sln`
 
 ### Mac / Linux
 
-Open the main openBVE source directory in the terminal.
-You may either build using the makefile, which supports the following options:
-
-* make - Restores the NuGet packages only.
-* make all-release - Creates a release build.
-* make all-debug - Creates a debug build.
-* make debian - On Debian and compatibles, creates an installable deb package.
-* make publish - On Mac, creates an app package.
+1. Open the main openBVE source directory in the terminal.
+2. You may either build using the makefile, which supports the following options:
+   - make - Restores the NuGet packages only.
+   - make all-release - Creates a release build.
+   - make all-debug - Creates a debug build.
+   - make debian - On Debian and compatibles, creates an installable deb package.
+   - make publish - On Mac, creates an app package.


### PR DESCRIPTION
This PR update Building.md.
- If NuGet version is lower than 2.16, package restore fails.
- Build fails when using Mono package from distribution.
  - On Fedora I have confirmed that the same version also fails. We need to see what happens in Debian.
  - Ubuntu on Travis seems to get Mono from the Mono project repository.

Related: https://bveworldwide.forumotion.com/t1890-missing-files-in-compilation-of-source-in-linux-not-debian