### PR TITLE
Change: Refactor car sound playback

### DIFF
--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -166,8 +166,9 @@ namespace OpenBve
 						 * For non-looping sounds, check if the sound is still playing.
 						 * */
 						gain = (gain - GainThreshold) / (1.0 - GainThreshold);
-						if (Sources[i].State != SoundSourceState.Playing) {
-							LoadBuffer(Sources[i].Buffer);
+						if (Sources[i].State != SoundSourceState.Playing)
+						{
+							Sources[i].Buffer.Load();
 							if (Sources[i].Buffer.Loaded) {
 								AL.GenSources(1, out Sources[i].OpenAlSourceName);
 								AL.Source(Sources[i].OpenAlSourceName, ALSourcei.Buffer, Sources[i].Buffer.OpenAlBufferName);
@@ -493,8 +494,9 @@ namespace OpenBve
 					/*
 					 * Ensure the buffer is loaded, then play the sound.
 					 * */
-					if (source.State != SoundSourceState.Playing) {
-						LoadBuffer(source.Buffer);
+					if (source.State != SoundSourceState.Playing)
+					{
+						source.Buffer.Load();
 						if (source.Buffer.Loaded) {
 							AL.GenSources(1, out source.OpenAlSourceName);
 							AL.Source(source.OpenAlSourceName, ALSourcei.Buffer, source.Buffer.OpenAlBufferName);

--- a/source/OpenBVE/Audio/Sounds.cs
+++ b/source/OpenBVE/Audio/Sounds.cs
@@ -13,20 +13,11 @@ namespace OpenBve
 		/// <param name="sound">The car sound.</param>
 		/// <param name="pitch">The pitch change factor.</param>
 		/// <param name="volume">The volume change factor.</param>
-		/// <param name="car">The train car sound is attached to.</param>
 		/// <param name="looped">Whether to play the sound in a loop.</param>
 		/// <returns>The sound source.</returns>
-		internal void PlayCarSound(CarSound sound, double pitch, double volume, AbstractCar car, bool looped)
+		internal void PlayCarSound(CarSound sound, double pitch, double volume, bool looped)
 		{
-			if (sound.Buffer == null)
-			{
-				return;
-			}
-			if (car == null)
-			{
-				throw new InvalidDataException("A valid car must be specified");
-			}
-			sound.Source = PlaySound(sound.Buffer, pitch, volume, sound.Position, car, looped);
+			sound.Play(pitch, volume, looped);
 		}
 
 		/// <summary>Stops all sounds that are attached to the specified train.</summary>

--- a/source/OpenBVE/Graphics/Renderers/Touch.cs
+++ b/source/OpenBVE/Graphics/Renderers/Touch.cs
@@ -428,9 +428,7 @@ namespace OpenBve.Graphics.Renderers
 
 					foreach (var index in TouchElement.SoundIndices.Where(x => x >= 0 && x < Car.Sounds.Touch.Length))
 					{
-						SoundBuffer Buffer = Car.Sounds.Touch[index].Buffer;
-						Vector3 Position = Car.Sounds.Touch[index].Position;
-						Program.Sounds.PlaySound(Buffer, 1.0, 1.0, Position, TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar], false);
+						Car.Sounds.Touch[index].Play(1.0, 1.0, false);
 					}
 				}
 

--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -172,21 +172,21 @@ namespace OpenBve
 				{
 					if (Car.Doors[0].OpenSound.Buffer != null & Car.Doors[1].OpenSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].OpenSound.Buffer);
-						Program.Sounds.LoadBuffer(Car.Doors[1].OpenSound.Buffer);
-						double a = Car.Doors[0].OpenSound.Buffer.Duration;
-						double b = Car.Doors[1].OpenSound.Buffer.Duration;
+						Car.Doors[0].OpenSound.Buffer.Load();
+						Car.Doors[1].OpenSound.Buffer.Load();
+						double a = Car.Doors[0].OpenSound.Duration;
+						double b = Car.Doors[1].OpenSound.Duration;
 						Car.Specs.DoorOpenFrequency = a + b > 0.0 ? 2.0 / (a + b) : 0.8;
 					}
 					else if (Car.Doors[0].OpenSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].OpenSound.Buffer);
+						Car.Doors[0].OpenSound.Buffer.Load();
 						double a = Car.Doors[0].OpenSound.Buffer.Duration;
 						Car.Specs.DoorOpenFrequency = a > 0.0 ? 1.0 / a : 0.8;
 					}
 					else if (Car.Doors[1].OpenSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].OpenSound.Buffer);
+						Car.Doors[0].OpenSound.Buffer.Load();
 						double b = Car.Doors[1].OpenSound.Buffer.Duration;
 						Car.Specs.DoorOpenFrequency = b > 0.0 ? 1.0 / b : 0.8;
 					}
@@ -199,22 +199,22 @@ namespace OpenBve
 				{
 					if (Car.Doors[0].CloseSound.Buffer != null & Car.Doors[1].CloseSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].CloseSound.Buffer);
-						Program.Sounds.LoadBuffer(Car.Doors[1].CloseSound.Buffer);
-						double a = Car.Doors[0].CloseSound.Buffer.Duration;
-						double b = Car.Doors[1].CloseSound.Buffer.Duration;
+						Car.Doors[0].CloseSound.Buffer.Load();
+						Car.Doors[1].CloseSound.Buffer.Load();
+						double a = Car.Doors[0].CloseSound.Duration;
+						double b = Car.Doors[1].CloseSound.Duration;
 						Car.Specs.DoorCloseFrequency = a + b > 0.0 ? 2.0 / (a + b) : 0.8;
 					}
 					else if (Car.Doors[0].CloseSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].CloseSound.Buffer);
-						double a = Car.Doors[0].CloseSound.Buffer.Duration;
+						Car.Doors[0].CloseSound.Buffer.Load();
+						double a = Car.Doors[0].CloseSound.Duration;
 						Car.Specs.DoorCloseFrequency = a > 0.0 ? 1.0 / a : 0.8;
 					}
 					else if (Car.Doors[1].CloseSound.Buffer != null)
 					{
-						Program.Sounds.LoadBuffer(Car.Doors[0].CloseSound.Buffer);
-						double b = Car.Doors[1].CloseSound.Buffer.Duration;
+						Car.Doors[0].CloseSound.Buffer.Load();
+						double b = Car.Doors[1].CloseSound.Duration;
 						Car.Specs.DoorCloseFrequency = b > 0.0 ? 1.0 / b : 0.8;
 					}
 					else

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Ats.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Ats.cs
@@ -13,12 +13,12 @@ namespace OpenBve
 			Vector3 position = new Vector3(train.Cars[train.DriverCar].Driver.X, train.Cars[train.DriverCar].Driver.Y, train.Cars[train.DriverCar].Driver.Z + 1.0);
 			const double radius = 2.0;
 			train.Cars[train.DriverCar].Sounds.Plugin = new CarSound[] {
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "ats.wav"), radius), position),
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "atscnt.wav"), radius), position),
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "ding.wav"), radius), position),
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "toats.wav"), radius), position),
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "toatc.wav"), radius), position),
-				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "eb.wav"), radius), position)
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "ats.wav"), radius), position, train.Cars[train.DriverCar]),
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "atscnt.wav"), radius), position, train.Cars[train.DriverCar]),
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "ding.wav"), radius), position, train.Cars[train.DriverCar]),
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "toats.wav"), radius), position, train.Cars[train.DriverCar]),
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "toatc.wav"), radius), position, train.Cars[train.DriverCar]),
+				new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "eb.wav"), radius), position, train.Cars[train.DriverCar])
 			};
 		}
 	}

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Base.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Base.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using OpenBveApi;
 using OpenBveApi.Math;
+using OpenBveApi.Trains;
 using SoundManager;
 
 namespace OpenBve
@@ -48,8 +49,9 @@ namespace OpenBve
 		/// <param name="FileEnd">The last sound file</param>
 		/// <param name="Position">The position the sound is to be emitted from within the car</param>
 		/// <param name="Radius">The sound radius</param>
+		/// <param name="Car">The car</param>
 		/// <returns>The new car sound array</returns>
-		internal static CarSound[] TryLoadSoundArray(string Folder, string FileStart, string FileEnd, Vector3 Position, double Radius)
+		internal static CarSound[] TryLoadSoundArray(string Folder, string FileStart, string FileEnd, Vector3 Position, double Radius, AbstractCar Car)
 		{
 			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
 			CarSound[] Sounds = { };
@@ -82,7 +84,7 @@ namespace OpenBve
 										Sounds[j].Source = null;
 									}
 								}
-								Sounds[n] = new CarSound(Program.Sounds.RegisterBuffer(Files[i], Radius), Position);
+								Sounds[n] = new CarSound(Program.Sounds.RegisterBuffer(Files[i], Radius), Position, Car);
 							}
 						}
 					}

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve2.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve2.cs
@@ -19,9 +19,9 @@ namespace OpenBve
 			Vector3 cab = new Vector3(-train.Cars[train.DriverCar].Driver.X, train.Cars[train.DriverCar].Driver.Y, train.Cars[train.DriverCar].Driver.Z - 0.5);
 			Vector3 panel = new Vector3(train.Cars[train.DriverCar].Driver.X, train.Cars[train.DriverCar].Driver.Y, train.Cars[train.DriverCar].Driver.Z + 1.0);
 			// load sounds for driver's car
-			train.SafetySystems.StationAdjust.AdjustAlarm = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Adjust.wav"), SoundCfgParser.tinyRadius), panel);
-			train.Cars[train.DriverCar].Sounds.Brake = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Brake.wav"), SoundCfgParser.smallRadius), center);
-			train.SafetySystems.PassAlarm.Sound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Halt.wav"), SoundCfgParser.tinyRadius), cab);
+			train.SafetySystems.StationAdjust.AdjustAlarm = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Adjust.wav"), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
+			train.Cars[train.DriverCar].Sounds.Brake = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Brake.wav"), SoundCfgParser.smallRadius), center, train.Cars[train.DriverCar]);
+			train.SafetySystems.PassAlarm.Sound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Halt.wav"), SoundCfgParser.tinyRadius), cab, train.Cars[train.DriverCar]);
 			train.Cars[train.DriverCar].Horns[0].LoopSound = Program.Sounds.TryToLoad(OpenBveApi.Path.CombineFile(trainFolder, "Klaxon0.wav"), SoundCfgParser.smallRadius);
 			train.Cars[train.DriverCar].Horns[0].Loop = false;
 			train.Cars[train.DriverCar].Horns[0].SoundPosition = front;
@@ -35,61 +35,61 @@ namespace OpenBve
 			train.Cars[train.DriverCar].Horns[2].LoopSound = Program.Sounds.TryToLoad(OpenBveApi.Path.CombineFile(trainFolder, "Klaxon2.wav"), SoundCfgParser.mediumRadius);
 			train.Cars[train.DriverCar].Horns[2].Loop = true;
 			train.Cars[train.DriverCar].Horns[2].SoundPosition = front;
