### PR TITLE
Change: Different approach to memory leak with VAOs

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -216,7 +216,10 @@ namespace LibRender2
 
 			try
 			{
-				DefaultShader = new Shader(this, "default", "default", true);
+				if (DefaultShader == null)
+				{
+					DefaultShader = new Shader(this, "default", "default", true);
+				}
 				DefaultShader.Activate();
 				DefaultShader.SetMaterialAmbient(Color32.White);
 				DefaultShader.SetMaterialDiffuse(Color32.White);

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -295,9 +295,8 @@ namespace LibRender2
 				}
 				iboToDelete.Clear();
 			}
-			
 		}
-		
+
 		/// <summary>
 		/// Performs a reset of OpenGL to the default state
 		/// </summary>
@@ -348,6 +347,10 @@ namespace LibRender2
 
 		public void Reset()
 		{
+			currentHost.AnimatedObjectCollectionCache.Clear();
+			currentHost.StaticObjectCache.Clear();
+			TextureManager.UnloadAllTextures();
+
 			Initialize(currentHost, currentOptions);
 		}
 
@@ -772,7 +775,7 @@ namespace LibRender2
 			Shader.SetOpacity(1.0f);
 			Shader.SetObjectIndex(0);
 		}
-		
+
 		public void SetBlendFunc()
 		{
 			SetBlendFunc(blendSrcFactor, blendDestFactor);

--- a/source/LibRender2/LibRender2.csproj
+++ b/source/LibRender2/LibRender2.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Backgrounds\Background.cs" />

--- a/source/LibRender2/Shaders/Shader.cs
+++ b/source/LibRender2/Shaders/Shader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -19,8 +19,6 @@ namespace LibRender2.Shaders
 	/// </summary>
 	public class Shader : IDisposable
 	{
-		public static List<Shader> Disposable = new List<Shader>();
-
 		private readonly int handle;
 		private int vertexShader;
 		private int fragmentShader;
@@ -89,8 +87,6 @@ namespace LibRender2.Shaders
 
 			VertexLayout = GetVertexLayout();
 			UniformLayout = GetUniformLayout();
-
-			Disposable.Add(this);
 		}
 
 		/// <summary>Loads the shader source and compiles the shader</summary>

--- a/source/LibRender2/openGL/IndexBufferObject.cs
+++ b/source/LibRender2/openGL/IndexBufferObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using OpenTK.Graphics.OpenGL;
 
 namespace LibRender2
@@ -59,6 +59,14 @@ namespace LibRender2
 				GL.DeleteBuffer(handle);
 				GC.SuppressFinalize(this);
 				disposed = true;
+			}
+		}
+
+		~IndexBufferObject()
+		{
+			if (!disposed)
+			{
+				BaseRenderer.iboToDelete.Add(handle);
 			}
 		}
 	}

--- a/source/LibRender2/openGL/IndexBufferObject.cs
+++ b/source/LibRender2/openGL/IndexBufferObject.cs
@@ -54,17 +54,24 @@ namespace LibRender2
 		/// </summary>
 		public void Dispose()
 		{
-			if (!disposed)
+			if (disposed)
 			{
-				GL.DeleteBuffer(handle);
-				GC.SuppressFinalize(this);
-				disposed = true;
+				return;
 			}
+
+			GL.DeleteBuffer(handle);
+			GC.SuppressFinalize(this);
+			disposed = true;
 		}
 
 		~IndexBufferObject()
 		{
-			if (!disposed)
+			if (disposed)
+			{
+				return;
+			}
+
+			lock (BaseRenderer.iboToDelete)
 			{
 				BaseRenderer.iboToDelete.Add(handle);
 			}

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenBveApi.Colors;
@@ -15,8 +15,6 @@ namespace LibRender2
 	/// </summary>
 	public class VertexArrayObject : IDisposable
 	{
-		public static readonly List<VertexArrayObject> Disposable = new List<VertexArrayObject>();
-
 		internal readonly int handle;
 		private VertexBufferObject vbo;
 		private IndexBufferObject ibo;
@@ -32,7 +30,6 @@ namespace LibRender2
 			{
 				throw new InvalidOperationException("Failed to generate the required vertex array handle- No openGL context.");
 			}
-			Disposable.Add(this);
 		}
 
 		/// <summary>
@@ -144,6 +141,14 @@ namespace LibRender2
 				GL.DeleteVertexArray(handle);
 				GC.SuppressFinalize(this);
 				disposed = true;
+			}
+		}
+
+		~VertexArrayObject()
+		{
+			if (!disposed)
+			{
+				BaseRenderer.vaoToDelete.Add(handle);
 			}
 		}
 	}

--- a/source/LibRender2/openGL/VertexArrayObject.cs
+++ b/source/LibRender2/openGL/VertexArrayObject.cs
@@ -133,20 +133,27 @@ namespace LibRender2
 		/// </summary>
 		public void Dispose()
 		{
-			if (!disposed)
+			if (disposed)
 			{
-				ibo?.Dispose();
-				vbo?.Dispose();
-
-				GL.DeleteVertexArray(handle);
-				GC.SuppressFinalize(this);
-				disposed = true;
+				return;
 			}
+
+			ibo?.Dispose();
+			vbo?.Dispose();
+
+			GL.DeleteVertexArray(handle);
+			GC.SuppressFinalize(this);
+			disposed = true;
 		}
 
 		~VertexArrayObject()
 		{
-			if (!disposed)
+			if (disposed)
+			{
+				return;
+			}
+
+			lock (BaseRenderer.vaoToDelete)
 			{
 				BaseRenderer.vaoToDelete.Add(handle);
 			}

--- a/source/LibRender2/openGL/VertexBufferObject.cs
+++ b/source/LibRender2/openGL/VertexBufferObject.cs
@@ -138,17 +138,24 @@ namespace LibRender2
 		/// </summary>
 		public void Dispose()
 		{
-			if (!disposed)
+			if (disposed)
 			{
-				GL.DeleteBuffer(handle);
-				GC.SuppressFinalize(this);
-				disposed = true;
+				return;
 			}
+
+			GL.DeleteBuffer(handle);
+			GC.SuppressFinalize(this);
+			disposed = true;
 		}
 
 		~VertexBufferObject()
 		{
-			if (!disposed)
+			if (disposed)
+			{
+				return;
+			}
+
+			lock (BaseRenderer.vboToDelete)
 			{
 				BaseRenderer.vboToDelete.Add(handle);
 			}

--- a/source/LibRender2/openGL/VertexBufferObject.cs
+++ b/source/LibRender2/openGL/VertexBufferObject.cs
@@ -145,5 +145,13 @@ namespace LibRender2
 				disposed = true;
 			}
 		}
