### PR TITLE
Move door interlock restrictions to TrainManager and fix related AI behaviour

### DIFF
--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -185,7 +185,14 @@ namespace OpenBve
 						{
 							Train.ApplyEmergencyBrake();
 						}
-						
+						if (Train.Station >= 0 && stopIndex >= 0 && Train.StationDistanceToStopPoint < Program.CurrentRoute.Stations[Train.Station].Stops[stopIndex].BackwardTolerance && (Program.CurrentRoute.Stations[Train.Station].StopsHere(Train) & (Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors | Program.CurrentRoute.Stations[Train.Station].OpenRightDoors) & Math.Abs(Train.CurrentSpeed) < 0.25 & Train.StationState == TrainStopState.Pending))
+						{
+							// doors not fully open at station - open doors
+							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
+							{
+								TrainManager.OpenTrainDoors(Train, Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors, Program.CurrentRoute.Stations[Train.Station].OpenRightDoors);
+							}
+						}
 						CurrentInterval = 1.0;
 					}
 					else
@@ -232,7 +239,7 @@ namespace OpenBve
 						if (Train.Station >= 0 & Train.StationState == TrainStopState.Completed)
 						{
 							// ready for departure - close doors
-							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked)
+							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 							{
 								TrainManager.CloseTrainDoors(Train, true, true);
 							}
@@ -240,10 +247,19 @@ namespace OpenBve
 						else if (Train.Station >= 0 & Train.StationState == TrainStopState.Boarding)
 						{
 						}
+						else if (Train.Station >= 0 && stopIndex >= 0 && Train.StationDistanceToStopPoint < Program.CurrentRoute.Stations[Train.Station].Stops[stopIndex].BackwardTolerance && (Program.CurrentRoute.Stations[Train.Station].StopsHere(Train) & (Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors | Program.CurrentRoute.Stations[Train.Station].OpenRightDoors) & Math.Abs(Train.CurrentSpeed) < 0.25 & Train.StationState == TrainStopState.Pending))
+						{
+							// doors not fully open at station - open doors
+							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
+							{
+								TrainManager.OpenTrainDoors(Train, Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors, Program.CurrentRoute.Stations[Train.Station].OpenRightDoors);
+							}
+							CurrentInterval = 1.0;
+						}
 						else
 						{
 							// not at station - close doors
-							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked)
+							if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 							{
 								TrainManager.CloseTrainDoors(Train, true, true);
 							}
