### PR TITLE
Fix: an issue with unwanted material flags being set

### DIFF
--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -724,13 +724,12 @@ namespace Plugin
 								for (int j = m; j < Builder.Materials.Length; j++) {
 									Builder.Materials[j] = new Material(Builder.Materials[j - m]);
 									Builder.Materials[j].EmissiveColor = new Color24((byte)r, (byte)g, (byte)b);
-									Builder.Materials[j].Flags |= MaterialFlags.Emissive;
+									Builder.Materials[j].Flags = Builder.Materials[0].Flags | MaterialFlags.Emissive;
 									Builder.Materials[j].BlendMode = Builder.Materials[0].BlendMode;
 									Builder.Materials[j].GlowAttenuationData = Builder.Materials[0].GlowAttenuationData;
 									Builder.Materials[j].DaytimeTexture = Builder.Materials[0].DaytimeTexture;
 									Builder.Materials[j].NighttimeTexture = Builder.Materials[0].NighttimeTexture;
 									Builder.Materials[j].TransparentColor = Builder.Materials[0].TransparentColor;
-									Builder.Materials[j].Flags |= MaterialFlags.TransparentColor;
 									Builder.Materials[j].WrapMode = Builder.Materials[0].WrapMode;
 								}
 								for (int j = 0; j < Builder.Faces.Length; j++) {


### PR DESCRIPTION
When enabling emissive, the material was flagged as transparent color.
Related: #533 