### PR TITLE
Fix: emissive hack

### DIFF
--- a/assets/Shaders/default.frag
+++ b/assets/Shaders/default.frag
@@ -19,7 +19,11 @@ uniform bool uFogIsLinear;
 
 void main(void)
 {
-	vec4 finalColor = uIsTexture ? texture2D(uTexture, oUv) : vec4(oColor.rgb, 1.0);
+	vec4 finalColor = vec4(oColor.rgb, 1.0);
+	if(uIsTexture)
+	{
+		finalColor *= texture2D(uTexture, oUv);
+	}
 	if((uMaterialFlags & 1) == 0 && (uMaterialFlags & 4) == 0)
 	{
 		//Material is not emissive and lighting is enabled, so multiply by brightness

--- a/assets/Shaders/default.frag
+++ b/assets/Shaders/default.frag
@@ -3,10 +3,11 @@
 in vec4 oViewPos;
 in vec2 oUv;
 in vec4 oColor;
-in vec4 lightResult;
+in vec4 oLightResult;
 
 uniform bool uIsTexture;
 uniform sampler2D uTexture;
+uniform int uMaterialFlags;
 uniform float uBrightness;
 uniform float uOpacity;
 uniform bool uIsFog;
@@ -15,24 +16,19 @@ uniform float uFogEnd;
 uniform vec3  uFogColor;
 uniform float uFogDensity;
 uniform bool uFogIsLinear;
-uniform int uMaterialFlags;
 
 void main(void)
 {
-	vec4 textureColor = vec4(oColor);
-	if(uIsTexture)
-	{
-		textureColor *= texture2D(uTexture, oUv);
-	}
+	vec4 finalColor = uIsTexture ? texture2D(uTexture, oUv) : vec4(oColor.rgb, 1.0);
 	if((uMaterialFlags & 1) == 0 && (uMaterialFlags & 4) == 0)
 	{
 		//Material is not emissive and lighting is enabled, so multiply by brightness
-		textureColor.rgb *= uBrightness;
+		finalColor.rgb *= uBrightness;
 	}
-	
-	vec4 finalColor = vec4(((textureColor.rgb) * 1.0) + (oColor.rgb * (1 - textureColor.a)), textureColor.a * uOpacity);
+	finalColor.a *= uOpacity;
 	//Apply the lighting results *after* the final color has been calculated
-	finalColor *= lightResult;	
+	finalColor *= oLightResult;
+
 	// Fog
 	float fogFactor = 1.0;
 
@@ -40,11 +36,11 @@ void main(void)
 	{
 		if(uFogIsLinear)
 		{
-			fogFactor *= clamp((uFogEnd - length(oViewPos)) / (uFogEnd - uFogStart), 0.0, 1.0);
+			fogFactor = clamp((uFogEnd - length(oViewPos)) / (uFogEnd - uFogStart), 0.0, 1.0);
 		}
 		else
 		{
-			fogFactor = exp(-pow((uFogDensity * (gl_FragCoord.z / gl_FragCoord.w)), 2.0));
+			fogFactor = exp(-pow(uFogDensity * (gl_FragCoord.z / gl_FragCoord.w), 2.0));
 		}
 	}
 

--- a/assets/Shaders/default.vert
+++ b/assets/Shaders/default.vert
@@ -1,5 +1,6 @@
 #version 150
 precision highp int;
+
 struct Light
 {
 	vec3 position;
@@ -16,7 +17,7 @@ struct MaterialColor
 	vec4 specular;
 	vec3 emission;
 	float shininess;
-}; 
+};
 
 in vec3 iPosition;
 in vec3 iNormal;
@@ -35,79 +36,30 @@ uniform int uMaterialFlags;
 out vec4 oViewPos;
 out vec2 oUv;
 out vec4 oColor;
-out vec4 lightResult;
+out vec4 oLightResult;
 
-
-//Temp working colors
-vec4 Ambient;
-vec4 Diffuse;
-vec4 Specular;
-
-void findDirectionalLight(in vec3 normal)
+vec4 getLightResult()
 {
-   float pf;
-   float nDotVP = max(0.0, dot(normal, normalize(vec3 (uLight.position))));
-   float nDotHV = max(0.0, dot(normal, normalize(vec3(oViewPos.xyz + uLight.position))));
+	vec3 normal = normalize(mat3(transpose(inverse(uCurrentModelViewMatrix))) * vec3(iNormal.x, iNormal.y, -iNormal.z));
+	float nDotVP = max(0.0, dot(normal, normalize(vec3(uLight.position))));
+	float nDotHV = max(0.0, dot(normal, normalize(vec3(oViewPos.xyz + uLight.position))));
+	float pf = nDotVP == 0.0 ? 0.0 : pow(nDotHV, uMaterial.shininess);
 
-   if (nDotVP == 0.0)
-   {
-       pf = 0.0;
-   }
-   else
-   {
-       pf = pow(nDotHV, uMaterial.shininess);
-   }
-   
-   Ambient  += vec4(uLight.ambient, 1.0);
-   Diffuse  += vec4(uLight.diffuse, 1.0) * nDotVP;
-   Specular += vec4(uLight.specular, 1.0) * pf;
+	vec4 ambient = vec4(uLight.ambient, 1.0);
+	vec4 diffuse = vec4(uLight.diffuse, 1.0) * nDotVP;
+	vec4 specular = vec4(uLight.specular, 1.0) * pf;
+
+	vec4 sceneColor = (uMaterialFlags & 1) != 0 ? vec4(uMaterial.emission, 1.0) + uMaterial.ambient * uLight.lightModel : uLight.lightModel;
+	vec4 finalColor = sceneColor + ambient * uMaterial.ambient + diffuse * uMaterial.specular + specular * uMaterial.specular;
+	return clamp(finalColor, 0.0, 1.0);
 }
-
-vec4 getLightResult(in vec3 normal, in vec4 ecPosition)
-{
-    vec4 color;
-    vec3 ecPosition3;
-    vec3 eye;
-
-    ecPosition3 = (vec3 (ecPosition)) / ecPosition.w;
-    eye = vec3 (0.0, 0.0, 1.0);
-
-    Ambient  = vec4 (0.0);
-    Diffuse  = vec4 (0.0);
-    Specular = vec4 (0.0);
-
-    findDirectionalLight(normal);
-	vec4 sceneColor = uLight.lightModel;
-	if((uMaterialFlags & 1) != 0)
-	{
-		sceneColor = vec4(uMaterial.emission, 1.0) + uMaterial.ambient * uLight.lightModel;
-	}
-    color = sceneColor + Ambient  * uMaterial.ambient + Diffuse  * uMaterial.specular;
-    color += Specular * uMaterial.specular;
-    color = clamp(color, 0.0, 1.0);
-	return color;
-}
-
 
 void main()
 {
 	oViewPos = uCurrentModelViewMatrix * vec4(vec3(iPosition.x, iPosition.y, -iPosition.z), 1.0);
 	gl_Position = uCurrentProjectionMatrix * oViewPos;
 
-	vec3 eyeNormal = normalize(mat3(transpose(inverse(uCurrentModelViewMatrix))) * vec3(iNormal.x, iNormal.y, -iNormal.z));
-	vec3 eyePosition = vec3(uCurrentModelViewMatrix * vec4(iPosition.x, iPosition.y, -iPosition.z, 1.0));
-
 	oUv = (uCurrentTextureMatrix * vec4(iUv, 1.0, 1.0)).xy;
-
 	oColor = iColor;
-	
-	if (uIsLight && (uMaterialFlags & 4) == 0)
-	{
-		lightResult = getLightResult(eyeNormal, oViewPos);
-	}
-	else
-	{
-		lightResult = uMaterial.ambient;
-	}
-	oColor.rgb *= oColor.a;
+	oLightResult = uIsLight && (uMaterialFlags & 4) == 0 ? getLightResult() : uMaterial.ambient;
 }


### PR DESCRIPTION
If you combine textures with emission colors, the new renderer will make the colors brighter.

- Old renderer
![Emissive_OR](https://user-images.githubusercontent.com/29241703/93334807-7ca5a200-f860-11ea-811f-2ed03fabb178.PNG)

- New renderer (Emissive branch #525)
![Emissive_NR](https://user-images.githubusercontent.com/29241703/93334836-83341980-f860-11ea-878f-2d12c4f226cf.PNG)

- New renderer (This PR)
![Emissive_NR_Fix](https://user-images.githubusercontent.com/29241703/93334859-8c24eb00-f860-11ea-80aa-2ebce280d3b9.PNG)

I also removed and cleaned up unused variables in the shader.