### PR TITLE
Change: Add try / catch to some more GL inits in case of failure

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -173,10 +173,12 @@ namespace LibRender2
 
 		internal int lastVAO;
 
-		public bool ForceLegacyOpenGL
+		/// <summary>Whether to force fallback to the GL1.2 renderer</summary>
+		/// <remarks>Set when initialising a shader VBO, FBO etc. fails</remarks>
+		public static bool ForceLegacyOpenGL
 		{
 			get;
-			protected set;
+			set;
 		}
 
 		public bool AvailableNewRenderer => currentOptions != null && currentOptions.IsUseNewRenderer && !ForceLegacyOpenGL;

--- a/source/LibRender2/Objects/ObjectLibrary.cs
+++ b/source/LibRender2/Objects/ObjectLibrary.cs
@@ -87,7 +87,7 @@ namespace LibRender2.Objects
 		{
 			bool result = AddObject(State);
 
-			if (!renderer.ForceLegacyOpenGL && State.Prototype.Mesh.VAO == null)
+			if (!BaseRenderer.ForceLegacyOpenGL && State.Prototype.Mesh.VAO == null)
 			{
 				VAOExtensions.CreateVAO(ref State.Prototype.Mesh, State.Prototype.Dynamic, renderer.DefaultShader.VertexLayout);
 			}

--- a/source/LibRender2/Primitives/Cube.cs
+++ b/source/LibRender2/Primitives/Cube.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using OpenBveApi.Colors;
 using OpenBveApi.Math;
 using OpenBveApi.Textures;
@@ -177,14 +178,22 @@ namespace LibRender2.Primitives
 				}
 			};
 
-			if (!renderer.ForceLegacyOpenGL)
+			if (!BaseRenderer.ForceLegacyOpenGL)
 			{
-				defaultVAO = new VertexArrayObject();
-				defaultVAO.Bind();
-				defaultVAO.SetVBO(new VertexBufferObject(vertexData, BufferUsageHint.StaticDraw));
-				defaultVAO.SetIBO(new IndexBufferObject(Enumerable.Range(0, vertexData.Length).Select(x => (ushort) x).ToArray(), BufferUsageHint.StaticDraw));
-				defaultVAO.SetAttributes(renderer.DefaultShader.VertexLayout);
-				defaultVAO.UnBind();
+				try
+				{
+					defaultVAO = new VertexArrayObject();
+					defaultVAO.Bind();
+					defaultVAO.SetVBO(new VertexBufferObject(vertexData, BufferUsageHint.StaticDraw));
+					defaultVAO.SetIBO(new IndexBufferObject(Enumerable.Range(0, vertexData.Length).Select(x => (ushort) x).ToArray(), BufferUsageHint.StaticDraw));
+					defaultVAO.SetAttributes(renderer.DefaultShader.VertexLayout);
+					defaultVAO.UnBind();
+				}
+				catch
+				{
+					BaseRenderer.ForceLegacyOpenGL = true;
+				}
+				
 			}
 		}
 

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -149,8 +149,10 @@ namespace LibRender2
 
 	public static class VAOExtensions
 	{
-		/// <summary>Create an OpenGL/OpenTK VAO for a mesh</summary>
-		/// <param name="isDynamic"></param>
+		/// <summary>Creates an OpenGL/OpenTK VAO for a mesh</summary>
+		/// <param name="mesh">The mesh to create the VAO for</param>
+		/// <param name="isDynamic">Whether the mesh is dynamic (e.g. part of train, animated object etc.)</param>
+		/// <param name="vertexLayout">The vertex layout for the shader</param>
 		public static void CreateVAO(ref Mesh mesh, bool isDynamic, VertexLayout vertexLayout)
 		{
 			var hint = isDynamic ? BufferUsageHint.DynamicDraw : BufferUsageHint.StaticDraw;
@@ -204,28 +206,36 @@ namespace LibRender2
 				normalsIndexData.AddRange(Enumerable.Range(mesh.Faces[i].NormalsIboStartIndex, mesh.Faces[i].Vertices.Length * 2).Select(x => (ushort) x));
 			}
 
-			VertexArrayObject VAO = (VertexArrayObject) mesh.VAO;
-			VAO?.UnBind();
-			VAO?.Dispose();
+			try
+			{
+				VertexArrayObject VAO = (VertexArrayObject) mesh.VAO;
+				VAO?.UnBind();
+				VAO?.Dispose();
 
-			VAO = new VertexArrayObject();
-			VAO.Bind();
-			VAO.SetVBO(new VertexBufferObject(vertexData.ToArray(), hint));
-			VAO.SetIBO(new IndexBufferObject(indexData.ToArray(), hint));
-			VAO.SetAttributes(vertexLayout);
-			VAO.UnBind();
-			mesh.VAO = VAO;
-			VertexArrayObject NormalsVAO = (VertexArrayObject) mesh.NormalsVAO;
-			NormalsVAO?.UnBind();
-			NormalsVAO?.Dispose();
+				VAO = new VertexArrayObject();
+				VAO.Bind();
+				VAO.SetVBO(new VertexBufferObject(vertexData.ToArray(), hint));
+				VAO.SetIBO(new IndexBufferObject(indexData.ToArray(), hint));
+				VAO.SetAttributes(vertexLayout);
+				VAO.UnBind();
+				mesh.VAO = VAO;
+				VertexArrayObject NormalsVAO = (VertexArrayObject) mesh.NormalsVAO;
+				NormalsVAO?.UnBind();
+				NormalsVAO?.Dispose();
 
-			NormalsVAO = new VertexArrayObject();
-			NormalsVAO.Bind();
-			NormalsVAO.SetVBO(new VertexBufferObject(normalsVertexData.ToArray(), hint));
-			NormalsVAO.SetIBO(new IndexBufferObject(normalsIndexData.ToArray(), hint));
-			NormalsVAO.SetAttributes(vertexLayout);
-			NormalsVAO.UnBind();
-			mesh.NormalsVAO = NormalsVAO;
+				NormalsVAO = new VertexArrayObject();
+				NormalsVAO.Bind();
+				NormalsVAO.SetVBO(new VertexBufferObject(normalsVertexData.ToArray(), hint));
+				NormalsVAO.SetIBO(new IndexBufferObject(normalsIndexData.ToArray(), hint));
+				NormalsVAO.SetAttributes(vertexLayout);
+				NormalsVAO.UnBind();
+				mesh.NormalsVAO = NormalsVAO;
+			}
+			catch
+			{
+				BaseRenderer.ForceLegacyOpenGL = true;
+			}
+			
 		}
 
 		public static void CreateVAO(this StaticBackground background, VertexLayout vertexLayout)
