### PR TITLE
Crossfading improvements

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -755,7 +755,7 @@ namespace LibRender2
 
 			if (lastError != ErrorCode.NoError)
 			{
-				throw new InvalidOperationException($"OpenGL Error: {lastError.ToString()}");
+				throw new InvalidOperationException($"OpenGL Error: {lastError}");
 			}
 #endif
 
@@ -959,6 +959,23 @@ namespace LibRender2
 					break;
 			}
 
+			// blend factor
+			float distanceFactor;
+			if (material.GlowAttenuationData != 0)
+			{
+				distanceFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData);
+			}
+			else
+			{
+				distanceFactor = 1.0f;
+			}
+
+			float blendFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
+			if (blendFactor > 1.0)
+			{
+				blendFactor = 1.0f;
+			}
+
 			// daytime polygon
 			{
 				// texture
@@ -989,13 +1006,7 @@ namespace LibRender2
 				else if (material.NighttimeTexture == null || material.NighttimeTexture == material.DaytimeTexture)
 				{
 					//No nighttime texture or both are identical- Darken the polygon to match the light conditions
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					factor = 1.0f - 0.7f * blend;
+					factor = 1.0f - 0.7f * blendFactor;
 				}
 				else
 				{
@@ -1004,15 +1015,10 @@ namespace LibRender2
 				}
 				Shader.SetBrightness(factor);
 
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
+				float alphaFactor = distanceFactor;
+				if (material.EnableCrossfading)
 				{
-					GlowAttenuationMode mode;
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData, out mode);
-				}
-				else
-				{
-					alphaFactor = 1.0f;
+					alphaFactor *= 1.0f - blendFactor;
 				}
 
 				Shader.SetOpacity(inv255 * material.Color.A * alphaFactor);
@@ -1040,26 +1046,7 @@ namespace LibRender2
 				GL.AlphaFunc(AlphaFunction.Greater, 0.0f);
 
 				// blend mode
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
-				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, State.Prototype.Mesh.Vertices, ref Face, material.GlowAttenuationData);
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					alphaFactor *= blend;
-				}
-				else
-				{
-					alphaFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (alphaFactor > 1.0f)
-					{
-						alphaFactor = 1.0f;
-					}
-				}
+				float alphaFactor = distanceFactor * blendFactor;
 
 				Shader.SetOpacity(inv255 * material.Color.A * alphaFactor);
 
@@ -1208,6 +1195,23 @@ namespace LibRender2
 					break;
 			}
 
+			// blend factor
+			float distanceFactor;
+			if (material.GlowAttenuationData != 0)
+			{
+				distanceFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
+			}
+			else
+			{
+				distanceFactor = 1.0f;
+			}
+
+			float blendFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
+			if (blendFactor > 1.0)
+			{
+				blendFactor = 1.0f;
+			}
+
 			// daytime polygon
 			{
 				// texture
@@ -1235,14 +1239,7 @@ namespace LibRender2
 				}
 				else if (material.NighttimeTexture == null)
 				{
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					factor = 1.0f - 0.7f * blend;
+					factor = 1.0f - 0.7f * blendFactor;
 				}
 				else
 				{
@@ -1253,14 +1250,11 @@ namespace LibRender2
 				{
 					GL.Disable(EnableCap.Lighting);
 				}
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
+
+				float alphaFactor = distanceFactor;
+				if (material.EnableCrossfading)
 				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
-				}
-				else
-				{
-					alphaFactor = 1.0f;
+					alphaFactor *= 1.0f - blendFactor;
 				}
 
 				GL.Begin(DrawMode);
@@ -1309,26 +1303,7 @@ namespace LibRender2
 				GL.AlphaFunc(AlphaFunction.Greater, 0.0f);
 
 				// blend mode