-			train.SafetySystems.PilotLamp.OnSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Leave.wav"), SoundCfgParser.tinyRadius), cab);
+			train.SafetySystems.PilotLamp.OnSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Leave.wav"), SoundCfgParser.tinyRadius), cab, train.Cars[train.DriverCar]);
 			// load sounds for all cars
 			for (int i = 0; i < train.Cars.Length; i++)
 			{
 				Vector3 frontaxle = new Vector3(0.0, 0.0, train.Cars[i].FrontAxle.Position);
 				Vector3 rearaxle = new Vector3(0.0, 0.0, train.Cars[i].RearAxle.Position);
-				train.Cars[i].CarBrake.Air = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Air.wav"), SoundCfgParser.smallRadius), center);
-				train.Cars[i].CarBrake.AirHigh = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "AirHigh.wav"), SoundCfgParser.smallRadius), center);
-				train.Cars[i].CarBrake.AirZero = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "AirZero.wav"), SoundCfgParser.smallRadius), center);
+				train.Cars[i].CarBrake.Air = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Air.wav"), SoundCfgParser.smallRadius), center, train.Cars[i]);
+				train.Cars[i].CarBrake.AirHigh = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "AirHigh.wav"), SoundCfgParser.smallRadius), center, train.Cars[i]);
+				train.Cars[i].CarBrake.AirZero = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "AirZero.wav"), SoundCfgParser.smallRadius), center, train.Cars[i]);
 				if (train.Cars[i].CarBrake.brakeType == BrakeType.Main)
 				{
-					train.Cars[i].CarBrake.airCompressor.EndSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpEnd.wav"), SoundCfgParser.mediumRadius), center);
-					train.Cars[i].CarBrake.airCompressor.LoopSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpLoop.wav"), SoundCfgParser.mediumRadius), center);
-					train.Cars[i].CarBrake.airCompressor.StartSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpStart.wav"), SoundCfgParser.mediumRadius), center);
+					train.Cars[i].CarBrake.airCompressor.EndSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpEnd.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
+					train.Cars[i].CarBrake.airCompressor.LoopSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpLoop.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
+					train.Cars[i].CarBrake.airCompressor.StartSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "CpStart.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
 				}
 				train.Cars[i].Sounds.BreakerResume = new CarSound();
 				train.Cars[i].Sounds.BreakerResumeOrInterrupt = new CarSound();
 				train.Cars[i].Sounds.BreakerResumed = false;
-				train.Cars[i].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorClsL.wav"), SoundCfgParser.smallRadius), left);
-				train.Cars[i].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorClsR.wav"), SoundCfgParser.smallRadius), right);
+				train.Cars[i].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorClsL.wav"), SoundCfgParser.smallRadius), left, train.Cars[i]);
+				train.Cars[i].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorClsR.wav"), SoundCfgParser.smallRadius), right, train.Cars[i]);
 				if (train.Cars[i].Doors[0].CloseSound.Buffer == null)
 				{
-					train.Cars[i].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorCls.wav"), SoundCfgParser.smallRadius), left);
+					train.Cars[i].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorCls.wav"), SoundCfgParser.smallRadius), left, train.Cars[i]);
 				}
 				if (train.Cars[i].Doors[1].CloseSound.Buffer == null)
 				{
-					train.Cars[i].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorCls.wav"), SoundCfgParser.smallRadius), right);
+					train.Cars[i].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorCls.wav"), SoundCfgParser.smallRadius), right, train.Cars[i]);
 				}
-				train.Cars[i].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpnL.wav"), SoundCfgParser.smallRadius), left);
-				train.Cars[i].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpnR.wav"), SoundCfgParser.smallRadius), right);
+				train.Cars[i].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpnL.wav"), SoundCfgParser.smallRadius), left, train.Cars[i]);
+				train.Cars[i].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpnR.wav"), SoundCfgParser.smallRadius), right, train.Cars[i]);
 				if (train.Cars[i].Doors[0].OpenSound.Buffer == null)
 				{
-					train.Cars[i].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpn.wav"), SoundCfgParser.smallRadius), left);
+					train.Cars[i].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpn.wav"), SoundCfgParser.smallRadius), left, train.Cars[i]);
 				}
 				if (train.Cars[i].Doors[1].OpenSound.Buffer == null)
 				{
-					train.Cars[i].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpn.wav"), SoundCfgParser.smallRadius), right);
+					train.Cars[i].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "DoorOpn.wav"), SoundCfgParser.smallRadius), right, train.Cars[i]);
 				}
-				train.Handles.EmergencyBrake.ApplicationSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "EmrBrake.wav"), SoundCfgParser.mediumRadius), center);
-				train.Cars[i].Sounds.Flange = SoundCfgParser.TryLoadSoundArray(trainFolder, "Flange", ".wav", center, SoundCfgParser.mediumRadius);
+				train.Handles.EmergencyBrake.ApplicationSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "EmrBrake.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
+				train.Cars[i].Sounds.Flange = SoundCfgParser.TryLoadSoundArray(trainFolder, "Flange", ".wav", center, SoundCfgParser.mediumRadius, train.Cars[i]);
 				train.Cars[i].Sounds.FlangeVolume = new double[train.Cars[i].Sounds.Flange.Length];
-				train.Cars[i].Sounds.Loop = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Loop.wav"), SoundCfgParser.mediumRadius), center);
+				train.Cars[i].Sounds.Loop = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Loop.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
 				train.Cars[i].FrontAxle.PointSounds = new CarSound[]
 				{
-					new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Point.wav"), SoundCfgParser.smallRadius), frontaxle)
+					new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Point.wav"), SoundCfgParser.smallRadius), frontaxle, train.Cars[i])
 				};
 				train.Cars[i].RearAxle.PointSounds = new CarSound[]
 				{
-					new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Point.wav"), SoundCfgParser.smallRadius), rearaxle)
+					new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Point.wav"), SoundCfgParser.smallRadius), rearaxle, train.Cars[i])
 				};
-				train.Cars[i].CarBrake.Rub = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Rub.wav"), SoundCfgParser.mediumRadius), center);
-				train.Cars[i].Sounds.Run = SoundCfgParser.TryLoadSoundArray(trainFolder, "Run", ".wav", center, SoundCfgParser.mediumRadius);
+				train.Cars[i].CarBrake.Rub = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Rub.wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
+				train.Cars[i].Sounds.Run = SoundCfgParser.TryLoadSoundArray(trainFolder, "Run", ".wav", center, SoundCfgParser.mediumRadius, train.Cars[i]);
 				train.Cars[i].Sounds.RunVolume = new double[train.Cars[i].Sounds.Run.Length];
-				train.Cars[i].Sounds.SpringL = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "SpringL.wav"), SoundCfgParser.smallRadius), left);
-				train.Cars[i].Sounds.SpringR = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "SpringR.wav"), SoundCfgParser.smallRadius), right);
+				train.Cars[i].Sounds.SpringL = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "SpringL.wav"), SoundCfgParser.smallRadius), left, train.Cars[i]);
+				train.Cars[i].Sounds.SpringR = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "SpringR.wav"), SoundCfgParser.smallRadius), right, train.Cars[i]);
 				// motor sound
 				if (train.Cars[i].Specs.IsMotorCar)
 				{
@@ -102,7 +102,7 @@ namespace OpenBve
 							int idx = train.Cars[i].Sounds.Motor.Tables[j].Entries[k].SoundIndex;
 							if (idx >= 0)
 							{
-								CarSound snd = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Motor" + idx.ToString(Culture) + ".wav"), SoundCfgParser.mediumRadius), center);
+								CarSound snd = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, "Motor" + idx.ToString(Culture) + ".wav"), SoundCfgParser.mediumRadius), center, train.Cars[i]);
 								train.Cars[i].Sounds.Motor.Tables[j].Entries[k].Buffer = snd.Buffer;
 							}
 						}

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Bve4.cs
@@ -114,7 +114,7 @@ namespace OpenBve
 													train.Cars[c].Sounds.Run[h] = new CarSound();
 												}
 											}
-											train.Cars[c].Sounds.Run[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+											train.Cars[c].Sounds.Run[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 										}
 									}
 									else
@@ -158,7 +158,7 @@ namespace OpenBve
 													train.Cars[c].Sounds.Flange[h] = new CarSound();
 												}
 											}
-											train.Cars[c].Sounds.Flange[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+											train.Cars[c].Sounds.Flange[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 										}
 									}
 									else
@@ -242,8 +242,8 @@ namespace OpenBve
 										}
 										Vector3 frontaxle = new Vector3(0.0, 0.0, train.Cars[c].FrontAxle.Position);
 										Vector3 rearaxle = new Vector3(0.0, 0.0, train.Cars[c].RearAxle.Position);
-										train.Cars[c].FrontAxle.PointSounds[runIndex] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), frontaxle);
-										train.Cars[c].RearAxle.PointSounds[runIndex] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), rearaxle);
+										train.Cars[c].FrontAxle.PointSounds[runIndex] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), frontaxle, train.Cars[c]);
+										train.Cars[c].RearAxle.PointSounds[runIndex] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), rearaxle, train.Cars[c]);
 									}
 								}
 								else
@@ -273,31 +273,31 @@ namespace OpenBve
 										case "bc release high":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].CarBrake.AirHigh = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center);
+												train.Cars[c].CarBrake.AirHigh = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center, train.Cars[c]);
 											}
 											break;
 										case "bc release":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].CarBrake.Air = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center);
+												train.Cars[c].CarBrake.Air = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center, train.Cars[c]);
 											}
 											break;
 										case "bc release full":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].CarBrake.AirZero = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center);
+												train.Cars[c].CarBrake.AirZero = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center, train.Cars[c]);
 											}
 											break;
 										case "emergency":
-											train.Handles.EmergencyBrake.ApplicationSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+											train.Handles.EmergencyBrake.ApplicationSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[train.DriverCar]);
 											break;
 										case "emergencyrelease":
-											train.Handles.EmergencyBrake.ReleaseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+											train.Handles.EmergencyBrake.ReleaseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[train.DriverCar]);
 											break;
 										case "bp decomp":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Sounds.Brake = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center);
+												train.Cars[c].Sounds.Brake = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), center, train.Cars[c]);
 											}
 											break;
 										default:
@@ -330,13 +330,13 @@ namespace OpenBve
 											switch (a.ToLowerInvariant())
 											{
 												case "attack":
-													train.Cars[c].CarBrake.airCompressor.StartSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+													train.Cars[c].CarBrake.airCompressor.StartSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 													break;
 												case "loop":
-													train.Cars[c].CarBrake.airCompressor.LoopSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+													train.Cars[c].CarBrake.airCompressor.LoopSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 													break;
 												case "release":
-													train.Cars[c].CarBrake.airCompressor.EndSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+													train.Cars[c].CarBrake.airCompressor.EndSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 													break;
 												default:
 													Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -368,13 +368,13 @@ namespace OpenBve
 										case "left":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Sounds.SpringL = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left);
