### PR TITLE
Fix: error on files with incorrect cbSize

### DIFF
--- a/source/Plugins/Sound.RiffWave/Plugin.Parser.cs
+++ b/source/Plugins/Sound.RiffWave/Plugin.Parser.cs
@@ -223,7 +223,9 @@ namespace Plugin
 						if (ckSize > 16)
 						{
 							format.cbSize = reader.ReadUInt16(endianness);
-							reader.BaseStream.Position += format.cbSize;
+
+							// This is a countermeasure to the cbSize is not correct file.
+							reader.BaseStream.Position += Math.Min(format.cbSize, ckSize - 18);
 						}
 
 						if (format is WaveFormatPcm)


### PR DESCRIPTION
This PR fix error on files with incorrect cbSize.
Related) https://bveworldwide.forumotion.com/t1939-door-sounds-not-being-played