### PR TITLE
Add: cross-fading to switch between day and night textures

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -755,7 +755,7 @@ namespace LibRender2
 
 			if (lastError != ErrorCode.NoError)
 			{
-				throw new InvalidOperationException($"OpenGL Error: {lastError.ToString()}");
+				throw new InvalidOperationException($"OpenGL Error: {lastError}");
 			}
 #endif
 
@@ -959,6 +959,23 @@ namespace LibRender2
 					break;
 			}
 
+			// blend factor
+			float distanceFactor;
+			if (material.GlowAttenuationData != 0)
+			{
+				distanceFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData);
+			}
+			else
+			{
+				distanceFactor = 1.0f;
+			}
+
+			float blendFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
+			if (blendFactor > 1.0)
+			{
+				blendFactor = 1.0f;
+			}
+
 			// daytime polygon
 			{
 				// texture
@@ -989,13 +1006,7 @@ namespace LibRender2
 				else if (material.NighttimeTexture == null || material.NighttimeTexture == material.DaytimeTexture)
 				{
 					//No nighttime texture or both are identical- Darken the polygon to match the light conditions
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					factor = 1.0f - 0.7f * blend;
+					factor = 1.0f - 0.7f * blendFactor;
 				}
 				else
 				{
@@ -1004,15 +1015,10 @@ namespace LibRender2
 				}
 				Shader.SetBrightness(factor);
 
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
+				float alphaFactor = distanceFactor;
+				if (material.EnableCrossfading)
 				{
-					GlowAttenuationMode mode;
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData, out mode);
-				}
-				else
-				{
-					alphaFactor = 1.0f;
+					alphaFactor *= 1.0f - blendFactor;
 				}
 
 				Shader.SetOpacity(inv255 * material.Color.A * alphaFactor);
@@ -1040,26 +1046,7 @@ namespace LibRender2
 				GL.AlphaFunc(AlphaFunction.Greater, 0.0f);
 
 				// blend mode
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
-				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData);
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					alphaFactor *= blend;
-				}
-				else
-				{
-					alphaFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (alphaFactor > 1.0f)
-					{
-						alphaFactor = 1.0f;
-					}
-				}
+				float alphaFactor = distanceFactor * blendFactor;
 
 				Shader.SetOpacity(inv255 * material.Color.A * alphaFactor);
 
@@ -1208,6 +1195,23 @@ namespace LibRender2
 					break;
 			}
 
+			// blend factor
+			float distanceFactor;
+			if (material.GlowAttenuationData != 0)
+			{
+				distanceFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
+			}
+			else
+			{
+				distanceFactor = 1.0f;
+			}
+
+			float blendFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
+			if (blendFactor > 1.0)
+			{
+				blendFactor = 1.0f;
+			}
+
 			// daytime polygon
 			{
 				// texture
@@ -1235,14 +1239,7 @@ namespace LibRender2
 				}
 				else if (material.NighttimeTexture == null)
 				{
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					factor = 1.0f - 0.7f * blend;
+					factor = 1.0f - 0.7f * blendFactor;
 				}
 				else
 				{
@@ -1253,14 +1250,11 @@ namespace LibRender2
 				{
 					GL.Disable(EnableCap.Lighting);
 				}
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
+
+				float alphaFactor = distanceFactor;
+				if (material.EnableCrossfading)
 				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
-				}
-				else
-				{
-					alphaFactor = 1.0f;
+					alphaFactor *= 1.0f - blendFactor;
 				}
 
 				GL.Begin(DrawMode);
@@ -1309,26 +1303,7 @@ namespace LibRender2
 				GL.AlphaFunc(AlphaFunction.Greater, 0.0f);
 
 				// blend mode
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
-				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					alphaFactor *= blend;
-				}
-				else
-				{
-					alphaFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (alphaFactor > 1.0f)
-					{
-						alphaFactor = 1.0f;
-					}
-				}
+				float alphaFactor = distanceFactor * blendFactor;
 
 				GL.Begin(DrawMode);
 

