### PR TITLE
Fix: issue where panel elements with NighttimeImage defined are rendered with lighting enabled

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -1016,7 +1016,7 @@ namespace LibRender2
 				Shader.SetBrightness(factor);
 
 				float alphaFactor = distanceFactor;
-				if ((material.Flags & MaterialFlags.CrossFadeTexture) != 0)
+				if (material.NighttimeTexture != null && (material.Flags & MaterialFlags.CrossFadeTexture) != 0)
 				{
 					alphaFactor *= 1.0f - blendFactor;
 				}
@@ -1252,7 +1252,7 @@ namespace LibRender2
 				}
 
 				float alphaFactor = distanceFactor;
-				if ((material.Flags & MaterialFlags.CrossFadeTexture) != 0)
+				if (material.NighttimeTexture != null && (material.Flags & MaterialFlags.CrossFadeTexture) != 0)
 				{
 					alphaFactor *= 1.0f - blendFactor;
 				}

--- a/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
+++ b/source/OpenBVE/Parsers/Panel/Panel2CfgParser.cs
@@ -1463,6 +1463,12 @@ namespace OpenBve {
 			if (DaytimeTexture != null)
 			{
 				Object.Mesh.Materials[0].Flags |= MaterialFlags.TransparentColor;
+
+				if (NighttimeTexture != null)
+				{
+					// In BVE4 and versions of OpenBVE prior to v1.7.1.0, elements with NighttimeImage defined are rendered with lighting disabled.
+					Object.Mesh.Materials[0].Flags |= MaterialFlags.DisableLighting;
+				}
 			}
 			Object.Mesh.Materials[0].Color = Color;
 			Object.Mesh.Materials[0].TransparentColor = Color24.Blue;

--- a/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
+++ b/source/OpenBveApi/Objects/Helpers/MeshBuilder.cs
@@ -77,7 +77,7 @@ namespace OpenBveApi.Objects
 						{
 							/*
 							 * Versions of openBVE prior to 1.7.0 rendered polygons with two defined textures as unlit
-							* The new GL 3.2 renderer corrects this behaviour
+							 * The new GL 3.2 renderer corrects this behaviour
 							 * Horrid workaround....
 							 */
 							Materials[i].Flags |= MaterialFlags.DisableLighting;
@@ -136,10 +136,6 @@ namespace OpenBveApi.Objects
 						}
 
 						Object.Mesh.Materials[mm + i].NighttimeTexture = tnight;
-						if ((Materials[i].Flags & MaterialFlags.CrossFadeTexture) != 0)
-						{
-							Object.Mesh.Materials[mm + i].Flags |= MaterialFlags.CrossFadeTexture;
-						}
 					}
 					else
 					{


### PR DESCRIPTION
In BVE4 and 5, panel elements with NighttimeImage defined are rendered with lighting disabled. (#498)

Currently, it is not possible to specify an emissive color for the panel, so the author cannot substitute this effect.
If we want to address this issue like that of a CSV object, we should add an emissive color setting.
However, this effect is the same from BVE4, so I don't think it needs to be changed.