-				float alphaFactor;
-				if (material.GlowAttenuationData != 0)
-				{
-					alphaFactor = (float)Glow.GetDistanceFactor(modelMatrix, vertices, ref Face, material.GlowAttenuationData);
-					float blend = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (blend > 1.0f)
-					{
-						blend = 1.0f;
-					}
-
-					alphaFactor *= blend;
-				}
-				else
-				{
-					alphaFactor = inv255 * material.DaytimeNighttimeBlend + 1.0f - Lighting.OptionLightingResultingAmount;
-					if (alphaFactor > 1.0f)
-					{
-						alphaFactor = 1.0f;
-					}
-				}
+				float alphaFactor = distanceFactor * blendFactor;
 
 				GL.Begin(DrawMode);
 

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -1016,7 +1016,7 @@ namespace LibRender2
 				Shader.SetBrightness(factor);
 
 				float alphaFactor = distanceFactor;
-				if (material.EnableCrossfading)
+				if ((material.Flags & MaterialFlags.CrossFadeTexture) != 0)
 				{
 					alphaFactor *= 1.0f - blendFactor;
 				}
@@ -1252,7 +1252,7 @@ namespace LibRender2
 				}
 
 				float alphaFactor = distanceFactor;
-				if (material.EnableCrossfading)
+				if ((material.Flags & MaterialFlags.CrossFadeTexture) != 0)
 				{
 					alphaFactor *= 1.0f - blendFactor;
 				}

--- a/source/OpenBveApi/Objects/Glow.cs
+++ b/source/OpenBveApi/Objects/Glow.cs
@@ -29,44 +29,19 @@ namespace OpenBveApi.Objects
 
 		/// <summary>Gets the current intensity glow intensity, using the glow attenuation factor</summary>
 		/// <param name="ModelMatrix">The model transformation matrix to apply</param>
-		/// <param name="Vertices">The verticies to which the glow is to be applied</param>
+		/// <param name="Vertices">The vertices to which the glow is to be applied</param>
 		/// <param name="Face">The face which these vertices make up</param>
 		/// <param name="GlowAttenuationData">The current glow attenuation</param>
 		/// <returns></returns>
 		public static double GetDistanceFactor(Matrix4D ModelMatrix, VertexTemplate[] Vertices, ref MeshFace Face, ushort GlowAttenuationData)
 		{
-			if (Face.Vertices.Length == 0)
-			{
-				return 1.0;
-			}
 			GlowAttenuationMode mode;
-			double halfdistance;
-			Glow.SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
-			int i = (int)Face.Vertices[0].Index;
-			Vector3 d = new Vector3(Vertices[i].Coordinates.X, Vertices[i].Coordinates.Y, -Vertices[i].Coordinates.Z);
-			d.Transform(ModelMatrix);
-			switch (mode)
-			{
-				case GlowAttenuationMode.DivisionExponent2:
-				{
-					double t = d.NormSquared();
-					return t / (t + halfdistance * halfdistance);
-				}
-				case GlowAttenuationMode.DivisionExponent4:
-				{
-					double t = d.NormSquared();
-					t *= t;
-					halfdistance *= halfdistance;
-					return t / (t + halfdistance * halfdistance);
-				}
-				default:
-					return 1.0;
-			}
+			return GetDistanceFactor(ModelMatrix, Vertices, ref Face, GlowAttenuationData, out mode);
 		}
 
 		/// <summary>Gets the current intensity glow intensity, using the glow attenuation factor</summary>
 		/// <param name="ModelMatrix">The model transformation matrix to apply</param>
-		/// <param name="Vertices">The verticies to which the glow is to be applied</param>
+		/// <param name="Vertices">The vertices to which the glow is to be applied</param>
 		/// <param name="Face">The face which these vertices make up</param>
 		/// <param name="GlowAttenuationData">The current glow attenuation</param>
 		/// <param name="mode">The returned glow attenuation mode</param>
@@ -78,26 +53,26 @@ namespace OpenBveApi.Objects
 			{
 				return 1.0;
 			}
-			
+
 			double halfdistance;