+												train.Cars[c].Sounds.SpringL = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left, train.Cars[c]);
 											}
 											break;
 										case "right":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Sounds.SpringR = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right);
+												train.Cars[c].Sounds.SpringR = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right, train.Cars[c]);
 											}
 											break;
 										default:
@@ -485,25 +485,25 @@ namespace OpenBve
 										case "open left":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left);
+												train.Cars[c].Doors[0].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left, train.Cars[c]);
 											}
 											break;
 										case "open right":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right);
+												train.Cars[c].Doors[1].OpenSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right, train.Cars[c]);
 											}
 											break;
 										case "close left":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left);
+												train.Cars[c].Doors[0].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), left, train.Cars[c]);
 											}
 											break;
 										case "close right":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right);
+												train.Cars[c].Doors[1].CloseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), right, train.Cars[c]);
 											}
 											break;
 										default:
@@ -547,7 +547,7 @@ namespace OpenBve
 													train.Cars[train.DriverCar].Sounds.Plugin[h] = new CarSound();
 												}
 											}
-											train.Cars[train.DriverCar].Sounds.Plugin[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Cars[train.DriverCar].Sounds.Plugin[k] = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 										}
 										else
 										{
@@ -576,7 +576,7 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "correct":
-											train.SafetySystems.StationAdjust.AdjustAlarm = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.SafetySystems.StationAdjust.AdjustAlarm = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -604,10 +604,10 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "on":
-											train.SafetySystems.PilotLamp.OnSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.SafetySystems.PilotLamp.OnSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "off":
-											train.SafetySystems.PilotLamp.OffSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.SafetySystems.PilotLamp.OffSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -635,22 +635,22 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "apply":
-											train.Handles.Brake.Increase = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.Increase = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "applyfast":
-											train.Handles.Brake.IncreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.IncreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "release":
-											train.Handles.Brake.Decrease = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.Decrease = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "releasefast":
-											train.Handles.Brake.DecreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.DecreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "min":
-											train.Handles.Brake.Min = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.Min = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "max":
-											train.Handles.Brake.Max = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Brake.Max = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -678,22 +678,22 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "up":
-											train.Handles.Power.Increase = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.Increase = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "upfast":
-											train.Handles.Power.IncreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.IncreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "down":
-											train.Handles.Power.Decrease = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.Decrease = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "downfast":
-											train.Handles.Power.DecreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.DecreaseFast = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "min":
-											train.Handles.Power.Min = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.Min = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "max":
-											train.Handles.Power.Max = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Power.Max = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -721,10 +721,10 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "on":
-											train.Handles.Reverser.EngageSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Reverser.EngageSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "off":
-											train.Handles.Reverser.ReleaseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+											train.Handles.Reverser.ReleaseSound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -752,10 +752,10 @@ namespace OpenBve
 									switch (a.ToLowerInvariant())
 									{
 										case "on":
-											train.Cars[train.DriverCar].Sounds.BreakerResume = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), panel);
+											train.Cars[train.DriverCar].Sounds.BreakerResume = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										case "off":
-											train.Cars[train.DriverCar].Sounds.BreakerResumeOrInterrupt = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), panel);
+											train.Cars[train.DriverCar].Sounds.BreakerResumeOrInterrupt = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.smallRadius), panel, train.Cars[train.DriverCar]);
 											break;
 										default:
 											Interface.AddMessage(MessageType.Warning, false, "Unsupported key " + a + " encountered at line " + (i + 1).ToString(Culture) + " in file " + FileName);
@@ -787,20 +787,20 @@ namespace OpenBve
 											{
 												if (train.Cars[c].Specs.IsMotorCar | c == train.DriverCar)
 												{
-													train.Cars[c].Sounds.Loop = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+													train.Cars[c].Sounds.Loop = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 												}
 											}
 											break;
 										case "shoe":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.Cars[c].CarBrake.Rub = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center);
+												train.Cars[c].CarBrake.Rub = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius), center, train.Cars[c]);
 											}
 											break;
 										case "halt":
 											for (int c = 0; c < train.Cars.Length; c++)
 											{
-												train.SafetySystems.PassAlarm.Sound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel);
+												train.SafetySystems.PassAlarm.Sound = new CarSound(Program.Sounds.RegisterBuffer(OpenBveApi.Path.CombineFile(trainFolder, b), SoundCfgParser.tinyRadius), panel, train.Cars[c]);
 											}
 											break;
 										default:

--- a/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
+++ b/source/OpenBVE/Parsers/SoundConfiguration/SoundCfg.Xml.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using OpenBve.BrakeSystems;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
+using OpenBveApi.Trains;
 using SoundManager;
 
 namespace OpenBve
@@ -75,7 +76,7 @@ namespace OpenBve
 									{
 										break;
 									}
-									ParseArrayNode(c, out car.Sounds.Plugin, center, SoundCfgParser.mediumRadius);
+									ParseArrayNode(c, out car.Sounds.Plugin, center, SoundCfgParser.mediumRadius, car);
 									break;
 								case "brake":
 									if (!c.ChildNodes.OfType<XmlElement>().Any())
