### PR TITLE
Fix:compile error with mono-complete package

### DIFF
--- a/source/Plugins/Texture.Tga/Texture.Tga.csproj
+++ b/source/Plugins/Texture.Tga/Texture.Tga.csproj
@@ -48,7 +48,7 @@
     <OutputPath>..\..\..\bin_release\</OutputPath>
     <LangVersion>6</LangVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
At
https://www.mono-project.com/download/stable/#download-lin-ubuntu
This installed filename at Ubuntu is
/usr/lib/mono/msbuild/15.0/bin/Microsoft.CSharp.targets
So, compile error causes.