-			Glow.SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
-			int i = (int)Face.Vertices[0].Index;
+			SplitAttenuationData(GlowAttenuationData, out mode, out halfdistance);
+			int i = Face.Vertices[0].Index;
 			Vector3 d = new Vector3(Vertices[i].Coordinates.X, Vertices[i].Coordinates.Y, -Vertices[i].Coordinates.Z);
 			d.Transform(ModelMatrix);
 			switch (mode)
 			{
 				case GlowAttenuationMode.DivisionExponent2:
-				{
-					double t = d.NormSquared();
-					return t / (t + halfdistance * halfdistance);
-				}
+					{
+						double t = d.NormSquared();
+						return t / (t + halfdistance * halfdistance);
+					}
 				case GlowAttenuationMode.DivisionExponent4:
-				{
-					double t = d.NormSquared();
-					t *= t;
-					halfdistance *= halfdistance;
-					return t / (t + halfdistance * halfdistance);
-				}
+					{
+						double t = d.NormSquared();
+						t *= t;
+						halfdistance *= halfdistance;
+						return t / (t + halfdistance * halfdistance);
+					}
 				default:
 					return 1.0;
 			}

--- a/source/OpenBveApi/Objects/Helpers/Material.cs
+++ b/source/OpenBveApi/Objects/Helpers/Material.cs
@@ -40,8 +40,6 @@ namespace OpenBveApi.Objects
 		public string Font;
 		/// <summary>The text padding to apply</summary>
 		public Vector2 TextPadding;
