### PR TITLE
Change: Deploy new release builds to Github also [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,25 @@ env:
     - secure: "xhY40lPWCokuabAfN7t2gd4DTrNXpxvKiH6Xobo5XkAiDNseBw+MZ/ce4XZeAXnq9jHdeTXVMu1rtcdFlC5St2XCeltNpchS4Km8dv+7ErtTBAawgl+5rGwTTnIF5jUTPsbzfEcIgnL6ud7NWDEqYQm5oeEMpuS3z/gqSc/HKx3Fp5cIPte65Oo37oMuL0dwNh2XIwrogaSOHX+Jwh7B5ZkCMzAe/MOxg0b34A4noAtCHbtc2QmmDhOhdlk+OBx5iSIwqUvmW8YYUX+14mIFAqWQ6E7MOUY9gjDgedXnbfvPsw+gLeXyCoNunc980EMdrIF2KHaPa772TFi7MzOiPwXno2jxlK3INvGylYdymI4YwI97H53oasfT1RiOzG9j1zCqJZv3U1L5KdscX8LKPYXsOeP78okB5lXt2E2jiO7hVJMIhQtJrNiCmlok3/U65jD30WLBsZtIBzZ4RhpESYr2a5QayhFmbHmIeMbfhY6OkRiE/enCMYuCFlnV6twWA4J6gBUVilYj+qjR6Js2xRAtaY0ljnPhK0EE2RIjPOKks3CPlchP3ZbI9jFCaupBfLlT0uBfmMu0aD/q/AZ0wDf1Dp1OdRzGbBcvhDcijpmZ8GatLyZS64Iq27WqUC6XouI17SIj0XftnBkcKTbSXY9UbSXM2bPYuHLIGk61aXU="
 notifications:
       email: false
+#Also deploy new releases to Github Releases
+#zipped build
+deploy:
+  provider: releases
+  api_key: $GITHUB_RELEASE_OAUTH
+  on.tags: true
+  file: "OpenBVE-$TRAVIS_TAG.zip"
+  skip_cleanup: true
+#Debian package
+deploy:
+  provider: releases
+  api_key: $GITHUB_RELEASE_OAUTH
+  on.tags: true
+  file: "OpenBVE-$TRAVIS_TAG.deb"
+  skip_cleanup: true
+#Mac DMG
+deploy:
+  provider: releases
+  api_key: $GITHUB_RELEASE_OAUTH
+  on.tags: true
+  file: "OpenBVE-$TRAVIS_TAG.dmg"
+  skip_cleanup: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,3 +38,17 @@ notifications:
     on_build_success: false
     on_build_failure: false
     on_build_status_changed: false
+deploy:
+#Must provide description else the GitHub API falls over
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: $env:GITHUB_DEPLOY_TOKEN
+  artifact: installers\windows\Output\*.exe
+  draft: false
+  prerelease: false
+#Need to update the existing, not overwrite as Travis is also uploading
+  force_update: true
+  on:
+    branch: master
+    APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
This is intended to mirror all new builds so that we get the compiled binary artifacts in Github releases.
Needs mirroring to AppVeyor to produce the installer artifact, which since this has hopefully been fixed will think about later.

Minor wondering if we can get the entire site updated automatically by script (as per the translation bot)

https://docs.travis-ci.com/user/deployment/releases/

Not sure we can automatically link to the latest with the current file naming schema, as this would require the same filename:
https://docs.travis-ci.com/user/deployment/releases/

cc @s520 