@@ -89,27 +90,27 @@ namespace OpenBve
 										{
 											case "releasehigh":
 												//Release brakes from high pressure
-												ParseNode(cc, out car.CarBrake.AirHigh, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.CarBrake.AirHigh, center, SoundCfgParser.smallRadius, car);
 												break;
 											case "release":
 												//Release brakes from normal pressure
-												ParseNode(cc, out car.CarBrake.Air, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.CarBrake.Air, center, SoundCfgParser.smallRadius, car);
 												break;
 											case "releasefull":
 												//Release brakes from full pressure
-												ParseNode(cc, out car.CarBrake.AirZero, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.CarBrake.AirZero, center, SoundCfgParser.smallRadius, car);
 												break;
 											case "emergency":
 												//Apply EB
-												ParseNode(cc, out Train.Handles.EmergencyBrake.ApplicationSound, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out Train.Handles.EmergencyBrake.ApplicationSound, center, SoundCfgParser.smallRadius, car);
 												break;
 											case "emergencyrelease":
 												//Release EB
-												ParseNode(cc, out Train.Handles.EmergencyBrake.ReleaseSound, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out Train.Handles.EmergencyBrake.ReleaseSound, center, SoundCfgParser.smallRadius, car);
 												break;
 											case "application":
 												//Standard application
-												ParseNode(cc, out car.Sounds.Brake, center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.Brake, center, SoundCfgParser.smallRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -132,24 +133,24 @@ namespace OpenBve
 										switch (cc.Name.ToLowerInvariant())
 										{
 											case "apply":
-												ParseNode(cc, out Train.Handles.Brake.Increase, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.Increase, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "applyfast":
-												ParseNode(cc, out Train.Handles.Brake.IncreaseFast, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.IncreaseFast, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "release":
-												ParseNode(cc, out Train.Handles.Brake.Decrease, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.Decrease, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "releasefast":
-												ParseNode(cc, out Train.Handles.Brake.DecreaseFast, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.DecreaseFast, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "min":
 											case "minimum":
-												ParseNode(cc, out Train.Handles.Brake.Min, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.Min, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "max":
 											case "maximum":
-												ParseNode(cc, out Train.Handles.Brake.Max, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Brake.Max, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -172,10 +173,10 @@ namespace OpenBve
 										switch (cc.Name.ToLowerInvariant())
 										{
 											case "on":
-												ParseNode(cc, out car.Sounds.BreakerResume, panel, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.BreakerResume, panel, SoundCfgParser.smallRadius, car);
 												break;
 											case "off":
-												ParseNode(cc, out car.Sounds.BreakerResumeOrInterrupt, panel, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.BreakerResumeOrInterrupt, panel, SoundCfgParser.smallRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -188,7 +189,7 @@ namespace OpenBve
 									{
 										break;
 									}
-									ParseNode(c, out Train.SafetySystems.StationAdjust.AdjustAlarm, panel, SoundCfgParser.tinyRadius);
+									ParseNode(c, out Train.SafetySystems.StationAdjust.AdjustAlarm, panel, SoundCfgParser.tinyRadius, car);
 									break;
 								case "compressor":
 									if (!c.ChildNodes.OfType<XmlElement>().Any())
@@ -207,17 +208,17 @@ namespace OpenBve
 											case "attack":
 											case "start":
 												//Compressor starting sound
-												ParseNode(cc, out car.CarBrake.airCompressor.StartSound, center, SoundCfgParser.mediumRadius);
+												ParseNode(cc, out car.CarBrake.airCompressor.StartSound, center, SoundCfgParser.mediumRadius, car);
 												break;
 											case "loop":
 												//Compressor loop sound
-												ParseNode(cc, out car.CarBrake.airCompressor.LoopSound, center, SoundCfgParser.mediumRadius);
+												ParseNode(cc, out car.CarBrake.airCompressor.LoopSound, center, SoundCfgParser.mediumRadius, car);
 												break;
 											case "release":
 											case "stop":
 											case "end":
 												//Compressor end sound
-												ParseNode(cc, out car.CarBrake.airCompressor.EndSound, center, SoundCfgParser.mediumRadius);
+												ParseNode(cc, out car.CarBrake.airCompressor.EndSound, center, SoundCfgParser.mediumRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -237,19 +238,19 @@ namespace OpenBve
 										{
 											case "openleft":
 											case "leftopen":
-												ParseNode(cc, out car.Doors[0].OpenSound, left, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Doors[0].OpenSound, left, SoundCfgParser.smallRadius, car);
 												break;
 											case "openright":
 											case "rightopen":
-												ParseNode(cc, out car.Doors[1].OpenSound, right, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Doors[1].OpenSound, right, SoundCfgParser.smallRadius, car);
 												break;
 											case "closeleft":
 											case "leftclose":
-												ParseNode(cc, out car.Doors[0].CloseSound, left, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Doors[0].CloseSound, left, SoundCfgParser.smallRadius, car);
 												break;
 											case "closeright":
 											case "rightclose":
-												ParseNode(cc, out car.Doors[1].CloseSound, right, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Doors[1].CloseSound, right, SoundCfgParser.smallRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -263,7 +264,7 @@ namespace OpenBve
 										Interface.AddMessage(MessageType.Error, false, "An empty list of flange sounds was defined in in XML file " + fileName);
 										break;
 									}
-									ParseArrayNode(c, out car.Sounds.Flange, center, SoundCfgParser.mediumRadius);
+									ParseArrayNode(c, out car.Sounds.Flange, center, SoundCfgParser.mediumRadius, car);
 									break;
 								case "horn":
 									if (!c.ChildNodes.OfType<XmlElement>().Any())
@@ -299,7 +300,7 @@ namespace OpenBve
 									break;
 								case "loop":
 								case "noise":
-									ParseNode(c, out car.Sounds.Loop, center, SoundCfgParser.mediumRadius);
+									ParseNode(c, out car.Sounds.Loop, center, SoundCfgParser.mediumRadius, car);
 									break;
 								case "mastercontroller":
 								case "powerhandle":
@@ -318,27 +319,27 @@ namespace OpenBve
 										{
 											case "up":
 											case "increase":
-												ParseNode(cc, out Train.Handles.Power.Increase, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.Increase, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "upfast":
 											case "increasefast":
-												ParseNode(cc, out Train.Handles.Power.IncreaseFast, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.IncreaseFast, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "down":
 											case "decrease":
-												ParseNode(cc, out Train.Handles.Power.Decrease, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.Decrease, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "downfast":
 											case "decreasefast":
-												ParseNode(cc, out Train.Handles.Power.DecreaseFast, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.DecreaseFast, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "min":
 											case "minimum":
-												ParseNode(cc, out Train.Handles.Power.Min, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.Min, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "max":
 											case "maximum":
-												ParseNode(cc, out Train.Handles.Power.Max, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Power.Max, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -373,10 +374,10 @@ namespace OpenBve
 										switch (cc.Name.ToLowerInvariant())
 										{
 											case "on":
-												ParseNode(cc, out Train.SafetySystems.PilotLamp.OnSound, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.SafetySystems.PilotLamp.OnSound, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "off":
-												ParseNode(cc, out Train.SafetySystems.PilotLamp.OffSound, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.SafetySystems.PilotLamp.OffSound, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -393,7 +394,7 @@ namespace OpenBve
 									}
 
 									CarSound[] frontAxlePointSounds;
-									ParseArrayNode(c, out frontAxlePointSounds, new Vector3(0.0, 0.0, car.FrontAxle.Position), SoundCfgParser.smallRadius);
+									ParseArrayNode(c, out frontAxlePointSounds, new Vector3(0.0, 0.0, car.FrontAxle.Position), SoundCfgParser.smallRadius, car);
 									car.FrontAxle.PointSounds = frontAxlePointSounds;
 									break;
 								case "pointrearaxle":
@@ -404,7 +405,7 @@ namespace OpenBve
 										break;
 									}
 									CarSound[] rearAxlePointSounds;
-									ParseArrayNode(c, out rearAxlePointSounds, new Vector3(0.0, 0.0, car.FrontAxle.Position), SoundCfgParser.smallRadius);
+									ParseArrayNode(c, out rearAxlePointSounds, new Vector3(0.0, 0.0, car.FrontAxle.Position), SoundCfgParser.smallRadius, car);
 									car.RearAxle.PointSounds = rearAxlePointSounds;
 									break;
 								case "reverser":
@@ -423,10 +424,10 @@ namespace OpenBve
 										switch (cc.Name.ToLowerInvariant())
 										{
 											case "on":
-												ParseNode(cc, out Train.Handles.Reverser.EngageSound, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Reverser.EngageSound, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											case "off":
-												ParseNode(cc, out Train.Handles.Reverser.ReleaseSound, panel, SoundCfgParser.tinyRadius);
+												ParseNode(cc, out Train.Handles.Reverser.ReleaseSound, panel, SoundCfgParser.tinyRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -440,11 +441,11 @@ namespace OpenBve
 										Interface.AddMessage(MessageType.Error, false, "An empty list of run sounds was defined in in XML file " + fileName);
 										break;
 									}
-									ParseArrayNode(c, out car.Sounds.Run, center, SoundCfgParser.mediumRadius);
+									ParseArrayNode(c, out car.Sounds.Run, center, SoundCfgParser.mediumRadius, car);
 									break;
 								case "shoe":
 								case "rub":
-									ParseNode(c, out car.CarBrake.Rub, center, SoundCfgParser.mediumRadius);
+									ParseNode(c, out car.CarBrake.Rub, center, SoundCfgParser.mediumRadius, car);
 									break;
 								case "suspension":
 								case "spring":
@@ -459,11 +460,11 @@ namespace OpenBve
 										{
 											case "left":
 												//Left suspension springs
-												ParseNode(cc, out car.Sounds.SpringL, left, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.SpringL, left, SoundCfgParser.smallRadius, car);
 												break;
 											case "right":
 												//right suspension springs
-												ParseNode(cc, out car.Sounds.SpringR, right, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.SpringR, right, SoundCfgParser.smallRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -482,13 +483,13 @@ namespace OpenBve
 										switch (cc.Name.ToLowerInvariant())
 										{
 											case "stop":
-												ParseNode(cc, out car.Sounds.RequestStop[0], center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.RequestStop[0], center, SoundCfgParser.smallRadius, car);
 												break;
 											case "pass":
-												ParseNode(cc, out car.Sounds.RequestStop[1], center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.RequestStop[1], center, SoundCfgParser.smallRadius, car);
 												break;
 											case "ignored":
-												ParseNode(cc, out car.Sounds.RequestStop[2], center, SoundCfgParser.smallRadius);
+												ParseNode(cc, out car.Sounds.RequestStop[2], center, SoundCfgParser.smallRadius, car);
 												break;
 											default:
 												Interface.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
@@ -506,7 +507,7 @@ namespace OpenBve
 									{
 										break;
 									}
-									ParseArrayNode(c, out car.Sounds.Touch, center, SoundCfgParser.mediumRadius);
+									ParseArrayNode(c, out car.Sounds.Touch, center, SoundCfgParser.mediumRadius, car);
 									break;
 							}
 						}
@@ -677,7 +678,7 @@ namespace OpenBve
 		/// <param name="Sound">The car sound</param>
 		/// <param name="Position">The default position of this sound (May be overriden by the node)</param>
 		/// <param name="Radius">The default radius of this sound (May be overriden by the node)</param>
-		private static void ParseNode(XmlNode node, out CarSound Sound, Vector3 Position, double Radius)
+		private static void ParseNode(XmlNode node, out CarSound Sound, Vector3 Position, double Radius, AbstractCar Car)
 		{
 			string fileName = null;
 			foreach (XmlNode c in node.ChildNodes)
@@ -740,7 +741,7 @@ namespace OpenBve
 				Sound = new CarSound();
 				return;
 			}
-			Sound = new CarSound(Program.Sounds.RegisterBuffer(fileName,Radius), Position);
+			Sound = new CarSound(Program.Sounds.RegisterBuffer(fileName,Radius), Position, Car);
 		}
 
 		/// <summary>Parses an XML node containing a list of sounds into a car sound array</summary>
@@ -748,7 +749,7 @@ namespace OpenBve
 		/// <param name="Sounds">The car sound array</param>
 		/// <param name="Position">The default position of the sound (May be overriden by any node)</param>
 		/// <param name="Radius">The default radius of the sound (May be overriden by any node)</param>
-		private static void ParseArrayNode(XmlNode node, out CarSound[] Sounds, Vector3 Position, double Radius)
+		private static void ParseArrayNode(XmlNode node, out CarSound[] Sounds, Vector3 Position, double Radius, AbstractCar Car)
 		{
 			Sounds = new CarSound[0];
 			foreach (XmlNode c in node.ChildNodes)
@@ -781,7 +782,7 @@ namespace OpenBve
 							Sounds[l] = new CarSound();
 							l++;
 						}
-						ParseNode(c, out Sounds[idx], Position, Radius);
+						ParseNode(c, out Sounds[idx], Position, Radius, Car);
 					}
 					else
 					{

--- a/source/OpenBVE/Parsers/Train/TrainDatParser.cs
+++ b/source/OpenBVE/Parsers/Train/TrainDatParser.cs
@@ -1090,7 +1090,7 @@ namespace OpenBve {
 				Train.Handles.SingleHandle = false;
 				Train.Handles.HasHoldBrake = false;
 			}
-			Train.SafetySystems.PassAlarm = new PassAlarm(passAlarm, Train.Cars[DriverCar]);
+			Train.SafetySystems.PassAlarm = new PassAlarm(passAlarm);
 			Train.SafetySystems.PilotLamp = new PilotLamp(Train.Cars[DriverCar]);
 			Train.SafetySystems.StationAdjust = new StationAdjustAlarm(Train);
 			switch (Game.TrainStart)

--- a/source/OpenBVE/Simulation/TrainManager/Brake/AirBrake/Components/AirCompressor.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Brake/AirBrake/Components/AirCompressor.cs
@@ -44,17 +44,8 @@ namespace OpenBve.BrakeSystems
 				{
 					Enabled = false;
 					LoopStarted = false;
-					SoundBuffer buffer = EndSound.Buffer;
-					if (buffer != null)
-					{
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, EndSound.Position, baseCar, false);
-					}
-
-					buffer = LoopSound.Buffer;
-					if (buffer != null)
-					{
-						LoopSound.Stop();
-					}
+					EndSound.Play(1.0, 1.0, false);
+					LoopSound.Stop();
 				}
 				else
 				{
@@ -62,11 +53,7 @@ namespace OpenBve.BrakeSystems
 					if (!LoopStarted && Program.CurrentRoute.SecondsSinceMidnight > TimeStarted + 5.0)
 					{
 						LoopStarted = true;
-						SoundBuffer buffer = LoopSound.Buffer;
-						if (buffer != null)
-						{
-							LoopSound.Source = Program.Sounds.PlaySound(buffer, 1.0, 1.0, LoopSound.Position, baseCar, true);
-						}
+						LoopSound.Play(1.0, 1.0, true);
 					}
 				}
 			}
@@ -76,11 +63,7 @@ namespace OpenBve.BrakeSystems
 				{
 					Enabled = true;
 					TimeStarted = Program.CurrentRoute.SecondsSinceMidnight;
-					SoundBuffer buffer = StartSound.Buffer;
-					if (buffer != null)
-					{
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, StartSound.Position, baseCar, false);
-					}
+					StartSound.Play(1.0, 1.0, false);
 				}
 			}
 		}

--- a/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Car/Car.cs
@@ -1,4 +1,5 @@
 using System;
+using CSScriptLibrary;
 using LibRender2;
 using LibRender2.Camera;
 using LibRender2.Cameras;
@@ -283,15 +284,11 @@ namespace OpenBve
 					{
 						if (FrontAxle.RunIndex < Sounds.Run.Length)
 						{
-							SoundBuffer buffer = Sounds.Run[FrontAxle.RunIndex].Buffer;
-							if (buffer != null)
+							double duration = Sounds.Run[FrontAxle.RunIndex].Duration;
+							if (duration > 0.0)
 							{
-								double duration = Program.Sounds.GetDuration(buffer);
-								if (duration > 0.0)
-								{
-									double offset = distance > maxDistance ? 25.0 : 300.0;
-									Sounds.RunNextReasynchronizationPosition = duration * Math.Ceiling((baseTrain.Cars[0].FrontAxle.Follower.TrackPosition + offset) / duration);
-								}
+								double offset = distance > maxDistance ? 25.0 : 300.0;
+								Sounds.RunNextReasynchronizationPosition = duration * Math.Ceiling((baseTrain.Cars[0].FrontAxle.Follower.TrackPosition + offset) / duration);
 							}
 						}
 					}
@@ -332,11 +329,7 @@ namespace OpenBve
 					}
 					else if (pitch > 0.02 & gain > 0.01)
 					{
-						SoundBuffer buffer = Sounds.Run[j].Buffer;
-						if (buffer != null)
-						{
-							Sounds.Run[j].Source = Program.Sounds.PlaySound(buffer, pitch, gain, Sounds.Run[j].Position, this, true);
-						}
+						Sounds.Run[j].Play(pitch, gain, true);
 					}
 				}
 			}
@@ -1027,25 +1020,17 @@ namespace OpenBve
 					const double angleTolerance = 0.001;
 					if (diff < -angleTolerance)
 					{
-						SoundBuffer buffer = Sounds.SpringL.Buffer;
-						if (buffer != null)
+						if (!Program.Sounds.IsPlaying(Sounds.SpringL))
 						{
-							if (!Program.Sounds.IsPlaying(Sounds.SpringL.Source))
-							{
-								Sounds.SpringL.Source = Program.Sounds.PlaySound(buffer, 1.0, 1.0, Sounds.SpringL.Position, this, false);
-							}
+							Sounds.SpringL.Play(1.0, 1.0, false);
 						}
 						Sounds.SpringPlayedAngle = a;
 					}
 					else if (diff > angleTolerance)
 					{
-						SoundBuffer buffer = Sounds.SpringR.Buffer;
-						if (buffer != null)
+						if (!Program.Sounds.IsPlaying(Sounds.SpringR))
 						{
-							if (!Program.Sounds.IsPlaying(Sounds.SpringR.Source))
-							{
-								Sounds.SpringR.Source = Program.Sounds.PlaySound(buffer, 1.0, 1.0, Sounds.SpringR.Position, this, false);
-							}
+							Sounds.SpringR.Play(1.0, 1.0, false);
 						}
 						Sounds.SpringPlayedAngle = a;
 					}
@@ -1116,11 +1101,7 @@ namespace OpenBve
 						}
 						else if (pitch > 0.02 & gain > 0.01)
 						{
-							SoundBuffer buffer = Sounds.Flange[i].Buffer;
-							if (buffer != null)
-							{
-								Sounds.Flange[i].Source = Program.Sounds.PlaySound(buffer, pitch, gain, Sounds.Flange[i].Position, this, true);
-							}
+							Sounds.Flange[i].Play(pitch, gain, true);
 						}
 					}
 				}

--- a/source/OpenBVE/Simulation/TrainManager/Doors.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Doors.cs
@@ -215,12 +215,7 @@ namespace OpenBve
 			{
 				for (int i = 0; i < Train.Cars.Length; i++)
 				{
-					SoundBuffer buffer = Train.Cars[i].Doors[0].OpenSound.Buffer;
-					if (buffer != null)
-					{
-						OpenBveApi.Math.Vector3 pos = Train.Cars[i].Doors[0].OpenSound.Position;
-						Program.Sounds.PlaySound(buffer, Train.Cars[i].Specs.DoorOpenPitch, 1.0, pos, Train.Cars[i], false);
-					}
+					Train.Cars[i].Doors[0].OpenSound.Play(Train.Cars[i].Specs.DoorOpenPitch, 1.0, false);
 					for (int j = 0; j < Train.Cars[i].Doors.Length; j++)
 					{
 						if (Train.Cars[i].Doors[j].Direction == -1)
@@ -234,12 +229,7 @@ namespace OpenBve
 			{
 				for (int i = 0; i < Train.Cars.Length; i++)
 				{
-					SoundBuffer buffer = Train.Cars[i].Doors[1].OpenSound.Buffer;
-					if (buffer != null)
-					{
-						OpenBveApi.Math.Vector3 pos = Train.Cars[i].Doors[1].OpenSound.Position;
-						Program.Sounds.PlaySound(buffer, Train.Cars[i].Specs.DoorOpenPitch, 1.0, pos, Train.Cars[i], false);
-					}
+					Train.Cars[i].Doors[1].OpenSound.Play(Train.Cars[i].Specs.DoorOpenPitch, 1.0, false);
 					for (int j = 0; j < Train.Cars[i].Doors.Length; j++)
 					{
 						if (Train.Cars[i].Doors[j].Direction == 1)
@@ -271,12 +261,7 @@ namespace OpenBve
 			}
 			if (sl)
 			{
-				SoundBuffer buffer = Train.Cars[CarIndex].Doors[0].OpenSound.Buffer;
-				if (buffer != null)
-				{
-					OpenBveApi.Math.Vector3 pos = Train.Cars[CarIndex].Doors[0].OpenSound.Position;
-					Program.Sounds.PlaySound(buffer, Train.Cars[CarIndex].Specs.DoorOpenPitch, 1.0, pos, Train.Cars[CarIndex], false);
-				}
+				Train.Cars[CarIndex].Doors[0].OpenSound.Play(Train.Cars[CarIndex].Specs.DoorOpenPitch, 1.0, false);
 				for (int i = 0; i < Train.Cars[CarIndex].Doors.Length; i++)
 				{
 					if (Train.Cars[CarIndex].Doors[i].Direction == -1)
@@ -287,12 +272,7 @@ namespace OpenBve
 			}
 			if (sr)
 			{
-				SoundBuffer buffer = Train.Cars[CarIndex].Doors[1].OpenSound.Buffer;
-				if (buffer != null)
-				{
-					OpenBveApi.Math.Vector3 pos = Train.Cars[CarIndex].Doors[1].OpenSound.Position;
-					Program.Sounds.PlaySound(buffer, Train.Cars[CarIndex].Specs.DoorOpenPitch, 1.0, pos, Train.Cars[CarIndex], false);
-				}
+				Train.Cars[CarIndex].Doors[1].OpenSound.Play(Train.Cars[CarIndex].Specs.DoorOpenPitch, 1.0, false);
 				for (int i = 0; i < Train.Cars[CarIndex].Doors.Length; i++)
 				{
 					if (Train.Cars[CarIndex].Doors[i].Direction == 1)
@@ -335,24 +315,14 @@ namespace OpenBve
 			{
 				for (int i = 0; i < Train.Cars.Length; i++)
 				{
-					SoundBuffer buffer = Train.Cars[i].Doors[0].CloseSound.Buffer;
-					if (buffer != null)
-					{
-						OpenBveApi.Math.Vector3 pos = Train.Cars[i].Doors[0].CloseSound.Position;
-						Program.Sounds.PlaySound(buffer, Train.Cars[i].Specs.DoorClosePitch, 1.0, pos, Train.Cars[i], false);
-					}
+					Train.Cars[i].Doors[0].CloseSound.Play(Train.Cars[i].Specs.DoorClosePitch, 1.0, false);
 				}
 			}
 			if (sr)
 			{
 				for (int i = 0; i < Train.Cars.Length; i++)
 				{
-					SoundBuffer buffer = Train.Cars[i].Doors[1].CloseSound.Buffer;
-					if (buffer != null)
-					{
-						OpenBveApi.Math.Vector3 pos = Train.Cars[i].Doors[1].CloseSound.Position;
-						Program.Sounds.PlaySound(buffer, Train.Cars[i].Specs.DoorClosePitch, 1.0, pos, Train.Cars[i], false);
-					}
+					Train.Cars[i].Doors[1].CloseSound.Play(Train.Cars[i].Specs.DoorClosePitch, 1.0, false);
 				}
 			}
 		}

--- a/source/OpenBVE/Simulation/TrainManager/Train/BrakeSystem.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/BrakeSystem.cs
@@ -173,11 +173,7 @@ namespace OpenBve
 
 				if(Cars[CarIndex].CarBrake.airSound != null)
 				{
-					SoundBuffer buffer = Cars[CarIndex].CarBrake.airSound.Buffer;
-					if (buffer != null)
-					{
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, Cars[CarIndex].CarBrake.airSound.Position, Cars[CarIndex], false);
-					}
+					Cars[CarIndex].CarBrake.airSound.Play(1.0, 1.0, false);
 				}
 
 				// deceleration provided by motor
@@ -205,8 +201,8 @@ namespace OpenBve
 				Cars[CarIndex].Specs.HoldBrake.Update(ref DecelerationDueToMotor, Handles.HoldBrake.Actual);
 				{
 					// rub sound
-					SoundBuffer buffer = Cars[CarIndex].CarBrake.Rub.Buffer;
-					if (buffer != null)
+					CarSound rub = Cars[CarIndex].CarBrake.Rub;
+					if (rub != null)
 					{
 						double spd = Math.Abs(Cars[CarIndex].CurrentSpeed);
 						double pitch = 1.0 / (spd + 1.0) + 1.0;
@@ -227,8 +223,8 @@ namespace OpenBve
 						{
 							if (pitch > 0.01 & gain > 0.001)
 							{
-								Cars[CarIndex].CarBrake.Rub.Source.Pitch = pitch;
-								Cars[CarIndex].CarBrake.Rub.Source.Volume = gain;
+								rub.Source.Pitch = pitch;
+								rub.Source.Volume = gain;
 							}
 							else
 							{
@@ -237,7 +233,7 @@ namespace OpenBve
 						}
 						else if (pitch > 0.02 & gain > 0.01)
 						{
-							Cars[CarIndex].CarBrake.Rub.Source = Program.Sounds.PlaySound(buffer, pitch, gain, Cars[CarIndex].CarBrake.Rub.Position, Cars[CarIndex], true);
+							rub.Play(pitch, gain, true);
 						}
 					}
 				}

--- a/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/PassAlarm.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/PassAlarm.cs
@@ -5,8 +5,6 @@ namespace OpenBve.SafetySystems
 {
 	internal class PassAlarm
 	{
-		/// <summary>Holds the reference to the base train's driver car</summary>
-		private readonly AbstractCar baseCar;
 		/// <summary>The type of pass alarm</summary>
 		private readonly PassAlarmType Type;
 		/// <summary>The sound played when this alarm is triggered</summary>
@@ -14,35 +12,33 @@ namespace OpenBve.SafetySystems
 		/// <summary>Whether the pass alarm light is currently lit</summary>
 		internal bool Lit;
 
-		public PassAlarm(PassAlarmType type, AbstractCar Car)
+		public PassAlarm(PassAlarmType type)
 		{
-			this.baseCar = Car;
 			this.Type = type;
 			this.Sound = new CarSound();
 			this.Lit = false;
 		}
+
 		/// <summary>Triggers the pass alarm</summary>
 		internal void Trigger()
 		{
 			Lit = true;
-			SoundBuffer buffer = Sound.Buffer;
 			if (Program.Sounds.IsPlaying(Sound.Source))
 			{
 				return;
 			}
-			if (buffer != null)
+			switch (Type)
 			{
-				switch (Type)
-				{
-					case PassAlarmType.Single:
-						Sound.Source = Program.Sounds.PlaySound(buffer, 1.0, 1.0, Sound.Position, baseCar, false);
-						break;
-					case PassAlarmType.Loop:
-						Sound.Source = Program.Sounds.PlaySound(buffer, 1.0, 1.0, Sound.Position, baseCar, true);
-						break;
-				}
+				case PassAlarmType.Single:
+					Sound.Play(1.0, 1.0,false);
+					break;
+				case PassAlarmType.Loop:
+					Sound.Play(1.0, 1.0,true);
+					break;
 			}
+
 		}
+
 		/// <summary>Halts the pass alarm</summary>
 		internal void Halt()
 		{

--- a/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/PilotLamp.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/PilotLamp.cs
@@ -30,20 +30,12 @@ namespace OpenBve.SafetySystems
 			if (oldState != DoorStates.None & newState == DoorStates.None)
 			{
 				Lit = true;
-				SoundBuffer buffer = OnSound.Buffer;
-				if (buffer != null)
-				{
-					Program.Sounds.PlaySound(buffer, 1.0, 1.0, OnSound.Position, baseCar, false);
-				}
+				OnSound.Play(1.0, 1.0, false);
 			}
 			else if (oldState == DoorStates.None & newState != DoorStates.None)
 			{
 				Lit = false;
-				SoundBuffer buffer = OffSound.Buffer;
-				if (buffer != null)
-				{
-					Program.Sounds.PlaySound(buffer, 1.0, 1.0, OffSound.Position, baseCar, false);
-				}
+				OffSound.Play(1.0, 1.0, false);
 			}
 			oldState = newState;
 		}

--- a/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/StationAdjustAlarm.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/SafetySystems/StationAdjustAlarm.cs
@@ -29,12 +29,7 @@ namespace OpenBve.SafetySystems
 				// correct stop position
 				if (!Lit & (baseTrain.StationDistanceToStopPoint > tb | baseTrain.StationDistanceToStopPoint < -tf))
 				{
-					SoundBuffer buffer = AdjustAlarm.Buffer;
-					if (buffer != null)
-					{
-						OpenBveApi.Math.Vector3 pos = AdjustAlarm.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, baseTrain.Cars[baseTrain.DriverCar], false);
-					}
+					AdjustAlarm.Play(1.0, 1.0, false);
 					if (baseTrain.IsPlayerTrain)
 					{
 						MessageManager.AddMessage(Translations.GetInterfaceString("message_station_correct"), MessageDependency.None, GameMode.Normal, MessageColor.Orange, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);

--- a/source/OpenBVE/Simulation/TrainManager/Train/TrackFollowingObject.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/TrackFollowingObject.cs
@@ -74,11 +74,7 @@ namespace OpenBve
 
 							if (Cars[i].Specs.IsMotorCar)
 							{
-								if (Cars[i].Sounds.Loop.Buffer != null)
-								{
-									Vector3 pos = Cars[i].Sounds.Loop.Position;
-									Cars[i].Sounds.Loop.Source = Program.Sounds.PlaySound(Cars[i].Sounds.Loop.Buffer, 1.0, 1.0, pos, Cars[i], true);
-								}
+								Cars[i].Sounds.Loop.Play(1.0, 1.0, true);
 							}
 						}
 					}

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.Handles.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.Handles.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Sounds;
 using SoundManager;
 
 namespace OpenBve
@@ -52,20 +53,16 @@ namespace OpenBve
 					if (p > 0)
 					{
 						// down (not min)
-						SoundBuffer buffer;
+						CarSound sound;
 						if ((Handles.Power.Driver - p > 2 | Handles.Power.ContinuousMovement) && Handles.Power.DecreaseFast.Buffer != null)
 						{
-							buffer = Handles.Power.DecreaseFast.Buffer;
+							sound = Handles.Power.DecreaseFast;
 						}
 						else
 						{
-							buffer = Handles.Power.Decrease.Buffer;
+							sound = Handles.Power.Decrease;
 						}
-						if (buffer != null)
-						{
-							Vector3 pos = Handles.Power.Decrease.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-						}
+						sound.Play(1.0, 1.0, false);
 					}
 					else
 					{
@@ -73,8 +70,7 @@ namespace OpenBve
 						SoundBuffer buffer = Handles.Power.Min.Buffer;
 						if (buffer != null)
 						{
-							Vector3 pos = Handles.Power.Min.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+							Handles.Power.Min.Play(1.0, 1.0, false);
 						}
 					}
 				}
@@ -83,30 +79,22 @@ namespace OpenBve
 					if (p < Handles.Power.MaximumDriverNotch)
 					{
 						// up (not max)
-						SoundBuffer buffer;
+						CarSound sound;
 						if ((Handles.Power.Driver - p > 2 | Handles.Power.ContinuousMovement) && Handles.Power.IncreaseFast.Buffer != null)
 						{
-							buffer = Handles.Power.IncreaseFast.Buffer;
+							sound = Handles.Power.IncreaseFast;
 						}
 						else
 						{
-							buffer = Handles.Power.Increase.Buffer;
+							sound = Handles.Power.Increase;
 						}
-						if (buffer != null)
-						{
-							Vector3 pos = Handles.Power.Increase.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-						}
+
+						sound.Play(1.0, 1.0, false);
 					}
 					else
 					{
 						// max
-						SoundBuffer buffer = Handles.Power.Max.Buffer;
-						if (buffer != null)
-						{
-							Vector3 pos = Handles.Power.Max.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-						}
+						Handles.Power.Max.Play(1.0, 1.0, false);
 					}
 				}
 
@@ -117,8 +105,7 @@ namespace OpenBve
 					SoundBuffer buffer = Cars[DriverCar].Sounds.Brake.Buffer;
 					if (buffer != null)
 					{
-						Vector3 pos = Cars[DriverCar].Sounds.Brake.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Cars[DriverCar].Sounds.Brake.Play(1.0, 1.0, false);
 					}
 
 					if (b > 0)
@@ -134,8 +121,7 @@ namespace OpenBve
 						}
 						if (buffer != null)
 						{
-							Vector3 pos = Handles.Brake.Decrease.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+							Handles.Brake.Decrease.Play(1.0, 1.0, false);
 						}
 					}
 					else
@@ -144,8 +130,7 @@ namespace OpenBve
 						buffer = Handles.Brake.Min.Buffer;
 						if (buffer != null)
 						{
-							Vector3 pos = Handles.Brake.Min.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+							Handles.Brake.Min.Play(1.0, 1.0, false);
 						}
 					}
 				}
@@ -164,8 +149,7 @@ namespace OpenBve
 					
 					if (buffer != null)
 					{
-						Vector3 pos = Handles.Brake.Increase.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Handles.Brake.Increase.Play(1.0, 1.0, false);
 					}
 				}
 
@@ -208,8 +192,7 @@ namespace OpenBve
 					SoundBuffer buffer = Cars[DriverCar].Sounds.Brake.Buffer;
 					if (buffer != null)
 					{
-						Vector3 pos = Cars[DriverCar].Sounds.Brake.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Cars[DriverCar].Sounds.Brake.Play(1.0, 1.0, false);
 					}
 
 					if (b > 0)
@@ -225,8 +208,7 @@ namespace OpenBve
 						}
 						if (buffer != null)
 						{
-							Vector3 pos = Handles.Brake.Decrease.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+							Handles.Brake.Decrease.Play(1.0, 1.0, false);
 						}
 					}
 					else
@@ -235,8 +217,7 @@ namespace OpenBve
 						buffer = Handles.Brake.Min.Buffer;
 						if (buffer != null)
 						{
-							Vector3 pos = Handles.Brake.Min.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+							Handles.Brake.Min.Play(1.0, 1.0, false);
 						}
 					}
 				}
@@ -254,8 +235,7 @@ namespace OpenBve
 					}
 					if (buffer != null)
 					{
-						Vector3 pos = Handles.Brake.Increase.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Handles.Brake.Increase.Play(1.0, 1.0, false);
 					}
 				}
 
@@ -283,17 +263,11 @@ namespace OpenBve
 					// sound
 					if (a == 0 & r != 0)
 					{
-						SoundBuffer buffer = Handles.Reverser.EngageSound.Buffer;
-						if (buffer == null) return;
-						Vector3 pos = Handles.Reverser.EngageSound.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Handles.Reverser.EngageSound.Play(1.0, 1.0, false);
 					}
 					else if (a != 0 & r == 0)
 					{
-						SoundBuffer buffer = Handles.Reverser.ReleaseSound.Buffer;
-						if (buffer == null) return;
-						Vector3 pos = Handles.Reverser.ReleaseSound.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+						Handles.Reverser.ReleaseSound.Play(1.0, 1.0, false);
 					}
 				}
 			}
@@ -304,21 +278,12 @@ namespace OpenBve
 				// sound
 				if (!Handles.EmergencyBrake.Driver)
 				{
-					SoundBuffer buffer = Handles.Brake.Max.Buffer;
-					if (buffer != null)
-					{
-						Vector3 pos = Handles.Brake.Max.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-					}
-
+					Handles.Brake.Max.Play(1.0, 1.0, false);
 					for (int i = 0; i < Cars.Length; i++)
 					{
-						buffer = Handles.EmergencyBrake.ApplicationSound.Buffer;
-						if (buffer != null)
-						{
-							Vector3 pos = Handles.EmergencyBrake.ApplicationSound.Position;
-							Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-						}
+						//BUG: This should be attached to every car, not the driver car I presume
+						//Broken from Michelle or us?
+						Handles.EmergencyBrake.ApplicationSound.Play(1.0, 1.0, false);
 					}
 				}
 
@@ -365,21 +330,17 @@ namespace OpenBve
 				if (Handles.EmergencyBrake.Driver)
 				{
 					// sound
-					SoundBuffer buffer;
+					CarSound sound;
 					if (Handles.EmergencyBrake.ReleaseSound != null)
 					{
-						buffer = Handles.EmergencyBrake.ReleaseSound.Buffer;
+						sound = Handles.EmergencyBrake.ReleaseSound;
 					}
 					else
 					{
-						buffer = Handles.Brake.Decrease.Buffer;
+						sound = Handles.Brake.Decrease;
 					}
-					
-					if (buffer != null)
-					{
-						Vector3 pos = Handles.Brake.Decrease.Position;
-						Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-					}
+					sound.Play(1.0, 1.0, false);
+
 
 					// apply
 					
@@ -453,12 +414,7 @@ namespace OpenBve
 						// sound when moved to service
 						if (newState == AirBrakeHandleState.Service)
 						{
-							SoundBuffer buffer = Cars[DriverCar].Sounds.Brake.Buffer;
-							if (buffer != null)
-							{
-								Vector3 pos = Cars[DriverCar].Sounds.Brake.Position;
-								Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-							}
+							Cars[DriverCar].Sounds.Brake.Play(1.0, 1.0, false);
 						}
 
 						// sound
@@ -468,30 +424,21 @@ namespace OpenBve
 							if ((int) newState > 0)
 							{
 								// brake release (not min)
-								SoundBuffer buffer;
+								CarSound sound;
 								if ((Handles.Brake.Driver - (int)newState > 2 | Handles.Brake.ContinuousMovement) && Handles.Brake.Decrease.Buffer != null)
 								{
-									buffer = Handles.Brake.DecreaseFast.Buffer;
+									sound = Handles.Brake.DecreaseFast;
 								}
 								else
 								{
-									buffer = Handles.Brake.Decrease.Buffer;
+									sound = Handles.Brake.Decrease;
 								}
-								if (buffer != null)
-								{
-									Vector3 pos = Handles.Brake.Decrease.Position;
-									Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-								}
+								sound.Play(1.0,1.0, false);
 							}
 							else
 							{
 								// brake min
-								SoundBuffer buffer = Handles.Brake.Min.Buffer;
-								if (buffer != null)
-								{
-									Vector3 pos = Handles.Brake.Min.Position;
-									Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-								}
+								Handles.Brake.Min.Play(1.0, 1.0, false);
 							}
 						}
 						else if ((int) newState > (int) Handles.Brake.Driver)
@@ -508,8 +455,7 @@ namespace OpenBve
 							}
 							if (buffer != null)
 							{
-								Vector3 pos = Handles.Brake.Increase.Position;
-								Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+								Handles.Brake.Increase.Play(1.0, 1.0, false);
 							}
 						}
 
@@ -537,12 +483,7 @@ namespace OpenBve
 						// sound when moved to service
 						if (newState == AirBrakeHandleState.Service)
 						{
-							SoundBuffer buffer = Cars[DriverCar].Sounds.Brake.Buffer;
-							if (buffer != null)
-							{
-								Vector3 pos = Cars[DriverCar].Sounds.Brake.Position;
-								Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-							}
+							Cars[DriverCar].Sounds.Brake.Play(1.0, 1.0, false);
 						}
 
 						// sound
@@ -552,30 +493,21 @@ namespace OpenBve
 							if ((int) newState > 0)
 							{
 								// brake release (not min)
-								SoundBuffer buffer;
+								CarSound sound;
 								if ((Handles.Brake.Driver - (int)newState > 2 | Handles.Brake.ContinuousMovement) && Handles.Brake.DecreaseFast.Buffer != null)
 								{
-									buffer = Handles.Brake.DecreaseFast.Buffer;
+									sound = Handles.Brake.DecreaseFast;
 								}
 								else
 								{
-									buffer = Handles.Brake.Decrease.Buffer;
+									sound = Handles.Brake.Decrease;
 								}
-								if (buffer != null)
-								{
-									Vector3 pos = Handles.Brake.Decrease.Position;
-									Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-								}
+								sound.Play(1.0, 1.0, false);
 							}
 							else
 							{
 								// brake min
-								SoundBuffer buffer = Handles.Brake.Min.Buffer;
-								if (buffer != null)
-								{
-									Vector3 pos = Handles.Brake.Min.Position;
-									Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
-								}
+								Handles.Brake.Min.Play(1.0, 1.0, false);
 							}
 						}
 						else if ((int) newState > (int) Handles.LocoBrake.Driver)
@@ -592,8 +524,7 @@ namespace OpenBve
 							}
 							if (buffer != null)
 							{
-								Vector3 pos = Handles.Brake.Increase.Position;
-								Program.Sounds.PlaySound(buffer, 1.0, 1.0, pos, Cars[DriverCar], false);
+								Handles.Brake.Increase.Play(1.0, 1.0, false);
 							}
 						}
 

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.RequestStop.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.RequestStop.cs
@@ -18,7 +18,7 @@ namespace OpenBve
 				if (stopRequest.MaxCars != 0 && NumberOfCars > stopRequest.MaxCars)
 				{
 					//Check whether our train length is valid for this before doing anything else
-					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[2], 1.0, 1.0, Cars[DriverCar], false);
+					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[2], 1.0, 1.0, false);
 					return;
 				}
 				if (Program.RandomNumberGenerator.Next(0, 100) <= stopRequest.Probability)