--- a/source/OpenBveApi/Objects/Glow.cs
+++ b/source/OpenBveApi/Objects/Glow.cs
@@ -29,44 +29,19 @@ namespace OpenBveApi.Objects
 
 		/// <summary>Gets the current intensity glow intensity, using the glow attenuation factor</summary>
 		/// <param name="ModelMatrix">The model transformation matrix to apply</param>
-		/// <param name="Vertices">The verticies to which the glow is to be applied</param>
+		/// <param name="Vertices">The vertices to which the glow is to be applied</param>
 		/// <param name="Face">The face which these vertices make up</param>
 		/// <param name="GlowAttenuationData">The current glow attenuation</param>
 		/// <returns></returns>
 		public static double GetDistanceFactor(Matrix4D ModelMatrix, VertexTemplate[] Vertices, ref MeshFace Face, ushort GlowAttenuationData)
 		{
-			if (Face.Vertices.Length == 0)
-			{
-				return 1.0;
-			}
 			GlowAttenuationMode mode;
-			double halfdistance;
-			Glow.SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
-			int i = (int)Face.Vertices[0].Index;
-			Vector3 d = new Vector3(Vertices[i].Coordinates.X, Vertices[i].Coordinates.Y, -Vertices[i].Coordinates.Z);
-			d.Transform(ModelMatrix);
-			switch (mode)
-			{
-				case GlowAttenuationMode.DivisionExponent2:
-				{
-					double t = d.NormSquared();
-					return t / (t + halfdistance * halfdistance);
-				}
-				case GlowAttenuationMode.DivisionExponent4:
-				{
-					double t = d.NormSquared();
-					t *= t;
-					halfdistance *= halfdistance;
-					return t / (t + halfdistance * halfdistance);
-				}
-				default:
-					return 1.0;
-			}
+			return GetDistanceFactor(ModelMatrix, Vertices, ref Face, GlowAttenuationData, out mode);
 		}
 
 		/// <summary>Gets the current intensity glow intensity, using the glow attenuation factor</summary>
 		/// <param name="ModelMatrix">The model transformation matrix to apply</param>
-		/// <param name="Vertices">The verticies to which the glow is to be applied</param>
+		/// <param name="Vertices">The vertices to which the glow is to be applied</param>
 		/// <param name="Face">The face which these vertices make up</param>
 		/// <param name="GlowAttenuationData">The current glow attenuation</param>
 		/// <param name="mode">The returned glow attenuation mode</param>
@@ -78,26 +53,26 @@ namespace OpenBveApi.Objects
 			{
 				return 1.0;
 			}
-			
+
 			double halfdistance;
-			Glow.SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
-			int i = (int)Face.Vertices[0].Index;
+			SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
+			int i = Face.Vertices[0].Index;
 			Vector3 d = new Vector3(Vertices[i].Coordinates.X, Vertices[i].Coordinates.Y, -Vertices[i].Coordinates.Z);
 			d.Transform(ModelMatrix);
 			switch (mode)
 			{
 				case GlowAttenuationMode.DivisionExponent2:
-				{
-					double t = d.NormSquared();
-					return t / (t + halfdistance * halfdistance);
-				}
+					{
+						double t = d.NormSquared();
+						return t / (t + halfdistance * halfdistance);
+					}
 				case GlowAttenuationMode.DivisionExponent4:
-				{
-					double t = d.NormSquared();
-					t *= t;
-					halfdistance *= halfdistance;
-					return t / (t + halfdistance * halfdistance);
-				}
+					{
+						double t = d.NormSquared();
+						t *= t;
+						halfdistance *= halfdistance;
+						return t / (t + halfdistance * halfdistance);
+					}
 				default:
 					return 1.0;
 			}

--- a/source/OpenBveApi/Objects/Helpers/Material.cs
+++ b/source/OpenBveApi/Objects/Helpers/Material.cs
@@ -44,6 +44,8 @@ namespace OpenBveApi.Objects
 		public Vector2 TextPadding;
 		/// <summary>Whether lighting is disabled by the renderer</summary>
 		internal bool DisableLighting;