+
+		~VertexBufferObject()
+		{
+			if (!disposed)
+			{
+				BaseRenderer.vboToDelete.Add(handle);
+			}
+		}
 	}
 }

--- a/source/LibRender2/packages.config
+++ b/source/LibRender2/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="OpenTK" version="3.2" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/source/ObjectViewer/NewRendererS.cs
+++ b/source/ObjectViewer/NewRendererS.cs
@@ -124,6 +124,7 @@ namespace OpenBve
 		// render scene
 		internal void RenderScene()
 		{
+			ReleaseResources();
 			// initialize
 			ResetOpenGlState();
 

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -180,7 +180,6 @@ namespace OpenBve {
 			// reset
 			LightingRelative = -1.0;
 			Game.Reset();
-			Renderer.TextureManager.UnloadAllTextures();
 			//Fonts.Initialize();
 			Interface.ClearMessages();
 			for (int i = 0; i < Files.Length; i++)
@@ -325,11 +324,8 @@ namespace OpenBve {
 	                break;
 	            case Key.F5:
 	                // reset
-					CurrentHost.AnimatedObjectCollectionCache.Clear();
-					CurrentHost.StaticObjectCache.Clear();
 	                LightingRelative = -1.0;
 	                Game.Reset();
-	                Renderer.TextureManager.UnloadAllTextures();
 	                Interface.ClearMessages();
 	                for (int i = 0; i < Files.Length; i++)
 	                {
@@ -427,7 +423,6 @@ namespace OpenBve {
 			            // reset
 			            LightingRelative = -1.0;
 			            Game.Reset();
-			            Renderer.TextureManager.UnloadAllTextures();
 			            Interface.ClearMessages();
 			            for (int i = 0; i < Files.Length; i++)
 			            {
@@ -531,7 +526,6 @@ namespace OpenBve {
 	            case Key.Delete:
 		            LightingRelative = -1.0;
 	                Game.Reset();
-	                Renderer.TextureManager.UnloadAllTextures();
 	                Interface.ClearMessages();
 	                Files = new string[] {};
 					Renderer.ApplyBackgroundColor();

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -292,8 +292,6 @@ namespace OpenBve
 
         public override void Dispose()
         {
-			Program.Renderer.Finalization();
-
 	        base.Dispose();
         }
     }

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -97,7 +97,6 @@ namespace OpenBve
             {
 	            Program.LightingRelative = -1.0;
                     Game.Reset();
-                    Program.Renderer.TextureManager.UnloadAllTextures();
                     Interface.ClearMessages();
                     for (int i = 0; i < Program.Files.Length; i++)
                     {

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -58,7 +58,10 @@ namespace OpenBve.Graphics
 
 			try
 			{
-				pickingShader = new Shader(this, "default", "picking", true);
+				if (pickingShader == null)
+				{
+					pickingShader = new Shader(this, "default", "picking", true);
+				}
 				pickingShader.Activate();
 				pickingShader.Deactivate();
 			}

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -235,6 +235,7 @@ namespace OpenBve.Graphics
 		// render scene
 		internal void RenderScene(double TimeElapsed)
 		{
+			ReleaseResources();
 			// initialize
 			ResetOpenGlState();
 

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -1047,8 +1047,6 @@ namespace OpenBve
 		
 		public override void Dispose()
 		{
-			Program.Renderer.Finalization();
-
 			base.Dispose();
 		}
 	}

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -190,6 +190,7 @@ namespace OpenBve
 		// render scene
 		internal void RenderScene(double TimeElapsed)
 		{
+			ReleaseResources();
 			// initialize
 			ResetOpenGlState();
 

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -300,8 +300,6 @@ namespace OpenBve {
 					AltPressed = true;
 					break;
 				case Key.F5:
-					CurrentHost.AnimatedObjectCollectionCache.Clear();
-					CurrentHost.StaticObjectCache.Clear();
 					if (CurrentRouteFile != null && CurrentlyLoading == false)
 					{
 						Bitmap bitmap = null;

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -241,8 +241,6 @@ namespace OpenBve
 
 		public override void Dispose()
 		{
-			Program.Renderer.Finalization();
-
 			base.Dispose();
 		}
     }

--- a/source/TrainEditor2/Views/FormEditor.cs
+++ b/source/TrainEditor2/Views/FormEditor.cs
@@ -603,7 +603,6 @@ namespace TrainEditor2.Views
 					}
 
 					glControlMotor.MakeCurrent();
-					Program.Renderer.Finalization();
 					break;
 			}
 


### PR DESCRIPTION
This takes a different approach entirely to https://github.com/leezer3/OpenBVE/pull/508

If the resources have not explicitly been released, the destructor now enqueues them to be deleted in the next render pass thread.

Appears to solve things properly.
cc @s520 @LabRatAndy