-		/// <summary>Whether cross-fading is enabled</summary>
-		public bool EnableCrossfading;
 
 		/// <summary>Creates a new Material with default properties</summary>
 		public Material() {

--- a/source/OpenBveApi/Objects/Helpers/Material.cs
+++ b/source/OpenBveApi/Objects/Helpers/Material.cs
@@ -44,6 +44,8 @@ namespace OpenBveApi.Objects
 		public Vector2 TextPadding;
 		/// <summary>Whether lighting is disabled by the renderer</summary>
 		internal bool DisableLighting;
+		/// <summary>Whether cross-fading is enabled</summary>
+		public bool EnableCrossfading;
 
 		/// <summary>Creates a new Material with default properties</summary>
 		public Material() {

--- a/source/OpenBveApi/Objects/Helpers/Material.cs
+++ b/source/OpenBveApi/Objects/Helpers/Material.cs
@@ -11,12 +11,10 @@ namespace OpenBveApi.Objects
 		public Color32 Color;
 		/// <summary>The emissive color</summary>
 		public Color24 EmissiveColor;
-		/// <summary>Whether the emissive color is in use</summary>
-		public bool EmissiveColorUsed;
 		/// <summary>The transparent color</summary>
 		public Color24 TransparentColor;
-		/// <summary>Whether the transparent color is in use</summary>
-		public bool TransparentColorUsed;
+		/// <summary>Describes the special properties (if any) of the material</summary>
+		public MaterialFlags Flags;
 		/// <summary>The absolute on-disk path to the daytime texture</summary>
 		public string DaytimeTexture;
 		/// <summary>The absolute on-disk path to the nighttime texture</summary>
@@ -42,8 +40,6 @@ namespace OpenBveApi.Objects
 		public string Font;
 		/// <summary>The text padding to apply</summary>
 		public Vector2 TextPadding;
-		/// <summary>Whether lighting is disabled by the renderer</summary>
-		internal bool DisableLighting;
 		/// <summary>Whether cross-fading is enabled</summary>
 		public bool EnableCrossfading;
 
@@ -51,9 +47,8 @@ namespace OpenBveApi.Objects
 		public Material() {
 			this.Color = Color32.White;
 			this.EmissiveColor = Color24.Black;
-			this.EmissiveColorUsed = false;
 			this.TransparentColor = Color24.Black;
-			this.TransparentColorUsed = false;
+			this.Flags = MaterialFlags.None;
 			this.DaytimeTexture = null;
 			this.NighttimeTexture = null;
 			this.BlendMode = MeshMaterialBlendMode.Normal;
@@ -70,9 +65,8 @@ namespace OpenBveApi.Objects
 		public Material(string Texture) {
 			this.Color = Color32.White;
 			this.EmissiveColor = Color24.Black;
-			this.EmissiveColorUsed = false;
 			this.TransparentColor = Color24.Black;
-			this.TransparentColorUsed = false;
+			this.Flags = MaterialFlags.None;
 			this.DaytimeTexture = null;
 			this.NighttimeTexture = null;
 			this.BlendMode = MeshMaterialBlendMode.Normal;
@@ -89,9 +83,8 @@ namespace OpenBveApi.Objects
 		public Material(Material Prototype) {
 			this.Color = Prototype.Color;
 			this.EmissiveColor = Prototype.EmissiveColor;
-			this.EmissiveColorUsed = Prototype.EmissiveColorUsed;
 			this.TransparentColor = Prototype.TransparentColor;
-			this.TransparentColorUsed = Prototype.TransparentColorUsed;
+			this.Flags = Prototype.Flags;
 			this.DaytimeTexture = Prototype.DaytimeTexture;
 			this.NighttimeTexture = Prototype.NighttimeTexture;
 			this.BlendMode = Prototype.BlendMode;

--- a/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
+++ b/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
@@ -80,23 +80,11 @@ namespace OpenBveApi.Objects
 							* The new GL 3.2 renderer corrects this behaviour
 							 * Horrid workaround....
 							 */
-							Materials[i].DisableLighting = true;
+							Materials[i].Flags |= MaterialFlags.DisableLighting;
 						}
 					}
 
-					Object.Mesh.Materials[mm + i].Flags = new MaterialFlags();
-					if (Materials[i].EmissiveColorUsed)
-					{
-						Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.Emissive;
-					}
-					if (Materials[i].TransparentColorUsed)
-					{
-						Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.TransparentColor;
-					}
-					if (Materials[i].DisableLighting)
-					{
-						Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.DisableLighting;
-					}
+					Object.Mesh.Materials[mm + i].Flags = Materials[i].Flags;
 					Object.Mesh.Materials[mm + i].Color = Materials[i].Color;
 					Object.Mesh.Materials[mm + i].TransparentColor = Materials[i].TransparentColor;
 					if (Materials[i].DaytimeTexture != null || Materials[i].Text != null)
@@ -115,7 +103,7 @@ namespace OpenBveApi.Objects
 						}
 						else
 						{
-							if (Materials[i].TransparentColorUsed)
+							if ((Materials[i].Flags & MaterialFlags.TransparentColor) != 0)
 							{
 								currentHost.RegisterTexture(Materials[i].DaytimeTexture, new TextureParameters(null,
 										new Color24(Materials[i].TransparentColor.R, Materials[i].TransparentColor.G,
@@ -138,7 +126,7 @@ namespace OpenBveApi.Objects
 					if (Materials[i].NighttimeTexture != null)
 					{
 						Textures.Texture tnight;
-						if (Materials[i].TransparentColorUsed)
+						if ((Materials[i].Flags & MaterialFlags.TransparentColor) != 0)
 						{
 							currentHost.RegisterTexture(Materials[i].NighttimeTexture, new TextureParameters(null, new Color24(Materials[i].TransparentColor.R, Materials[i].TransparentColor.G, Materials[i].TransparentColor.B)), out tnight);
 						}
@@ -148,7 +136,10 @@ namespace OpenBveApi.Objects
 						}
 
 						Object.Mesh.Materials[mm + i].NighttimeTexture = tnight;
-						Object.Mesh.Materials[mm + i].EnableCrossfading = Materials[i].EnableCrossfading;
+						if ((Materials[i].Flags & MaterialFlags.CrossFadeTexture) != 0)
+						{
+							Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.CrossFadeTexture;
+						}
 					}
 					else
 					{

--- a/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
+++ b/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
@@ -148,6 +148,7 @@ namespace OpenBveApi.Objects
 						}
 
 						Object.Mesh.Materials[mm + i].NighttimeTexture = tnight;
+						Object.Mesh.Materials[mm + i].EnableCrossfading = Materials[i].EnableCrossfading;
 					}
 					else
 					{

--- a/source/OpenBveApi/Objects/MeshMaterial.Flags.cs
+++ b/source/OpenBveApi/Objects/MeshMaterial.Flags.cs
@@ -6,11 +6,16 @@ namespace OpenBveApi.Objects
 	[Flags]
 	public enum MaterialFlags
 	{
+		/// <summary>The material has no special properties</summary>
+		None = 0,
 		/// <summary>The material is emissive</summary>
 		Emissive = 1,
 		/// <summary>The material uses the Transparent Color in its texture</summary>
 		TransparentColor = 2,
 		/// <summary>The material is to be rendered with disabled lighting</summary>
-		DisableLighting = 4
+		DisableLighting = 4,
+		/// <summary>The daytime and night-time textures are to be cross-faded</summary>
+		/// <remarks>Disabled by default</remarks>
+		CrossFadeTexture = 8
 	}
 }

--- a/source/OpenBveApi/Objects/MeshMaterial.cs
+++ b/source/OpenBveApi/Objects/MeshMaterial.cs
@@ -30,8 +30,6 @@ namespace OpenBveApi.Objects
 		public ushort GlowAttenuationData;
 		/// <summary>The wrap mode, or null to allow the renderer to decide</summary>
 		public OpenGlTextureWrapMode? WrapMode;
-		/// <summary>Whether cross-fading is enabled</summary>
-		public bool EnableCrossfading;
 
 		/// <summary>Returns whether two MeshMaterial structs are equal</summary>
 		public static bool operator ==(MeshMaterial A, MeshMaterial B)

--- a/source/OpenBveApi/Objects/MeshMaterial.cs
+++ b/source/OpenBveApi/Objects/MeshMaterial.cs
@@ -30,6 +30,8 @@ namespace OpenBveApi.Objects
 		public ushort GlowAttenuationData;
 		/// <summary>The wrap mode, or null to allow the renderer to decide</summary>
 		public OpenGlTextureWrapMode? WrapMode;
+		/// <summary>Whether cross-fading is enabled</summary>
+		public bool EnableCrossfading;
 
 		/// <summary>Returns whether two MeshMaterial structs are equal</summary>
 		public static bool operator ==(MeshMaterial A, MeshMaterial B)

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -42,7 +42,8 @@ namespace Plugin
 			"loadtexture",
 			"settexturecoordinates",
 			"setemissivecolor",
-			"setdecaltransparentcolor"
+			"setdecaltransparentcolor",
+			"enablecrossfading"
 		};
 
 		private static int SecondIndexOfAny(string testString, string[] values)
@@ -678,7 +679,8 @@ namespace Plugin
 										NighttimeTexture = Builder.Materials[0].NighttimeTexture,
 										TransparentColor = Builder.Materials[0].TransparentColor,
 										TransparentColorUsed = Builder.Materials[0].TransparentColorUsed,
-										WrapMode = Builder.Materials[0].WrapMode
+										WrapMode = Builder.Materials[0].WrapMode,
+										EnableCrossfading = Builder.Materials[0].EnableCrossfading
 									};
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
@@ -731,6 +733,7 @@ namespace Plugin
 									Builder.Materials[j].TransparentColor = Builder.Materials[0].TransparentColor;
 									Builder.Materials[j].TransparentColorUsed = Builder.Materials[0].TransparentColorUsed;
 									Builder.Materials[j].WrapMode = Builder.Materials[0].WrapMode;
+									Builder.Materials[j].EnableCrossfading = Builder.Materials[0].EnableCrossfading;
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
 									Builder.Faces[j].Material += (ushort)m;
@@ -1164,6 +1167,28 @@ namespace Plugin
 									currentHost.AddMessage(MessageType.Error, false, "VertexIndex references a non-existing vertex in " + Command + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 								}
 							} break;
+						case "enablecrossfading":
+						case "crossfading":
+							{
+								if (Arguments.Length > 1)
+								{
+									currentHost.AddMessage(MessageType.Warning, false, $"At most 1 arguments are expected in {Command} at line {(i + 1).ToString(Culture)} in file {FileName}");
+								}
+
+								bool value = false;
+
+								if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !bool.TryParse(Arguments[0], out value))
+								{
+									currentHost.AddMessage(MessageType.Error, false, $"Invalid argument Value in {Command} at line {(i + 1).ToString(Culture)} in file {FileName}");
+									value = false;
+								}
+
+								foreach (Material material in Builder.Materials)
+								{
+									material.EnableCrossfading = value;
+								}
+							}
+							break;
 						default:
 							if (Command.Length != 0) {
 								if (IsUtf(Encoding))

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -679,8 +679,7 @@ namespace Plugin
 										NighttimeTexture = Builder.Materials[0].NighttimeTexture,
 										TransparentColor = Builder.Materials[0].TransparentColor,
 										Flags =  Builder.Materials[0].Flags,
-										WrapMode = Builder.Materials[0].WrapMode,
-										EnableCrossfading = Builder.Materials[0].EnableCrossfading
+										WrapMode = Builder.Materials[0].WrapMode
 									};
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
@@ -733,7 +732,6 @@ namespace Plugin
 									Builder.Materials[j].TransparentColor = Builder.Materials[0].TransparentColor;
 									Builder.Materials[j].Flags |= MaterialFlags.TransparentColor;
 									Builder.Materials[j].WrapMode = Builder.Materials[0].WrapMode;
-									Builder.Materials[j].EnableCrossfading = Builder.Materials[0].EnableCrossfading;
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {
 									Builder.Faces[j].Material += (ushort)m;
@@ -1185,7 +1183,14 @@ namespace Plugin
 
 								foreach (Material material in Builder.Materials)
 								{
-									material.EnableCrossfading = value;
+									if (value)
+									{
+										material.Flags |= MaterialFlags.CrossFadeTexture;
+									}
+									else
+									{
+										material.Flags &= ~MaterialFlags.CrossFadeTexture;
+									}
 								}
 							}
 							break;

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -678,7 +678,7 @@ namespace Plugin
 										DaytimeTexture = Builder.Materials[0].DaytimeTexture,
 										NighttimeTexture = Builder.Materials[0].NighttimeTexture,
 										TransparentColor = Builder.Materials[0].TransparentColor,
-										TransparentColorUsed = Builder.Materials[0].TransparentColorUsed,
+										Flags =  Builder.Materials[0].Flags,
 										WrapMode = Builder.Materials[0].WrapMode,
 										EnableCrossfading = Builder.Materials[0].EnableCrossfading
 									};