@@ -253,7 +269,7 @@ namespace OpenBve
 				else if (Train.Station >= 0 && stopIndex >= 0 && Train.StationDistanceToStopPoint < Program.CurrentRoute.Stations[Train.Station].Stops[stopIndex].BackwardTolerance && (Program.CurrentRoute.Stations[Train.Station].StopsHere(Train) & (Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors | Program.CurrentRoute.Stations[Train.Station].OpenRightDoors) & Math.Abs(Train.CurrentSpeed) < 0.25 & Train.StationState == TrainStopState.Pending))
 				{
 					// arrived at station - open doors
-					if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic && Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked)
+					if (Train.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 					{
 						TrainManager.OpenTrainDoors(Train, Program.CurrentRoute.Stations[Train.Station].OpenLeftDoors, Program.CurrentRoute.Stations[Train.Station].OpenRightDoors);
 					}

--- a/source/OpenBVE/Simulation/TrainManager/Doors.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Doors.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OpenBveApi.Runtime;
 using SoundManager;
 
 namespace OpenBve
@@ -199,12 +200,12 @@ namespace OpenBve
 			bool sl = false, sr = false;
 			for (int i = 0; i < Train.Cars.Length; i++)
 			{
-				if (Left & !Train.Cars[i].Doors[0].AnticipatedOpen)
+				if (Left & !Train.Cars[i].Doors[0].AnticipatedOpen  & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Left | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 				{
 					Train.Cars[i].Doors[0].AnticipatedOpen = true;
 					sl = true;
 				}
-				if (Right & !Train.Cars[i].Doors[1].AnticipatedOpen)
+				if (Right & !Train.Cars[i].Doors[1].AnticipatedOpen & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Right | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 				{
 					Train.Cars[i].Doors[1].AnticipatedOpen = true;
 					sr = true;
@@ -258,12 +259,12 @@ namespace OpenBve
 		internal static void OpenTrainDoors(Train Train, int CarIndex, bool Left, bool Right)
 		{
 			bool sl = false, sr = false;
-			if (Left & !Train.Cars[CarIndex].Doors[0].AnticipatedOpen)
+			if (Left & !Train.Cars[CarIndex].Doors[0].AnticipatedOpen & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Left | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 			{
 				Train.Cars[CarIndex].Doors[0].AnticipatedOpen = true;
 				sl = true;
 			}
-			if (Right & !Train.Cars[CarIndex].Doors[1].AnticipatedOpen)
+			if (Right & !Train.Cars[CarIndex].Doors[1].AnticipatedOpen & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Right | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 			{
 				Train.Cars[CarIndex].Doors[1].AnticipatedOpen = true;
 				sr = true;
@@ -319,12 +320,12 @@ namespace OpenBve
 			bool sl = false, sr = false;
 			for (int i = 0; i < Train.Cars.Length; i++)
 			{
-				if (Left & Train.Cars[i].Doors[0].AnticipatedOpen)
+				if (Left & Train.Cars[i].Doors[0].AnticipatedOpen & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Left | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 				{
 					Train.Cars[i].Doors[0].AnticipatedOpen = false;
 					sl = true;
 				}
-				if (Right & Train.Cars[i].Doors[1].AnticipatedOpen)
+				if (Right & Train.Cars[i].Doors[1].AnticipatedOpen & (Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Right | Train.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked))
 				{
 					Train.Cars[i].Doors[1].AnticipatedOpen = false;
 					sr = true;

--- a/source/OpenBVE/Simulation/TrainManager/Station.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Station.cs
@@ -48,32 +48,7 @@ namespace OpenBve
 							if (Math.Abs(Train.CurrentSpeed) < 0.1 / 3.6 &
 							    Math.Abs(Train.Specs.CurrentAverageAcceleration) < 0.1 / 3.6)
 							{
-								//Check the interlock state for the doors
-								switch (Train.SafetySystems.DoorInterlockState)
-								{
-									case DoorInterlockStates.Unlocked:
-										if (Program.CurrentRoute.Stations[i].OpenLeftDoors || Program.CurrentRoute.Stations[i].OpenRightDoors)
-										{
-											AttemptToOpenDoors(Train, i, tb, tf);
-										}
-										break;
-									case DoorInterlockStates.Left:
-										if (Program.CurrentRoute.Stations[i].OpenLeftDoors && !Program.CurrentRoute.Stations[i].OpenRightDoors)
-										{
-											AttemptToOpenDoors(Train, i, tb, tf);
-										}
-										break;
-									case DoorInterlockStates.Right:
-										if (!Program.CurrentRoute.Stations[i].OpenLeftDoors && Program.CurrentRoute.Stations[i].OpenRightDoors)
-										{
-											AttemptToOpenDoors(Train, i, tb, tf);
-										}
-										break;
-									case DoorInterlockStates.Locked:
-										//All doors are currently locked, do nothing
-										break;
-
-								}
+								AttemptToOpenDoors(Train, i, tb, tf);
 							}
 						}
 						// detect arrival
@@ -228,30 +203,9 @@ namespace OpenBve
 							//e.g. Change ends
 							if (Train.Specs.DoorCloseMode != DoorMode.Manual & Program.CurrentRoute.Stations[i].Type == StationType.Normal)
 							{
-								//Check the interlock state for the doors
-								switch (Train.SafetySystems.DoorInterlockState)
-								{
-									case DoorInterlockStates.Unlocked:
-										AttemptToCloseDoors(Train);
-										break;
-									case DoorInterlockStates.Left:
-										if (Program.CurrentRoute.Stations[i].OpenLeftDoors)
-										{
-											AttemptToCloseDoors(Train);
-										}
-										break;
-									case DoorInterlockStates.Right:
-										if (Program.CurrentRoute.Stations[i].OpenRightDoors)
-										{
-											AttemptToCloseDoors(Train);
-										}
-										break;
-									case DoorInterlockStates.Locked:
-										//All doors are currently locked, do nothing
-										break;
-								}
+								AttemptToCloseDoors(Train);
 
-								if (Train.SafetySystems.DoorInterlockState != DoorInterlockStates.Locked & Train.Specs.DoorClosureAttempted)
+								if (Train.Specs.DoorClosureAttempted)
 								{
 									if (Program.CurrentRoute.Stations[i].OpenLeftDoors && !Train.Cars[j].Doors[0].AnticipatedReopen && Program.RandomNumberGenerator.NextDouble() < Program.CurrentRoute.Stations[i].ReopenDoor)
 									{
@@ -456,7 +410,7 @@ namespace OpenBve
 				
 			}
 			// automatically close doors
-			if (Train.Specs.DoorCloseMode != DoorMode.Manual & Train.SafetySystems.DoorInterlockState != DoorInterlockStates.Locked & !Train.Specs.DoorClosureAttempted)
+			if (Train.Specs.DoorCloseMode != DoorMode.Manual & !Train.Specs.DoorClosureAttempted)
 			{
 				if (Train.Station == -1 | Train.StationState == TrainStopState.Completed)
 				{

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1433,18 +1433,14 @@ namespace OpenBve
 										if ((TrainManager.GetDoorsState(TrainManager.PlayerTrain, true, false) &
 											 TrainManager.TrainDoorState.Opened) == 0)
 										{
-											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic
-												& (TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked
-												   | TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Left))
+											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 											{
 												TrainManager.OpenTrainDoors(TrainManager.PlayerTrain, true, false);
 											}
 										}
 										else
 										{
-											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic
-												& (TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked
-												   | TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Left))
+											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 											{
 												TrainManager.CloseTrainDoors(TrainManager.PlayerTrain, true, false);
 											}
@@ -1465,18 +1461,14 @@ namespace OpenBve
 										if ((TrainManager.GetDoorsState(TrainManager.PlayerTrain, false, true) &
 											 TrainManager.TrainDoorState.Opened) == 0)
 										{
-											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic
-												& (TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked
-												   | TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Right))
+											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 											{
 												TrainManager.OpenTrainDoors(TrainManager.PlayerTrain, false, true);
 											}
 										}
 										else
 										{
-											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic
-												& (TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Unlocked
-												   | TrainManager.PlayerTrain.SafetySystems.DoorInterlockState == DoorInterlockStates.Right))
+											if (TrainManager.PlayerTrain.Specs.DoorOpenMode != TrainManager.DoorMode.Automatic)
 											{
 												TrainManager.CloseTrainDoors(TrainManager.PlayerTrain, false, true);
 											}


### PR DESCRIPTION
This pull request solves the following issues:

1. The checks related to door interlocking were scattered in the code for user input, AI and stations. They are now part of TrainManager.
2. The AI would only open the doors if both sides were unlocked. If a plugin restricted the doors to only one side, the AI would not even try to open the doors and wait indefinitely.
3. At stations where doors should be opened on both sides, boarding does not start until both sides are open. The AI now keeps trying to open all doors in this situation even if one side is already open, in case partial door interlocking was applied initially, to avoid the AI from waiting indefinitely doing nothing.

By the way, the AI currently does not notify plugins about the recently added door virtual keys. Given that the AI is supposed to represent a real human pressing buttons and that plugins may rely on them for functionality regardless of the state of the AI, I think it makes sense to add this too. What do you think?