@@ -31,7 +31,7 @@ namespace OpenBve
 						Station = stopRequest.StationIndex;
 						NextStopSkipped = StopSkipMode.None;
 						//Play sound
-						Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[0], 1.0, 1.0, Cars[DriverCar], false);
+						Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[0], 1.0, 1.0, false);
 					}
 					else
 					{
@@ -47,7 +47,7 @@ namespace OpenBve
 						}
 
 						//Play sound
-						Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Cars[DriverCar], false);
+						Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, false);
 						//If message is not empty, add it
 						if (!string.IsNullOrEmpty(stopRequest.PassMessage) && IsPlayerTrain)
 						{
@@ -58,7 +58,7 @@ namespace OpenBve
 					}
 
 					//Play sound
-					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[0], 1.0, 1.0, Cars[DriverCar], false);
+					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[0], 1.0, 1.0, false);
 					//If message is not empty, add it
 					if (!string.IsNullOrEmpty(stopRequest.StopMessage) && IsPlayerTrain)
 					{
@@ -67,7 +67,7 @@ namespace OpenBve
 				}
 				else
 				{
-					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Cars[DriverCar], false);
+					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, false);
 					if (stopRequest.FullSpeed)
 					{
 						//Pass at linespeed, rather than braking as if for stop
@@ -79,7 +79,7 @@ namespace OpenBve
 					}
 
 					//Play sound