@@ -725,13 +725,13 @@ namespace Plugin
 								for (int j = m; j < Builder.Materials.Length; j++) {
 									Builder.Materials[j] = new Material(Builder.Materials[j - m]);
 									Builder.Materials[j].EmissiveColor = new Color24((byte)r, (byte)g, (byte)b);
-									Builder.Materials[j].EmissiveColorUsed = true;
+									Builder.Materials[j].Flags |= MaterialFlags.Emissive;
 									Builder.Materials[j].BlendMode = Builder.Materials[0].BlendMode;
 									Builder.Materials[j].GlowAttenuationData = Builder.Materials[0].GlowAttenuationData;
 									Builder.Materials[j].DaytimeTexture = Builder.Materials[0].DaytimeTexture;
 									Builder.Materials[j].NighttimeTexture = Builder.Materials[0].NighttimeTexture;
 									Builder.Materials[j].TransparentColor = Builder.Materials[0].TransparentColor;
-									Builder.Materials[j].TransparentColorUsed = Builder.Materials[0].TransparentColorUsed;
+									Builder.Materials[j].Flags |= MaterialFlags.TransparentColor;
 									Builder.Materials[j].WrapMode = Builder.Materials[0].WrapMode;
 									Builder.Materials[j].EnableCrossfading = Builder.Materials[0].EnableCrossfading;
 								}