@@ -333,17 +343,25 @@ namespace LibRender2
 				textureX += textureIncrement;
 			}
 
-			VertexArrayObject VAO = (VertexArrayObject) background.VAO;
-			VAO?.UnBind();
-			VAO?.Dispose();
+			try
+			{
+				VertexArrayObject VAO = (VertexArrayObject) background.VAO;
+				VAO?.UnBind();
+				VAO?.Dispose();
 
-			VAO = new VertexArrayObject();
-			VAO.Bind();
-			VAO.SetVBO(new VertexBufferObject(vertexData.ToArray(), BufferUsageHint.StaticDraw));
-			VAO.SetIBO(new IndexBufferObject(indexData.ToArray(), BufferUsageHint.StaticDraw));
-			VAO.SetAttributes(vertexLayout);
-			VAO.UnBind();
-			background.VAO = VAO;
+				VAO = new VertexArrayObject();
+				VAO.Bind();
+				VAO.SetVBO(new VertexBufferObject(vertexData.ToArray(), BufferUsageHint.StaticDraw));
+				VAO.SetIBO(new IndexBufferObject(indexData.ToArray(), BufferUsageHint.StaticDraw));
+				VAO.SetAttributes(vertexLayout);
+				VAO.UnBind();
+				background.VAO = VAO;
+			}
+			catch
+			{
+				BaseRenderer.ForceLegacyOpenGL = true;
+			}
+			
 		}
 	}
 }

--- a/source/OpenBVE/Graphics/Renderers/Touch.cs
+++ b/source/OpenBVE/Graphics/Renderers/Touch.cs
@@ -32,13 +32,21 @@ namespace OpenBve.Graphics.Renderers
 			this.renderer = renderer;
 			touchableObject = new List<ObjectState>();
 
-			if (!renderer.ForceLegacyOpenGL)
+			if (!BaseRenderer.ForceLegacyOpenGL)
 			{
-				fbo = new FrameBufferObject();
-				fbo.Bind();
-				fbo.SetTextureBuffer(FrameBufferObject.TargetBuffer.Color, PixelInternalFormat.R32f, PixelFormat.Red, PixelType.Float, renderer.Screen.Width, renderer.Screen.Height);
-				fbo.DrawBuffers(new[] { DrawBuffersEnum.ColorAttachment0 });
-				fbo.UnBind();
+				try
+				{
+					fbo = new FrameBufferObject();
+					fbo.Bind();
+					fbo.SetTextureBuffer(FrameBufferObject.TargetBuffer.Color, PixelInternalFormat.R32f, PixelFormat.Red, PixelType.Float, renderer.Screen.Width, renderer.Screen.Height);
+					fbo.DrawBuffers(new[] { DrawBuffersEnum.ColorAttachment0 });
+					fbo.UnBind();
+				}
+				catch
+				{
+					BaseRenderer.ForceLegacyOpenGL = true;
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
https://github.com/leezer3/OpenBVE/pull/474

Wrap the VBO creation in a catch block. 
Testing at draw time is going to be an expensive no-go, but this at least eliminates another point of failure.

Question though is whether we bother....
Assuming the shader has been created properly, we *ought* therefore to have a valid GL 3.0 context and thus the ability to create VBOs etc.

cc @s520