-					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, Cars[DriverCar], false);
+					Program.Sounds.PlayCarSound(Cars[DriverCar].Sounds.RequestStop[1], 1.0, 1.0, false);
 					//If message is not empty, add it
 					if (!string.IsNullOrEmpty(stopRequest.PassMessage) && IsPlayerTrain)
 					{

--- a/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
+++ b/source/OpenBVE/Simulation/TrainManager/Train/Train.cs
@@ -405,10 +405,7 @@ namespace OpenBve
 								
 								if (Cars[j].Specs.IsMotorCar)
 								{
-									if (Cars[j].Sounds.Loop.Buffer != null)
-									{
-										Cars[j].Sounds.Loop.Source = Program.Sounds.PlaySound(Cars[j].Sounds.Loop.Buffer, 1.0, 1.0, Cars[j].Sounds.Loop.Position, Cars[j], true);
-									}
+									Cars[j].Sounds.Loop.Play(1.0, 1.0, true);
 								}
 							}
 						}
@@ -458,8 +455,7 @@ namespace OpenBve
 				//Trigger point sounds if appropriate
 				for (int i = 0; i < Cars.Length; i++)
 				{
-					Vector3 p = Vector3.Zero;
-					SoundBuffer buffer = null;
+					CarSound pointSound = null;
 					if (Cars[i].FrontAxle.PointSoundTriggered)
 					{
 						
@@ -481,21 +477,20 @@ namespace OpenBve
 						{
 							c = (CarSound)Cars[i].FrontAxle.PointSounds[0];
 						}
-						buffer = c.Buffer;
-						p = c.Position;
+						pointSound = c;
 					}
-					if (buffer != null)
+					if (pointSound != null)
 					{
 						double spd = Math.Abs(CurrentSpeed);
 						double pitch = spd / 12.5;
 						double gain = pitch < 0.5 ? 2.0 * pitch : 1.0;
 						if (pitch < 0.2 | gain < 0.2)
 						{
-							buffer = null;
+							pointSound = null;
 						}
-						if (buffer != null)
+						if (pointSound != null)
 						{
-							Program.Sounds.PlaySound(buffer, pitch, gain, p, Cars[i], false);
+							pointSound.Play(pitch, gain, false);
 						}
 					}
 				}