@@ -774,7 +774,7 @@ namespace Plugin
 								}
 								for (int j = 0; j < Builder.Materials.Length; j++) {
 									Builder.Materials[j].TransparentColor = new Color24((byte)r, (byte)g, (byte)b);
-									Builder.Materials[j].TransparentColorUsed = true;
+									Builder.Materials[j].Flags |= MaterialFlags.TransparentColor;
 								}
 							} break;
 						case "setblendingmode":

--- a/source/Plugins/Object.DirectX/Parsers/AssimpXParser.cs
+++ b/source/Plugins/Object.DirectX/Parsers/AssimpXParser.cs
@@ -152,9 +152,9 @@ namespace Plugin
 				double mPower = mesh.Materials[i].SpecularExponent; //TODO: Unsure what this does...
 				Color24 mSpecular = new Color24((byte)mesh.Materials[i].Specular.R, (byte)mesh.Materials[i].Specular.G, (byte)mesh.Materials[i].Specular.B);
 				builder.Materials[m].EmissiveColor = new Color24((byte)(255 * mesh.Materials[i].Emissive.R), (byte)(255 * mesh.Materials[i].Emissive.G), (byte)(255 * mesh.Materials[i].Emissive.B));
-				builder.Materials[m].EmissiveColorUsed = true; //TODO: Check exact behaviour
+				builder.Materials[m].Flags |= MaterialFlags.Emissive; //TODO: Check exact behaviour
 				builder.Materials[m].TransparentColor = Color24.Black; //TODO: Check, also can we optimise which faces have the transparent color set?