+		/// <summary>Whether cross-fading is enabled</summary>
+		public bool EnableCrossfading;
 
 		/// <summary>Creates a new Material with default properties</summary>
 		public Material() {

--- a/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
+++ b/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
@@ -148,6 +148,7 @@ namespace OpenBveApi.Objects
 						}
 
 						Object.Mesh.Materials[mm + i].NighttimeTexture = tnight;
+						Object.Mesh.Materials[mm + i].EnableCrossfading = Materials[i].EnableCrossfading;
 					}
 					else
 					{

--- a/source/OpenBveApi/Objects/MeshMaterial.cs
+++ b/source/OpenBveApi/Objects/MeshMaterial.cs
@@ -30,6 +30,8 @@ namespace OpenBveApi.Objects
 		public ushort GlowAttenuationData;
 		/// <summary>The wrap mode, or null to allow the renderer to decide</summary>
 		public OpenGlTextureWrapMode? WrapMode;
+		/// <summary>Whether cross-fading is enabled</summary>
+		public bool EnableCrossfading;
 
 		/// <summary>Returns whether two MeshMaterial structs are equal</summary>
 		public static bool operator ==(MeshMaterial A, MeshMaterial B)

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -42,7 +42,8 @@ namespace Plugin
 			"loadtexture",
 			"settexturecoordinates",
 			"setemissivecolor",
-			"setdecaltransparentcolor"
+			"setdecaltransparentcolor",
+			"enablecrossfading"
 		};
 
 		private static int SecondIndexOfAny(string testString, string[] values)
@@ -678,7 +679,8 @@ namespace Plugin
 										NighttimeTexture = Builder.Materials[0].NighttimeTexture,
 										TransparentColor = Builder.Materials[0].TransparentColor,
 										TransparentColorUsed = Builder.Materials[0].TransparentColorUsed,
-										WrapMode = Builder.Materials[0].WrapMode
+										WrapMode = Builder.Materials[0].WrapMode,
+										EnableCrossfading = Builder.Materials[0].EnableCrossfading
 									};
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
@@ -731,6 +733,7 @@ namespace Plugin
 									Builder.Materials[j].TransparentColor = Builder.Materials[0].TransparentColor;
 									Builder.Materials[j].TransparentColorUsed = Builder.Materials[0].TransparentColorUsed;
 									Builder.Materials[j].WrapMode = Builder.Materials[0].WrapMode;
+									Builder.Materials[j].EnableCrossfading = Builder.Materials[0].EnableCrossfading;
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
 									Builder.Faces[j].Material += (ushort)m;
@@ -1164,6 +1167,28 @@ namespace Plugin
 									currentHost.AddMessage(MessageType.Error, false, "VertexIndex references a non-existing vertex in " + Command + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 								}
 							} break;
+						case "enablecrossfading":
+						case "crossfading":
+							{
+								if (Arguments.Length > 1)
+								{
+									currentHost.AddMessage(MessageType.Warning, false, $"At most 1 arguments are expected in {Command} at line {(i + 1).ToString(Culture)} in file {FileName}");
+								}
+
+								bool value = false;
+
+								if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !bool.TryParse(Arguments[0], out value))
+								{
+									currentHost.AddMessage(MessageType.Error, false, $"Invalid argument Value in {Command} at line {(i + 1).ToString(Culture)} in file {FileName}");
+									value = false;
+								}
+
+								foreach (Material material in Builder.Materials)
+								{
+									material.EnableCrossfading = value;
+								}
+							}
+							break;
 						default:
 							if (Command.Length != 0) {
 								if (IsUtf(Encoding))


### PR DESCRIPTION
This PR adds cross-fading mode to CSV objects.

Cross-fading mode changes the transparency of DaytimeTexture as opposed to the transparency of NighttimeTexture.
This behavior is different from the conventional one, so it is disabled by default and can be enabled by command.

The command format is as follows:
`EnableCrossfading, value` (value: true or false)

Closed #425