@@ -566,23 +561,13 @@ namespace OpenBve
 					if (breaker & !Cars[DriverCar].Sounds.BreakerResumed)
 					{
 						// resume
-						if (Cars[DriverCar].Sounds.BreakerResume.Buffer != null)
-						{
-							Program.Sounds.PlaySound(Cars[DriverCar].Sounds.BreakerResume.Buffer, 1.0, 1.0, Cars[DriverCar].Sounds.BreakerResume.Position, Cars[DriverCar], false);
-						}
-						if (Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Buffer != null)
-						{
-							Program.Sounds.PlaySound(Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Buffer, 1.0, 1.0, Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Position, Cars[DriverCar], false);
-						}
+						Cars[DriverCar].Sounds.BreakerResume.Play(1.0, 1.0, false);
 						Cars[DriverCar].Sounds.BreakerResumed = true;
 					}
 					else if (!breaker & Cars[DriverCar].Sounds.BreakerResumed)
 					{
 						// interrupt
-						if (Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Buffer != null)
-						{
-							Program.Sounds.PlaySound(Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Buffer, 1.0, 1.0, Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Position, Cars[DriverCar], false);
-						}
+						Cars[DriverCar].Sounds.BreakerResumeOrInterrupt.Play(1.0, 1.0, false);
 						Cars[DriverCar].Sounds.BreakerResumed = false;
 					}
 				}

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -278,18 +278,20 @@ namespace OpenBve {
 					// door open/close speed
 					for (int i = 0; i < TrainManager.Trains[k].Cars.Length; i++) {
 						if (TrainManager.Trains[k].Cars[i].Specs.DoorOpenFrequency <= 0.0) {
-							if (TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer != null & TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer);
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer);
+							if (TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer != null & TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer != null)
+							{
+								TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer.Load();
+								TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer.Load();
 								double a = TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer.Duration;
 								double b = TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorOpenFrequency = a + b > 0.0 ? 2.0 / (a + b) : 0.8;
 							} else if (TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer);
+								TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer.Load();
 								double a = TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorOpenFrequency = a > 0.0 ? 1.0 / a : 0.8;
-							} else if (TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer);
+							} else if (TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer != null)
+							{
+								TrainManager.Trains[k].Cars[i].Doors[0].OpenSound.Buffer.Load();
 								double b = TrainManager.Trains[k].Cars[i].Doors[1].OpenSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorOpenFrequency = b > 0.0 ? 1.0 / b : 0.8;
 							} else {
@@ -298,17 +300,18 @@ namespace OpenBve {
 						}
 						if (TrainManager.Trains[k].Cars[i].Specs.DoorCloseFrequency <= 0.0) {
 							if (TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer != null & TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer);
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer);
+								TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer.Load();
+								TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer.Load();
 								double a = TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer.Duration;
 								double b = TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorCloseFrequency = a + b > 0.0 ? 2.0 / (a + b) : 0.8;
 							} else if (TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer);
+								TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer.Load();
 								double a = TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorCloseFrequency = a > 0.0 ? 1.0 / a : 0.8;