-				builder.Materials[m].TransparentColorUsed = true;
+				builder.Materials[m].Flags |= MaterialFlags.TransparentColor;
 
 				if (mesh.Materials[i].Textures.Count > 0)
 				{

--- a/source/Plugins/Object.DirectX/Parsers/NewXParser.cs
+++ b/source/Plugins/Object.DirectX/Parsers/NewXParser.cs
@@ -321,9 +321,9 @@ namespace Plugin
 					double mPower = block.ReadSingle(); //TODO: Unsure what this does...
 					Color24 mSpecular = new Color24((byte)block.ReadSingle(), (byte)block.ReadSingle(), (byte)block.ReadSingle());
 					builder.Materials[m].EmissiveColor = new Color24((byte)(255 *block.ReadSingle()), (byte)(255 * block.ReadSingle()), (byte)(255 * block.ReadSingle()));
-					builder.Materials[m].EmissiveColorUsed = true; //TODO: Check exact behaviour
+					builder.Materials[m].Flags |= MaterialFlags.Emissive; //TODO: Check exact behaviour
 					builder.Materials[m].TransparentColor = Color24.Black; //TODO: Check, also can we optimise which faces have the transparent color set?
-					builder.Materials[m].TransparentColorUsed = true;
+					builder.Materials[m].Flags |= MaterialFlags.TransparentColor;
 					if (block.Position() < block.Length() - 5)
 					{
 						subBlock = block.ReadSubBlock(TemplateID.TextureFilename);

--- a/source/Plugins/Object.LokSim/ObjectParser.cs
+++ b/source/Plugins/Object.LokSim/ObjectParser.cs
@@ -405,7 +405,7 @@ namespace Plugin
 					for (int j = 0; j < Builder.Materials.Length; j++)
 					{
 						Builder.Materials[j].TransparentColor = FirstPxTransparent ? FirstPxColor : transparentColor;
-						Builder.Materials[j].TransparentColorUsed = true;
+						Builder.Materials[j].Flags |= MaterialFlags.TransparentColor;
 					}
 				}
 

--- a/source/Plugins/Object.Wavefront/Parsers/AssimpObjParser.cs
+++ b/source/Plugins/Object.Wavefront/Parsers/AssimpObjParser.cs
@@ -85,9 +85,9 @@ namespace Plugin
 							Color24 mSpecular = new Color24((byte)material.Specular.R, (byte)material.Specular.G, (byte)material.Specular.B);
 #pragma warning restore 0219
 							builder.Materials[m].EmissiveColor = new Color24((byte)(255 * material.Emissive.R), (byte)(255 * material.Emissive.G), (byte)(255 * material.Emissive.B));
-							builder.Materials[m].EmissiveColorUsed = true; //TODO: Check exact behaviour
+							builder.Materials[m].Flags |= MaterialFlags.Emissive; //TODO: Check exact behaviour
 							builder.Materials[m].TransparentColor = new Color24((byte)(255 * material.Transparent.R), (byte)(255 * material.Transparent.G), (byte)(255 * material.Transparent.B));
-							builder.Materials[m].TransparentColorUsed = true;
+							builder.Materials[m].Flags |= MaterialFlags.TransparentColor;
 
 							if (material.Texture != null)
 							{

--- a/source/Plugins/Object.Wavefront/Parsers/WavefrontObjParser.cs
+++ b/source/Plugins/Object.Wavefront/Parsers/WavefrontObjParser.cs
@@ -465,21 +465,13 @@ namespace Plugin
 				}
 				for (int i = 0; i < Builder.Materials.Length; i++)
 				{
-					Object.Mesh.Materials[mm + i].Flags = new MaterialFlags();
-					if (Builder.Materials[i].EmissiveColorUsed)
-					{
-						Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.Emissive;
-					}
-					if (Builder.Materials[i].TransparentColorUsed)
-					{
-						Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.TransparentColor;
-					}
+					Object.Mesh.Materials[mm + i].Flags = Builder.Materials[i].Flags;
 					Object.Mesh.Materials[mm + i].Color = Builder.Materials[i].Color;
 					Object.Mesh.Materials[mm + i].TransparentColor = Builder.Materials[i].TransparentColor;
 					if (Builder.Materials[i].DaytimeTexture != null)
 					{
 						Texture tday;
-						if (Builder.Materials[i].TransparentColorUsed)
+						if ((Builder.Materials[i].Flags & MaterialFlags.TransparentColor) != 0)
 						{
 							Plugin.currentHost.RegisterTexture(Builder.Materials[i].DaytimeTexture, new TextureParameters(null, new Color24(Builder.Materials[i].TransparentColor.R, Builder.Materials[i].TransparentColor.G, Builder.Materials[i].TransparentColor.B)), out tday);
 						}
@@ -497,7 +489,7 @@ namespace Plugin
 					if (Builder.Materials[i].NighttimeTexture != null)
 					{
 						Texture tnight;
-						if (Builder.Materials[i].TransparentColorUsed)
+						if ((Builder.Materials[i].Flags & MaterialFlags.TransparentColor) != 0)
 						{
 							Plugin.currentHost.RegisterTexture(Builder.Materials[i].NighttimeTexture, new TextureParameters(null, new Color24(Builder.Materials[i].TransparentColor.R, Builder.Materials[i].TransparentColor.G, Builder.Materials[i].TransparentColor.B)), out tnight);
 						}


### PR DESCRIPTION
Slightly improved version of https://github.com/leezer3/OpenBVE/pull/518

This moves the CrossFadeTexture bool to the MaterialFlags enum, and uses the same enum in the parsers, as opposed to a bunch of bools which then set the flags.

Not done any major testing, but appears to work

cc @s520 