-							} else if (TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer != null) {
-								Program.Sounds.LoadBuffer(TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer);
+							} else if (TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer != null)
+							{
+								TrainManager.Trains[k].Cars[i].Doors[0].CloseSound.Buffer.Load();
 								double b = TrainManager.Trains[k].Cars[i].Doors[1].CloseSound.Buffer.Duration;
 								TrainManager.Trains[k].Cars[i].Specs.DoorCloseFrequency = b > 0.0 ? 1.0 / b : 0.8;
 							} else {

--- a/source/OpenBVE/System/Plugins/NetPlugin.cs
+++ b/source/OpenBVE/System/Plugins/NetPlugin.cs
@@ -332,12 +332,11 @@ namespace OpenBve {
 		{
 			if (index >= 0 && index < this.Train.Cars[this.Train.DriverCar].Sounds.Plugin.Length && this.Train.Cars[this.Train.DriverCar].Sounds.Plugin[index].Buffer != null) {
 				SoundBuffer buffer = Train.Cars[Train.DriverCar].Sounds.Plugin[index].Buffer;
-				OpenBveApi.Math.Vector3 position = this.Train.Cars[this.Train.DriverCar].Sounds.Plugin[index].Position;
-				SoundSource source = Program.Sounds.PlaySound(buffer, pitch, volume, position, Train.Cars[Train.DriverCar], looped);
+				this.Train.Cars[this.Train.DriverCar].Sounds.Plugin[index].Play(pitch, volume, looped);
 				if (this.SoundHandlesCount == this.SoundHandles.Length) {
 					Array.Resize<SoundHandleEx>(ref this.SoundHandles, this.SoundHandles.Length << 1);
 				}
-				this.SoundHandles[this.SoundHandlesCount] = new SoundHandleEx(volume, pitch, source);
+				this.SoundHandles[this.SoundHandlesCount] = new SoundHandleEx(volume, pitch, this.Train.Cars[this.Train.DriverCar].Sounds.Plugin[index].Source);
 				this.SoundHandlesCount++;
 				return this.SoundHandles[this.SoundHandlesCount - 1];
 			}

--- a/source/RouteViewer/Audio/Sounds.Update.cs
+++ b/source/RouteViewer/Audio/Sounds.Update.cs
@@ -159,8 +159,9 @@ namespace OpenBve
 						 * For non-looping sounds, check if the sound is still playing.
 						 * */
 						gain = (gain - GainThreshold) / (1.0 - GainThreshold);
-						if (Sources[i].State != SoundSourceState.Playing) {
-							LoadBuffer(Sources[i].Buffer);
+						if (Sources[i].State != SoundSourceState.Playing)
+						{
+							Sources[i].Buffer.Load();
 							if (Sources[i].Buffer.Loaded) {
 								AL.GenSources(1, out Sources[i].OpenAlSourceName);
 								AL.Source(Sources[i].OpenAlSourceName, ALSourcei.Buffer, Sources[i].Buffer.OpenAlBufferName);
@@ -481,7 +482,7 @@ namespace OpenBve
 					 * Ensure the buffer is loaded, then play the sound.
 					 * */
 					if (source.State != SoundSourceState.Playing) {
-						LoadBuffer(source.Buffer);
+						source.Buffer.Load();
 						if (source.Buffer.Loaded) {
 							AL.GenSources(1, out source.OpenAlSourceName);
 							AL.Source(source.OpenAlSourceName, ALSourcei.Buffer, source.Buffer.OpenAlBufferName);

--- a/source/RouteViewer/Audio/Sounds.cs
+++ b/source/RouteViewer/Audio/Sounds.cs
@@ -15,15 +15,7 @@ namespace OpenBve
 		/// <returns>The sound source.</returns>
 		internal void PlayCarSound(CarSound sound, double pitch, double volume, AbstractCar car, bool looped)
 		{
-			if (sound.Buffer == null)
-			{
-				return;
-			}
-			if (car == null)
-			{
-				throw new InvalidDataException("A valid car must be specified");
-			}
-			sound.Source = PlaySound(sound.Buffer, pitch, volume, sound.Position, car, looped);
+			sound.Play(pitch, volume, looped);
 		}
 	}
 }

--- a/source/SoundManager/Sounds.CarSound.cs
+++ b/source/SoundManager/Sounds.CarSound.cs
@@ -1,4 +1,7 @@
-﻿using OpenBveApi.Math;
+﻿using System;
+using System.IO;
+using OpenBveApi.Math;
+using OpenBveApi.Trains;
 
 namespace SoundManager
 {
@@ -10,17 +13,21 @@ namespace SoundManager
 		/// <summary>The source of the sound within the car</summary>
 		public SoundSource Source;
 		/// <summary>A Vector3 describing the position of the sound source</summary>
-		public Vector3 Position;
-		
+		public readonly Vector3 Position;
+		/// <summary>The car this sound is attached to</summary>
+		private readonly AbstractCar Car;
+
 		/// <summary>Creates a new car sound</summary>
 		/// <param name="buffer">The sound buffer</param>
-		/// <param name="Position">The position that the sound is emitted from within the car</param>
+		/// <param name="position">The position that the sound is emitted from within the car</param>
+		/// <param name="car">The parent car reference</param>
 		/// <returns>The new car sound</returns>
-		public CarSound(SoundBuffer buffer, Vector3 Position)
+		public CarSound(SoundBuffer buffer, Vector3 position, AbstractCar car)
 		{
-			this.Position = Position;
+			this.Position = position;
 			this.Source = null;
 			this.Buffer = buffer;
+			this.Car = car;
 		}
 
 		/// <summary>Creates a new empty car sound</summary>
@@ -31,6 +38,29 @@ namespace SoundManager
 			this.Buffer = null;
 		}
 
+		/// <summary>Plays the sound.</summary>
+		/// <param name="pitch">The pitch change factor.</param>
+		/// <param name="volume">The volume change factor.</param>
+		/// <param name="looped">Whether to play the sound in a loop.</param>
+		public void Play(double pitch, double volume, bool looped)
+		{
+			if (Buffer == null)
+			{
+				return;
+			}
+			if (Car == null)
+			{
+				throw new InvalidDataException("Sound does not have a valid car specified");
+			}
+			if (SoundsBase.Sources.Length == SoundsBase.SourceCount)
+			{
+				Array.Resize(ref SoundsBase.Sources, SoundsBase.Sources.Length << 1);
+			}
+			SoundsBase.Sources[SoundsBase.SourceCount] = new SoundSource(Buffer, Buffer.Radius, pitch, volume, Position, Car, looped);
+			this.Source = SoundsBase.Sources[SoundsBase.SourceCount];
+			SoundsBase.SourceCount++;
+		}
+
 		/// <summary>Unconditionally stops the playing sound</summary>
 		public void Stop()
 		{
@@ -39,6 +69,16 @@ namespace SoundManager
 				return;
 			}
 			Source.Stop();
+		}
+
+		/// <summary>Gets the duration of the sound</summary>
+		public double Duration
+		{
+			get
+			{
+				Buffer.Load();
+				return Buffer.Duration;
+			}
 		}
 	}
 }

--- a/source/SoundManager/Sounds.SoundBuffer.cs
+++ b/source/SoundManager/Sounds.SoundBuffer.cs
@@ -1,6 +1,7 @@
 ﻿using OpenBveApi.FunctionScripting;
 using OpenBveApi.Hosts;
 using OpenBveApi.Sounds;
+using OpenTK.Audio.OpenAL;
 
 namespace SoundManager
 {
@@ -105,6 +106,35 @@ namespace SoundManager
 				PitchFunction = b.PitchFunction,
 				VolumeFunction = b.VolumeFunction
 			};
+		}
+
+		/// <summary>Loads the specified sound buffer.</summary>
+		/// <returns>Whether loading the buffer was successful.</returns>
+		public void Load()
+		{
+			if (Loaded)
+			{
+				return;
+			}
+			if (Ignore)
+			{
+				return;
+			}
+			Sound sound;
+			if (Origin.GetSound(out sound))
+			{
+				if (sound.BitsPerSample == 8 | sound.BitsPerSample == 16)
+				{
+					byte[] bytes = sound.GetMonoMix();
+					AL.GenBuffers(1, out OpenAlBufferName);
+					ALFormat format = sound.BitsPerSample == 8 ? ALFormat.Mono8 : ALFormat.Mono16;
+					AL.BufferData(OpenAlBufferName, format, bytes, bytes.Length, sound.SampleRate);
+					Duration = sound.Duration;
+					Loaded = true;
+					return;
+				}
+			}
+			Ignore = true;
 		}
 	}
 }

--- a/source/TrainEditor2/Audio/SoundApi.Update.cs
+++ b/source/TrainEditor2/Audio/SoundApi.Update.cs
@@ -253,7 +253,7 @@ namespace TrainEditor2.Audio
 					 * */
 					if (source.State != SoundSourceState.Playing)
 					{
-						LoadBuffer(source.Buffer);
+						source.Buffer.Load();
 						if (source.Buffer.Loaded)
 						{
 							AL.GenSources(1, out source.OpenAlSourceName);

--- a/source/TrainEditor2/Simulation/TrainManager/Car/Car.cs
+++ b/source/TrainEditor2/Simulation/TrainManager/Car/Car.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using OpenBveApi.Math;
+using OpenBveApi.Trains;
 using SoundManager;
 using TrainEditor2.Models.Sounds;
 
@@ -76,13 +77,7 @@ namespace TrainEditor2.Simulation.TrainManager
 					}
 					else if (pitch > 0.02 & gain > 0.01)
 					{
-						SoundBuffer buffer = Sounds.Run[j].Buffer;
-
-						if (buffer != null)
-						{
-							Vector3 pos = Sounds.Run[j].Position;
-							Sounds.Run[j].Source = Program.SoundApi.PlaySound(buffer, pitch, gain, pos, baseTrain, true);
-						}
+						Sounds.Run[j].Play(pitch, gain, true);
 					}
 				}
 			}
@@ -215,7 +210,7 @@ namespace TrainEditor2.Simulation.TrainManager
 						}
 					}
 
-					Sounds.Run[element.Key] = new CarSound(Program.SoundApi.RegisterBuffer(element.FilePath, mediumRadius), center);
+					Sounds.Run[element.Key] = new CarSound(Program.SoundApi.RegisterBuffer(element.FilePath, mediumRadius), center, new AbstractCar());
 				}
 
 				Sounds.RunVolume = new double[Sounds.Run.Length];


### PR DESCRIPTION
This refactors car sound playback to use a method call within the sound.

In general, it's much simpler code than the previous, and should probably be merged prior to https://github.com/leezer3/OpenBVE/tree/TrainManager (this would allow the removal of a bunch of stored references)

### Potential issues:
* Each CarSound now stores it's car reference internally. Are these all correct?
* No immediate method to change which car a CarSound plays from. (Introduced as an API playback function a while back, this might need redesign?)
* The emergency brake sound appears to have a bug / undefined piece of behaviour- By the looks of things, it was intended to play once (simulataneously) positioned for each car in the train, but either by us or Michelle, actually only played in the driver car. Check when this was introduced!
* null checks moved to within the sound play call. Have any been missed?