### PR TITLE
Densha de GO! controller plugin

### DIFF
--- a/OpenBVE.sln
+++ b/OpenBVE.sln
@@ -96,6 +96,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SanYingInput", "source\Inpu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DefaultDisplayPlugin", "source\InputDevicePlugins\DefaultDisplayPlugin\DefaultDisplayPlugin.csproj", "{3D833D81-4F14-4A68-B0DE-6469B8CF4E62}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DenshaDeGoInput", "source\InputDevicePlugins\DenshaDeGoInput\DenshaDeGoInput.csproj", "{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texture.Tga", "source\Plugins\Texture.Tga\Texture.Tga.csproj", "{F714A9FA-1C4B-456B-BACF-D6763223A81C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssimpParser", "source\AssimpParser\AssimpParser.csproj", "{77CCAE62-D374-468E-98A0-DD8ADB461C10}"
@@ -551,6 +553,10 @@ Global
 		{8DAA1CF4-A29A-42CE-8649-34E0FBC0D97C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{8DAA1CF4-A29A-42CE-8649-34E0FBC0D97C}.Release|x86.ActiveCfg = Release|Any CPU
 		{8DAA1CF4-A29A-42CE-8649-34E0FBC0D97C}.Release|x86.Build.0 = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -582,6 +588,7 @@ Global
 		{C841EA02-4918-4162-ADC1-C09F5BC28AF9} = {16553295-E70F-4596-AA78-848EEA576C4A}
 		{8D21C5C6-73E9-42E0-92FB-63500E321836} = {16553295-E70F-4596-AA78-848EEA576C4A}
 		{F49789F2-97F3-45B3-BC85-F4E09C0D120D} = {16553295-E70F-4596-AA78-848EEA576C4A}
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32} = {851ADF1E-4500-4A14-B4AA-C1087A6C537E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {50B52A67-69B1-4B19-A59C-FF058FD9EBDF}

--- a/OpenBVE.sln
+++ b/OpenBVE.sln
@@ -557,6 +557,14 @@ Global
 		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Debug|x86.Build.0 = Debug|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|x86.ActiveCfg = Release|Any CPU
+		{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -2464,6 +2464,56 @@
 						<source>Z</source>
 					</trans-unit>
 				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="joystick">
+						<source>Joystick [index]</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -2478,7 +2478,7 @@
 						<source>Device:</source>
 					</trans-unit>
 					<trans-unit id="joystick">
-						<source>Joystick [index]</source>
+						<source>[index]: [name]</source>
 					</trans-unit>
 					<trans-unit id="button_section">
 						<source>Button mapping</source>

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -2513,6 +2513,21 @@
 					<trans-unit id="calibrate_power">
 						<source>Move the power handle to [notch] and press OK.</source>
 					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
 				</group>
 			</group>
 			<group id="train_editor">

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -52,628 +52,849 @@ namespace DenshaDeGoInput
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.deviceInputBox = new System.Windows.Forms.GroupBox();
-			this.buttonCalibrate = new System.Windows.Forms.Button();
-			this.label_select = new System.Windows.Forms.Label();
-			this.label_brakeemg = new System.Windows.Forms.Label();
-			this.label_braken = new System.Windows.Forms.Label();
-			this.label_start = new System.Windows.Forms.Label();
-			this.label_brake1 = new System.Windows.Forms.Label();
-			this.label_brake2 = new System.Windows.Forms.Label();
-			this.label_d = new System.Windows.Forms.Label();
-			this.label_c = new System.Windows.Forms.Label();
-			this.label_brake3 = new System.Windows.Forms.Label();
-			this.label_b = new System.Windows.Forms.Label();
-			this.label_powern = new System.Windows.Forms.Label();
-			this.label_a = new System.Windows.Forms.Label();
-			this.label_power1 = new System.Windows.Forms.Label();
-			this.label_power5 = new System.Windows.Forms.Label();
-			this.label_power3 = new System.Windows.Forms.Label();
-			this.label_power4 = new System.Windows.Forms.Label();
-			this.label_power2 = new System.Windows.Forms.Label();
-			this.label_brake4 = new System.Windows.Forms.Label();
-			this.label_brake5 = new System.Windows.Forms.Label();
-			this.label_brake6 = new System.Windows.Forms.Label();
-			this.label_brake7 = new System.Windows.Forms.Label();
-			this.label_brake8 = new System.Windows.Forms.Label();
-			this.timer1 = new System.Windows.Forms.Timer(this.components);
-			this.buttonMappingBox = new System.Windows.Forms.GroupBox();
-			this.buttonselectBox = new System.Windows.Forms.ComboBox();
-			this.buttonstartBox = new System.Windows.Forms.ComboBox();
-			this.buttoncBox = new System.Windows.Forms.ComboBox();
-			this.buttonbBox = new System.Windows.Forms.ComboBox();
-			this.buttonaBox = new System.Windows.Forms.ComboBox();
-			this.label_buttonselect = new System.Windows.Forms.Label();
-			this.label_buttonstart = new System.Windows.Forms.Label();
-			this.label_buttonc = new System.Windows.Forms.Label();
-			this.label_buttonb = new System.Windows.Forms.Label();
-			this.label_buttona = new System.Windows.Forms.Label();
-			this.buttonSave = new System.Windows.Forms.Button();
-			this.buttonCancel = new System.Windows.Forms.Button();
-			this.handleMappingBox = new System.Windows.Forms.GroupBox();
-			this.deviceBox = new System.Windows.Forms.ComboBox();
-			this.convertnotchesCheck = new System.Windows.Forms.CheckBox();
-			this.minmaxCheck = new System.Windows.Forms.CheckBox();
-			this.holdbrakeCheck = new System.Windows.Forms.CheckBox();
-			this.label_device = new System.Windows.Forms.Label();
-			this.deviceInputBox.SuspendLayout();
-			this.buttonMappingBox.SuspendLayout();
-			this.handleMappingBox.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// deviceInputBox
-			// 
-			this.deviceInputBox.Controls.Add(this.buttonCalibrate);
-			this.deviceInputBox.Controls.Add(this.label_select);
-			this.deviceInputBox.Controls.Add(this.label_brakeemg);
-			this.deviceInputBox.Controls.Add(this.label_braken);
-			this.deviceInputBox.Controls.Add(this.label_start);
-			this.deviceInputBox.Controls.Add(this.label_brake1);
-			this.deviceInputBox.Controls.Add(this.label_brake2);
-			this.deviceInputBox.Controls.Add(this.label_d);
-			this.deviceInputBox.Controls.Add(this.label_c);
-			this.deviceInputBox.Controls.Add(this.label_brake3);
-			this.deviceInputBox.Controls.Add(this.label_b);
-			this.deviceInputBox.Controls.Add(this.label_powern);
-			this.deviceInputBox.Controls.Add(this.label_a);
-			this.deviceInputBox.Controls.Add(this.label_power1);
-			this.deviceInputBox.Controls.Add(this.label_power5);
-			this.deviceInputBox.Controls.Add(this.label_power3);
-			this.deviceInputBox.Controls.Add(this.label_power4);
-			this.deviceInputBox.Controls.Add(this.label_power2);
-			this.deviceInputBox.Controls.Add(this.label_brake4);
-			this.deviceInputBox.Controls.Add(this.label_brake5);
-			this.deviceInputBox.Controls.Add(this.label_brake6);
-			this.deviceInputBox.Controls.Add(this.label_brake7);
-			this.deviceInputBox.Controls.Add(this.label_brake8);
-			this.deviceInputBox.Location = new System.Drawing.Point(12, 12);
-			this.deviceInputBox.Name = "deviceInputBox";
-			this.deviceInputBox.Size = new System.Drawing.Size(236, 320);
-			this.deviceInputBox.TabIndex = 1;
-			this.deviceInputBox.TabStop = false;
-			this.deviceInputBox.Text = "Device input";
-			// 
-			// buttonCalibrate
-			// 
-			this.buttonCalibrate.Location = new System.Drawing.Point(84, 286);
-			this.buttonCalibrate.Name = "buttonCalibrate";
-			this.buttonCalibrate.Size = new System.Drawing.Size(146, 24);
-			this.buttonCalibrate.TabIndex = 21;
-			this.buttonCalibrate.Text = "Start calibration";
-			this.buttonCalibrate.UseVisualStyleBackColor = true;
-			this.buttonCalibrate.Click += new System.EventHandler(this.buttonCalibrate_Click);
-			// 
-			// label_select
-			// 
-			this.label_select.BackColor = System.Drawing.Color.Plum;
-			this.label_select.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_select.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_select.ForeColor = System.Drawing.Color.Black;
-			this.label_select.Location = new System.Drawing.Point(158, 16);
-			this.label_select.Margin = new System.Windows.Forms.Padding(3);
-			this.label_select.Name = "label_select";
-			this.label_select.Size = new System.Drawing.Size(70, 24);
-			this.label_select.TabIndex = 19;
-			this.label_select.Text = "SELECT";
-			this.label_select.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brakeemg
-			// 
-			this.label_brakeemg.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brakeemg.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brakeemg.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brakeemg.ForeColor = System.Drawing.Color.Black;
-			this.label_brakeemg.Location = new System.Drawing.Point(6, 16);
-			this.label_brakeemg.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brakeemg.Name = "label_brakeemg";
-			this.label_brakeemg.Size = new System.Drawing.Size(70, 24);
-			this.label_brakeemg.TabIndex = 15;
-			this.label_brakeemg.Text = "EMG";
-			this.label_brakeemg.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_braken
-			// 
-			this.label_braken.BackColor = System.Drawing.Color.LightBlue;
-			this.label_braken.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_braken.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_braken.ForeColor = System.Drawing.Color.Black;
-			this.label_braken.Location = new System.Drawing.Point(6, 286);
-			this.label_braken.Margin = new System.Windows.Forms.Padding(3);
-			this.label_braken.Name = "label_braken";
-			this.label_braken.Size = new System.Drawing.Size(70, 24);
-			this.label_braken.TabIndex = 8;
-			this.label_braken.Text = "N";
-			this.label_braken.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_start
-			// 
-			this.label_start.BackColor = System.Drawing.Color.Plum;
-			this.label_start.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_start.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_start.ForeColor = System.Drawing.Color.Black;
-			this.label_start.Location = new System.Drawing.Point(158, 46);
-			this.label_start.Margin = new System.Windows.Forms.Padding(3);
-			this.label_start.Name = "label_start";
-			this.label_start.Size = new System.Drawing.Size(70, 24);
-			this.label_start.TabIndex = 20;
-			this.label_start.Text = "START";
-			this.label_start.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake1
-			// 
-			this.label_brake1.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake1.ForeColor = System.Drawing.Color.Black;
-			this.label_brake1.Location = new System.Drawing.Point(6, 256);
-			this.label_brake1.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake1.Name = "label_brake1";
-			this.label_brake1.Size = new System.Drawing.Size(70, 24);
-			this.label_brake1.TabIndex = 7;
-			this.label_brake1.Text = "B1";
-			this.label_brake1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake2
-			// 
-			this.label_brake2.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake2.ForeColor = System.Drawing.Color.Black;
-			this.label_brake2.Location = new System.Drawing.Point(6, 226);
-			this.label_brake2.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake2.Name = "label_brake2";
-			this.label_brake2.Size = new System.Drawing.Size(70, 24);
-			this.label_brake2.TabIndex = 6;
-			this.label_brake2.Text = "B2";
-			this.label_brake2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_d
-			// 
-			this.label_d.BackColor = System.Drawing.Color.Plum;
-			this.label_d.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_d.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_d.ForeColor = System.Drawing.Color.Black;
-			this.label_d.Location = new System.Drawing.Point(158, 166);
-			this.label_d.Margin = new System.Windows.Forms.Padding(3);
-			this.label_d.Name = "label_d";
-			this.label_d.Size = new System.Drawing.Size(70, 24);
-			this.label_d.TabIndex = 18;
-			this.label_d.Text = "D";
-			this.label_d.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_c
-			// 
-			this.label_c.BackColor = System.Drawing.Color.Plum;
-			this.label_c.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_c.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_c.ForeColor = System.Drawing.Color.Black;
-			this.label_c.Location = new System.Drawing.Point(158, 136);
-			this.label_c.Margin = new System.Windows.Forms.Padding(3);
-			this.label_c.Name = "label_c";
-			this.label_c.Size = new System.Drawing.Size(70, 24);
-			this.label_c.TabIndex = 18;
-			this.label_c.Text = "C";
-			this.label_c.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake3
-			// 
-			this.label_brake3.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake3.ForeColor = System.Drawing.Color.Black;
-			this.label_brake3.Location = new System.Drawing.Point(6, 196);
-			this.label_brake3.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake3.Name = "label_brake3";
-			this.label_brake3.Size = new System.Drawing.Size(70, 24);
-			this.label_brake3.TabIndex = 5;
-			this.label_brake3.Text = "B3";
-			this.label_brake3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_b
-			// 
-			this.label_b.BackColor = System.Drawing.Color.Plum;
-			this.label_b.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_b.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_b.ForeColor = System.Drawing.Color.Black;
-			this.label_b.Location = new System.Drawing.Point(158, 106);
-			this.label_b.Margin = new System.Windows.Forms.Padding(3);
-			this.label_b.Name = "label_b";
-			this.label_b.Size = new System.Drawing.Size(70, 24);
-			this.label_b.TabIndex = 17;
-			this.label_b.Text = "B";
-			this.label_b.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_powern
-			// 
-			this.label_powern.BackColor = System.Drawing.Color.LightBlue;
-			this.label_powern.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_powern.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_powern.ForeColor = System.Drawing.Color.Black;
-			this.label_powern.Location = new System.Drawing.Point(82, 16);
-			this.label_powern.Margin = new System.Windows.Forms.Padding(3);
-			this.label_powern.Name = "label_powern";
-			this.label_powern.Size = new System.Drawing.Size(70, 24);
-			this.label_powern.TabIndex = 9;
-			this.label_powern.Text = "N";
-			this.label_powern.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_a
-			// 
-			this.label_a.BackColor = System.Drawing.Color.Plum;
-			this.label_a.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_a.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_a.ForeColor = System.Drawing.Color.Black;
-			this.label_a.Location = new System.Drawing.Point(158, 76);
-			this.label_a.Margin = new System.Windows.Forms.Padding(3);
-			this.label_a.Name = "label_a";
-			this.label_a.Size = new System.Drawing.Size(70, 24);
-			this.label_a.TabIndex = 16;
-			this.label_a.Text = "A";
-			this.label_a.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_power1
-			// 
-			this.label_power1.BackColor = System.Drawing.Color.LightGreen;
-			this.label_power1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_power1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_power1.ForeColor = System.Drawing.Color.Black;
-			this.label_power1.Location = new System.Drawing.Point(82, 46);
-			this.label_power1.Margin = new System.Windows.Forms.Padding(3);
-			this.label_power1.Name = "label_power1";
-			this.label_power1.Size = new System.Drawing.Size(70, 24);
-			this.label_power1.TabIndex = 10;
-			this.label_power1.Text = "P1";
-			this.label_power1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_power5
-			// 
-			this.label_power5.BackColor = System.Drawing.Color.LightGreen;
-			this.label_power5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_power5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_power5.ForeColor = System.Drawing.Color.Black;
-			this.label_power5.Location = new System.Drawing.Point(82, 166);
-			this.label_power5.Margin = new System.Windows.Forms.Padding(3);
-			this.label_power5.Name = "label_power5";
-			this.label_power5.Size = new System.Drawing.Size(70, 24);
-			this.label_power5.TabIndex = 14;
-			this.label_power5.Text = "P5";
-			this.label_power5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_power3
-			// 
-			this.label_power3.BackColor = System.Drawing.Color.LightGreen;
-			this.label_power3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_power3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_power3.ForeColor = System.Drawing.Color.Black;
-			this.label_power3.Location = new System.Drawing.Point(82, 106);
-			this.label_power3.Margin = new System.Windows.Forms.Padding(3);
-			this.label_power3.Name = "label_power3";
-			this.label_power3.Size = new System.Drawing.Size(70, 24);
-			this.label_power3.TabIndex = 12;
-			this.label_power3.Text = "P3";
-			this.label_power3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_power4
-			// 
-			this.label_power4.BackColor = System.Drawing.Color.LightGreen;
-			this.label_power4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_power4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_power4.ForeColor = System.Drawing.Color.Black;
-			this.label_power4.Location = new System.Drawing.Point(82, 136);
-			this.label_power4.Margin = new System.Windows.Forms.Padding(3);
-			this.label_power4.Name = "label_power4";
-			this.label_power4.Size = new System.Drawing.Size(70, 24);
-			this.label_power4.TabIndex = 13;
-			this.label_power4.Text = "P4";
-			this.label_power4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_power2
-			// 
-			this.label_power2.BackColor = System.Drawing.Color.LightGreen;
-			this.label_power2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_power2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_power2.ForeColor = System.Drawing.Color.Black;
-			this.label_power2.Location = new System.Drawing.Point(82, 76);
-			this.label_power2.Margin = new System.Windows.Forms.Padding(3);
-			this.label_power2.Name = "label_power2";
-			this.label_power2.Size = new System.Drawing.Size(70, 24);
-			this.label_power2.TabIndex = 11;
-			this.label_power2.Text = "P2";
-			this.label_power2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake4
-			// 
-			this.label_brake4.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake4.ForeColor = System.Drawing.Color.Black;
-			this.label_brake4.Location = new System.Drawing.Point(6, 166);
-			this.label_brake4.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake4.Name = "label_brake4";
-			this.label_brake4.Size = new System.Drawing.Size(70, 24);
-			this.label_brake4.TabIndex = 4;
-			this.label_brake4.Text = "B4";
-			this.label_brake4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake5
-			// 
-			this.label_brake5.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake5.ForeColor = System.Drawing.Color.Black;
-			this.label_brake5.Location = new System.Drawing.Point(6, 136);
-			this.label_brake5.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake5.Name = "label_brake5";
-			this.label_brake5.Size = new System.Drawing.Size(70, 24);
-			this.label_brake5.TabIndex = 3;
-			this.label_brake5.Text = "B5";
-			this.label_brake5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake6
-			// 
-			this.label_brake6.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake6.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake6.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake6.ForeColor = System.Drawing.Color.Black;
-			this.label_brake6.Location = new System.Drawing.Point(6, 106);
-			this.label_brake6.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake6.Name = "label_brake6";
-			this.label_brake6.Size = new System.Drawing.Size(70, 24);
-			this.label_brake6.TabIndex = 2;
-			this.label_brake6.Text = "B6";
-			this.label_brake6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake7
-			// 
-			this.label_brake7.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake7.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake7.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake7.ForeColor = System.Drawing.Color.Black;
-			this.label_brake7.Location = new System.Drawing.Point(6, 76);
-			this.label_brake7.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake7.Name = "label_brake7";
-			this.label_brake7.Size = new System.Drawing.Size(70, 24);
-			this.label_brake7.TabIndex = 1;
-			this.label_brake7.Text = "B7";
-			this.label_brake7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label_brake8
-			// 
-			this.label_brake8.BackColor = System.Drawing.Color.LightCoral;
-			this.label_brake8.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.label_brake8.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label_brake8.ForeColor = System.Drawing.Color.Black;
-			this.label_brake8.Location = new System.Drawing.Point(6, 46);
-			this.label_brake8.Margin = new System.Windows.Forms.Padding(3);
-			this.label_brake8.Name = "label_brake8";
-			this.label_brake8.Size = new System.Drawing.Size(70, 24);
-			this.label_brake8.TabIndex = 0;
-			this.label_brake8.Text = "B8";
-			this.label_brake8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// timer1
-			// 
-			this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-			// 
-			// buttonMappingBox
-			// 
-			this.buttonMappingBox.Controls.Add(this.buttonselectBox);
-			this.buttonMappingBox.Controls.Add(this.buttonstartBox);
-			this.buttonMappingBox.Controls.Add(this.buttoncBox);
-			this.buttonMappingBox.Controls.Add(this.buttonbBox);
-			this.buttonMappingBox.Controls.Add(this.buttonaBox);
-			this.buttonMappingBox.Controls.Add(this.label_buttonselect);
-			this.buttonMappingBox.Controls.Add(this.label_buttonstart);
-			this.buttonMappingBox.Controls.Add(this.label_buttonc);
-			this.buttonMappingBox.Controls.Add(this.label_buttonb);
-			this.buttonMappingBox.Controls.Add(this.label_buttona);
-			this.buttonMappingBox.Location = new System.Drawing.Point(254, 43);
-			this.buttonMappingBox.Name = "buttonMappingBox";
-			this.buttonMappingBox.Size = new System.Drawing.Size(250, 158);
-			this.buttonMappingBox.TabIndex = 2;
-			this.buttonMappingBox.TabStop = false;
-			this.buttonMappingBox.Text = "Button mapping";
-			// 
-			// buttonselectBox
-			// 
-			this.buttonselectBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.buttonselectBox.FormattingEnabled = true;
-			this.buttonselectBox.Location = new System.Drawing.Point(62, 20);
-			this.buttonselectBox.Name = "buttonselectBox";
-			this.buttonselectBox.Size = new System.Drawing.Size(182, 21);
-			this.buttonselectBox.TabIndex = 8;
-			this.buttonselectBox.SelectedIndexChanged += new System.EventHandler(this.buttonselectBox_SelectedIndexChanged);
-			// 
-			// buttonstartBox
-			// 
-			this.buttonstartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.buttonstartBox.FormattingEnabled = true;
-			this.buttonstartBox.Location = new System.Drawing.Point(62, 47);
-			this.buttonstartBox.Name = "buttonstartBox";
-			this.buttonstartBox.Size = new System.Drawing.Size(182, 21);
-			this.buttonstartBox.TabIndex = 6;
-			this.buttonstartBox.SelectedIndexChanged += new System.EventHandler(this.buttonstartBox_SelectedIndexChanged);
-			// 
-			// buttoncBox
-			// 
-			this.buttoncBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.buttoncBox.FormattingEnabled = true;
-			this.buttoncBox.Location = new System.Drawing.Point(62, 128);
-			this.buttoncBox.Name = "buttoncBox";
-			this.buttoncBox.Size = new System.Drawing.Size(182, 21);
-			this.buttoncBox.TabIndex = 7;
-			this.buttoncBox.SelectedIndexChanged += new System.EventHandler(this.buttoncBox_SelectedIndexChanged);
-			// 
-			// buttonbBox
-			// 
-			this.buttonbBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.buttonbBox.FormattingEnabled = true;
-			this.buttonbBox.Location = new System.Drawing.Point(62, 101);
-			this.buttonbBox.Name = "buttonbBox";
-			this.buttonbBox.Size = new System.Drawing.Size(182, 21);
-			this.buttonbBox.TabIndex = 6;
-			this.buttonbBox.SelectedIndexChanged += new System.EventHandler(this.buttonbBox_SelectedIndexChanged);
-			// 
-			// buttonaBox
-			// 
-			this.buttonaBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.buttonaBox.FormattingEnabled = true;
-			this.buttonaBox.Location = new System.Drawing.Point(62, 74);
-			this.buttonaBox.Name = "buttonaBox";
-			this.buttonaBox.Size = new System.Drawing.Size(182, 21);
-			this.buttonaBox.TabIndex = 5;
-			this.buttonaBox.SelectedIndexChanged += new System.EventHandler(this.buttonaBox_SelectedIndexChanged);
-			// 
-			// label_buttonselect
-			// 
-			this.label_buttonselect.Location = new System.Drawing.Point(6, 23);
-			this.label_buttonselect.Margin = new System.Windows.Forms.Padding(3);
-			this.label_buttonselect.Name = "label_buttonselect";
-			this.label_buttonselect.Size = new System.Drawing.Size(50, 15);
-			this.label_buttonselect.TabIndex = 3;
-			this.label_buttonselect.Text = "SELECT";
-			// 
-			// label_buttonstart
-			// 
-			this.label_buttonstart.Location = new System.Drawing.Point(6, 50);
-			this.label_buttonstart.Margin = new System.Windows.Forms.Padding(3);
-			this.label_buttonstart.Name = "label_buttonstart";
-			this.label_buttonstart.Size = new System.Drawing.Size(50, 15);
-			this.label_buttonstart.TabIndex = 4;
-			this.label_buttonstart.Text = "START";
-			// 
-			// label_buttonc
-			// 
-			this.label_buttonc.Location = new System.Drawing.Point(6, 131);
-			this.label_buttonc.Margin = new System.Windows.Forms.Padding(3);
-			this.label_buttonc.Name = "label_buttonc";
-			this.label_buttonc.Size = new System.Drawing.Size(50, 15);
-			this.label_buttonc.TabIndex = 2;
-			this.label_buttonc.Text = "C";
-			// 
-			// label_buttonb
-			// 
-			this.label_buttonb.Location = new System.Drawing.Point(6, 104);
-			this.label_buttonb.Margin = new System.Windows.Forms.Padding(3);
-			this.label_buttonb.Name = "label_buttonb";
-			this.label_buttonb.Size = new System.Drawing.Size(50, 15);
-			this.label_buttonb.TabIndex = 1;
-			this.label_buttonb.Text = "B";
-			// 
-			// label_buttona
-			// 
-			this.label_buttona.Location = new System.Drawing.Point(6, 77);
-			this.label_buttona.Margin = new System.Windows.Forms.Padding(3);
-			this.label_buttona.Name = "label_buttona";
-			this.label_buttona.Size = new System.Drawing.Size(50, 15);
-			this.label_buttona.TabIndex = 0;
-			this.label_buttona.Text = "A";
-			// 
-			// buttonSave
-			// 
-			this.buttonSave.Location = new System.Drawing.Point(348, 309);
-			this.buttonSave.Name = "buttonSave";
-			this.buttonSave.Size = new System.Drawing.Size(75, 23);
-			this.buttonSave.TabIndex = 3;
-			this.buttonSave.Text = "Save";
-			this.buttonSave.UseVisualStyleBackColor = true;
-			this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
-
-			// 
-			// buttonCancel
-			// 
-			this.buttonCancel.Location = new System.Drawing.Point(429, 309);
-			this.buttonCancel.Name = "buttonCancel";
-			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-			this.buttonCancel.TabIndex = 4;
-			this.buttonCancel.Text = "Cancel";
-			this.buttonCancel.UseVisualStyleBackColor = true;
-			this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
-			// 
-			// handleMappingBox
-			// 
-			this.handleMappingBox.Controls.Add(this.holdbrakeCheck);
-			this.handleMappingBox.Controls.Add(this.minmaxCheck);
-			this.handleMappingBox.Controls.Add(this.convertnotchesCheck);
-			this.handleMappingBox.Location = new System.Drawing.Point(254, 207);
-			this.handleMappingBox.Name = "handleMappingBox";
-			this.handleMappingBox.Size = new System.Drawing.Size(250, 96);
-			this.handleMappingBox.TabIndex = 5;
-			this.handleMappingBox.TabStop = false;
-			this.handleMappingBox.Text = "Handle mapping";
-			// 
-			// deviceBox
-			// 
-			this.deviceBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.deviceBox.FormattingEnabled = true;
-			this.deviceBox.Location = new System.Drawing.Point(348, 16);
-			this.deviceBox.Name = "deviceBox";
-			this.deviceBox.Size = new System.Drawing.Size(150, 21);
-			this.deviceBox.TabIndex = 6;
-			this.deviceBox.SelectedIndexChanged += new System.EventHandler(this.deviceBox_SelectedIndexChanged);
-			// 
-			// convertnotchesCheck
-			// 
-			this.convertnotchesCheck.Location = new System.Drawing.Point(6, 19);
-			this.convertnotchesCheck.Name = "convertnotchesCheck";
-			this.convertnotchesCheck.Size = new System.Drawing.Size(238, 19);
-			this.convertnotchesCheck.TabIndex = 0;
-			this.convertnotchesCheck.Text = "Convert notches";
-			this.convertnotchesCheck.UseVisualStyleBackColor = true;
-			this.convertnotchesCheck.CheckedChanged += new System.EventHandler(this.convertnotchesCheck_CheckedChanged);
-			// 
-			// minmaxCheck
-			// 
-			this.minmaxCheck.Location = new System.Drawing.Point(6, 44);
-			this.minmaxCheck.Name = "minmaxCheck";
-			this.minmaxCheck.Size = new System.Drawing.Size(238, 19);
-			this.minmaxCheck.TabIndex = 1;
-			this.minmaxCheck.Text = "Keep minimum and maximum";
-			this.minmaxCheck.UseVisualStyleBackColor = true;
-			this.minmaxCheck.CheckedChanged += new System.EventHandler(this.minmaxCheck_CheckedChanged);
-			// 
-			// holdbrakeCheck
-			// 
-			this.holdbrakeCheck.Location = new System.Drawing.Point(6, 69);
-			this.holdbrakeCheck.Name = "holdbrakeCheck";
-			this.holdbrakeCheck.Size = new System.Drawing.Size(238, 19);
-			this.holdbrakeCheck.TabIndex = 2;
-			this.holdbrakeCheck.Text = "Map hold brake to B1";
-			this.holdbrakeCheck.UseVisualStyleBackColor = true;
-			this.holdbrakeCheck.CheckedChanged += new System.EventHandler(this.holdbrakeCheck_CheckedChanged);
-
-			// 
-			// label_device
-			// 
-			this.label_device.Location = new System.Drawing.Point(260, 19);
-			this.label_device.Name = "label_device";
-			this.label_device.Size = new System.Drawing.Size(82, 18);
-			this.label_device.TabIndex = 7;
-			this.label_device.Text = "Device";
-			// 
-			// Config
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(516, 339);
-			this.Controls.Add(this.label_device);
-			this.Controls.Add(this.deviceBox);
-			this.Controls.Add(this.handleMappingBox);
-			this.Controls.Add(this.buttonCancel);
-			this.Controls.Add(this.buttonSave);
-			this.Controls.Add(this.buttonMappingBox);
-			this.Controls.Add(this.deviceInputBox);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.CenterToParent();
-			this.Name = "Config";
-			this.Text = "Densha de GO! controller configuration";
-			this.deviceInputBox.ResumeLayout(false);
-			this.buttonMappingBox.ResumeLayout(false);
-			this.handleMappingBox.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.Shown += new System.EventHandler(this.Config_Shown);
-			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Config_FormClosed);
+            this.components = new System.ComponentModel.Container();
+            this.deviceInputBox = new System.Windows.Forms.GroupBox();
+            this.buttonCalibrate = new System.Windows.Forms.Button();
+            this.label_select = new System.Windows.Forms.Label();
+            this.label_brakeemg = new System.Windows.Forms.Label();
+            this.label_braken = new System.Windows.Forms.Label();
+            this.label_start = new System.Windows.Forms.Label();
+            this.label_brake1 = new System.Windows.Forms.Label();
+            this.label_brake2 = new System.Windows.Forms.Label();
+            this.label_d = new System.Windows.Forms.Label();
+            this.label_c = new System.Windows.Forms.Label();
+            this.label_brake3 = new System.Windows.Forms.Label();
+            this.label_b = new System.Windows.Forms.Label();
+            this.label_powern = new System.Windows.Forms.Label();
+            this.label_a = new System.Windows.Forms.Label();
+            this.label_power1 = new System.Windows.Forms.Label();
+            this.label_power5 = new System.Windows.Forms.Label();
+            this.label_power3 = new System.Windows.Forms.Label();
+            this.label_power4 = new System.Windows.Forms.Label();
+            this.label_power2 = new System.Windows.Forms.Label();
+            this.label_brake4 = new System.Windows.Forms.Label();
+            this.label_brake5 = new System.Windows.Forms.Label();
+            this.label_brake6 = new System.Windows.Forms.Label();
+            this.label_brake7 = new System.Windows.Forms.Label();
+            this.label_brake8 = new System.Windows.Forms.Label();
+            this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.buttonMappingBox = new System.Windows.Forms.GroupBox();
+            this.buttonselectBox = new System.Windows.Forms.ComboBox();
+            this.buttonstartBox = new System.Windows.Forms.ComboBox();
+            this.buttoncBox = new System.Windows.Forms.ComboBox();
+            this.buttonbBox = new System.Windows.Forms.ComboBox();
+            this.buttonaBox = new System.Windows.Forms.ComboBox();
+            this.label_buttonselect = new System.Windows.Forms.Label();
+            this.label_buttonstart = new System.Windows.Forms.Label();
+            this.label_buttonc = new System.Windows.Forms.Label();
+            this.label_buttonb = new System.Windows.Forms.Label();
+            this.label_buttona = new System.Windows.Forms.Label();
+            this.buttonSave = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.handleMappingBox = new System.Windows.Forms.GroupBox();
+            this.holdbrakeCheck = new System.Windows.Forms.CheckBox();
+            this.minmaxCheck = new System.Windows.Forms.CheckBox();
+            this.convertnotchesCheck = new System.Windows.Forms.CheckBox();
+            this.deviceBox = new System.Windows.Forms.ComboBox();
+            this.label_device = new System.Windows.Forms.Label();
+            this.label_up = new System.Windows.Forms.Label();
+            this.label_down = new System.Windows.Forms.Label();
+            this.label_left = new System.Windows.Forms.Label();
+            this.label_right = new System.Windows.Forms.Label();
+            this.buttonupBox = new System.Windows.Forms.ComboBox();
+            this.buttondownBox = new System.Windows.Forms.ComboBox();
+            this.buttonpedalBox = new System.Windows.Forms.ComboBox();
+            this.buttonrightBox = new System.Windows.Forms.ComboBox();
+            this.buttonleftBox = new System.Windows.Forms.ComboBox();
+            this.label_buttonup = new System.Windows.Forms.Label();
+            this.label_buttondown = new System.Windows.Forms.Label();
+            this.label_buttonpedal = new System.Windows.Forms.Label();
+            this.label_buttonright = new System.Windows.Forms.Label();
+            this.label_buttonleft = new System.Windows.Forms.Label();
+            this.buttondBox = new System.Windows.Forms.ComboBox();
+            this.label_buttond = new System.Windows.Forms.Label();
+            this.label_pedal = new System.Windows.Forms.Label();
+            this.deviceInputBox.SuspendLayout();
+            this.buttonMappingBox.SuspendLayout();
+            this.handleMappingBox.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // deviceInputBox
+            // 
+            this.deviceInputBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.deviceInputBox.Controls.Add(this.label_pedal);
+            this.deviceInputBox.Controls.Add(this.label_right);
+            this.deviceInputBox.Controls.Add(this.label_left);
+            this.deviceInputBox.Controls.Add(this.label_down);
+            this.deviceInputBox.Controls.Add(this.label_up);
+            this.deviceInputBox.Controls.Add(this.buttonCalibrate);
+            this.deviceInputBox.Controls.Add(this.label_select);
+            this.deviceInputBox.Controls.Add(this.label_brakeemg);
+            this.deviceInputBox.Controls.Add(this.label_braken);
+            this.deviceInputBox.Controls.Add(this.label_start);
+            this.deviceInputBox.Controls.Add(this.label_brake1);
+            this.deviceInputBox.Controls.Add(this.label_brake2);
+            this.deviceInputBox.Controls.Add(this.label_d);
+            this.deviceInputBox.Controls.Add(this.label_c);
+            this.deviceInputBox.Controls.Add(this.label_brake3);
+            this.deviceInputBox.Controls.Add(this.label_b);
+            this.deviceInputBox.Controls.Add(this.label_powern);
+            this.deviceInputBox.Controls.Add(this.label_a);
+            this.deviceInputBox.Controls.Add(this.label_power1);
+            this.deviceInputBox.Controls.Add(this.label_power5);
+            this.deviceInputBox.Controls.Add(this.label_power3);
+            this.deviceInputBox.Controls.Add(this.label_power4);
+            this.deviceInputBox.Controls.Add(this.label_power2);
+            this.deviceInputBox.Controls.Add(this.label_brake4);
+            this.deviceInputBox.Controls.Add(this.label_brake5);
+            this.deviceInputBox.Controls.Add(this.label_brake6);
+            this.deviceInputBox.Controls.Add(this.label_brake7);
+            this.deviceInputBox.Controls.Add(this.label_brake8);
+            this.deviceInputBox.Location = new System.Drawing.Point(12, 12);
+            this.deviceInputBox.Name = "deviceInputBox";
+            this.deviceInputBox.Size = new System.Drawing.Size(236, 320);
+            this.deviceInputBox.TabIndex = 1;
+            this.deviceInputBox.TabStop = false;
+            this.deviceInputBox.Text = "Device input";
+            // 
+            // buttonCalibrate
+            // 
+            this.buttonCalibrate.Location = new System.Drawing.Point(82, 286);
+            this.buttonCalibrate.Name = "buttonCalibrate";
+            this.buttonCalibrate.Size = new System.Drawing.Size(146, 24);
+            this.buttonCalibrate.TabIndex = 21;
+            this.buttonCalibrate.Text = "Start calibration";
+            this.buttonCalibrate.UseVisualStyleBackColor = true;
+            this.buttonCalibrate.Click += new System.EventHandler(this.buttonCalibrate_Click);
+            // 
+            // label_select
+            // 
+            this.label_select.BackColor = System.Drawing.Color.Plum;
+            this.label_select.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_select.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_select.ForeColor = System.Drawing.Color.Black;
+            this.label_select.Location = new System.Drawing.Point(158, 16);
+            this.label_select.Margin = new System.Windows.Forms.Padding(3);
+            this.label_select.Name = "label_select";
+            this.label_select.Size = new System.Drawing.Size(70, 24);
+            this.label_select.TabIndex = 19;
+            this.label_select.Text = "SELECT";
+            this.label_select.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brakeemg
+            // 
+            this.label_brakeemg.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brakeemg.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brakeemg.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brakeemg.ForeColor = System.Drawing.Color.Black;
+            this.label_brakeemg.Location = new System.Drawing.Point(6, 16);
+            this.label_brakeemg.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brakeemg.Name = "label_brakeemg";
+            this.label_brakeemg.Size = new System.Drawing.Size(70, 24);
+            this.label_brakeemg.TabIndex = 15;
+            this.label_brakeemg.Text = "EMG";
+            this.label_brakeemg.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_braken
+            // 
+            this.label_braken.BackColor = System.Drawing.Color.LightBlue;
+            this.label_braken.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_braken.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_braken.ForeColor = System.Drawing.Color.Black;
+            this.label_braken.Location = new System.Drawing.Point(6, 286);
+            this.label_braken.Margin = new System.Windows.Forms.Padding(3);
+            this.label_braken.Name = "label_braken";
+            this.label_braken.Size = new System.Drawing.Size(70, 24);
+            this.label_braken.TabIndex = 8;
+            this.label_braken.Text = "N";
+            this.label_braken.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_start
+            // 
+            this.label_start.BackColor = System.Drawing.Color.Plum;
+            this.label_start.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_start.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_start.ForeColor = System.Drawing.Color.Black;
+            this.label_start.Location = new System.Drawing.Point(158, 46);
+            this.label_start.Margin = new System.Windows.Forms.Padding(3);
+            this.label_start.Name = "label_start";
+            this.label_start.Size = new System.Drawing.Size(70, 24);
+            this.label_start.TabIndex = 20;
+            this.label_start.Text = "START";
+            this.label_start.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake1
+            // 
+            this.label_brake1.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake1.ForeColor = System.Drawing.Color.Black;
+            this.label_brake1.Location = new System.Drawing.Point(6, 256);
+            this.label_brake1.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake1.Name = "label_brake1";
+            this.label_brake1.Size = new System.Drawing.Size(70, 24);
+            this.label_brake1.TabIndex = 7;
+            this.label_brake1.Text = "B1";
+            this.label_brake1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake2
+            // 
+            this.label_brake2.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake2.ForeColor = System.Drawing.Color.Black;
+            this.label_brake2.Location = new System.Drawing.Point(6, 226);
+            this.label_brake2.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake2.Name = "label_brake2";
+            this.label_brake2.Size = new System.Drawing.Size(70, 24);
+            this.label_brake2.TabIndex = 6;
+            this.label_brake2.Text = "B2";
+            this.label_brake2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_d
+            // 
+            this.label_d.BackColor = System.Drawing.Color.Plum;
+            this.label_d.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_d.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_d.ForeColor = System.Drawing.Color.Black;
+            this.label_d.Location = new System.Drawing.Point(158, 166);
+            this.label_d.Margin = new System.Windows.Forms.Padding(3);
+            this.label_d.Name = "label_d";
+            this.label_d.Size = new System.Drawing.Size(70, 24);
+            this.label_d.TabIndex = 18;
+            this.label_d.Text = "D";
+            this.label_d.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_c
+            // 
+            this.label_c.BackColor = System.Drawing.Color.Plum;
+            this.label_c.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_c.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_c.ForeColor = System.Drawing.Color.Black;
+            this.label_c.Location = new System.Drawing.Point(158, 136);
+            this.label_c.Margin = new System.Windows.Forms.Padding(3);
+            this.label_c.Name = "label_c";
+            this.label_c.Size = new System.Drawing.Size(70, 24);
+            this.label_c.TabIndex = 18;
+            this.label_c.Text = "C";
+            this.label_c.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake3
+            // 
+            this.label_brake3.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake3.ForeColor = System.Drawing.Color.Black;
+            this.label_brake3.Location = new System.Drawing.Point(6, 196);
+            this.label_brake3.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake3.Name = "label_brake3";
+            this.label_brake3.Size = new System.Drawing.Size(70, 24);
+            this.label_brake3.TabIndex = 5;
+            this.label_brake3.Text = "B3";
+            this.label_brake3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_b
+            // 
+            this.label_b.BackColor = System.Drawing.Color.Plum;
+            this.label_b.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_b.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_b.ForeColor = System.Drawing.Color.Black;
+            this.label_b.Location = new System.Drawing.Point(158, 106);
+            this.label_b.Margin = new System.Windows.Forms.Padding(3);
+            this.label_b.Name = "label_b";
+            this.label_b.Size = new System.Drawing.Size(70, 24);
+            this.label_b.TabIndex = 17;
+            this.label_b.Text = "B";
+            this.label_b.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_powern
+            // 
+            this.label_powern.BackColor = System.Drawing.Color.LightBlue;
+            this.label_powern.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_powern.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_powern.ForeColor = System.Drawing.Color.Black;
+            this.label_powern.Location = new System.Drawing.Point(82, 16);
+            this.label_powern.Margin = new System.Windows.Forms.Padding(3);
+            this.label_powern.Name = "label_powern";
+            this.label_powern.Size = new System.Drawing.Size(70, 24);
+            this.label_powern.TabIndex = 9;
+            this.label_powern.Text = "N";
+            this.label_powern.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_a
+            // 
+            this.label_a.BackColor = System.Drawing.Color.Plum;
+            this.label_a.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_a.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_a.ForeColor = System.Drawing.Color.Black;
+            this.label_a.Location = new System.Drawing.Point(158, 76);
+            this.label_a.Margin = new System.Windows.Forms.Padding(3);
+            this.label_a.Name = "label_a";
+            this.label_a.Size = new System.Drawing.Size(70, 24);
+            this.label_a.TabIndex = 16;
+            this.label_a.Text = "A";
+            this.label_a.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_power1
+            // 
+            this.label_power1.BackColor = System.Drawing.Color.LightGreen;
+            this.label_power1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_power1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_power1.ForeColor = System.Drawing.Color.Black;
+            this.label_power1.Location = new System.Drawing.Point(82, 46);
+            this.label_power1.Margin = new System.Windows.Forms.Padding(3);
+            this.label_power1.Name = "label_power1";
+            this.label_power1.Size = new System.Drawing.Size(70, 24);
+            this.label_power1.TabIndex = 10;
+            this.label_power1.Text = "P1";
+            this.label_power1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_power5
+            // 
+            this.label_power5.BackColor = System.Drawing.Color.LightGreen;
+            this.label_power5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_power5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_power5.ForeColor = System.Drawing.Color.Black;
+            this.label_power5.Location = new System.Drawing.Point(82, 166);
+            this.label_power5.Margin = new System.Windows.Forms.Padding(3);
+            this.label_power5.Name = "label_power5";
+            this.label_power5.Size = new System.Drawing.Size(70, 24);
+            this.label_power5.TabIndex = 14;
+            this.label_power5.Text = "P5";
+            this.label_power5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_power3
+            // 
+            this.label_power3.BackColor = System.Drawing.Color.LightGreen;
+            this.label_power3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_power3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_power3.ForeColor = System.Drawing.Color.Black;
+            this.label_power3.Location = new System.Drawing.Point(82, 106);
+            this.label_power3.Margin = new System.Windows.Forms.Padding(3);
+            this.label_power3.Name = "label_power3";
+            this.label_power3.Size = new System.Drawing.Size(70, 24);
+            this.label_power3.TabIndex = 12;
+            this.label_power3.Text = "P3";
+            this.label_power3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_power4
+            // 
+            this.label_power4.BackColor = System.Drawing.Color.LightGreen;
+            this.label_power4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_power4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_power4.ForeColor = System.Drawing.Color.Black;
+            this.label_power4.Location = new System.Drawing.Point(82, 136);
+            this.label_power4.Margin = new System.Windows.Forms.Padding(3);
+            this.label_power4.Name = "label_power4";
+            this.label_power4.Size = new System.Drawing.Size(70, 24);
+            this.label_power4.TabIndex = 13;
+            this.label_power4.Text = "P4";
+            this.label_power4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_power2
+            // 
+            this.label_power2.BackColor = System.Drawing.Color.LightGreen;
+            this.label_power2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_power2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_power2.ForeColor = System.Drawing.Color.Black;
+            this.label_power2.Location = new System.Drawing.Point(82, 76);
+            this.label_power2.Margin = new System.Windows.Forms.Padding(3);
+            this.label_power2.Name = "label_power2";
+            this.label_power2.Size = new System.Drawing.Size(70, 24);
+            this.label_power2.TabIndex = 11;
+            this.label_power2.Text = "P2";
+            this.label_power2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake4
+            // 
+            this.label_brake4.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake4.ForeColor = System.Drawing.Color.Black;
+            this.label_brake4.Location = new System.Drawing.Point(6, 166);
+            this.label_brake4.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake4.Name = "label_brake4";
+            this.label_brake4.Size = new System.Drawing.Size(70, 24);
+            this.label_brake4.TabIndex = 4;
+            this.label_brake4.Text = "B4";
+            this.label_brake4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake5
+            // 
+            this.label_brake5.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake5.ForeColor = System.Drawing.Color.Black;
+            this.label_brake5.Location = new System.Drawing.Point(6, 136);
+            this.label_brake5.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake5.Name = "label_brake5";
+            this.label_brake5.Size = new System.Drawing.Size(70, 24);
+            this.label_brake5.TabIndex = 3;
+            this.label_brake5.Text = "B5";
+            this.label_brake5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake6
+            // 
+            this.label_brake6.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake6.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake6.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake6.ForeColor = System.Drawing.Color.Black;
+            this.label_brake6.Location = new System.Drawing.Point(6, 106);
+            this.label_brake6.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake6.Name = "label_brake6";
+            this.label_brake6.Size = new System.Drawing.Size(70, 24);
+            this.label_brake6.TabIndex = 2;
+            this.label_brake6.Text = "B6";
+            this.label_brake6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake7
+            // 
+            this.label_brake7.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake7.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake7.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake7.ForeColor = System.Drawing.Color.Black;
+            this.label_brake7.Location = new System.Drawing.Point(6, 76);
+            this.label_brake7.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake7.Name = "label_brake7";
+            this.label_brake7.Size = new System.Drawing.Size(70, 24);
+            this.label_brake7.TabIndex = 1;
+            this.label_brake7.Text = "B7";
+            this.label_brake7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_brake8
+            // 
+            this.label_brake8.BackColor = System.Drawing.Color.LightCoral;
+            this.label_brake8.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_brake8.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_brake8.ForeColor = System.Drawing.Color.Black;
+            this.label_brake8.Location = new System.Drawing.Point(6, 46);
+            this.label_brake8.Margin = new System.Windows.Forms.Padding(3);
+            this.label_brake8.Name = "label_brake8";
+            this.label_brake8.Size = new System.Drawing.Size(70, 24);
+            this.label_brake8.TabIndex = 0;
+            this.label_brake8.Text = "B8";
+            this.label_brake8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // timer1
+            // 
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            // 
+            // buttonMappingBox
+            // 
+            this.buttonMappingBox.Controls.Add(this.buttondBox);
+            this.buttonMappingBox.Controls.Add(this.label_buttond);
+            this.buttonMappingBox.Controls.Add(this.buttonupBox);
+            this.buttonMappingBox.Controls.Add(this.buttondownBox);
+            this.buttonMappingBox.Controls.Add(this.buttonpedalBox);
+            this.buttonMappingBox.Controls.Add(this.buttonrightBox);
+            this.buttonMappingBox.Controls.Add(this.buttonleftBox);
+            this.buttonMappingBox.Controls.Add(this.label_buttonup);
+            this.buttonMappingBox.Controls.Add(this.label_buttondown);
+            this.buttonMappingBox.Controls.Add(this.label_buttonpedal);
+            this.buttonMappingBox.Controls.Add(this.label_buttonright);
+            this.buttonMappingBox.Controls.Add(this.label_buttonleft);
+            this.buttonMappingBox.Controls.Add(this.buttonselectBox);
+            this.buttonMappingBox.Controls.Add(this.buttonstartBox);
+            this.buttonMappingBox.Controls.Add(this.buttoncBox);
+            this.buttonMappingBox.Controls.Add(this.buttonbBox);
+            this.buttonMappingBox.Controls.Add(this.buttonaBox);
+            this.buttonMappingBox.Controls.Add(this.label_buttonselect);
+            this.buttonMappingBox.Controls.Add(this.label_buttonstart);
+            this.buttonMappingBox.Controls.Add(this.label_buttonc);
+            this.buttonMappingBox.Controls.Add(this.label_buttonb);
+            this.buttonMappingBox.Controls.Add(this.label_buttona);
+            this.buttonMappingBox.Location = new System.Drawing.Point(254, 43);
+            this.buttonMappingBox.Name = "buttonMappingBox";
+            this.buttonMappingBox.Size = new System.Drawing.Size(500, 184);
+            this.buttonMappingBox.TabIndex = 2;
+            this.buttonMappingBox.TabStop = false;
+            this.buttonMappingBox.Text = "Button mapping";
+            // 
+            // buttonselectBox
+            // 
+            this.buttonselectBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonselectBox.FormattingEnabled = true;
+            this.buttonselectBox.Location = new System.Drawing.Point(62, 20);
+            this.buttonselectBox.Name = "buttonselectBox";
+            this.buttonselectBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonselectBox.TabIndex = 8;
+            this.buttonselectBox.SelectedIndexChanged += new System.EventHandler(this.buttonselectBox_SelectedIndexChanged);
+            // 
+            // buttonstartBox
+            // 
+            this.buttonstartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonstartBox.FormattingEnabled = true;
+            this.buttonstartBox.Location = new System.Drawing.Point(62, 47);
+            this.buttonstartBox.Name = "buttonstartBox";
+            this.buttonstartBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonstartBox.TabIndex = 6;
+            this.buttonstartBox.SelectedIndexChanged += new System.EventHandler(this.buttonstartBox_SelectedIndexChanged);
+            // 
+            // buttoncBox
+            // 
+            this.buttoncBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttoncBox.FormattingEnabled = true;
+            this.buttoncBox.Location = new System.Drawing.Point(62, 128);
+            this.buttoncBox.Name = "buttoncBox";
+            this.buttoncBox.Size = new System.Drawing.Size(182, 21);
+            this.buttoncBox.TabIndex = 7;
+            this.buttoncBox.SelectedIndexChanged += new System.EventHandler(this.buttoncBox_SelectedIndexChanged);
+            // 
+            // buttonbBox
+            // 
+            this.buttonbBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonbBox.FormattingEnabled = true;
+            this.buttonbBox.Location = new System.Drawing.Point(62, 101);
+            this.buttonbBox.Name = "buttonbBox";
+            this.buttonbBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonbBox.TabIndex = 6;
+            this.buttonbBox.SelectedIndexChanged += new System.EventHandler(this.buttonbBox_SelectedIndexChanged);
+            // 
+            // buttonaBox
+            // 
+            this.buttonaBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonaBox.FormattingEnabled = true;
+            this.buttonaBox.Location = new System.Drawing.Point(62, 74);
+            this.buttonaBox.Name = "buttonaBox";
+            this.buttonaBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonaBox.TabIndex = 5;
+            this.buttonaBox.SelectedIndexChanged += new System.EventHandler(this.buttonaBox_SelectedIndexChanged);
+            // 
+            // label_buttonselect
+            // 
+            this.label_buttonselect.Location = new System.Drawing.Point(6, 23);
+            this.label_buttonselect.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonselect.Name = "label_buttonselect";
+            this.label_buttonselect.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonselect.TabIndex = 3;
+            this.label_buttonselect.Text = "SELECT";
+            // 
+            // label_buttonstart
+            // 
+            this.label_buttonstart.Location = new System.Drawing.Point(6, 50);
+            this.label_buttonstart.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonstart.Name = "label_buttonstart";
+            this.label_buttonstart.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonstart.TabIndex = 4;
+            this.label_buttonstart.Text = "START";
+            // 
+            // label_buttonc
+            // 
+            this.label_buttonc.Location = new System.Drawing.Point(6, 131);
+            this.label_buttonc.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonc.Name = "label_buttonc";
+            this.label_buttonc.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonc.TabIndex = 2;
+            this.label_buttonc.Text = "C";
+            // 
+            // label_buttonb
+            // 
+            this.label_buttonb.Location = new System.Drawing.Point(6, 104);
+            this.label_buttonb.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonb.Name = "label_buttonb";
+            this.label_buttonb.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonb.TabIndex = 1;
+            this.label_buttonb.Text = "B";
+            // 
+            // label_buttona
+            // 
+            this.label_buttona.Location = new System.Drawing.Point(6, 77);
+            this.label_buttona.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttona.Name = "label_buttona";
+            this.label_buttona.Size = new System.Drawing.Size(50, 15);
+            this.label_buttona.TabIndex = 0;
+            this.label_buttona.Text = "A";
+            // 
+            // buttonSave
+            // 
+            this.buttonSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonSave.Location = new System.Drawing.Point(598, 309);
+            this.buttonSave.Name = "buttonSave";
+            this.buttonSave.Size = new System.Drawing.Size(75, 23);
+            this.buttonSave.TabIndex = 3;
+            this.buttonSave.Text = "Save";
+            this.buttonSave.UseVisualStyleBackColor = true;
+            this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.Location = new System.Drawing.Point(679, 309);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 4;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
+            // 
+            // handleMappingBox
+            // 
+            this.handleMappingBox.Controls.Add(this.holdbrakeCheck);
+            this.handleMappingBox.Controls.Add(this.minmaxCheck);
+            this.handleMappingBox.Controls.Add(this.convertnotchesCheck);
+            this.handleMappingBox.Location = new System.Drawing.Point(254, 233);
+            this.handleMappingBox.Name = "handleMappingBox";
+            this.handleMappingBox.Size = new System.Drawing.Size(500, 70);
+            this.handleMappingBox.TabIndex = 5;
+            this.handleMappingBox.TabStop = false;
+            this.handleMappingBox.Text = "Handle mapping";
+            // 
+            // holdbrakeCheck
+            // 
+            this.holdbrakeCheck.Location = new System.Drawing.Point(259, 19);
+            this.holdbrakeCheck.Name = "holdbrakeCheck";
+            this.holdbrakeCheck.Size = new System.Drawing.Size(235, 19);
+            this.holdbrakeCheck.TabIndex = 2;
+            this.holdbrakeCheck.Text = "Map hold brake to B1";
+            this.holdbrakeCheck.UseVisualStyleBackColor = true;
+            this.holdbrakeCheck.CheckedChanged += new System.EventHandler(this.holdbrakeCheck_CheckedChanged);
+            // 
+            // minmaxCheck
+            // 
+            this.minmaxCheck.Location = new System.Drawing.Point(6, 44);
+            this.minmaxCheck.Name = "minmaxCheck";
+            this.minmaxCheck.Size = new System.Drawing.Size(238, 19);
+            this.minmaxCheck.TabIndex = 1;
+            this.minmaxCheck.Text = "Keep minimum and maximum";
+            this.minmaxCheck.UseVisualStyleBackColor = true;
+            this.minmaxCheck.CheckedChanged += new System.EventHandler(this.minmaxCheck_CheckedChanged);
+            // 
+            // convertnotchesCheck
+            // 
+            this.convertnotchesCheck.Location = new System.Drawing.Point(6, 19);
+            this.convertnotchesCheck.Name = "convertnotchesCheck";
+            this.convertnotchesCheck.Size = new System.Drawing.Size(238, 19);
+            this.convertnotchesCheck.TabIndex = 0;
+            this.convertnotchesCheck.Text = "Convert notches";
+            this.convertnotchesCheck.UseVisualStyleBackColor = true;
+            this.convertnotchesCheck.CheckedChanged += new System.EventHandler(this.convertnotchesCheck_CheckedChanged);
+            // 
+            // deviceBox
+            // 
+            this.deviceBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.deviceBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.deviceBox.FormattingEnabled = true;
+            this.deviceBox.Location = new System.Drawing.Point(598, 16);
+            this.deviceBox.Name = "deviceBox";
+            this.deviceBox.Size = new System.Drawing.Size(150, 21);
+            this.deviceBox.TabIndex = 6;
+            this.deviceBox.SelectedIndexChanged += new System.EventHandler(this.deviceBox_SelectedIndexChanged);
+            // 
+            // label_device
+            // 
+            this.label_device.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label_device.Location = new System.Drawing.Point(510, 19);
+            this.label_device.Name = "label_device";
+            this.label_device.Size = new System.Drawing.Size(82, 18);
+            this.label_device.TabIndex = 7;
+            this.label_device.Text = "Device";
+            // 
+            // label_up
+            // 
+            this.label_up.BackColor = System.Drawing.Color.Khaki;
+            this.label_up.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_up.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_up.ForeColor = System.Drawing.Color.Black;
+            this.label_up.Location = new System.Drawing.Point(82, 196);
+            this.label_up.Margin = new System.Windows.Forms.Padding(3);
+            this.label_up.Name = "label_up";
+            this.label_up.Size = new System.Drawing.Size(70, 24);
+            this.label_up.TabIndex = 22;
+            this.label_up.Text = "UP";
+            this.label_up.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_down
+            // 
+            this.label_down.BackColor = System.Drawing.Color.Khaki;
+            this.label_down.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_down.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_down.ForeColor = System.Drawing.Color.Black;
+            this.label_down.Location = new System.Drawing.Point(82, 226);
+            this.label_down.Margin = new System.Windows.Forms.Padding(3);
+            this.label_down.Name = "label_down";
+            this.label_down.Size = new System.Drawing.Size(70, 24);
+            this.label_down.TabIndex = 23;
+            this.label_down.Text = "DOWN";
+            this.label_down.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_left
+            // 
+            this.label_left.BackColor = System.Drawing.Color.Khaki;
+            this.label_left.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_left.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_left.ForeColor = System.Drawing.Color.Black;
+            this.label_left.Location = new System.Drawing.Point(158, 196);
+            this.label_left.Margin = new System.Windows.Forms.Padding(3);
+            this.label_left.Name = "label_left";
+            this.label_left.Size = new System.Drawing.Size(70, 24);
+            this.label_left.TabIndex = 24;
+            this.label_left.Text = "LEFT";
+            this.label_left.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_right
+            // 
+            this.label_right.BackColor = System.Drawing.Color.Khaki;
+            this.label_right.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_right.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_right.ForeColor = System.Drawing.Color.Black;
+            this.label_right.Location = new System.Drawing.Point(158, 226);
+            this.label_right.Margin = new System.Windows.Forms.Padding(3);
+            this.label_right.Name = "label_right";
+            this.label_right.Size = new System.Drawing.Size(70, 24);
+            this.label_right.TabIndex = 25;
+            this.label_right.Text = "RIGHT";
+            this.label_right.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // buttonupBox
+            // 
+            this.buttonupBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonupBox.FormattingEnabled = true;
+            this.buttonupBox.Location = new System.Drawing.Point(312, 20);
+            this.buttonupBox.Name = "buttonupBox";
+            this.buttonupBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonupBox.TabIndex = 18;
+			this.buttonupBox.SelectedIndexChanged += new System.EventHandler(this.buttonupBox_SelectedIndexChanged);
+			// 
+			// buttondownBox
+			// 
+			this.buttondownBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttondownBox.FormattingEnabled = true;
+            this.buttondownBox.Location = new System.Drawing.Point(312, 47);
+            this.buttondownBox.Name = "buttondownBox";
+            this.buttondownBox.Size = new System.Drawing.Size(182, 21);
+            this.buttondownBox.TabIndex = 15;
+			this.buttondownBox.SelectedIndexChanged += new System.EventHandler(this.buttondownBox_SelectedIndexChanged);
+			// 
+			// buttonpedalBox
+			// 
+			this.buttonpedalBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonpedalBox.FormattingEnabled = true;
+            this.buttonpedalBox.Location = new System.Drawing.Point(312, 128);
+            this.buttonpedalBox.Name = "buttonpedalBox";
+            this.buttonpedalBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonpedalBox.TabIndex = 17;
+			this.buttonpedalBox.SelectedIndexChanged += new System.EventHandler(this.buttonpedalBox_SelectedIndexChanged);
+			// 
+			// buttonrightBox
+			// 
+			this.buttonrightBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonrightBox.FormattingEnabled = true;
+            this.buttonrightBox.Location = new System.Drawing.Point(312, 101);
+            this.buttonrightBox.Name = "buttonrightBox";
+            this.buttonrightBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonrightBox.TabIndex = 16;
+			this.buttonrightBox.SelectedIndexChanged += new System.EventHandler(this.buttonrightBox_SelectedIndexChanged);
+			// 
+			// buttonleftBox
+			// 
+			this.buttonleftBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonleftBox.FormattingEnabled = true;
+            this.buttonleftBox.Location = new System.Drawing.Point(312, 74);
+            this.buttonleftBox.Name = "buttonleftBox";
+            this.buttonleftBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonleftBox.TabIndex = 14;
+			this.buttonleftBox.SelectedIndexChanged += new System.EventHandler(this.buttonleftBox_SelectedIndexChanged);
+			// 
+			// label_buttonup
+			// 
+			this.label_buttonup.Location = new System.Drawing.Point(256, 23);
+            this.label_buttonup.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonup.Name = "label_buttonup";
+            this.label_buttonup.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonup.TabIndex = 12;
+            this.label_buttonup.Text = "UP";
+            // 
+            // label_buttondown
+            // 
+            this.label_buttondown.Location = new System.Drawing.Point(256, 50);
+            this.label_buttondown.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttondown.Name = "label_buttondown";
+            this.label_buttondown.Size = new System.Drawing.Size(50, 15);
+            this.label_buttondown.TabIndex = 13;
+            this.label_buttondown.Text = "DOWN";
+            // 
+            // label_buttonpedal
+            // 
+            this.label_buttonpedal.Location = new System.Drawing.Point(256, 131);
+            this.label_buttonpedal.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonpedal.Name = "label_buttonpedal";
+            this.label_buttonpedal.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonpedal.TabIndex = 11;
+            this.label_buttonpedal.Text = "PEDAL";
+            // 
+            // label_buttonright
+            // 
+            this.label_buttonright.Location = new System.Drawing.Point(256, 104);
+            this.label_buttonright.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonright.Name = "label_buttonright";
+            this.label_buttonright.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonright.TabIndex = 10;
+            this.label_buttonright.Text = "RIGHT";
+            // 
+            // label_buttonleft
+            // 
+            this.label_buttonleft.Location = new System.Drawing.Point(256, 77);
+            this.label_buttonleft.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonleft.Name = "label_buttonleft";
+            this.label_buttonleft.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonleft.TabIndex = 9;
+            this.label_buttonleft.Text = "LEFT";
+            // 
+            // buttondBox
+            // 
+            this.buttondBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttondBox.FormattingEnabled = true;
+            this.buttondBox.Location = new System.Drawing.Point(62, 155);
+            this.buttondBox.Name = "buttondBox";
+            this.buttondBox.Size = new System.Drawing.Size(182, 21);
+            this.buttondBox.TabIndex = 20;
+			this.buttondBox.SelectedIndexChanged += new System.EventHandler(this.buttondBox_SelectedIndexChanged);
+			// 
+			// label_buttond
+			// 
+			this.label_buttond.Location = new System.Drawing.Point(6, 158);
+            this.label_buttond.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttond.Name = "label_buttond";
+            this.label_buttond.Size = new System.Drawing.Size(50, 15);
+            this.label_buttond.TabIndex = 19;
+            this.label_buttond.Text = "D";
+            // 
+            // label_pedal
+            // 
+            this.label_pedal.BackColor = System.Drawing.Color.Silver;
+            this.label_pedal.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_pedal.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_pedal.ForeColor = System.Drawing.Color.Black;
+            this.label_pedal.Location = new System.Drawing.Point(82, 256);
+            this.label_pedal.Margin = new System.Windows.Forms.Padding(3);
+            this.label_pedal.Name = "label_pedal";
+            this.label_pedal.Size = new System.Drawing.Size(145, 24);
+            this.label_pedal.TabIndex = 26;
+            this.label_pedal.Text = "PEDAL";
+            this.label_pedal.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // Config
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(766, 339);
+            this.Controls.Add(this.label_device);
+            this.Controls.Add(this.deviceBox);
+            this.Controls.Add(this.handleMappingBox);
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.buttonSave);
+            this.Controls.Add(this.buttonMappingBox);
+            this.Controls.Add(this.deviceInputBox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Name = "Config";
+            this.Text = "Densha de GO! controller configuration";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Config_FormClosed);
+            this.Shown += new System.EventHandler(this.Config_Shown);
+            this.deviceInputBox.ResumeLayout(false);
+            this.buttonMappingBox.ResumeLayout(false);
+            this.handleMappingBox.ResumeLayout(false);
+            this.ResumeLayout(false);
 
 		}
 
@@ -722,5 +943,22 @@ namespace DenshaDeGoInput
 		private System.Windows.Forms.CheckBox minmaxCheck;
 		private System.Windows.Forms.CheckBox convertnotchesCheck;
 		private System.Windows.Forms.Label label_device;
+		private System.Windows.Forms.Label label_right;
+		private System.Windows.Forms.Label label_left;
+		private System.Windows.Forms.Label label_down;
+		private System.Windows.Forms.Label label_up;
+		private System.Windows.Forms.ComboBox buttondBox;
+		private System.Windows.Forms.Label label_buttond;
+		private System.Windows.Forms.ComboBox buttonupBox;
+		private System.Windows.Forms.ComboBox buttondownBox;
+		private System.Windows.Forms.ComboBox buttonpedalBox;
+		private System.Windows.Forms.ComboBox buttonrightBox;
+		private System.Windows.Forms.ComboBox buttonleftBox;
+		private System.Windows.Forms.Label label_buttonup;
+		private System.Windows.Forms.Label label_buttondown;
+		private System.Windows.Forms.Label label_buttonpedal;
+		private System.Windows.Forms.Label label_buttonright;
+		private System.Windows.Forms.Label label_buttonleft;
+		private System.Windows.Forms.Label label_pedal;
 	}
 }

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -140,7 +140,7 @@ namespace DenshaDeGoInput
 			this.buttonCalibrate.Name = "buttonCalibrate";
 			this.buttonCalibrate.Size = new System.Drawing.Size(146, 24);
 			this.buttonCalibrate.TabIndex = 21;
-			this.buttonCalibrate.Text = "Calibrate";
+			this.buttonCalibrate.Text = "Start calibration";
 			this.buttonCalibrate.UseVisualStyleBackColor = true;
 			this.buttonCalibrate.Click += new System.EventHandler(this.buttonCalibrate_Click);
 			// 
@@ -469,6 +469,7 @@ namespace DenshaDeGoInput
 			this.buttonselectBox.Name = "buttonselectBox";
 			this.buttonselectBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonselectBox.TabIndex = 8;
+			this.buttonselectBox.SelectedIndexChanged += new System.EventHandler(this.buttonselectBox_SelectedIndexChanged);
 			// 
 			// buttonstartBox
 			// 
@@ -478,6 +479,7 @@ namespace DenshaDeGoInput
 			this.buttonstartBox.Name = "buttonstartBox";
 			this.buttonstartBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonstartBox.TabIndex = 6;
+			this.buttonstartBox.SelectedIndexChanged += new System.EventHandler(this.buttonstartBox_SelectedIndexChanged);
 			// 
 			// buttoncBox
 			// 
@@ -487,6 +489,7 @@ namespace DenshaDeGoInput
 			this.buttoncBox.Name = "buttoncBox";
 			this.buttoncBox.Size = new System.Drawing.Size(182, 21);
 			this.buttoncBox.TabIndex = 7;
+			this.buttoncBox.SelectedIndexChanged += new System.EventHandler(this.buttoncBox_SelectedIndexChanged);
 			// 
 			// buttonbBox
 			// 
@@ -496,6 +499,7 @@ namespace DenshaDeGoInput
 			this.buttonbBox.Name = "buttonbBox";
 			this.buttonbBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonbBox.TabIndex = 6;
+			this.buttonbBox.SelectedIndexChanged += new System.EventHandler(this.buttonbBox_SelectedIndexChanged);
 			// 
 			// buttonaBox
 			// 
@@ -505,6 +509,7 @@ namespace DenshaDeGoInput
 			this.buttonaBox.Name = "buttonaBox";
 			this.buttonaBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonaBox.TabIndex = 5;
+			this.buttonaBox.SelectedIndexChanged += new System.EventHandler(this.buttonaBox_SelectedIndexChanged);
 			// 
 			// label_buttonselect
 			// 
@@ -623,6 +628,7 @@ namespace DenshaDeGoInput
 			this.holdbrakeCheck.Text = "Map hold brake to B1";
 			this.holdbrakeCheck.UseVisualStyleBackColor = true;
 			this.holdbrakeCheck.CheckedChanged += new System.EventHandler(this.holdbrakeCheck_CheckedChanged);
+
 			// 
 			// label_device
 			// 

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -61,6 +61,7 @@ namespace DenshaDeGoInput
 			this.label_start = new System.Windows.Forms.Label();
 			this.label_brake1 = new System.Windows.Forms.Label();
 			this.label_brake2 = new System.Windows.Forms.Label();
+			this.label_d = new System.Windows.Forms.Label();
 			this.label_c = new System.Windows.Forms.Label();
 			this.label_brake3 = new System.Windows.Forms.Label();
 			this.label_b = new System.Windows.Forms.Label();
@@ -110,6 +111,7 @@ namespace DenshaDeGoInput
 			this.deviceInputBox.Controls.Add(this.label_start);
 			this.deviceInputBox.Controls.Add(this.label_brake1);
 			this.deviceInputBox.Controls.Add(this.label_brake2);
+			this.deviceInputBox.Controls.Add(this.label_d);
 			this.deviceInputBox.Controls.Add(this.label_c);
 			this.deviceInputBox.Controls.Add(this.label_brake3);
 			this.deviceInputBox.Controls.Add(this.label_b);
@@ -226,13 +228,27 @@ namespace DenshaDeGoInput
 			this.label_brake2.Text = "B2";
 			this.label_brake2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
+			// label_d
+			// 
+			this.label_d.BackColor = System.Drawing.Color.Plum;
+			this.label_d.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_d.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_d.ForeColor = System.Drawing.Color.Black;
+			this.label_d.Location = new System.Drawing.Point(158, 166);
+			this.label_d.Margin = new System.Windows.Forms.Padding(3);
+			this.label_d.Name = "label_d";
+			this.label_d.Size = new System.Drawing.Size(70, 24);
+			this.label_d.TabIndex = 18;
+			this.label_d.Text = "D";
+			this.label_d.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
 			// label_c
 			// 
 			this.label_c.BackColor = System.Drawing.Color.Plum;
 			this.label_c.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.label_c.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label_c.ForeColor = System.Drawing.Color.Black;
-			this.label_c.Location = new System.Drawing.Point(158, 166);
+			this.label_c.Location = new System.Drawing.Point(158, 136);
 			this.label_c.Margin = new System.Windows.Forms.Padding(3);
 			this.label_c.Name = "label_c";
 			this.label_c.Size = new System.Drawing.Size(70, 24);
@@ -260,7 +276,7 @@ namespace DenshaDeGoInput
 			this.label_b.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.label_b.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label_b.ForeColor = System.Drawing.Color.Black;
-			this.label_b.Location = new System.Drawing.Point(158, 136);
+			this.label_b.Location = new System.Drawing.Point(158, 106);
 			this.label_b.Margin = new System.Windows.Forms.Padding(3);
 			this.label_b.Name = "label_b";
 			this.label_b.Size = new System.Drawing.Size(70, 24);
@@ -288,7 +304,7 @@ namespace DenshaDeGoInput
 			this.label_a.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.label_a.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label_a.ForeColor = System.Drawing.Color.Black;
-			this.label_a.Location = new System.Drawing.Point(158, 106);
+			this.label_a.Location = new System.Drawing.Point(158, 76);
 			this.label_a.Margin = new System.Windows.Forms.Padding(3);
 			this.label_a.Name = "label_a";
 			this.label_a.Size = new System.Drawing.Size(70, 24);
@@ -463,7 +479,7 @@ namespace DenshaDeGoInput
 			// 
 			this.buttonselectBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.buttonselectBox.FormattingEnabled = true;
-			this.buttonselectBox.Location = new System.Drawing.Point(62, 101);
+			this.buttonselectBox.Location = new System.Drawing.Point(62, 20);
 			this.buttonselectBox.Name = "buttonselectBox";
 			this.buttonselectBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonselectBox.TabIndex = 8;
@@ -473,7 +489,7 @@ namespace DenshaDeGoInput
 			// 
 			this.buttonstartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.buttonstartBox.FormattingEnabled = true;
-			this.buttonstartBox.Location = new System.Drawing.Point(62, 128);
+			this.buttonstartBox.Location = new System.Drawing.Point(62, 47);
 			this.buttonstartBox.Name = "buttonstartBox";
 			this.buttonstartBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonstartBox.TabIndex = 6;
@@ -483,7 +499,7 @@ namespace DenshaDeGoInput
 			// 
 			this.buttoncBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.buttoncBox.FormattingEnabled = true;
-			this.buttoncBox.Location = new System.Drawing.Point(62, 74);
+			this.buttoncBox.Location = new System.Drawing.Point(62, 128);
 			this.buttoncBox.Name = "buttoncBox";
 			this.buttoncBox.Size = new System.Drawing.Size(182, 21);
 			this.buttoncBox.TabIndex = 7;
@@ -493,7 +509,7 @@ namespace DenshaDeGoInput
 			// 
 			this.buttonbBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.buttonbBox.FormattingEnabled = true;
-			this.buttonbBox.Location = new System.Drawing.Point(62, 47);
+			this.buttonbBox.Location = new System.Drawing.Point(62, 101);
 			this.buttonbBox.Name = "buttonbBox";
 			this.buttonbBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonbBox.TabIndex = 6;
@@ -503,7 +519,7 @@ namespace DenshaDeGoInput
 			// 
 			this.buttonaBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.buttonaBox.FormattingEnabled = true;
-			this.buttonaBox.Location = new System.Drawing.Point(62, 20);
+			this.buttonaBox.Location = new System.Drawing.Point(62, 74);
 			this.buttonaBox.Name = "buttonaBox";
 			this.buttonaBox.Size = new System.Drawing.Size(182, 21);
 			this.buttonaBox.TabIndex = 5;
@@ -511,7 +527,7 @@ namespace DenshaDeGoInput
 			// 
 			// label_buttonselect
 			// 
-			this.label_buttonselect.Location = new System.Drawing.Point(6, 104);
+			this.label_buttonselect.Location = new System.Drawing.Point(6, 23);
 			this.label_buttonselect.Margin = new System.Windows.Forms.Padding(3);
 			this.label_buttonselect.Name = "label_buttonselect";
 			this.label_buttonselect.Size = new System.Drawing.Size(50, 15);
@@ -520,7 +536,7 @@ namespace DenshaDeGoInput
 			// 
 			// label_buttonstart
 			// 
-			this.label_buttonstart.Location = new System.Drawing.Point(6, 131);
+			this.label_buttonstart.Location = new System.Drawing.Point(6, 50);
 			this.label_buttonstart.Margin = new System.Windows.Forms.Padding(3);
 			this.label_buttonstart.Name = "label_buttonstart";
 			this.label_buttonstart.Size = new System.Drawing.Size(50, 15);
@@ -529,7 +545,7 @@ namespace DenshaDeGoInput
 			// 
 			// label_buttonc
 			// 
-			this.label_buttonc.Location = new System.Drawing.Point(6, 77);
+			this.label_buttonc.Location = new System.Drawing.Point(6, 131);
 			this.label_buttonc.Margin = new System.Windows.Forms.Padding(3);
 			this.label_buttonc.Name = "label_buttonc";
 			this.label_buttonc.Size = new System.Drawing.Size(50, 15);
@@ -538,7 +554,7 @@ namespace DenshaDeGoInput
 			// 
 			// label_buttonb
 			// 
-			this.label_buttonb.Location = new System.Drawing.Point(6, 50);
+			this.label_buttonb.Location = new System.Drawing.Point(6, 104);
 			this.label_buttonb.Margin = new System.Windows.Forms.Padding(3);
 			this.label_buttonb.Name = "label_buttonb";
 			this.label_buttonb.Size = new System.Drawing.Size(50, 15);
@@ -547,7 +563,7 @@ namespace DenshaDeGoInput
 			// 
 			// label_buttona
 			// 
-			this.label_buttona.Location = new System.Drawing.Point(6, 23);
+			this.label_buttona.Location = new System.Drawing.Point(6, 77);
 			this.label_buttona.Margin = new System.Windows.Forms.Padding(3);
 			this.label_buttona.Name = "label_buttona";
 			this.label_buttona.Size = new System.Drawing.Size(50, 15);
@@ -666,6 +682,7 @@ namespace DenshaDeGoInput
 		private System.Windows.Forms.Timer timer1;
 		private System.Windows.Forms.Label label_select;
 		private System.Windows.Forms.Label label_start;
+		private System.Windows.Forms.Label label_d;
 		private System.Windows.Forms.Label label_c;
 		private System.Windows.Forms.Label label_b;
 		private System.Windows.Forms.Label label_a;

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -675,20 +675,21 @@ namespace DenshaDeGoInput
             this.deviceBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.deviceBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.deviceBox.FormattingEnabled = true;
-            this.deviceBox.Location = new System.Drawing.Point(598, 16);
+            this.deviceBox.Location = new System.Drawing.Point(566, 16);
             this.deviceBox.Name = "deviceBox";
-            this.deviceBox.Size = new System.Drawing.Size(150, 21);
+            this.deviceBox.Size = new System.Drawing.Size(182, 21);
             this.deviceBox.TabIndex = 6;
             this.deviceBox.SelectedIndexChanged += new System.EventHandler(this.deviceBox_SelectedIndexChanged);
             // 
             // label_device
             // 
             this.label_device.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label_device.Location = new System.Drawing.Point(510, 19);
+            this.label_device.Location = new System.Drawing.Point(478, 19);
             this.label_device.Name = "label_device";
             this.label_device.Size = new System.Drawing.Size(82, 18);
             this.label_device.TabIndex = 7;
             this.label_device.Text = "Device";
+            this.label_device.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label_up
             // 

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -1,0 +1,677 @@
+using System;
+
+namespace DenshaDeGoInput
+{
+	partial class Config
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			this.deviceInputBox = new System.Windows.Forms.GroupBox();
+			this.buttonCalibrate = new System.Windows.Forms.Button();
+			this.label_select = new System.Windows.Forms.Label();
+			this.label_brakeemg = new System.Windows.Forms.Label();
+			this.label_braken = new System.Windows.Forms.Label();
+			this.label_start = new System.Windows.Forms.Label();
+			this.label_brake1 = new System.Windows.Forms.Label();
+			this.label_brake2 = new System.Windows.Forms.Label();
+			this.label_c = new System.Windows.Forms.Label();
+			this.label_brake3 = new System.Windows.Forms.Label();
+			this.label_b = new System.Windows.Forms.Label();
+			this.label_powern = new System.Windows.Forms.Label();
+			this.label_a = new System.Windows.Forms.Label();
+			this.label_power1 = new System.Windows.Forms.Label();
+			this.label_power5 = new System.Windows.Forms.Label();
+			this.label_power3 = new System.Windows.Forms.Label();
+			this.label_power4 = new System.Windows.Forms.Label();
+			this.label_power2 = new System.Windows.Forms.Label();
+			this.label_brake4 = new System.Windows.Forms.Label();
+			this.label_brake5 = new System.Windows.Forms.Label();
+			this.label_brake6 = new System.Windows.Forms.Label();
+			this.label_brake7 = new System.Windows.Forms.Label();
+			this.label_brake8 = new System.Windows.Forms.Label();
+			this.timer1 = new System.Windows.Forms.Timer(this.components);
+			this.buttonMappingBox = new System.Windows.Forms.GroupBox();
+			this.buttonselectBox = new System.Windows.Forms.ComboBox();
+			this.buttonstartBox = new System.Windows.Forms.ComboBox();
+			this.buttoncBox = new System.Windows.Forms.ComboBox();
+			this.buttonbBox = new System.Windows.Forms.ComboBox();
+			this.buttonaBox = new System.Windows.Forms.ComboBox();
+			this.label_buttonselect = new System.Windows.Forms.Label();
+			this.label_buttonstart = new System.Windows.Forms.Label();
+			this.label_buttonc = new System.Windows.Forms.Label();
+			this.label_buttonb = new System.Windows.Forms.Label();
+			this.label_buttona = new System.Windows.Forms.Label();
+			this.buttonSave = new System.Windows.Forms.Button();
+			this.buttonCancel = new System.Windows.Forms.Button();
+			this.handleMappingBox = new System.Windows.Forms.GroupBox();
+			this.deviceBox = new System.Windows.Forms.ComboBox();
+			this.convertnotchesCheck = new System.Windows.Forms.CheckBox();
+			this.minmaxCheck = new System.Windows.Forms.CheckBox();
+			this.holdbrakeCheck = new System.Windows.Forms.CheckBox();
+			this.label_device = new System.Windows.Forms.Label();
+			this.deviceInputBox.SuspendLayout();
+			this.buttonMappingBox.SuspendLayout();
+			this.handleMappingBox.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// deviceInputBox
+			// 
+			this.deviceInputBox.Controls.Add(this.buttonCalibrate);
+			this.deviceInputBox.Controls.Add(this.label_select);
+			this.deviceInputBox.Controls.Add(this.label_brakeemg);
+			this.deviceInputBox.Controls.Add(this.label_braken);
+			this.deviceInputBox.Controls.Add(this.label_start);
+			this.deviceInputBox.Controls.Add(this.label_brake1);
+			this.deviceInputBox.Controls.Add(this.label_brake2);
+			this.deviceInputBox.Controls.Add(this.label_c);
+			this.deviceInputBox.Controls.Add(this.label_brake3);
+			this.deviceInputBox.Controls.Add(this.label_b);
+			this.deviceInputBox.Controls.Add(this.label_powern);
+			this.deviceInputBox.Controls.Add(this.label_a);
+			this.deviceInputBox.Controls.Add(this.label_power1);
+			this.deviceInputBox.Controls.Add(this.label_power5);
+			this.deviceInputBox.Controls.Add(this.label_power3);
+			this.deviceInputBox.Controls.Add(this.label_power4);
+			this.deviceInputBox.Controls.Add(this.label_power2);
+			this.deviceInputBox.Controls.Add(this.label_brake4);
+			this.deviceInputBox.Controls.Add(this.label_brake5);
+			this.deviceInputBox.Controls.Add(this.label_brake6);
+			this.deviceInputBox.Controls.Add(this.label_brake7);
+			this.deviceInputBox.Controls.Add(this.label_brake8);
+			this.deviceInputBox.Location = new System.Drawing.Point(12, 12);
+			this.deviceInputBox.Name = "deviceInputBox";
+			this.deviceInputBox.Size = new System.Drawing.Size(236, 320);
+			this.deviceInputBox.TabIndex = 1;
+			this.deviceInputBox.TabStop = false;
+			this.deviceInputBox.Text = "Device input";
+			// 
+			// buttonCalibrate
+			// 
+			this.buttonCalibrate.Location = new System.Drawing.Point(84, 286);
+			this.buttonCalibrate.Name = "buttonCalibrate";
+			this.buttonCalibrate.Size = new System.Drawing.Size(146, 24);
+			this.buttonCalibrate.TabIndex = 21;
+			this.buttonCalibrate.Text = "Calibrate";
+			this.buttonCalibrate.UseVisualStyleBackColor = true;
+			this.buttonCalibrate.Click += new System.EventHandler(this.buttonCalibrate_Click);
+			// 
+			// label_select
+			// 
+			this.label_select.BackColor = System.Drawing.Color.Plum;
+			this.label_select.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_select.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_select.ForeColor = System.Drawing.Color.Black;
+			this.label_select.Location = new System.Drawing.Point(158, 16);
+			this.label_select.Margin = new System.Windows.Forms.Padding(3);
+			this.label_select.Name = "label_select";
+			this.label_select.Size = new System.Drawing.Size(70, 24);
+			this.label_select.TabIndex = 19;
+			this.label_select.Text = "SELECT";
+			this.label_select.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brakeemg
+			// 
+			this.label_brakeemg.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brakeemg.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brakeemg.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brakeemg.ForeColor = System.Drawing.Color.Black;
+			this.label_brakeemg.Location = new System.Drawing.Point(6, 16);
+			this.label_brakeemg.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brakeemg.Name = "label_brakeemg";
+			this.label_brakeemg.Size = new System.Drawing.Size(70, 24);
+			this.label_brakeemg.TabIndex = 15;
+			this.label_brakeemg.Text = "EMG";
+			this.label_brakeemg.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_braken
+			// 
+			this.label_braken.BackColor = System.Drawing.Color.LightBlue;
+			this.label_braken.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_braken.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_braken.ForeColor = System.Drawing.Color.Black;
+			this.label_braken.Location = new System.Drawing.Point(6, 286);
+			this.label_braken.Margin = new System.Windows.Forms.Padding(3);
+			this.label_braken.Name = "label_braken";
+			this.label_braken.Size = new System.Drawing.Size(70, 24);
+			this.label_braken.TabIndex = 8;
+			this.label_braken.Text = "N";
+			this.label_braken.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_start
+			// 
+			this.label_start.BackColor = System.Drawing.Color.Plum;
+			this.label_start.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_start.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_start.ForeColor = System.Drawing.Color.Black;
+			this.label_start.Location = new System.Drawing.Point(158, 46);
+			this.label_start.Margin = new System.Windows.Forms.Padding(3);
+			this.label_start.Name = "label_start";
+			this.label_start.Size = new System.Drawing.Size(70, 24);
+			this.label_start.TabIndex = 20;
+			this.label_start.Text = "START";
+			this.label_start.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake1
+			// 
+			this.label_brake1.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake1.ForeColor = System.Drawing.Color.Black;
+			this.label_brake1.Location = new System.Drawing.Point(6, 256);
+			this.label_brake1.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake1.Name = "label_brake1";
+			this.label_brake1.Size = new System.Drawing.Size(70, 24);
+			this.label_brake1.TabIndex = 7;
+			this.label_brake1.Text = "B1";
+			this.label_brake1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake2
+			// 
+			this.label_brake2.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake2.ForeColor = System.Drawing.Color.Black;
+			this.label_brake2.Location = new System.Drawing.Point(6, 226);
+			this.label_brake2.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake2.Name = "label_brake2";
+			this.label_brake2.Size = new System.Drawing.Size(70, 24);
+			this.label_brake2.TabIndex = 6;
+			this.label_brake2.Text = "B2";
+			this.label_brake2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_c
+			// 
+			this.label_c.BackColor = System.Drawing.Color.Plum;
+			this.label_c.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_c.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_c.ForeColor = System.Drawing.Color.Black;
+			this.label_c.Location = new System.Drawing.Point(158, 166);
+			this.label_c.Margin = new System.Windows.Forms.Padding(3);
+			this.label_c.Name = "label_c";
+			this.label_c.Size = new System.Drawing.Size(70, 24);
+			this.label_c.TabIndex = 18;
+			this.label_c.Text = "C";
+			this.label_c.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake3
+			// 
+			this.label_brake3.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake3.ForeColor = System.Drawing.Color.Black;
+			this.label_brake3.Location = new System.Drawing.Point(6, 196);
+			this.label_brake3.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake3.Name = "label_brake3";
+			this.label_brake3.Size = new System.Drawing.Size(70, 24);
+			this.label_brake3.TabIndex = 5;
+			this.label_brake3.Text = "B3";
+			this.label_brake3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_b
+			// 
+			this.label_b.BackColor = System.Drawing.Color.Plum;
+			this.label_b.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_b.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_b.ForeColor = System.Drawing.Color.Black;
+			this.label_b.Location = new System.Drawing.Point(158, 136);
+			this.label_b.Margin = new System.Windows.Forms.Padding(3);
+			this.label_b.Name = "label_b";
+			this.label_b.Size = new System.Drawing.Size(70, 24);
+			this.label_b.TabIndex = 17;
+			this.label_b.Text = "B";
+			this.label_b.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_powern
+			// 
+			this.label_powern.BackColor = System.Drawing.Color.LightBlue;
+			this.label_powern.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_powern.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_powern.ForeColor = System.Drawing.Color.Black;
+			this.label_powern.Location = new System.Drawing.Point(82, 16);
+			this.label_powern.Margin = new System.Windows.Forms.Padding(3);
+			this.label_powern.Name = "label_powern";
+			this.label_powern.Size = new System.Drawing.Size(70, 24);
+			this.label_powern.TabIndex = 9;
+			this.label_powern.Text = "N";
+			this.label_powern.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_a
+			// 
+			this.label_a.BackColor = System.Drawing.Color.Plum;
+			this.label_a.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_a.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_a.ForeColor = System.Drawing.Color.Black;
+			this.label_a.Location = new System.Drawing.Point(158, 106);
+			this.label_a.Margin = new System.Windows.Forms.Padding(3);
+			this.label_a.Name = "label_a";
+			this.label_a.Size = new System.Drawing.Size(70, 24);
+			this.label_a.TabIndex = 16;
+			this.label_a.Text = "A";
+			this.label_a.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_power1
+			// 
+			this.label_power1.BackColor = System.Drawing.Color.LightGreen;
+			this.label_power1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_power1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_power1.ForeColor = System.Drawing.Color.Black;
+			this.label_power1.Location = new System.Drawing.Point(82, 46);
+			this.label_power1.Margin = new System.Windows.Forms.Padding(3);
+			this.label_power1.Name = "label_power1";
+			this.label_power1.Size = new System.Drawing.Size(70, 24);
+			this.label_power1.TabIndex = 10;
+			this.label_power1.Text = "P1";
+			this.label_power1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_power5
+			// 
+			this.label_power5.BackColor = System.Drawing.Color.LightGreen;
+			this.label_power5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_power5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_power5.ForeColor = System.Drawing.Color.Black;
+			this.label_power5.Location = new System.Drawing.Point(82, 166);
+			this.label_power5.Margin = new System.Windows.Forms.Padding(3);
+			this.label_power5.Name = "label_power5";
+			this.label_power5.Size = new System.Drawing.Size(70, 24);
+			this.label_power5.TabIndex = 14;
+			this.label_power5.Text = "P5";
+			this.label_power5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_power3
+			// 
+			this.label_power3.BackColor = System.Drawing.Color.LightGreen;
+			this.label_power3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_power3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_power3.ForeColor = System.Drawing.Color.Black;
+			this.label_power3.Location = new System.Drawing.Point(82, 106);
+			this.label_power3.Margin = new System.Windows.Forms.Padding(3);
+			this.label_power3.Name = "label_power3";
+			this.label_power3.Size = new System.Drawing.Size(70, 24);
+			this.label_power3.TabIndex = 12;
+			this.label_power3.Text = "P3";
+			this.label_power3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_power4
+			// 
+			this.label_power4.BackColor = System.Drawing.Color.LightGreen;
+			this.label_power4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_power4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_power4.ForeColor = System.Drawing.Color.Black;
+			this.label_power4.Location = new System.Drawing.Point(82, 136);
+			this.label_power4.Margin = new System.Windows.Forms.Padding(3);
+			this.label_power4.Name = "label_power4";
+			this.label_power4.Size = new System.Drawing.Size(70, 24);
+			this.label_power4.TabIndex = 13;
+			this.label_power4.Text = "P4";
+			this.label_power4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_power2
+			// 
+			this.label_power2.BackColor = System.Drawing.Color.LightGreen;
+			this.label_power2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_power2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_power2.ForeColor = System.Drawing.Color.Black;
+			this.label_power2.Location = new System.Drawing.Point(82, 76);
+			this.label_power2.Margin = new System.Windows.Forms.Padding(3);
+			this.label_power2.Name = "label_power2";
+			this.label_power2.Size = new System.Drawing.Size(70, 24);
+			this.label_power2.TabIndex = 11;
+			this.label_power2.Text = "P2";
+			this.label_power2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake4
+			// 
+			this.label_brake4.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake4.ForeColor = System.Drawing.Color.Black;
+			this.label_brake4.Location = new System.Drawing.Point(6, 166);
+			this.label_brake4.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake4.Name = "label_brake4";
+			this.label_brake4.Size = new System.Drawing.Size(70, 24);
+			this.label_brake4.TabIndex = 4;
+			this.label_brake4.Text = "B4";
+			this.label_brake4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake5
+			// 
+			this.label_brake5.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake5.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake5.ForeColor = System.Drawing.Color.Black;
+			this.label_brake5.Location = new System.Drawing.Point(6, 136);
+			this.label_brake5.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake5.Name = "label_brake5";
+			this.label_brake5.Size = new System.Drawing.Size(70, 24);
+			this.label_brake5.TabIndex = 3;
+			this.label_brake5.Text = "B5";
+			this.label_brake5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake6
+			// 
+			this.label_brake6.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake6.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake6.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake6.ForeColor = System.Drawing.Color.Black;
+			this.label_brake6.Location = new System.Drawing.Point(6, 106);
+			this.label_brake6.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake6.Name = "label_brake6";
+			this.label_brake6.Size = new System.Drawing.Size(70, 24);
+			this.label_brake6.TabIndex = 2;
+			this.label_brake6.Text = "B6";
+			this.label_brake6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake7
+			// 
+			this.label_brake7.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake7.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake7.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake7.ForeColor = System.Drawing.Color.Black;
+			this.label_brake7.Location = new System.Drawing.Point(6, 76);
+			this.label_brake7.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake7.Name = "label_brake7";
+			this.label_brake7.Size = new System.Drawing.Size(70, 24);
+			this.label_brake7.TabIndex = 1;
+			this.label_brake7.Text = "B7";
+			this.label_brake7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// label_brake8
+			// 
+			this.label_brake8.BackColor = System.Drawing.Color.LightCoral;
+			this.label_brake8.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.label_brake8.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label_brake8.ForeColor = System.Drawing.Color.Black;
+			this.label_brake8.Location = new System.Drawing.Point(6, 46);
+			this.label_brake8.Margin = new System.Windows.Forms.Padding(3);
+			this.label_brake8.Name = "label_brake8";
+			this.label_brake8.Size = new System.Drawing.Size(70, 24);
+			this.label_brake8.TabIndex = 0;
+			this.label_brake8.Text = "B8";
+			this.label_brake8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// timer1
+			// 
+			this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+			// 
+			// buttonMappingBox
+			// 
+			this.buttonMappingBox.Controls.Add(this.buttonselectBox);
+			this.buttonMappingBox.Controls.Add(this.buttonstartBox);
+			this.buttonMappingBox.Controls.Add(this.buttoncBox);
+			this.buttonMappingBox.Controls.Add(this.buttonbBox);
+			this.buttonMappingBox.Controls.Add(this.buttonaBox);
+			this.buttonMappingBox.Controls.Add(this.label_buttonselect);
+			this.buttonMappingBox.Controls.Add(this.label_buttonstart);
+			this.buttonMappingBox.Controls.Add(this.label_buttonc);
+			this.buttonMappingBox.Controls.Add(this.label_buttonb);
+			this.buttonMappingBox.Controls.Add(this.label_buttona);
+			this.buttonMappingBox.Location = new System.Drawing.Point(254, 43);
+			this.buttonMappingBox.Name = "buttonMappingBox";
+			this.buttonMappingBox.Size = new System.Drawing.Size(250, 158);
+			this.buttonMappingBox.TabIndex = 2;
+			this.buttonMappingBox.TabStop = false;
+			this.buttonMappingBox.Text = "Button mapping";
+			// 
+			// buttonselectBox
+			// 
+			this.buttonselectBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.buttonselectBox.FormattingEnabled = true;
+			this.buttonselectBox.Location = new System.Drawing.Point(62, 101);
+			this.buttonselectBox.Name = "buttonselectBox";
+			this.buttonselectBox.Size = new System.Drawing.Size(182, 21);
+			this.buttonselectBox.TabIndex = 8;
+			// 
+			// buttonstartBox
+			// 
+			this.buttonstartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.buttonstartBox.FormattingEnabled = true;
+			this.buttonstartBox.Location = new System.Drawing.Point(62, 128);
+			this.buttonstartBox.Name = "buttonstartBox";
+			this.buttonstartBox.Size = new System.Drawing.Size(182, 21);
+			this.buttonstartBox.TabIndex = 6;
+			// 
+			// buttoncBox
+			// 
+			this.buttoncBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.buttoncBox.FormattingEnabled = true;
+			this.buttoncBox.Location = new System.Drawing.Point(62, 74);
+			this.buttoncBox.Name = "buttoncBox";
+			this.buttoncBox.Size = new System.Drawing.Size(182, 21);
+			this.buttoncBox.TabIndex = 7;
+			// 
+			// buttonbBox
+			// 
+			this.buttonbBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.buttonbBox.FormattingEnabled = true;
+			this.buttonbBox.Location = new System.Drawing.Point(62, 47);
+			this.buttonbBox.Name = "buttonbBox";
+			this.buttonbBox.Size = new System.Drawing.Size(182, 21);
+			this.buttonbBox.TabIndex = 6;
+			// 
+			// buttonaBox
+			// 
+			this.buttonaBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.buttonaBox.FormattingEnabled = true;
+			this.buttonaBox.Location = new System.Drawing.Point(62, 20);
+			this.buttonaBox.Name = "buttonaBox";
+			this.buttonaBox.Size = new System.Drawing.Size(182, 21);
+			this.buttonaBox.TabIndex = 5;
+			// 
+			// label_buttonselect
+			// 
+			this.label_buttonselect.Location = new System.Drawing.Point(6, 104);
+			this.label_buttonselect.Margin = new System.Windows.Forms.Padding(3);
+			this.label_buttonselect.Name = "label_buttonselect";
+			this.label_buttonselect.Size = new System.Drawing.Size(50, 15);
+			this.label_buttonselect.TabIndex = 3;
+			this.label_buttonselect.Text = "SELECT";
+			// 
+			// label_buttonstart
+			// 
+			this.label_buttonstart.Location = new System.Drawing.Point(6, 131);
+			this.label_buttonstart.Margin = new System.Windows.Forms.Padding(3);
+			this.label_buttonstart.Name = "label_buttonstart";
+			this.label_buttonstart.Size = new System.Drawing.Size(50, 15);
+			this.label_buttonstart.TabIndex = 4;
+			this.label_buttonstart.Text = "START";
+			// 
+			// label_buttonc
+			// 
+			this.label_buttonc.Location = new System.Drawing.Point(6, 77);
+			this.label_buttonc.Margin = new System.Windows.Forms.Padding(3);
+			this.label_buttonc.Name = "label_buttonc";
+			this.label_buttonc.Size = new System.Drawing.Size(50, 15);
+			this.label_buttonc.TabIndex = 2;
+			this.label_buttonc.Text = "C";
+			// 
+			// label_buttonb
+			// 
+			this.label_buttonb.Location = new System.Drawing.Point(6, 50);
+			this.label_buttonb.Margin = new System.Windows.Forms.Padding(3);
+			this.label_buttonb.Name = "label_buttonb";
+			this.label_buttonb.Size = new System.Drawing.Size(50, 15);
+			this.label_buttonb.TabIndex = 1;
+			this.label_buttonb.Text = "B";
+			// 
+			// label_buttona
+			// 
+			this.label_buttona.Location = new System.Drawing.Point(6, 23);
+			this.label_buttona.Margin = new System.Windows.Forms.Padding(3);
+			this.label_buttona.Name = "label_buttona";
+			this.label_buttona.Size = new System.Drawing.Size(50, 15);
+			this.label_buttona.TabIndex = 0;
+			this.label_buttona.Text = "A";
+			// 
+			// buttonSave
+			// 
+			this.buttonSave.Location = new System.Drawing.Point(348, 309);
+			this.buttonSave.Name = "buttonSave";
+			this.buttonSave.Size = new System.Drawing.Size(75, 23);
+			this.buttonSave.TabIndex = 3;
+			this.buttonSave.Text = "Save";
+			this.buttonSave.UseVisualStyleBackColor = true;
+			this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
+
+			// 
+			// buttonCancel
+			// 
+			this.buttonCancel.Location = new System.Drawing.Point(429, 309);
+			this.buttonCancel.Name = "buttonCancel";
+			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+			this.buttonCancel.TabIndex = 4;
+			this.buttonCancel.Text = "Cancel";
+			this.buttonCancel.UseVisualStyleBackColor = true;
+			this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
+			// 
+			// handleMappingBox
+			// 
+			this.handleMappingBox.Controls.Add(this.holdbrakeCheck);
+			this.handleMappingBox.Controls.Add(this.minmaxCheck);
+			this.handleMappingBox.Controls.Add(this.convertnotchesCheck);
+			this.handleMappingBox.Location = new System.Drawing.Point(254, 207);
+			this.handleMappingBox.Name = "handleMappingBox";
+			this.handleMappingBox.Size = new System.Drawing.Size(250, 96);
+			this.handleMappingBox.TabIndex = 5;
+			this.handleMappingBox.TabStop = false;
+			this.handleMappingBox.Text = "Handle mapping";
+			// 
+			// deviceBox
+			// 
+			this.deviceBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.deviceBox.FormattingEnabled = true;
+			this.deviceBox.Location = new System.Drawing.Point(348, 16);
+			this.deviceBox.Name = "deviceBox";
+			this.deviceBox.Size = new System.Drawing.Size(150, 21);
+			this.deviceBox.TabIndex = 6;
+			this.deviceBox.SelectedIndexChanged += new System.EventHandler(this.deviceBox_SelectedIndexChanged);
+			// 
+			// convertnotchesCheck
+			// 
+			this.convertnotchesCheck.Location = new System.Drawing.Point(6, 19);
+			this.convertnotchesCheck.Name = "convertnotchesCheck";
+			this.convertnotchesCheck.Size = new System.Drawing.Size(238, 19);
+			this.convertnotchesCheck.TabIndex = 0;
+			this.convertnotchesCheck.Text = "Convert notches";
+			this.convertnotchesCheck.UseVisualStyleBackColor = true;
+			// 
+			// minmaxCheck
+			// 
+			this.minmaxCheck.Location = new System.Drawing.Point(6, 44);
+			this.minmaxCheck.Name = "minmaxCheck";
+			this.minmaxCheck.Size = new System.Drawing.Size(238, 19);
+			this.minmaxCheck.TabIndex = 1;
+			this.minmaxCheck.Text = "Keep minimum and maximum";
+			this.minmaxCheck.UseVisualStyleBackColor = true;
+			// 
+			// holdbrakeCheck
+			// 
+			this.holdbrakeCheck.Location = new System.Drawing.Point(6, 69);
+			this.holdbrakeCheck.Name = "holdbrakeCheck";
+			this.holdbrakeCheck.Size = new System.Drawing.Size(238, 19);
+			this.holdbrakeCheck.TabIndex = 2;
+			this.holdbrakeCheck.Text = "Map hold brake to B1";
+			this.holdbrakeCheck.UseVisualStyleBackColor = true;
+			// 
+			// label_device
+			// 
+			this.label_device.Location = new System.Drawing.Point(260, 19);
+			this.label_device.Name = "label_device";
+			this.label_device.Size = new System.Drawing.Size(82, 18);
+			this.label_device.TabIndex = 7;
+			this.label_device.Text = "Device";
+			// 
+			// Config
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(516, 339);
+			this.Controls.Add(this.label_device);
+			this.Controls.Add(this.deviceBox);
+			this.Controls.Add(this.handleMappingBox);
+			this.Controls.Add(this.buttonCancel);
+			this.Controls.Add(this.buttonSave);
+			this.Controls.Add(this.buttonMappingBox);
+			this.Controls.Add(this.deviceInputBox);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.CenterToParent();
+			this.Name = "Config";
+			this.Text = "Densha de GO! controller configuration";
+			this.deviceInputBox.ResumeLayout(false);
+			this.buttonMappingBox.ResumeLayout(false);
+			this.handleMappingBox.ResumeLayout(false);
+			this.ResumeLayout(false);
+			this.Shown += new System.EventHandler(this.Config_Shown);
+
+		}
+
+		#endregion
+		private System.Windows.Forms.GroupBox deviceInputBox;
+		private System.Windows.Forms.Timer timer1;
+		private System.Windows.Forms.Label label_select;
+		private System.Windows.Forms.Label label_start;
+		private System.Windows.Forms.Label label_c;
+		private System.Windows.Forms.Label label_b;
+		private System.Windows.Forms.Label label_a;
+		private System.Windows.Forms.Label label_brakeemg;
+		private System.Windows.Forms.Label label_power5;
+		private System.Windows.Forms.Label label_power4;
+		private System.Windows.Forms.Label label_power3;
+		private System.Windows.Forms.Label label_power2;
+		private System.Windows.Forms.Label label_power1;
+		private System.Windows.Forms.Label label_powern;
+		private System.Windows.Forms.Label label_braken;
+		private System.Windows.Forms.Label label_brake1;
+		private System.Windows.Forms.Label label_brake2;
+		private System.Windows.Forms.Label label_brake3;
+		private System.Windows.Forms.Label label_brake4;
+		private System.Windows.Forms.Label label_brake5;
+		private System.Windows.Forms.Label label_brake6;
+		private System.Windows.Forms.Label label_brake7;
+		private System.Windows.Forms.Label label_brake8;
+		private System.Windows.Forms.GroupBox buttonMappingBox;
+		private System.Windows.Forms.ComboBox buttonselectBox;
+		private System.Windows.Forms.ComboBox buttonstartBox;
+		private System.Windows.Forms.ComboBox buttoncBox;
+		private System.Windows.Forms.ComboBox buttonbBox;
+		private System.Windows.Forms.ComboBox buttonaBox;
+		private System.Windows.Forms.Label label_buttonselect;
+		private System.Windows.Forms.Label label_buttonstart;
+		private System.Windows.Forms.Label label_buttonc;
+		private System.Windows.Forms.Label label_buttonb;
+		private System.Windows.Forms.Label label_buttona;
+		private System.Windows.Forms.Button buttonSave;
+		private System.Windows.Forms.Button buttonCancel;
+		private System.Windows.Forms.GroupBox handleMappingBox;
+		private System.Windows.Forms.ComboBox deviceBox;
+		private System.Windows.Forms.Button buttonCalibrate;
+		private System.Windows.Forms.CheckBox holdbrakeCheck;
+		private System.Windows.Forms.CheckBox minmaxCheck;
+		private System.Windows.Forms.CheckBox convertnotchesCheck;
+		private System.Windows.Forms.Label label_device;
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -22,8 +22,6 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-using System;
-
 namespace DenshaDeGoInput
 {
 	partial class Config
@@ -659,6 +657,7 @@ namespace DenshaDeGoInput
 			this.handleMappingBox.ResumeLayout(false);
 			this.ResumeLayout(false);
 			this.Shown += new System.EventHandler(this.Config_Shown);
+			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Config_FormClosed);
 
 		}
 

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -1,3 +1,27 @@
+//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 using System;
 
 namespace DenshaDeGoInput

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -602,6 +602,7 @@ namespace DenshaDeGoInput
 			this.convertnotchesCheck.TabIndex = 0;
 			this.convertnotchesCheck.Text = "Convert notches";
 			this.convertnotchesCheck.UseVisualStyleBackColor = true;
+			this.convertnotchesCheck.CheckedChanged += new System.EventHandler(this.convertnotchesCheck_CheckedChanged);
 			// 
 			// minmaxCheck
 			// 
@@ -611,6 +612,7 @@ namespace DenshaDeGoInput
 			this.minmaxCheck.TabIndex = 1;
 			this.minmaxCheck.Text = "Keep minimum and maximum";
 			this.minmaxCheck.UseVisualStyleBackColor = true;
+			this.minmaxCheck.CheckedChanged += new System.EventHandler(this.minmaxCheck_CheckedChanged);
 			// 
 			// holdbrakeCheck
 			// 
@@ -620,6 +622,7 @@ namespace DenshaDeGoInput
 			this.holdbrakeCheck.TabIndex = 2;
 			this.holdbrakeCheck.Text = "Map hold brake to B1";
 			this.holdbrakeCheck.UseVisualStyleBackColor = true;
+			this.holdbrakeCheck.CheckedChanged += new System.EventHandler(this.holdbrakeCheck_CheckedChanged);
 			// 
 			// label_device
 			// 

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -38,9 +38,15 @@ namespace DenshaDeGoInput
 			timer1.Enabled = true;
 
 			// Add connected devices to device list
+
 			ListControllers();
 
-			// Add commands to buttons
+			// Populate command boxes
+			buttonaBox.Items.Add(Translations.GetInterfaceString("None"));
+			buttonbBox.Items.Add(Translations.GetInterfaceString("None"));
+			buttoncBox.Items.Add(Translations.GetInterfaceString("None"));
+			buttonstartBox.Items.Add(Translations.GetInterfaceString("None"));
+			buttonselectBox.Items.Add(Translations.GetInterfaceString("None"));
 			for (int i = 0; i < Translations.CommandInfos.Length; i++)
 			{
 				buttonaBox.Items.Add(Translations.CommandInfos[i].Name);
@@ -177,11 +183,33 @@ namespace DenshaDeGoInput
 			{
 				deviceBox.SelectedIndex = InputTranslator.activeControllerIndex;
 			}
+
+			// Update checkboxes
+			convertnotchesCheck.Checked = DenshaDeGoInput.convertNotches;
+			minmaxCheck.Checked = DenshaDeGoInput.keepMaxMin;
+			holdbrakeCheck.Checked = DenshaDeGoInput.mapHoldBrake;
+			minmaxCheck.Enabled = DenshaDeGoInput.convertNotches;
 		}
 
 		private void deviceBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			InputTranslator.activeControllerIndex = deviceBox.SelectedIndex;
+		}
+
+		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.convertNotches = convertnotchesCheck.Checked;
+			minmaxCheck.Enabled = DenshaDeGoInput.convertNotches;
+		}
+
+		private void minmaxCheck_CheckedChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.keepMaxMin = minmaxCheck.Checked;
+		}
+
+		private void holdbrakeCheck_CheckedChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.mapHoldBrake = holdbrakeCheck.Checked;
 		}
 
 		private void buttonCalibrate_Click(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -33,9 +33,9 @@ namespace DenshaDeGoInput
 			{
 				JoystickState state = Joystick.GetState(i);
 				JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
-				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(state);
+				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(state, capabilities);
 				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
-				if (capabilities.ButtonCount > 0 && model != InputTranslator.ControllerModels.None)
+				if (capabilities.ButtonCount > 0 && model != InputTranslator.ControllerModels.Unsupported)
 				{
 					deviceBox.Items.Add("Joystick " + (i+1));
 				}

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -1,3 +1,27 @@
+//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 using System;
 using System.Windows.Forms;
 using System.Drawing;

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -87,13 +87,22 @@ namespace DenshaDeGoInput
 			for (int i = 0; i < 10; i++)
 			{
 				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(i);
-				deviceList.Add(Translations.GetInterfaceString("denshadego_joystick").Replace("[index]", (i + 1).ToString()));
+				deviceList.Add(Translations.GetInterfaceString("denshadego_joystick").Replace("[index]", (i + 1).ToString()).Replace("[name]", Joystick.GetName(i)));
 
-				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
-				JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
-				if (capabilities.ButtonCount > 0 && model != InputTranslator.ControllerModels.Unsupported)
+				if (Joystick.GetState(i).IsConnected && model != InputTranslator.ControllerModels.Unsupported)
 				{
 					deviceBox.Items.Add(deviceList[i]);
+				}
+			}
+
+			// Adjust the width of the device dropdown to prevent truncation
+			deviceBox.DropDownWidth = deviceBox.Width;
+			foreach (var item in deviceBox.Items)
+			{
+				int currentItemWidth = (int)deviceBox.CreateGraphics().MeasureString(item.ToString(), deviceBox.Font).Width;
+				if (currentItemWidth > deviceBox.DropDownWidth)
+				{
+					deviceBox.DropDownWidth = currentItemWidth;
 				}
 			}
 		}
@@ -103,134 +112,37 @@ namespace DenshaDeGoInput
 		/// </summary>
 		private void UpdateInterface()
 		{
-			label_brakeemg.ForeColor = Color.Black;
-			label_brake8.ForeColor = Color.Black;
-			label_brake7.ForeColor = Color.Black;
-			label_brake6.ForeColor = Color.Black;
-			label_brake5.ForeColor = Color.Black;
-			label_brake4.ForeColor = Color.Black;
-			label_brake3.ForeColor = Color.Black;
-			label_brake2.ForeColor = Color.Black;
-			label_brake1.ForeColor = Color.Black;
-			label_braken.ForeColor = Color.Black;
-			label_power5.ForeColor = Color.Black;
-			label_power4.ForeColor = Color.Black;
-			label_power3.ForeColor = Color.Black;
-			label_power2.ForeColor = Color.Black;
-			label_power1.ForeColor = Color.Black;
-			label_powern.ForeColor = Color.Black;
-			label_a.ForeColor = Color.Black;
-			label_b.ForeColor = Color.Black;
-			label_c.ForeColor = Color.Black;
-			label_d.ForeColor = Color.Black;
-			label_start.ForeColor = Color.Black;
-			label_select.ForeColor = Color.Black;
-			label_up.ForeColor = Color.Black;
-			label_down.ForeColor = Color.Black;
-			label_left.ForeColor = Color.Black;
-			label_right.ForeColor = Color.Black;
-			label_pedal.ForeColor = Color.Black;
-
 			if (InputTranslator.IsControllerConnected)
 			{
-				switch (InputTranslator.BrakeNotch)
-				{
-					case InputTranslator.BrakeNotches.Emergency:
-						label_brakeemg.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B8:
-						label_brake8.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B7:
-						label_brake7.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B6:
-						label_brake6.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B5:
-						label_brake5.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B4:
-						label_brake4.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B3:
-						label_brake3.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B2:
-						label_brake2.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.B1:
-						label_brake1.ForeColor = Color.White;
-						break;
-					case InputTranslator.BrakeNotches.Released:
-						label_braken.ForeColor = Color.White;
-						break;
-				}
-				switch (InputTranslator.PowerNotch)
-				{
-					case InputTranslator.PowerNotches.P5:
-						label_power5.ForeColor = Color.White;
-						break;
-					case InputTranslator.PowerNotches.P4:
-						label_power4.ForeColor = Color.White;
-						break;
-					case InputTranslator.PowerNotches.P3:
-						label_power3.ForeColor = Color.White;
-						break;
-					case InputTranslator.PowerNotches.P2:
-						label_power2.ForeColor = Color.White;
-						break;
-					case InputTranslator.PowerNotches.P1:
-						label_power1.ForeColor = Color.White;
-						break;
-					case InputTranslator.PowerNotches.N:
-						label_powern.ForeColor = Color.White;
-						break;
-				}
-				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_select.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_start.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_a.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_b.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_c.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_d.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_up.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_down.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_left.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_right.ForeColor = Color.White;
-				}
-				if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_pedal.ForeColor = Color.White;
-				}
+				label_brakeemg.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.Emergency ? Color.White : Color.Black;
+				label_brake8.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B8 ? Color.White : Color.Black;
+				label_brake7.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B7 ? Color.White : Color.Black;
+				label_brake6.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B6 ? Color.White : Color.Black;
+				label_brake5.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B5 ? Color.White : Color.Black;
+				label_brake4.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B4 ? Color.White : Color.Black;
+				label_brake3.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B3 ? Color.White : Color.Black;
+				label_brake2.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B2 ? Color.White : Color.Black;
+				label_brake1.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.B1 ? Color.White : Color.Black;
+				label_braken.ForeColor = InputTranslator.BrakeNotch == InputTranslator.BrakeNotches.Released ? Color.White : Color.Black;
+
+				label_power5.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.P5 ? Color.White : Color.Black;
+				label_power4.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.P4 ? Color.White : Color.Black;
+				label_power3.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.P3 ? Color.White : Color.Black;
+				label_power2.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.P2 ? Color.White : Color.Black;
+				label_power1.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.P1 ? Color.White : Color.Black;
+				label_powern.ForeColor = InputTranslator.PowerNotch == InputTranslator.PowerNotches.N ? Color.White : Color.Black;
+
+				label_select.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_start.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_a.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_b.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_c.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_d.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_up.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_down.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_left.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_right.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+				label_pedal.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Pedal] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
 			}
 
 			switch (InputTranslator.ControllerModel)
@@ -383,57 +295,57 @@ namespace DenshaDeGoInput
 
 		private void buttonselectBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[0].Command = buttonselectBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Select].Command = buttonselectBox.SelectedIndex;
 		}
 
 		private void buttonstartBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[1].Command = buttonstartBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Start].Command = buttonstartBox.SelectedIndex;
 		}
 
 		private void buttonaBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[2].Command = buttonaBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.A].Command = buttonaBox.SelectedIndex;
 		}
 
 		private void buttonbBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[3].Command = buttonbBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.B].Command = buttonbBox.SelectedIndex;
 		}
 
 		private void buttoncBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[4].Command = buttoncBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.C].Command = buttoncBox.SelectedIndex;
 		}
 
 		private void buttondBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[5].Command = buttondBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.D].Command = buttondBox.SelectedIndex;
 		}
 
 		private void buttonupBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[6].Command = buttonupBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Up].Command = buttonupBox.SelectedIndex;
 		}
 
 		private void buttondownBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[7].Command = buttondownBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Down].Command = buttondownBox.SelectedIndex;
 		}
 
 		private void buttonleftBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[8].Command = buttonleftBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Left].Command = buttonleftBox.SelectedIndex;
 		}
 
 		private void buttonrightBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[9].Command = buttonrightBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Right].Command = buttonrightBox.SelectedIndex;
 		}
 
 		private void buttonpedalBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonProperties[10].Command = buttonpedalBox.SelectedIndex;
+			DenshaDeGoInput.ButtonProperties[(int)InputTranslator.ControllerButton.Pedal].Command = buttonpedalBox.SelectedIndex;
 		}
 
 		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -75,6 +75,9 @@ namespace DenshaDeGoInput
 			}
 		}
 
+		/// <summary>
+		/// Adds the available controllers to the device dropdown list.
+		/// </summary>
 		private void ListControllers()
 		{
 			// Clear the internal and visible lists
@@ -95,6 +98,9 @@ namespace DenshaDeGoInput
 			}
 		}
 
+		/// <summary>
+		/// Updates the interface to reflect the input from the controller.
+		/// </summary>
 		private void UpdateInterface()
 		{
 			label_brakeemg.ForeColor = Color.Black;
@@ -241,11 +247,21 @@ namespace DenshaDeGoInput
 				case InputTranslator.ControllerModels.Unbalance:
 					buttonCalibrate.Visible = false;
 					label_d.Visible = true;
-					label_up.Visible = true;
-					label_down.Visible = true;
-					label_left.Visible = true;
-					label_right.Visible = true;
 					label_pedal.Visible = false;
+					if (ControllerUnbalance.hasDirectionButtons)
+					{
+						label_up.Visible = true;
+						label_down.Visible = true;
+						label_left.Visible = true;
+						label_right.Visible = true;
+					}
+					else
+					{
+						label_up.Visible = false;
+						label_down.Visible = false;
+						label_left.Visible = false;
+						label_right.Visible = false;
+					}
 					break;
 				default:
 					buttonCalibrate.Visible = false;
@@ -259,6 +275,9 @@ namespace DenshaDeGoInput
 			}
 		}
 
+		/// <summary>
+		/// Retranslates the configutarion interface.
+		/// </summary>
 		private void UpdateTranslation()
 		{
 			Text = Translations.GetInterfaceString("denshadego_config_title");

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -23,6 +23,7 @@
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
+using System.Linq;
 using System.Windows.Forms;
 using System.Drawing;
 using OpenTK.Input;
@@ -47,13 +48,14 @@ namespace DenshaDeGoInput
 			buttoncBox.Items.Add(Translations.GetInterfaceString("None"));
 			buttonstartBox.Items.Add(Translations.GetInterfaceString("None"));
 			buttonselectBox.Items.Add(Translations.GetInterfaceString("None"));
+			Translations.CommandInfo[] commands = Translations.CommandInfos.OrderBy(o=>o.Command).ToArray();
 			for (int i = 0; i < Translations.CommandInfos.Length; i++)
 			{
-				buttonaBox.Items.Add(Translations.CommandInfos[i].Name);
-				buttonbBox.Items.Add(Translations.CommandInfos[i].Name);
-				buttoncBox.Items.Add(Translations.CommandInfos[i].Name);
-				buttonstartBox.Items.Add(Translations.CommandInfos[i].Name);
-				buttonselectBox.Items.Add(Translations.CommandInfos[i].Name);
+				buttonaBox.Items.Add(commands[i].Name);
+				buttonbBox.Items.Add(commands[i].Name);
+				buttoncBox.Items.Add(commands[i].Name);
+				buttonstartBox.Items.Add(commands[i].Name);
+				buttonselectBox.Items.Add(commands[i].Name);
 			}
 		}
 
@@ -184,7 +186,14 @@ namespace DenshaDeGoInput
 				deviceBox.SelectedIndex = InputTranslator.activeControllerIndex;
 			}
 
-			// Update checkboxes
+			// Set command boxes
+			buttonselectBox.SelectedIndex = DenshaDeGoInput.buttonCommands[0];
+			buttonstartBox.SelectedIndex = DenshaDeGoInput.buttonCommands[1];
+			buttonaBox.SelectedIndex = DenshaDeGoInput.buttonCommands[2];
+			buttonbBox.SelectedIndex = DenshaDeGoInput.buttonCommands[3];
+			buttoncBox.SelectedIndex = DenshaDeGoInput.buttonCommands[4];
+
+			// Set checkboxes
 			convertnotchesCheck.Checked = DenshaDeGoInput.convertNotches;
 			minmaxCheck.Checked = DenshaDeGoInput.keepMaxMin;
 			holdbrakeCheck.Checked = DenshaDeGoInput.mapHoldBrake;
@@ -194,6 +203,31 @@ namespace DenshaDeGoInput
 		private void deviceBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			InputTranslator.activeControllerIndex = deviceBox.SelectedIndex;
+		}
+
+		private void buttonselectBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.buttonCommands[0] = buttonselectBox.SelectedIndex;
+		}
+
+		private void buttonstartBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.buttonCommands[1] = buttonstartBox.SelectedIndex;
+		}
+
+		private void buttonaBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.buttonCommands[2] = buttonaBox.SelectedIndex;
+		}
+
+		private void buttonbBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.buttonCommands[3] = buttonbBox.SelectedIndex;
+		}
+
+		private void buttoncBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.buttonCommands[4] = buttoncBox.SelectedIndex;
 		}
 
 		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -200,6 +200,12 @@ namespace DenshaDeGoInput
 			minmaxCheck.Enabled = DenshaDeGoInput.convertNotches;
 		}
 
+		private void Config_FormClosed(Object sender, FormClosedEventArgs e)
+		{
+			// Reload the previous config and close the config dialog
+			DenshaDeGoInput.LoadConfig();
+		}
+
 		private void deviceBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			InputTranslator.activeControllerIndex = deviceBox.SelectedIndex;

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Windows.Forms;
+using System.Drawing;
+using OpenTK.Input;
+using OpenBveApi.Interface;
+
+namespace DenshaDeGoInput
+{
+	public partial class Config : Form
+	{
+		public Config()
+		{
+			InitializeComponent();
+			timer1.Enabled = true;
+
+			// Add connected devices to device list
+			ListControllers();
+
+			// Add commands to buttons
+			for (int i = 0; i < Translations.CommandInfos.Length; i++)
+			{
+				buttonaBox.Items.Add(Translations.CommandInfos[i].Name);
+				buttonbBox.Items.Add(Translations.CommandInfos[i].Name);
+				buttoncBox.Items.Add(Translations.CommandInfos[i].Name);
+				buttonstartBox.Items.Add(Translations.CommandInfos[i].Name);
+				buttonselectBox.Items.Add(Translations.CommandInfos[i].Name);
+			}
+		}
+
+		private void ListControllers()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				JoystickState state = Joystick.GetState(i);
+				JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
+				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(state);
+				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
+				if (capabilities.ButtonCount > 0 && model != InputTranslator.ControllerModels.None)
+				{
+					deviceBox.Items.Add("Joystick " + (i+1));
+				}
+			}
+		}
+
+		private void UpdateInterface()
+		{
+			label_brakeemg.ForeColor = Color.Black;
+			label_brake8.ForeColor = Color.Black;
+			label_brake7.ForeColor = Color.Black;
+			label_brake6.ForeColor = Color.Black;
+			label_brake5.ForeColor = Color.Black;
+			label_brake4.ForeColor = Color.Black;
+			label_brake3.ForeColor = Color.Black;
+			label_brake2.ForeColor = Color.Black;
+			label_brake1.ForeColor = Color.Black;
+			label_braken.ForeColor = Color.Black;
+			label_power5.ForeColor = Color.Black;
+			label_power4.ForeColor = Color.Black;
+			label_power3.ForeColor = Color.Black;
+			label_power2.ForeColor = Color.Black;
+			label_power1.ForeColor = Color.Black;
+			label_powern.ForeColor = Color.Black;
+			label_a.ForeColor = Color.Black;
+			label_b.ForeColor = Color.Black;
+			label_c.ForeColor = Color.Black;
+			label_start.ForeColor = Color.Black;
+			label_select.ForeColor = Color.Black;
+
+
+			if (InputTranslator.IsControllerConnected)
+			{
+				switch (InputTranslator.BrakeNotch)
+				{
+					case InputTranslator.BrakeNotches.Emergency:
+						label_brakeemg.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B8:
+						label_brake8.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B7:
+						label_brake7.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B6:
+						label_brake6.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B5:
+						label_brake5.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B4:
+						label_brake4.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B3:
+						label_brake3.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B2:
+						label_brake2.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.B1:
+						label_brake1.ForeColor = Color.White;
+						break;
+					case InputTranslator.BrakeNotches.Released:
+						label_braken.ForeColor = Color.White;
+						break;
+				}
+				switch (InputTranslator.PowerNotch)
+				{
+					case InputTranslator.PowerNotches.P5:
+						label_power5.ForeColor = Color.White;
+						break;
+					case InputTranslator.PowerNotches.P4:
+						label_power4.ForeColor = Color.White;
+						break;
+					case InputTranslator.PowerNotches.P3:
+						label_power3.ForeColor = Color.White;
+						break;
+					case InputTranslator.PowerNotches.P2:
+						label_power2.ForeColor = Color.White;
+						break;
+					case InputTranslator.PowerNotches.P1:
+						label_power1.ForeColor = Color.White;
+						break;
+					case InputTranslator.PowerNotches.N:
+						label_powern.ForeColor = Color.White;
+						break;
+				}
+				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_a.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_b.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_c.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_start.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_select.ForeColor = Color.White;
+				}
+			}
+		}
+
+		private void Config_Shown(object sender, EventArgs e)
+		{
+			// Try to select the current device
+			if (InputTranslator.activeControllerIndex < deviceBox.Items.Count)
+			{
+				deviceBox.SelectedIndex = InputTranslator.activeControllerIndex;
+			}
+		}
+
+		private void deviceBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			InputTranslator.activeControllerIndex = deviceBox.SelectedIndex;
+		}
+
+		private void buttonCalibrate_Click(object sender, EventArgs e)
+		{
+			timer1.Stop();
+			PSController.Calibrate();
+			timer1.Start();
+		}
+
+		private void buttonSave_Click(object sender, EventArgs e)
+		{
+			// Save the config and close the config dialog
+			DenshaDeGoInput.SaveConfig();
+			Close();
+		}
+
+		private void buttonCancel_Click(object sender, EventArgs e)
+		{
+			// Reload the previous config and close the config dialog
+			DenshaDeGoInput.LoadConfig();
+			Close();
+		}
+
+		private void timer1_Tick(object sender, EventArgs e)
+		{
+			InputTranslator.Update();
+			UpdateInterface();
+		}
+
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -104,9 +104,9 @@ namespace DenshaDeGoInput
 			label_a.ForeColor = Color.Black;
 			label_b.ForeColor = Color.Black;
 			label_c.ForeColor = Color.Black;
+			label_d.ForeColor = Color.Black;
 			label_start.ForeColor = Color.Black;
 			label_select.ForeColor = Color.Black;
-
 
 			if (InputTranslator.IsControllerConnected)
 			{
@@ -164,6 +164,14 @@ namespace DenshaDeGoInput
 						label_powern.ForeColor = Color.White;
 						break;
 				}
+				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_select.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_start.ForeColor = Color.White;
+				}
 				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
 				{
 					label_a.ForeColor = Color.White;
@@ -176,14 +184,21 @@ namespace DenshaDeGoInput
 				{
 					label_c.ForeColor = Color.White;
 				}
-				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed)
 				{
-					label_start.ForeColor = Color.White;
+					label_d.ForeColor = Color.White;
 				}
-				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
-				{
-					label_select.ForeColor = Color.White;
-				}
+			}
+
+			if (InputTranslator.ControllerModel == InputTranslator.ControllerModels.Classic)
+			{
+				buttonCalibrate.Visible = true;
+				label_d.Visible = false;
+			}
+			else
+			{
+				buttonCalibrate.Visible = false;
+				label_d.Visible = true;
 			}
 		}
 
@@ -206,6 +221,23 @@ namespace DenshaDeGoInput
 			buttonaBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
 			buttonbBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
 			buttoncBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+
+			label_brakeemg.Text = Translations.QuickReferences.HandleEmergency;
+			label_brake8.Text = Translations.QuickReferences.HandleBrake + "8";
+			label_brake7.Text = Translations.QuickReferences.HandleBrake + "7";
+			label_brake6.Text = Translations.QuickReferences.HandleBrake + "6";
+			label_brake5.Text = Translations.QuickReferences.HandleBrake + "5";
+			label_brake4.Text = Translations.QuickReferences.HandleBrake + "4";
+			label_brake3.Text = Translations.QuickReferences.HandleBrake + "3";
+			label_brake2.Text = Translations.QuickReferences.HandleBrake + "2";
+			label_brake1.Text = Translations.QuickReferences.HandleBrake + "1";
+			label_braken.Text = Translations.QuickReferences.HandleBrakeNull;
+			label_power5.Text = Translations.QuickReferences.HandlePower + "5";
+			label_power4.Text = Translations.QuickReferences.HandlePower + "4";
+			label_power3.Text = Translations.QuickReferences.HandlePower + "3";
+			label_power2.Text = Translations.QuickReferences.HandlePower + "2";
+			label_power1.Text = Translations.QuickReferences.HandlePower + "1";
+			label_powern.Text = Translations.QuickReferences.HandlePowerNull;
 		}
 
 		private void Config_Shown(object sender, EventArgs e)
@@ -294,7 +326,7 @@ namespace DenshaDeGoInput
 		private void buttonCalibrate_Click(object sender, EventArgs e)
 		{
 			timer1.Stop();
-			PSController.Calibrate();
+			ControllerClassic.Calibrate();
 			timer1.Start();
 		}
 

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -47,19 +47,31 @@ namespace DenshaDeGoInput
 			Translations.LoadLanguageFiles(OpenBveApi.Path.CombineDirectory(DenshaDeGoInput.FileSystem.DataFolder, "Languages"));
 
 			// Populate command boxes
+			buttonselectBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttonstartBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
 			buttonaBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
 			buttonbBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
 			buttoncBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
-			buttonstartBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
-			buttonselectBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttondBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttonupBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttondownBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttonleftBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttonrightBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
+			buttonpedalBox.Items.Add(Translations.GetInterfaceString("denshadego_command_none"));
 			Translations.CommandInfo[] commands = Translations.CommandInfos.OrderBy(o => o.Command).ToArray();
 			for (int i = 0; i < Translations.CommandInfos.Length; i++)
 			{
+				buttonselectBox.Items.Add(commands[i].Name);
+				buttonstartBox.Items.Add(commands[i].Name);
 				buttonaBox.Items.Add(commands[i].Name);
 				buttonbBox.Items.Add(commands[i].Name);
 				buttoncBox.Items.Add(commands[i].Name);
-				buttonstartBox.Items.Add(commands[i].Name);
-				buttonselectBox.Items.Add(commands[i].Name);
+				buttondBox.Items.Add(commands[i].Name);
+				buttonupBox.Items.Add(commands[i].Name);
+				buttondownBox.Items.Add(commands[i].Name);
+				buttonleftBox.Items.Add(commands[i].Name);
+				buttonrightBox.Items.Add(commands[i].Name);
+				buttonpedalBox.Items.Add(commands[i].Name);
 			}
 		}
 
@@ -71,11 +83,11 @@ namespace DenshaDeGoInput
 
 			for (int i = 0; i < 10; i++)
 			{
-				JoystickState state = Joystick.GetState(i);
-				JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
-				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(state, capabilities);
-				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
+				InputTranslator.ControllerModels model = InputTranslator.GetControllerModel(i);
 				deviceList.Add(Translations.GetInterfaceString("denshadego_joystick").Replace("[index]", (i + 1).ToString()));
+
+				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
+				JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
 				if (capabilities.ButtonCount > 0 && model != InputTranslator.ControllerModels.Unsupported)
 				{
 					deviceBox.Items.Add(deviceList[i]);
@@ -107,6 +119,11 @@ namespace DenshaDeGoInput
 			label_d.ForeColor = Color.Black;
 			label_start.ForeColor = Color.Black;
 			label_select.ForeColor = Color.Black;
+			label_up.ForeColor = Color.Black;
+			label_down.ForeColor = Color.Black;
+			label_left.ForeColor = Color.Black;
+			label_right.ForeColor = Color.Black;
+			label_pedal.ForeColor = Color.Black;
 
 			if (InputTranslator.IsControllerConnected)
 			{
@@ -188,17 +205,57 @@ namespace DenshaDeGoInput
 				{
 					label_d.ForeColor = Color.White;
 				}
+				if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_up.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_down.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_left.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_right.ForeColor = Color.White;
+				}
+				if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed)
+				{
+					label_pedal.ForeColor = Color.White;
+				}
 			}
 
-			if (InputTranslator.ControllerModel == InputTranslator.ControllerModels.Classic)
+			switch (InputTranslator.ControllerModel)
 			{
-				buttonCalibrate.Visible = true;
-				label_d.Visible = false;
-			}
-			else
-			{
-				buttonCalibrate.Visible = false;
-				label_d.Visible = true;
+				case InputTranslator.ControllerModels.Classic:
+					buttonCalibrate.Visible = true;
+					label_d.Visible = false;
+					label_up.Visible = false;
+					label_down.Visible = false;
+					label_left.Visible = false;
+					label_right.Visible = false;
+					label_pedal.Visible = false;
+					break;
+				case InputTranslator.ControllerModels.Unbalance:
+					buttonCalibrate.Visible = false;
+					label_d.Visible = true;
+					label_up.Visible = true;
+					label_down.Visible = true;
+					label_left.Visible = true;
+					label_right.Visible = true;
+					label_pedal.Visible = false;
+					break;
+				default:
+					buttonCalibrate.Visible = false;
+					label_d.Visible = true;
+					label_up.Visible = true;
+					label_down.Visible = true;
+					label_left.Visible = true;
+					label_right.Visible = true;
+					label_pedal.Visible = true;
+					break;
 			}
 		}
 
@@ -221,6 +278,12 @@ namespace DenshaDeGoInput
 			buttonaBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
 			buttonbBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
 			buttoncBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttondBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttonupBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttondownBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttonleftBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttonrightBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
+			buttonpedalBox.Items[0] = Translations.GetInterfaceString("denshadego_command_none");
 
 			label_brakeemg.Text = Translations.QuickReferences.HandleEmergency;
 			label_brake8.Text = Translations.QuickReferences.HandleBrake + "8";
@@ -238,6 +301,17 @@ namespace DenshaDeGoInput
 			label_power2.Text = Translations.QuickReferences.HandlePower + "2";
 			label_power1.Text = Translations.QuickReferences.HandlePower + "1";
 			label_powern.Text = Translations.QuickReferences.HandlePowerNull;
+
+			label_up.Text = Translations.GetInterfaceString("denshadego_label_up");
+			label_down.Text = Translations.GetInterfaceString("denshadego_label_down");
+			label_left.Text = Translations.GetInterfaceString("denshadego_label_left");
+			label_right.Text = Translations.GetInterfaceString("denshadego_label_right");
+			label_pedal.Text = Translations.GetInterfaceString("denshadego_label_pedal");
+			label_buttonup.Text = Translations.GetInterfaceString("denshadego_label_up");
+			label_buttondown.Text = Translations.GetInterfaceString("denshadego_label_down");
+			label_buttonleft.Text = Translations.GetInterfaceString("denshadego_label_left");
+			label_buttonright.Text = Translations.GetInterfaceString("denshadego_label_right");
+			label_buttonpedal.Text = Translations.GetInterfaceString("denshadego_label_pedal");
 		}
 
 		private void Config_Shown(object sender, EventArgs e)
@@ -257,6 +331,12 @@ namespace DenshaDeGoInput
 			buttonaBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[2].Command;
 			buttonbBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[3].Command;
 			buttoncBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[4].Command;
+			buttondBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[5].Command;
+			buttonupBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[6].Command;
+			buttondownBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[7].Command;
+			buttonleftBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[8].Command;
+			buttonrightBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[9].Command;
+			buttonpedalBox.SelectedIndex = DenshaDeGoInput.ButtonProperties[10].Command;
 
 			// Set checkboxes
 			convertnotchesCheck.Checked = DenshaDeGoInput.convertNotches;
@@ -305,6 +385,36 @@ namespace DenshaDeGoInput
 		private void buttoncBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			DenshaDeGoInput.ButtonProperties[4].Command = buttoncBox.SelectedIndex;
+		}
+
+		private void buttondBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[5].Command = buttondBox.SelectedIndex;
+		}
+
+		private void buttonupBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[6].Command = buttonupBox.SelectedIndex;
+		}
+
+		private void buttondownBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[7].Command = buttondownBox.SelectedIndex;
+		}
+
+		private void buttonleftBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[8].Command = buttonleftBox.SelectedIndex;
+		}
+
+		private void buttonrightBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[9].Command = buttonrightBox.SelectedIndex;
+		}
+
+		private void buttonpedalBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonProperties[10].Command = buttonpedalBox.SelectedIndex;
 		}
 
 		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.resx
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
@@ -64,35 +64,9 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Class for the pressed state of the buttons used by the controller.
-		/// </summary>
-		internal class PressedButtons
-		{
-			internal bool Select;
-			internal bool Start;
-			internal bool A;
-			internal bool B;
-			internal bool C;
-			internal bool Power1;
-			internal bool Power2;
-			internal bool Power3;
-			internal bool Brake1;
-			internal bool Brake3;
-			internal bool Brake2;
-			internal bool Brake4;
-
-
-		}
-
-		/// <summary>
 		/// The button indices of the buttons used by the controller.
 		/// </summary>
 		internal static ButtonIndices ButtonIndex = new ButtonIndices();
-
-		/// <summary>
-		/// The pressed state of the buttons used by the controller.
-		/// </summary>
-		internal static PressedButtons ButtonPressed = new PressedButtons();
 
 		/// <summary>
 		/// Checks whether a joystick is a classic console controller.
@@ -113,93 +87,35 @@ namespace DenshaDeGoInput
 		/// Reads the input from the controller.
 		/// </summary>
 		/// <param name="joystick">The state of the joystick to read input from.</param>
-		internal static void ReadInput(JoystickState joystick)
+		/// <param name="powerNotch">The returned power notch</param>
+		/// <param name="brakeNotch">The returned brake notch</param>
+		internal static void ReadInput(JoystickState joystick, out InputTranslator.PowerNotches powerNotch, out InputTranslator.BrakeNotches brakeNotch)
 		{
-			ButtonPressed.Select = joystick.IsButtonDown(ButtonIndex.Select);
-			ButtonPressed.Start = joystick.IsButtonDown(ButtonIndex.Start);
-			ButtonPressed.A = joystick.IsButtonDown(ButtonIndex.A);
-			ButtonPressed.B = joystick.IsButtonDown(ButtonIndex.B);
-			ButtonPressed.C = joystick.IsButtonDown(ButtonIndex.C);
-			ButtonPressed.Power1 = joystick.IsButtonDown(ButtonIndex.Power1);
-			ButtonPressed.Brake1 = joystick.IsButtonDown(ButtonIndex.Brake1);
-			ButtonPressed.Brake2 = joystick.IsButtonDown(ButtonIndex.Brake2);
-			ButtonPressed.Brake3 = joystick.IsButtonDown(ButtonIndex.Brake3);
-			ButtonPressed.Brake4 = joystick.IsButtonDown(ButtonIndex.Brake4);
-
+			powerNotch = InputTranslator.PowerNotches.None;
+			brakeNotch = InputTranslator.BrakeNotches.None;
+			powerNotch = joystick.IsButtonDown(ButtonIndex.Power1) ? powerNotch | InputTranslator.PowerNotches.Power1 : powerNotch & ~InputTranslator.PowerNotches.Power1;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake1) ? brakeNotch | InputTranslator.BrakeNotches.Brake1 : brakeNotch & ~InputTranslator.BrakeNotches.Brake1;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake2) ? brakeNotch | InputTranslator.BrakeNotches.Brake2 : brakeNotch & ~InputTranslator.BrakeNotches.Brake2;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake3) ? brakeNotch | InputTranslator.BrakeNotches.Brake3 : brakeNotch & ~InputTranslator.BrakeNotches.Brake3;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake4) ? brakeNotch | InputTranslator.BrakeNotches.Brake4 : brakeNotch & ~InputTranslator.BrakeNotches.Brake4;
+			
 			if (usesHat)
 			{
 				// The adapter uses the hat to map the direction buttons.
 				// This is the case of some PlayStation adapters.
-				ButtonPressed.Power2 = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
-				ButtonPressed.Power3 = joystick.GetHat((JoystickHat)hatIndex).IsRight;
+				powerNotch = joystick.GetHat((JoystickHat)hatIndex).IsLeft ? powerNotch | InputTranslator.PowerNotches.Power2 : powerNotch & ~InputTranslator.PowerNotches.Power2;
+				powerNotch = joystick.GetHat((JoystickHat)hatIndex).IsRight ? powerNotch | InputTranslator.PowerNotches.Power3 : powerNotch & ~InputTranslator.PowerNotches.Power3;
 			}
 			else
 			{
 				// The adapter maps the direction buttons to independent buttons.
-				ButtonPressed.Power2 = joystick.IsButtonDown(ButtonIndex.Power2);
-				ButtonPressed.Power3 = joystick.IsButtonDown(ButtonIndex.Power3);
+				powerNotch = joystick.IsButtonDown(ButtonIndex.Power2) ? powerNotch | InputTranslator.PowerNotches.Power2 : powerNotch & ~InputTranslator.PowerNotches.Power2;
+				powerNotch = joystick.IsButtonDown(ButtonIndex.Power3) ? powerNotch | InputTranslator.PowerNotches.Power3 : powerNotch & ~InputTranslator.PowerNotches.Power3;
 			}
 
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && !ButtonPressed.Brake4)
+			if (usesHat && powerNotch == InputTranslator.PowerNotches.P4)
 			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
-			}
-			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
-			}
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
-			}
-			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
-			}
-			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
-			}
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
-			}
-			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
-			}
-
-			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
-			}
-			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
-			}
-			if (!ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
-			}
-			if (ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
-			}
-			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
-			{
-				if (usesHat && InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
+				if (InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
 				{
 					// Hack for adapters which map the direction buttons to a hat and confuse N with P4
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
@@ -209,17 +125,17 @@ namespace DenshaDeGoInput
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
 				}
 			}
-			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && !ButtonPressed.Power3)
+			else
 			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
+				InputTranslator.PowerNotch = powerNotch;
 			}
-
-			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
-			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
-			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.A ? 1 : 0);
-			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.B ? 1 : 0);
-			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.C ? 1 : 0);
+			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
 		}
+
 
 		/// <summary>
 		/// Launches the calibration wizard to guess the button indices used by the adapter.

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
@@ -24,19 +24,20 @@
 
 using System.Collections.Generic;
 using System.Windows.Forms;
-using OpenTK.Input;
 using OpenBveApi.Interface;
+using OpenTK.Input;
+
 namespace DenshaDeGoInput
 {
 	/// <summary>
-	/// Class for Densha de GO! controllers for the Sony PlayStation.
+	/// Class for Densha de GO! controllers for classic consoles.
 	/// </summary>
-	internal class PSController
+	internal static class ControllerClassic
 	{
 		/// <summary>
 		/// Whether the adapter uses a hat to map the direction buttons.
 		/// </summary>
-		internal static bool UsesHat = false;
+		internal static bool usesHat;
 
 		/// <summary>
 		/// The index of the hat used to map the direction buttons.
@@ -48,18 +49,18 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal class ButtonIndices
 		{
-			internal int Cross = -1;
-			internal int Circle = -1;
-			internal int Square = -1;
-			internal int Triangle = -1;
-			internal int L1 = -1;
-			internal int R1 = -1;
-			internal int L2 = -1;
-			internal int R2 = -1;
 			internal int Select = -1;
 			internal int Start = -1;
-			internal int Left = -1;
-			internal int Right = -1;
+			internal int A = -1;
+			internal int B = -1;
+			internal int C = -1;
+			internal int Power1 = -1;
+			internal int Power2 = -1;
+			internal int Power3 = -1;
+			internal int Brake1 = -1;
+			internal int Brake2 = -1;
+			internal int Brake3 = -1;
+			internal int Brake4 = -1;
 		}
 
 		/// <summary>
@@ -67,18 +68,20 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal class PressedButtons
 		{
-			internal bool Cross;
-			internal bool Circle;
-			internal bool Square;
-			internal bool Triangle;
-			internal bool L1;
-			internal bool R1;
-			internal bool L2;
-			internal bool R2;
 			internal bool Select;
 			internal bool Start;
-			internal bool Left;
-			internal bool Right;
+			internal bool A;
+			internal bool B;
+			internal bool C;
+			internal bool Power1;
+			internal bool Power2;
+			internal bool Power3;
+			internal bool Brake1;
+			internal bool Brake3;
+			internal bool Brake2;
+			internal bool Brake4;
+
+
 		}
 
 		/// <summary>
@@ -92,9 +95,9 @@ namespace DenshaDeGoInput
 		internal static PressedButtons ButtonPressed = new PressedButtons();
 
 		/// <summary>
-		/// Checks whether a joystick is a Sony PlayStation controller.
+		/// Checks whether a joystick is a classic console controller.
 		/// </summary>
-		public static bool IsPSController(JoystickCapabilities joystick)
+		public static bool IsCompatibleController(JoystickCapabilities joystick)
 		{
 			if ((joystick.ButtonCount >= 12 || (joystick.ButtonCount >= 10 && joystick.HatCount > 0)) && joystick.ButtonCount <= 20)
 			{
@@ -104,94 +107,95 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Reads the buttons from the controller.
+		/// Reads the input from the controller.
 		/// </summary>
-		public static void ReadButtons(JoystickState joystick)
+		public static void ReadInput(JoystickState joystick)
 		{
-			ButtonPressed.Cross = joystick.IsButtonDown(ButtonIndex.Cross);
-			ButtonPressed.Circle = joystick.IsButtonDown(ButtonIndex.Circle);
-			ButtonPressed.Square = joystick.IsButtonDown(ButtonIndex.Square);
-			ButtonPressed.Triangle = joystick.IsButtonDown(ButtonIndex.Triangle);
-			ButtonPressed.L1 = joystick.IsButtonDown(ButtonIndex.L1);
-			ButtonPressed.L2 = joystick.IsButtonDown(ButtonIndex.L2);
-			ButtonPressed.R1 = joystick.IsButtonDown(ButtonIndex.R1);
-			ButtonPressed.R2 = joystick.IsButtonDown(ButtonIndex.R2);
 			ButtonPressed.Select = joystick.IsButtonDown(ButtonIndex.Select);
 			ButtonPressed.Start = joystick.IsButtonDown(ButtonIndex.Start);
+			ButtonPressed.A = joystick.IsButtonDown(ButtonIndex.A);
+			ButtonPressed.B = joystick.IsButtonDown(ButtonIndex.B);
+			ButtonPressed.C = joystick.IsButtonDown(ButtonIndex.C);
+			ButtonPressed.Power1 = joystick.IsButtonDown(ButtonIndex.Power1);
+			ButtonPressed.Brake1 = joystick.IsButtonDown(ButtonIndex.Brake1);
+			ButtonPressed.Brake2 = joystick.IsButtonDown(ButtonIndex.Brake2);
+			ButtonPressed.Brake3 = joystick.IsButtonDown(ButtonIndex.Brake3);
+			ButtonPressed.Brake4 = joystick.IsButtonDown(ButtonIndex.Brake4);
 
-			if (UsesHat)
+			if (usesHat)
 			{
 				// The adapter uses the hat to map the direction buttons.
-				ButtonPressed.Left = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
-				ButtonPressed.Right = joystick.GetHat((JoystickHat)hatIndex).IsRight;
+				// This is the case of some PlayStation adapters.
+				ButtonPressed.Power2 = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
+				ButtonPressed.Power3 = joystick.GetHat((JoystickHat)hatIndex).IsRight;
 			}
 			else
 			{
 				// The adapter maps the direction buttons to independent buttons.
-				ButtonPressed.Left = joystick.IsButtonDown(ButtonIndex.Left);
-				ButtonPressed.Right = joystick.IsButtonDown(ButtonIndex.Right);
+				ButtonPressed.Power2 = joystick.IsButtonDown(ButtonIndex.Power2);
+				ButtonPressed.Power3 = joystick.IsButtonDown(ButtonIndex.Power3);
 			}
 
-			if (!ButtonPressed.L2 && !ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && !ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
 			}
-			if (ButtonPressed.L2 && !ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
 			}
-			if (ButtonPressed.L2 && !ButtonPressed.R2 && ButtonPressed.L1 && ButtonPressed.R1)
+			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
 			}
-			if (!ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
 			}
-			if (!ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && !ButtonPressed.R1)
+			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
 			}
-			if (ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
 			}
-			if (ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && !ButtonPressed.R1)
+			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
 			}
-			if (!ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
 			}
-			if (!ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && ButtonPressed.R1)
+			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
 			}
-			if (ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
 			{
 				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
 			}
 
-			if (ButtonPressed.Right && ButtonPressed.Left && !ButtonPressed.Triangle)
+			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && ButtonPressed.Power3)
 			{
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
 			}
-			if (ButtonPressed.Right && !ButtonPressed.Left && ButtonPressed.Triangle)
+			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
 			{
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
 			}
-			if (ButtonPressed.Right && !ButtonPressed.Left && !ButtonPressed.Triangle)
+			if (!ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
 			{
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
 			}
-			if (!ButtonPressed.Right && ButtonPressed.Left && ButtonPressed.Triangle)
+			if (ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
 			{
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
 			}
-			if (!ButtonPressed.Right && ButtonPressed.Left && !ButtonPressed.Triangle)
+			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
 			{
-				if (UsesHat && InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
+				if (usesHat && InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
 				{
 					// Hack for adapters which map the direction buttons to a hat and confuse N with P4
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
@@ -201,16 +205,16 @@ namespace DenshaDeGoInput
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
 				}
 			}
-			if (!ButtonPressed.Right && !ButtonPressed.Left && ButtonPressed.Triangle)
+			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && !ButtonPressed.Power3)
 			{
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
 			}
 
 			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
 			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
-			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.Square ? 1 : 0);
-			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.Cross ? 1 : 0);
-			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.Circle ? 1 : 0);
+			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.A ? 1 : 0);
+			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.B ? 1 : 0);
+			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.C ? 1 : 0);
 		}
 
 		/// <summary>
@@ -218,7 +222,25 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public static void Calibrate()
 		{
-			string[] input = { "SELECT", "START", "A", "B", "C", "EMG", "B6", "B5", "B4", "B8", "P5", "N", "P2", "P1", "P5" };
+			string[] input = 
+			{
+				"SELECT",
+				"START",
+				"A",
+				"B",
+				"C",
+				Translations.QuickReferences.HandleEmergency,
+				Translations.QuickReferences.HandleBrake + "6",
+				Translations.QuickReferences.HandleBrake + "5",
+				Translations.QuickReferences.HandleBrake + "4",
+				Translations.QuickReferences.HandleBrake + "8",
+				Translations.QuickReferences.HandlePower + "5",
+				Translations.QuickReferences.HandlePowerNull,
+				Translations.QuickReferences.HandlePower + "2",
+				Translations.QuickReferences.HandlePower + "1",
+				Translations.QuickReferences.HandlePower + "5",
+			};
+
 			List<OpenTK.Input.ButtonState> ButtonState = InputTranslator.GetButtonsState();
 			List<OpenTK.Input.ButtonState> PreviousButtonState;
 			List<HatPosition> HatPositions = InputTranslator.GetHatPositions();
@@ -242,13 +264,13 @@ namespace DenshaDeGoInput
 						ButtonIndex.Start = index;
 						break;
 					case 2:
-						ButtonIndex.Square = index;
+						ButtonIndex.A = index;
 						break;
 					case 3:
-						ButtonIndex.Cross = index;
+						ButtonIndex.B = index;
 						break;
 					case 4:
-						ButtonIndex.Circle = index;
+						ButtonIndex.C = index;
 						break;
 				}
 			}
@@ -267,16 +289,16 @@ namespace DenshaDeGoInput
 				switch (i)
 				{
 					case 6:
-						ButtonIndex.R2 = index;
+						ButtonIndex.Brake4 = index;
 						break;
 					case 7:
-						ButtonIndex.L1 = index;
+						ButtonIndex.Brake1 = index;
 						break;
 					case 8:
-						ButtonIndex.L2 = index;
+						ButtonIndex.Brake2 = index;
 						break;
 					case 9:
-						ButtonIndex.R1 = index;
+						ButtonIndex.Brake3 = index;
 						break;
 				}
 			}
@@ -305,24 +327,24 @@ namespace DenshaDeGoInput
 				if (hat != -1 && i != 13)
 				{
 					// If a hat has changed, it means the converter is mapping the direction buttons 
-					UsesHat = true;
+					usesHat = true;
 					hatIndex = hat;
 				}
 				else
 				{
-					UsesHat = false;
+					usesHat = false;
 				}
 
 				switch (i)
 				{
 					case 12:
-						ButtonIndex.Left = index;
+						ButtonIndex.Power2 = index;
 						break;
 					case 13:
-						ButtonIndex.Triangle = index;
+						ButtonIndex.Power1 = index;
 						break;
 					case 14:
-						ButtonIndex.Right = index;
+						ButtonIndex.Power3 = index;
 						break;
 				}
 			}

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
@@ -97,9 +97,12 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Checks whether a joystick is a classic console controller.
 		/// </summary>
-		public static bool IsCompatibleController(JoystickCapabilities joystick)
+		/// <param name="capabilities">the capabilities of the joystick.</param>
+		/// <returns>Whether the controller is compatible.</returns>
+		internal static bool IsCompatibleController(JoystickCapabilities capabilities)
 		{
-			if ((joystick.ButtonCount >= 12 || (joystick.ButtonCount >= 10 && joystick.HatCount > 0)) && joystick.ButtonCount <= 20)
+			// A valid controller needs at least 12 buttons or 10 buttons plus a hat. If there are more than 20 buttons, the joystick is unlikely a valid controller.
+			if ((capabilities.ButtonCount >= 12 || (capabilities.ButtonCount >= 10 && capabilities.HatCount > 0)) && capabilities.ButtonCount <= 20)
 			{
 				return true;
 			}
@@ -109,7 +112,8 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Reads the input from the controller.
 		/// </summary>
-		public static void ReadInput(JoystickState joystick)
+		/// <param name="joystick">The state of the joystick to read input from.</param>
+		internal static void ReadInput(JoystickState joystick)
 		{
 			ButtonPressed.Select = joystick.IsButtonDown(ButtonIndex.Select);
 			ButtonPressed.Start = joystick.IsButtonDown(ButtonIndex.Start);
@@ -220,7 +224,7 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Launches the calibration wizard to guess the button indices used by the adapter.
 		/// </summary>
-		public static void Calibrate()
+		internal static void Calibrate()
 		{
 			string[] input = 
 			{
@@ -349,6 +353,5 @@ namespace DenshaDeGoInput
 				}
 			}
 		}
-
 	}
 }

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
@@ -247,11 +247,11 @@ namespace DenshaDeGoInput
 				// Set notch only if it is not a transition nor an unmarked notch
 				InputTranslator.BrakeNotch = BrakeNotchMap[brakeNotch];
 			}
-			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
-			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
-			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
-			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
-			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] = joystick.GetButton(ButtonIndex.C);
 		}
 
 

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -97,9 +97,9 @@ namespace DenshaDeGoInput
 		{
 			// DGC-255/DGOC-44U
 			if (id == "0ae4:0003")
-				{
-					// DGC-255 has direction buttons
-					hasDirectionButtons = capabilities.HatCount > 0;
+			{
+				// DGC-255 has direction buttons
+				hasDirectionButtons = capabilities.HatCount > 0;
 				return true;
 			}
 			return false;
@@ -179,12 +179,12 @@ namespace DenshaDeGoInput
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
 			}
 
-			InputTranslator.ControllerButtons.Select = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Select) ? 1 : 0);
-			InputTranslator.ControllerButtons.Start = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Start) ? 1 : 0);
-			InputTranslator.ControllerButtons.A = (ButtonState)(joystick.IsButtonDown(ButtonIndex.A) ? 1 : 0);
-			InputTranslator.ControllerButtons.B = (ButtonState)(joystick.IsButtonDown(ButtonIndex.B) ? 1 : 0);
-			InputTranslator.ControllerButtons.C = (ButtonState)(joystick.IsButtonDown(ButtonIndex.C) ? 1 : 0);
-			InputTranslator.ControllerButtons.D = (ButtonState)(joystick.IsButtonDown(ButtonIndex.D) ? 1 : 0);
+			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
+			InputTranslator.ControllerButtons.D = joystick.GetButton(ButtonIndex.D);
 
 			if (hasDirectionButtons)
 			{

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -45,6 +45,9 @@ namespace DenshaDeGoInput
 			internal int D = 3;
 		}
 
+		/// <summary>
+		/// Represents the possible bytes for brake notches.
+		/// </summary>
 		internal enum BrakeByte
 		{
 			Released = 0x79,
@@ -60,6 +63,9 @@ namespace DenshaDeGoInput
 			Transition = 0xFF
 		}
 
+		/// <summary>
+		/// Represents the possible bytes for power notches.
+		/// </summary>
 		internal enum PowerByte
 		{
 			N = 0x81,
@@ -84,7 +90,10 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Checks whether a joystick is an Unbalance controller.
 		/// </summary>
-		public static bool IsCompatibleController(string id, JoystickCapabilities capabilities)
+		/// <param name="id">A string representing the vendor and product ID.</param>
+		/// <param name="capabilities">the capabilities of the joystick.</param>
+		/// <returns>Whether the controller is compatible.</returns>
+		internal static bool IsCompatibleController(string id, JoystickCapabilities capabilities)
 		{
 			// DGC-255/DGOC-44U
 			if (id == "0ae4:0003")
@@ -99,7 +108,8 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Reads the input from the controller.
 		/// </summary>
-		public static void ReadInput(JoystickState joystick)
+		/// <param name="joystick">The state of the joystick to read input from.</param>
+		internal static void ReadInput(JoystickState joystick)
 		{
 			double brakeAxis = joystick.GetAxis(0);
 			double powerAxis = joystick.GetAxis(1);
@@ -188,6 +198,8 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Gets the minimum value for a notch byte.
 		/// </summary>
+		/// <param name="notch">A notch byte.</param>
+		/// <returns>The minimum value for a notch byte.</returns>
 		private static double GetRangeMin(byte notch)
 		{
 			double value = (notch - 1) * (2.0 / 255) - 1;
@@ -197,6 +209,8 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Gets the maximum value for a notch byte.
 		/// </summary>
+		/// <param name="notch">A notch byte.</param>
+		/// <returns>The maximum value for a notch byte.</returns>
 		private static double GetRangeMax(byte notch)
 		{
 			double value = (notch + 1) * (2.0 / 255) - 1;

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -1,0 +1,93 @@
+﻿//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using OpenTK.Input;
+
+namespace DenshaDeGoInput
+{
+	/// <summary>
+	/// Class for Densha de GO! controllers for PC by Unbalance.
+	/// </summary>
+	internal static class ControllerUnbalance
+	{
+		/// <summary>
+		/// Class for the indices of the buttons used by the controller.
+		/// </summary>
+		internal class ButtonIndices
+		{
+			internal int Select = 4;
+			internal int Start = 5;
+			internal int A = 1;
+			internal int B = 0;
+			internal int C = 2;
+			internal int D = 3;
+		}
+
+		/// <summary>
+		/// The button indices of the buttons used by the controller.
+		/// </summary>
+		internal static ButtonIndices ButtonIndex = new ButtonIndices();
+
+		/// <summary>
+		/// Whether the controller has direction buttons.
+		/// </summary>
+		internal static bool hasDirectionButtons;
+
+		/// <summary>
+		/// Checks whether a joystick is an Unbalance controller.
+		/// </summary>
+		public static bool IsCompatibleController(JoystickCapabilities joystick)
+		{
+			// The controller's ID is 0AE4:0003, but we cannot use it here (yet)
+			if (joystick.ButtonCount == 6 && joystick.AxisCount == 2)
+			{
+				// The one-handle controller has direction buttons
+				hasDirectionButtons = joystick.HatCount > 0;
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Reads the input from the controller.
+		/// </summary>
+		public static void ReadInput(JoystickState joystick)
+		{
+			InputTranslator.ControllerButtons.Select = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Select) ? 1 : 0);
+			InputTranslator.ControllerButtons.Start = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Start) ? 1 : 0);
+			InputTranslator.ControllerButtons.A = (ButtonState)(joystick.IsButtonDown(ButtonIndex.A) ? 1 : 0);
+			InputTranslator.ControllerButtons.B = (ButtonState)(joystick.IsButtonDown(ButtonIndex.B) ? 1 : 0);
+			InputTranslator.ControllerButtons.C = (ButtonState)(joystick.IsButtonDown(ButtonIndex.C) ? 1 : 0);
+			InputTranslator.ControllerButtons.D = (ButtonState)(joystick.IsButtonDown(ButtonIndex.D) ? 1 : 0);
+
+			if (hasDirectionButtons)
+			{
+				InputTranslator.ControllerButtons.Up = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsUp ? 1 : 0);
+				InputTranslator.ControllerButtons.Down = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsDown ? 1 : 0);
+				InputTranslator.ControllerButtons.Left = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
+				InputTranslator.ControllerButtons.Right = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
+			}
+		}
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -22,6 +22,7 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using System;
 using OpenTK.Input;
 
 namespace DenshaDeGoInput
@@ -44,6 +45,32 @@ namespace DenshaDeGoInput
 			internal int D = 3;
 		}
 
+		internal enum BrakeByte
+		{
+			Released = 0x79,
+			B1 = 0x8A,
+			B2 = 0x94,
+			B3 = 0x9A,
+			B4 = 0xA2,
+			B5 = 0xA8,
+			B6 = 0xAF,
+			B7 = 0xB2,
+			B8 = 0xB5,
+			Emergency = 0xB9,
+			Transition = 0xFF
+		}
+
+		internal enum PowerByte
+		{
+			N = 0x81,
+			P1 = 0x6D,
+			P2 = 0x54,
+			P3 = 0x3F,
+			P4 = 0x21,
+			P5 = 0x00,
+			Transition = 0xFF
+		}
+
 		/// <summary>
 		/// The button indices of the buttons used by the controller.
 		/// </summary>
@@ -57,13 +84,13 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Checks whether a joystick is an Unbalance controller.
 		/// </summary>
-		public static bool IsCompatibleController(JoystickCapabilities joystick)
+		public static bool IsCompatibleController(string id, JoystickCapabilities capabilities)
 		{
-			// The controller's ID is 0AE4:0003, but we cannot use it here (yet)
-			if (joystick.ButtonCount == 6 && joystick.AxisCount == 2)
-			{
-				// The one-handle controller has direction buttons
-				hasDirectionButtons = joystick.HatCount > 0;
+			// DGC-255/DGOC-44U
+			if (id == "0ae4:0003")
+				{
+					// DGC-255 has direction buttons
+					hasDirectionButtons = capabilities.HatCount > 0;
 				return true;
 			}
 			return false;
@@ -74,6 +101,74 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public static void ReadInput(JoystickState joystick)
 		{
+			double brakeAxis = joystick.GetAxis(0);
+			double powerAxis = joystick.GetAxis(1);
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.Emergency) && brakeAxis <= GetRangeMax((byte)BrakeByte.Emergency))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B8) && brakeAxis <= GetRangeMax((byte)BrakeByte.B8))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B7) && brakeAxis <= GetRangeMax((byte)BrakeByte.B7))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B6) && brakeAxis <= GetRangeMax((byte)BrakeByte.B6))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B5) && brakeAxis <= GetRangeMax((byte)BrakeByte.B5))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B4) && brakeAxis <= GetRangeMax((byte)BrakeByte.B4))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B3) && brakeAxis <= GetRangeMax((byte)BrakeByte.B3))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B2) && brakeAxis <= GetRangeMax((byte)BrakeByte.B2))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B1) && brakeAxis <= GetRangeMax((byte)BrakeByte.B1))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
+			}
+			if (brakeAxis >= GetRangeMin((byte)BrakeByte.Released) && brakeAxis <= GetRangeMax((byte)BrakeByte.Released))
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
+			}
+
+			if (powerAxis >= GetRangeMin((byte)PowerByte.N) && powerAxis <= GetRangeMax((byte)PowerByte.N))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+			}
+			if (powerAxis >= GetRangeMin((byte)PowerByte.P1) && powerAxis <= GetRangeMax((byte)PowerByte.P1))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
+			}
+			if (powerAxis >= GetRangeMin((byte)PowerByte.P2) && powerAxis <= GetRangeMax((byte)PowerByte.P2))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
+			}
+			if (powerAxis >= GetRangeMin((byte)PowerByte.P3) && powerAxis <= GetRangeMax((byte)PowerByte.P3))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
+			}
+			if (powerAxis >= GetRangeMin((byte)PowerByte.P4) && powerAxis <= GetRangeMax((byte)PowerByte.P4))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
+			}
+			if (powerAxis >= GetRangeMin((byte)PowerByte.P5) && powerAxis <= GetRangeMax((byte)PowerByte.P5))
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
+			}
+
 			InputTranslator.ControllerButtons.Select = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Select) ? 1 : 0);
 			InputTranslator.ControllerButtons.Start = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Start) ? 1 : 0);
 			InputTranslator.ControllerButtons.A = (ButtonState)(joystick.IsButtonDown(ButtonIndex.A) ? 1 : 0);
@@ -88,6 +183,24 @@ namespace DenshaDeGoInput
 				InputTranslator.ControllerButtons.Left = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
 				InputTranslator.ControllerButtons.Right = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
 			}
+		}
+
+		/// <summary>
+		/// Gets the minimum value for a notch byte.
+		/// </summary>
+		private static double GetRangeMin(byte notch)
+		{
+			double value = (notch - 1) * (2.0 / 255) - 1;
+			return value;
+		}
+
+		/// <summary>
+		/// Gets the maximum value for a notch byte.
+		/// </summary>
+		private static double GetRangeMax(byte notch)
+		{
+			double value = (notch + 1) * (2.0 / 255) - 1;
+			return value;
 		}
 	}
 }

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -22,7 +22,7 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-using System;
+using System.Collections.Generic;
 using OpenTK.Input;
 
 namespace DenshaDeGoInput
@@ -64,6 +64,23 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
+		/// Dictionary storing the mapping of each brake notch.
+		/// </summary>
+		internal static readonly Dictionary<BrakeByte, InputTranslator.BrakeNotches> BrakeNotchMap = new Dictionary<BrakeByte, InputTranslator.BrakeNotches>
+		{
+			{ BrakeByte.Released, InputTranslator.BrakeNotches.Released },
+			{ BrakeByte.B1, InputTranslator.BrakeNotches.B1 },
+			{ BrakeByte.B2, InputTranslator.BrakeNotches.B2 },
+			{ BrakeByte.B3, InputTranslator.BrakeNotches.B3 },
+			{ BrakeByte.B4, InputTranslator.BrakeNotches.B4 },
+			{ BrakeByte.B5, InputTranslator.BrakeNotches.B5 },
+			{ BrakeByte.B6, InputTranslator.BrakeNotches.B6 },
+			{ BrakeByte.B7, InputTranslator.BrakeNotches.B7 },
+			{ BrakeByte.B8, InputTranslator.BrakeNotches.B8 },
+			{ BrakeByte.Emergency, InputTranslator.BrakeNotches.Emergency }
+		};
+
+		/// <summary>
 		/// Represents the possible bytes for power notches.
 		/// </summary>
 		internal enum PowerByte
@@ -76,6 +93,19 @@ namespace DenshaDeGoInput
 			P5 = 0x00,
 			Transition = 0xFF
 		}
+
+		/// <summary>
+		/// Dictionary storing the mapping of each power notch.
+		/// </summary>
+		internal static readonly Dictionary<PowerByte, InputTranslator.PowerNotches> PowerNotchMap = new Dictionary<PowerByte, InputTranslator.PowerNotches>
+		{
+			{ PowerByte.N, InputTranslator.PowerNotches.N },
+			{ PowerByte.P1, InputTranslator.PowerNotches.P1 },
+			{ PowerByte.P2, InputTranslator.PowerNotches.P2 },
+			{ PowerByte.P3, InputTranslator.PowerNotches.P3 },
+			{ PowerByte.P4, InputTranslator.PowerNotches.P4 },
+			{ PowerByte.P5, InputTranslator.PowerNotches.P5 }
+		};
 
 		/// <summary>
 		/// The button indices of the buttons used by the controller.
@@ -113,85 +143,34 @@ namespace DenshaDeGoInput
 		{
 			double brakeAxis = joystick.GetAxis(0);
 			double powerAxis = joystick.GetAxis(1);
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.Emergency) && brakeAxis <= GetRangeMax((byte)BrakeByte.Emergency))
+			foreach (var notch in BrakeNotchMap)
 			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
+				if (brakeAxis >= GetRangeMin((byte)notch.Key) && brakeAxis <= GetRangeMax((byte)notch.Key))
+				{
+					InputTranslator.BrakeNotch = notch.Value;
+				}
 			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B8) && brakeAxis <= GetRangeMax((byte)BrakeByte.B8))
+			foreach (var notch in PowerNotchMap)
 			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B7) && brakeAxis <= GetRangeMax((byte)BrakeByte.B7))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B6) && brakeAxis <= GetRangeMax((byte)BrakeByte.B6))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B5) && brakeAxis <= GetRangeMax((byte)BrakeByte.B5))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B4) && brakeAxis <= GetRangeMax((byte)BrakeByte.B4))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B3) && brakeAxis <= GetRangeMax((byte)BrakeByte.B3))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B2) && brakeAxis <= GetRangeMax((byte)BrakeByte.B2))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.B1) && brakeAxis <= GetRangeMax((byte)BrakeByte.B1))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
-			}
-			if (brakeAxis >= GetRangeMin((byte)BrakeByte.Released) && brakeAxis <= GetRangeMax((byte)BrakeByte.Released))
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
+				if (powerAxis >= GetRangeMin((byte)notch.Key) && powerAxis <= GetRangeMax((byte)notch.Key))
+				{
+					InputTranslator.PowerNotch = notch.Value;
+				}
 			}
 
-			if (powerAxis >= GetRangeMin((byte)PowerByte.N) && powerAxis <= GetRangeMax((byte)PowerByte.N))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
-			}
-			if (powerAxis >= GetRangeMin((byte)PowerByte.P1) && powerAxis <= GetRangeMax((byte)PowerByte.P1))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
-			}
-			if (powerAxis >= GetRangeMin((byte)PowerByte.P2) && powerAxis <= GetRangeMax((byte)PowerByte.P2))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
-			}
-			if (powerAxis >= GetRangeMin((byte)PowerByte.P3) && powerAxis <= GetRangeMax((byte)PowerByte.P3))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
-			}
-			if (powerAxis >= GetRangeMin((byte)PowerByte.P4) && powerAxis <= GetRangeMax((byte)PowerByte.P4))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
-			}
-			if (powerAxis >= GetRangeMin((byte)PowerByte.P5) && powerAxis <= GetRangeMax((byte)PowerByte.P5))
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
-			}
-
-			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
-			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
-			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
-			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
-			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
-			InputTranslator.ControllerButtons.D = joystick.GetButton(ButtonIndex.D);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] = joystick.GetButton(ButtonIndex.C);
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] = joystick.GetButton(ButtonIndex.D);
 
 			if (hasDirectionButtons)
 			{
-				InputTranslator.ControllerButtons.Up = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsUp ? 1 : 0);
-				InputTranslator.ControllerButtons.Down = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsDown ? 1 : 0);
-				InputTranslator.ControllerButtons.Left = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
-				InputTranslator.ControllerButtons.Right = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsUp ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsDown ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
 			}
 		}
 

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -508,6 +508,10 @@ namespace DenshaDeGoInput
 
 		public void SetMaxNotch(int powerNotch, int brakeNotch) { }
 
+		/// <summary>
+		/// A function notifying the plugin about the train's specifications.
+		/// </summary>
+		/// <param name="specs">The train's specifications.</param>
 		public void SetVehicleSpecs(VehicleSpecs specs)
 		{
 			vehicleSpecs = specs;
@@ -515,7 +519,7 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Configures the correct mappings for the buttons and notches according to the settings.
+		/// Configures the correct mappings for the buttons and notches according to the user settings.
 		/// </summary>
 		internal void ConfigureMappings()
 		{

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -94,24 +94,6 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static ButtonProp[] ButtonProperties = new ButtonProp[11];
 
-		/// <summary>
-		/// Dictionary storing the mapping of each brake notch.
-		/// </summary>
-		internal static readonly Dictionary<int, OpenTK.Input.ButtonState> ButtonMap = new Dictionary<int, OpenTK.Input.ButtonState>
-		{
-			{ 0, InputTranslator.ControllerButtons.Select},
-			{ 1, InputTranslator.ControllerButtons.Start},
-			{ 2, InputTranslator.ControllerButtons.A},
-			{ 3, InputTranslator.ControllerButtons.B},
-			{ 4, InputTranslator.ControllerButtons.C},
-			{ 5, InputTranslator.ControllerButtons.D},
-			{ 6, InputTranslator.ControllerButtons.Up},
-			{ 7, InputTranslator.ControllerButtons.Down},
-			{ 8, InputTranslator.ControllerButtons.Left},
-			{ 9, InputTranslator.ControllerButtons.Right},
-			{ 10, InputTranslator.ControllerButtons.Pedal}
-		};
-
 
 		/// <summary>
 		/// Whether to convert the handle notches to match the driver's train.
@@ -245,7 +227,7 @@ namespace DenshaDeGoInput
 				// Buttons
 				for (int i = 0; i < ButtonProperties.Length; i++)
 				{
-					if (ButtonMap[i] == OpenTK.Input.ButtonState.Pressed && ButtonProperties[i].Timer <= 0)
+					if (InputTranslator.ControllerButtons[i] == OpenTK.Input.ButtonState.Pressed && ButtonProperties[i].Timer <= 0)
 					{
 						KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[i].Command]));
 						if (ButtonProperties[i].Repeats)
@@ -275,7 +257,7 @@ namespace DenshaDeGoInput
 			// Button timers
 			for (int i = 0; i < ButtonProperties.Length; i++)
 			{
-				if (ButtonMap[i] == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons[i] == OpenTK.Input.ButtonState.Pressed)
 				{
 					ButtonProperties[i].Timer -= data.ElapsedTime.Milliseconds;
 				}

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -1,3 +1,27 @@
+//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 using System;
 using System.Globalization;
 using System.Windows.Forms;

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+using OpenBveApi.FileSystem;
+using OpenBveApi.Interface;
+using OpenBveApi.Runtime;
+
+namespace DenshaDeGoInput
+{
+	/// <summary>
+	/// Input Device Plugin class for controllers of the Densha de GO! series
+	/// </summary>
+	public class DenshaDeGoInput : IInputDevice
+	{
+		public event EventHandler<InputEventArgs> KeyDown;
+		public event EventHandler<InputEventArgs> KeyUp;
+
+		public InputControl[] Controls { get; private set; }
+
+		private static FileSystem FileSystem;
+
+		private Config configForm;
+
+		internal bool loading = true;
+		internal bool brakeHandleMoved;
+		internal bool powerHandleMoved;
+
+		internal VehicleSpecs vehicleSpecs = new VehicleSpecs(5, BrakeTypes.AutomaticAirBrake, 8, false, 1);
+
+		public void Config(IWin32Window owner)
+		{
+			configForm.ShowDialog(owner);
+		}
+
+		public bool Load(FileSystem fileSystem)
+		{
+			configForm = new Config();
+			FileSystem = fileSystem;
+
+			Controls = new InputControl[16];
+			for (int i = 0; i < 9; i++)
+			{
+				Controls[i].Command = Translations.Command.BrakeAnyNotch;
+				Controls[i].Option = i;
+			}
+			Controls[9].Command = Translations.Command.BrakeEmergency;
+			for (int i = 10; i < 16; i++)
+			{
+				Controls[i].Command = Translations.Command.PowerAnyNotch;
+				Controls[i].Option = i - 10;
+			}
+
+			LoadConfig();
+			return true;
+		}
+
+		public void OnUpdateFrame()
+		{
+			if (brakeHandleMoved)
+			{
+				KeyUp(this, new InputEventArgs(Controls[(int)InputTranslator.BrakeNotch]));
+				brakeHandleMoved = false;
+			}
+			if (powerHandleMoved)
+			{
+				KeyUp(this, new InputEventArgs(Controls[(int)InputTranslator.PowerNotch + 10]));
+				powerHandleMoved = false;
+			}
+
+			InputTranslator.Update();
+
+			if (InputTranslator.IsControllerConnected)
+			{
+				if (InputTranslator.BrakeNotch != InputTranslator.PreviousBrakeNotch || loading)
+				{
+					KeyDown(this, new InputEventArgs(Controls[(int)InputTranslator.BrakeNotch]));
+					brakeHandleMoved = true;
+				}
+				if (InputTranslator.PowerNotch != InputTranslator.PreviousPowerNotch || loading)
+				{
+					KeyDown(this, new InputEventArgs(Controls[(int)InputTranslator.PowerNotch + 10]));
+					powerHandleMoved = true;
+				}
+			}
+
+			loading = false;
+		}
+
+		public void SetElapseData(ElapseData data) {
+
+			data.DebugMessage = InputTranslator.BrakeNotch.ToString();
+}
+
+		public void SetMaxNotch(int powerNotch, int brakeNotch) { }
+
+		public void SetVehicleSpecs(VehicleSpecs specs)
+		{
+			vehicleSpecs = specs;
+		}
+
+		public void Unload() { }
+
+		internal static void LoadConfig()
+		{
+			string optionsFolder = OpenBveApi.Path.CombineDirectory(FileSystem.SettingsFolder, "1.5.0");
+			if (!System.IO.Directory.Exists(optionsFolder))
+			{
+				System.IO.Directory.CreateDirectory(optionsFolder);
+			}
+			string configFile = OpenBveApi.Path.CombineFile(optionsFolder, "options_denshadego.cfg");
+			if (System.IO.File.Exists(configFile))
+			{
+				// load options
+				string[] Lines = System.IO.File.ReadAllLines(configFile, new System.Text.UTF8Encoding());
+				string Section = "";
+				for (int i = 0; i < Lines.Length; i++)
+				{
+					Lines[i] = Lines[i].Trim(new char[] { });
+					if (Lines[i].Length != 0 && !Lines[i].StartsWith(";", StringComparison.OrdinalIgnoreCase))
+					{
+						if (Lines[i].StartsWith("[", StringComparison.Ordinal) &
+							Lines[i].EndsWith("]", StringComparison.Ordinal))
+						{
+							Section = Lines[i].Substring(1, Lines[i].Length - 2).Trim(new char[] { }).ToLowerInvariant();
+						}
+						else
+						{
+							int j = Lines[i].IndexOf("=", StringComparison.OrdinalIgnoreCase);
+							string Key, Value;
+							if (j >= 0)
+							{
+								Key = Lines[i].Substring(0, j).TrimEnd().ToLowerInvariant();
+								Value = Lines[i].Substring(j + 1).TrimStart(new char[] { });
+							}
+							else
+							{
+								Key = "";
+								Value = Lines[i];
+							}
+							switch (Section)
+							{
+								case "general":
+									switch (Key)
+									{
+										case "controller":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													InputTranslator.activeControllerIndex = a;
+												}
+											}
+											break;
+									}
+									break;
+								case "playstation":
+									switch (Key)
+									{
+										case "hat":
+											PSController.UsesHat = string.Compare(Value, "false", StringComparison.OrdinalIgnoreCase) != 0;
+											break;
+										case "hat_index":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.hatIndex = a;
+												}
+											}
+											break;
+										case "cross":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Cross = a;
+												}
+											}
+											break;
+										case "square":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Square = a;
+												}
+											}
+											break;
+										case "triangle":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Triangle = a;
+												}
+											}
+											break;
+										case "circle":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Circle = a;
+												}
+											}
+											break;
+										case "l1":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.L1 = a;
+												}
+											}
+											break;
+										case "l2":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.L2 = a;
+												}
+											}
+											break;
+										case "r1":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.R1 = a;
+												}
+											}
+											break;
+										case "r2":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.R2 = a;
+												}
+											}
+											break;
+										case "select":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Select = a;
+												}
+											}
+											break;
+										case "start":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Start = a;
+												}
+											}
+											break;
+										case "left":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Left = a;
+												}
+											}
+											break;
+										case "right":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													PSController.ButtonIndex.Right = a;
+												}
+											}
+											break;
+									}
+									break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		internal static void SaveConfig()
+		{
+			try
+			{
+				CultureInfo Culture = CultureInfo.InvariantCulture;
+				System.Text.StringBuilder Builder = new System.Text.StringBuilder();
+				Builder.AppendLine("; Options");
+				Builder.AppendLine("; =======");
+				Builder.AppendLine("; This file was automatically generated. Please modify only if you know what you're doing.");
+				Builder.AppendLine("; Specific options file for the Densha de GO! controller input plugin");
+				Builder.AppendLine();
+				Builder.AppendLine("[general]");
+				Builder.AppendLine("controller = " + InputTranslator.activeControllerIndex.ToString(Culture));
+				Builder.AppendLine();
+				Builder.AppendLine("[playstation]");
+				Builder.AppendLine("hat = " + PSController.UsesHat.ToString(Culture).ToLower());
+				Builder.AppendLine("hat_index = " + PSController.hatIndex.ToString(Culture));
+				Builder.AppendLine("cross = " + PSController.ButtonIndex.Cross.ToString(Culture));
+				Builder.AppendLine("square = " + PSController.ButtonIndex.Square.ToString(Culture));
+				Builder.AppendLine("triangle = " + PSController.ButtonIndex.Triangle.ToString(Culture));
+				Builder.AppendLine("circle = " + PSController.ButtonIndex.Circle.ToString(Culture));
+				Builder.AppendLine("l1 = " + PSController.ButtonIndex.L1.ToString(Culture));
+				Builder.AppendLine("l2 = " + PSController.ButtonIndex.L2.ToString(Culture));
+				Builder.AppendLine("r1 = " + PSController.ButtonIndex.R1.ToString(Culture));
+				Builder.AppendLine("r2 = " + PSController.ButtonIndex.R2.ToString(Culture));
+				Builder.AppendLine("select = " + PSController.ButtonIndex.Select.ToString(Culture));
+				Builder.AppendLine("start = " + PSController.ButtonIndex.Start.ToString(Culture));
+				Builder.AppendLine("left = " + PSController.ButtonIndex.Left.ToString(Culture));
+				Builder.AppendLine("right = " + PSController.ButtonIndex.Right.ToString(Culture));
+				string optionsFolder = OpenBveApi.Path.CombineDirectory(FileSystem.SettingsFolder, "1.5.0");
+				string configFile = OpenBveApi.Path.CombineFile(optionsFolder, "options_denshadego.cfg");
+				System.IO.File.WriteAllText(configFile, Builder.ToString(), new System.Text.UTF8Encoding(true));
+			}
+			catch
+			{
+				MessageBox.Show("An error occured whilst saving the options to disk." + System.Environment.NewLine +
+								"Please check you have write permission.");
+			}
+		}
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -257,6 +257,7 @@ namespace DenshaDeGoInput
 		public void SetVehicleSpecs(VehicleSpecs specs)
 		{
 			vehicleSpecs = specs;
+			ConfigureMappings();
 		}
 
 		/// <summary>
@@ -301,7 +302,7 @@ namespace DenshaDeGoInput
 				// Brake notches
 				if (mapHoldBrake && vehicleSpecs.HasHoldBrake)
 				{
-					double brakeStep = vehicleSpecs.BrakeNotches / 7.0;
+					double brakeStep = (vehicleSpecs.BrakeNotches - 1) / 7.0;
 					brakeCommands[0] = 0;
 					brakeCommands[1] = 100 + (int)Translations.Command.HoldBrake;
 					for (int i = 2; i < 9; i++)

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -23,6 +23,7 @@
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Forms;
 using OpenBveApi.FileSystem;
@@ -39,7 +40,10 @@ namespace DenshaDeGoInput
 		public event EventHandler<InputEventArgs> KeyDown;
 		public event EventHandler<InputEventArgs> KeyUp;
 
-		public InputControl[] Controls { get; private set; }
+		public InputControl[] Controls
+		{
+			get; private set;
+		}
 
 		internal static FileSystem FileSystem;
 
@@ -90,6 +94,24 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static ButtonProp[] ButtonProperties = new ButtonProp[11];
 
+		/// <summary>
+		/// Dictionary storing the mapping of each brake notch.
+		/// </summary>
+		internal static readonly Dictionary<int, OpenTK.Input.ButtonState> ButtonMap = new Dictionary<int, OpenTK.Input.ButtonState>
+		{
+			{ 0, InputTranslator.ControllerButtons.Select},
+			{ 1, InputTranslator.ControllerButtons.Start},
+			{ 2, InputTranslator.ControllerButtons.A},
+			{ 3, InputTranslator.ControllerButtons.B},
+			{ 4, InputTranslator.ControllerButtons.C},
+			{ 5, InputTranslator.ControllerButtons.D},
+			{ 6, InputTranslator.ControllerButtons.Up},
+			{ 7, InputTranslator.ControllerButtons.Down},
+			{ 8, InputTranslator.ControllerButtons.Left},
+			{ 9, InputTranslator.ControllerButtons.Right},
+			{ 10, InputTranslator.ControllerButtons.Pedal}
+		};
+
 
 		/// <summary>
 		/// Whether to convert the handle notches to match the driver's train.
@@ -115,7 +137,7 @@ namespace DenshaDeGoInput
 		/// Internval for repeating a button press.
 		/// </summary>
 		internal static int repeatInterval = 100;
-		
+
 		/// <summary>
 		/// A function call when the Config button is pressed.
 		/// </summary>
@@ -198,28 +220,11 @@ namespace DenshaDeGoInput
 				KeyUp(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 				powerHandleMoved = false;
 			}
-			// Select button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[0].Command]));
-			// Start button
-            KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[1].Command]));
-			// A button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[2].Command]));
-			// B button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[3].Command]));
-			// C button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
-			// D button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[5].Command]));
-			// Up button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[6].Command]));
-			// Down button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[7].Command]));
-			// Left button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[8].Command]));
-			// Right button
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[9].Command]));
-			// Pedal
-			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[10].Command]));
+			// Buttons
+			for (int i = 0; i < ButtonProperties.Length; i++)
+			{
+				KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[i].Command]));
+			}
 
 			InputTranslator.Update();
 
@@ -237,159 +242,21 @@ namespace DenshaDeGoInput
 					KeyDown(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 					powerHandleMoved = true;
 				}
-
-				// Select button
-				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed && ButtonProperties[0].Timer <= 0)
+				// Buttons
+				for (int i = 0; i < ButtonProperties.Length; i++)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[0].Command]));
-					if (ButtonProperties[0].Repeats)
+					if (ButtonMap[i] == OpenTK.Input.ButtonState.Pressed && ButtonProperties[i].Timer <= 0)
 					{
-						ButtonProperties[0].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[0].Timer = repeatDelay;
-						ButtonProperties[0].Repeats = true;
-					}
-				}
-				// Start button
-				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed && ButtonProperties[1].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[1].Command]));
-					if (ButtonProperties[1].Repeats)
-					{
-						ButtonProperties[1].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[1].Timer = repeatDelay;
-						ButtonProperties[1].Repeats = true;
-					}
-				}
-				// A button
-				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed && ButtonProperties[2].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[2].Command]));
-					if (ButtonProperties[2].Repeats)
-					{
-						ButtonProperties[2].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[2].Timer = repeatDelay;
-						ButtonProperties[2].Repeats = true;
-					}
-				}
-				// B button
-				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed && ButtonProperties[3].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[3].Command]));
-					if (ButtonProperties[3].Repeats)
-					{
-						ButtonProperties[3].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[3].Timer = repeatDelay;
-						ButtonProperties[3].Repeats = true;
-					}
-				}
-				// C button
-				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed && ButtonProperties[4].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
-					if (ButtonProperties[4].Repeats)
-					{
-						ButtonProperties[4].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[4].Timer = repeatDelay;
-						ButtonProperties[4].Repeats = true;
-					}
-				}
-				// D button
-				if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed && ButtonProperties[5].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[5].Command]));
-					if (ButtonProperties[5].Repeats)
-					{
-						ButtonProperties[5].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[5].Timer = repeatDelay;
-						ButtonProperties[5].Repeats = true;
-					}
-				}
-				// Up button
-				if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed && ButtonProperties[6].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[6].Command]));
-					if (ButtonProperties[6].Repeats)
-					{
-						ButtonProperties[6].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[6].Timer = repeatDelay;
-						ButtonProperties[6].Repeats = true;
-					}
-				}
-				// Down button
-				if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed && ButtonProperties[7].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[7].Command]));
-					if (ButtonProperties[7].Repeats)
-					{
-						ButtonProperties[7].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[7].Timer = repeatDelay;
-						ButtonProperties[7].Repeats = true;
-					}
-				}
-				// Left button
-				if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed && ButtonProperties[8].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[8].Command]));
-					if (ButtonProperties[8].Repeats)
-					{
-						ButtonProperties[8].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[8].Timer = repeatDelay;
-						ButtonProperties[8].Repeats = true;
-					}
-				}
-				// Right button
-				if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed && ButtonProperties[9].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[9].Command]));
-					if (ButtonProperties[9].Repeats)
-					{
-						ButtonProperties[9].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[9].Timer = repeatDelay;
-						ButtonProperties[9].Repeats = true;
-					}
-				}
-				// Pedal
-				if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed && ButtonProperties[10].Timer <= 0)
-				{
-					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[10].Command]));
-					if (ButtonProperties[10].Repeats)
-					{
-						ButtonProperties[10].Timer = repeatInterval;
-					}
-					else
-					{
-						ButtonProperties[10].Timer = repeatDelay;
-						ButtonProperties[10].Repeats = true;
+						KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[i].Command]));
+						if (ButtonProperties[i].Repeats)
+						{
+							ButtonProperties[i].Timer = repeatInterval;
+						}
+						else
+						{
+							ButtonProperties[i].Timer = repeatDelay;
+							ButtonProperties[i].Repeats = true;
+						}
 					}
 				}
 			}
@@ -405,108 +272,24 @@ namespace DenshaDeGoInput
 		{
 			Translations.CurrentLanguageCode = data.CurrentLanguageCode;
 
-			if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+			// Button timers
+			for (int i = 0; i < ButtonProperties.Length; i++)
 			{
-				ButtonProperties[0].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[0].Timer = 0;
-				ButtonProperties[0].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[1].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[1].Timer = 0;
-				ButtonProperties[1].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[2].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[2].Timer = 0;
-				ButtonProperties[2].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[3].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[3].Timer = 0;
-				ButtonProperties[3].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[4].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[4].Timer = 0;
-				ButtonProperties[4].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[5].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[5].Timer = 0;
-				ButtonProperties[5].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[6].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[6].Timer = 0;
-				ButtonProperties[6].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[7].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[7].Timer = 0;
-				ButtonProperties[7].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[8].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[8].Timer = 0;
-				ButtonProperties[8].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[9].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[9].Timer = 0;
-				ButtonProperties[9].Repeats = false;
-			}
-			if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed)
-			{
-				ButtonProperties[10].Timer -= data.ElapsedTime.Milliseconds;
-			}
-			else
-			{
-				ButtonProperties[10].Timer = 0;
-				ButtonProperties[10].Repeats = false;
+				if (ButtonMap[i] == OpenTK.Input.ButtonState.Pressed)
+				{
+					ButtonProperties[i].Timer -= data.ElapsedTime.Milliseconds;
+				}
+				else
+				{
+					ButtonProperties[i].Timer = 0;
+					ButtonProperties[i].Repeats = false;
+				}
 			}
 		}
 
-		public void SetMaxNotch(int powerNotch, int brakeNotch) { }
+		public void SetMaxNotch(int powerNotch, int brakeNotch)
+		{
+		}
 
 		/// <summary>
 		/// A function notifying the plugin about the train's specifications.
@@ -984,7 +767,7 @@ namespace DenshaDeGoInput
 											}
 											break;
 									}
-								break;
+									break;
 							}
 						}
 					}

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -42,6 +42,7 @@ namespace DenshaDeGoInput
 		public InputControl[] Controls { get; private set; }
 
 		private static FileSystem FileSystem;
+		public static string currentLanguage;
 
 		private Config configForm;
 
@@ -68,12 +69,17 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// An array with the command indices configured for each brake notch.
 		/// </summary>
-		internal int[] brakeCommands = new int[10];
+		internal static int[] brakeCommands = new int[10];
 
 		/// <summary>
 		/// An array with the command indices configured for each power notch.
 		/// </summary>
-		internal int[] powerCommands = new int[6];
+		internal static int[] powerCommands = new int[6];
+
+		/// <summary>
+		/// An array with the command indices configured for each button.
+		/// </summary>
+		internal static int[] buttonCommands = new int[5];
 
 
 		/// <summary>
@@ -153,30 +159,84 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public void OnUpdateFrame()
 		{
+			// Brake handle
 			if (brakeHandleMoved)
 			{
 				KeyUp(this, new InputEventArgs(Controls[brakeCommands[(int)InputTranslator.BrakeNotch]]));
 				brakeHandleMoved = false;
 			}
+			// Power handle
 			if (powerHandleMoved)
 			{
-				KeyUp(this, new InputEventArgs(Controls[powerCommands[(int)InputTranslator.PowerNotch]]));
+				KeyUp(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 				powerHandleMoved = false;
+			}
+			// Select button
+			//if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Released)
+			//{
+				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[0]]));
+			//}
+			// Start button
+			if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Released)
+			{
+				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[1]]));
+			}
+			// A button
+			if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Released)
+			{
+				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[2]]));
+			}
+			// B button
+			if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Released)
+			{
+				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[3]]));
+			}
+			// C button
+			if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Released)
+			{
+				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[4]]));
 			}
 
 			InputTranslator.Update();
 
 			if (InputTranslator.IsControllerConnected)
 			{
+				// Brake handle
 				if (InputTranslator.BrakeNotch != InputTranslator.PreviousBrakeNotch || loading)
 				{
 					KeyDown(this, new InputEventArgs(Controls[brakeCommands[(int)InputTranslator.BrakeNotch]]));
 					brakeHandleMoved = true;
 				}
+				// Power handle
 				if (InputTranslator.PowerNotch != InputTranslator.PreviousPowerNotch || loading)
 				{
-					KeyDown(this, new InputEventArgs(Controls[powerCommands[(int)InputTranslator.PowerNotch]]));
+					KeyDown(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 					powerHandleMoved = true;
+				}
+				// Select button
+				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[0]]));
+				}
+				// Start button
+				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[1]]));
+				}
+				// A button
+				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[2]]));
+				}
+				// B button
+				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[3]]));
+				}
+				// C button
+				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[4]]));
 				}
 			}
 
@@ -187,7 +247,10 @@ namespace DenshaDeGoInput
 		/// A function notifying the plugin about the train's existing status.
 		/// </summary>
 		/// <param name="data">Data</param>
-		public void SetElapseData(ElapseData data) { }
+		public void SetElapseData(ElapseData data)
+		{
+			currentLanguage = data.CurrentLanguageCode;
+		}
 
 		public void SetMaxNotch(int powerNotch, int brakeNotch) { }
 
@@ -229,7 +292,7 @@ namespace DenshaDeGoInput
 				// Power notches
 				for (int i = 0; i < 6; i++)
 				{
-					powerCommands[i] = 50 + i;
+					powerCommands[i] = i;
 				}
 			}
 			else
@@ -284,18 +347,18 @@ namespace DenshaDeGoInput
 				double powerStep = vehicleSpecs.PowerNotches / 5.0;
 				for (int i = 0; i < 6; i++)
 				{
-					powerCommands[i] = 50 + (int)Math.Round(powerStep * i, MidpointRounding.AwayFromZero);
-					if (i > 0 && powerCommands[i] == 50)
+					powerCommands[i] = (int)Math.Round(powerStep * i, MidpointRounding.AwayFromZero);
+					if (i > 0 && powerCommands[i] == 0)
 					{
-						powerCommands[i] = 51;
+						powerCommands[i] = 1;
 					}
 					if (keepMaxMin && i == 1)
 					{
-						powerCommands[i] = 51;
+						powerCommands[i] = 1;
 					}
 					if (keepMaxMin && i == 5)
 					{
-						powerCommands[i] = 50 + vehicleSpecs.PowerNotches;
+						powerCommands[i] = vehicleSpecs.PowerNotches;
 					}
 				}
 			}
@@ -355,6 +418,11 @@ namespace DenshaDeGoInput
 												}
 											}
 											break;
+									}
+									break;
+								case "handles":
+									switch (Key)
+									{
 										case "convert_notches":
 											convertNotches = string.Compare(Value, "false", StringComparison.OrdinalIgnoreCase) != 0;
 											break;
@@ -363,6 +431,56 @@ namespace DenshaDeGoInput
 											break;
 										case "map_hold_brake":
 											mapHoldBrake = string.Compare(Value, "false", StringComparison.OrdinalIgnoreCase) != 0;
+											break;
+									}
+									break;
+								case "buttons":
+									switch (Key)
+									{
+										case "select":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													buttonCommands[0] = a;
+												}
+											}
+											break;
+										case "start":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													buttonCommands[1] = a;
+												}
+											}
+											break;
+										case "a":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													buttonCommands[2] = a;
+												}
+											}
+											break;
+										case "b":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													buttonCommands[3] = a;
+												}
+											}
+											break;
+										case "c":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													buttonCommands[4] = a;
+												}
+											}
 											break;
 									}
 									break;
@@ -514,9 +632,18 @@ namespace DenshaDeGoInput
 				Builder.AppendLine();
 				Builder.AppendLine("[general]");
 				Builder.AppendLine("controller = " + InputTranslator.activeControllerIndex.ToString(Culture));
+				Builder.AppendLine();
+				Builder.AppendLine("[handles]");
 				Builder.AppendLine("convert_notches = " + convertNotches.ToString(Culture).ToLower());
 				Builder.AppendLine("keep_max_min = " + keepMaxMin.ToString(Culture).ToLower());
 				Builder.AppendLine("map_hold_brake = " + mapHoldBrake.ToString(Culture).ToLower());
+				Builder.AppendLine();
+				Builder.AppendLine("[buttons]");
+				Builder.AppendLine("select = " + buttonCommands[0].ToString(Culture));
+				Builder.AppendLine("start = " + buttonCommands[1].ToString(Culture));
+				Builder.AppendLine("a = " + buttonCommands[2].ToString(Culture));
+				Builder.AppendLine("b = " + buttonCommands[3].ToString(Culture));
+				Builder.AppendLine("c = " + buttonCommands[4].ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[playstation]");
 				Builder.AppendLine("hat = " + PSController.UsesHat.ToString(Culture).ToLower());

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -88,7 +88,7 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// An array with the properties for each button.
 		/// </summary>
-		internal static ButtonProp[] ButtonProperties = new ButtonProp[6];
+		internal static ButtonProp[] ButtonProperties = new ButtonProp[11];
 
 
 		/// <summary>
@@ -115,7 +115,7 @@ namespace DenshaDeGoInput
 		/// Internval for repeating a button press.
 		/// </summary>
 		internal static int repeatInterval = 100;
-
+		
 		/// <summary>
 		/// A function call when the Config button is pressed.
 		/// </summary>
@@ -210,6 +210,16 @@ namespace DenshaDeGoInput
 			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
 			// D button
 			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[5].Command]));
+			// Up button
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[6].Command]));
+			// Down button
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[7].Command]));
+			// Left button
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[8].Command]));
+			// Right button
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[9].Command]));
+			// Pedal
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[10].Command]));
 
 			InputTranslator.Update();
 
@@ -312,6 +322,76 @@ namespace DenshaDeGoInput
 						ButtonProperties[5].Repeats = true;
 					}
 				}
+				// Up button
+				if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed && ButtonProperties[6].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[6].Command]));
+					if (ButtonProperties[6].Repeats)
+					{
+						ButtonProperties[6].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[6].Timer = repeatDelay;
+						ButtonProperties[6].Repeats = true;
+					}
+				}
+				// Down button
+				if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed && ButtonProperties[7].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[7].Command]));
+					if (ButtonProperties[7].Repeats)
+					{
+						ButtonProperties[7].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[7].Timer = repeatDelay;
+						ButtonProperties[7].Repeats = true;
+					}
+				}
+				// Left button
+				if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed && ButtonProperties[8].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[8].Command]));
+					if (ButtonProperties[8].Repeats)
+					{
+						ButtonProperties[8].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[8].Timer = repeatDelay;
+						ButtonProperties[8].Repeats = true;
+					}
+				}
+				// Right button
+				if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed && ButtonProperties[9].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[9].Command]));
+					if (ButtonProperties[9].Repeats)
+					{
+						ButtonProperties[9].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[9].Timer = repeatDelay;
+						ButtonProperties[9].Repeats = true;
+					}
+				}
+				// Pedal
+				if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed && ButtonProperties[10].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[10].Command]));
+					if (ButtonProperties[10].Repeats)
+					{
+						ButtonProperties[10].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[10].Timer = repeatDelay;
+						ButtonProperties[10].Repeats = true;
+					}
+				}
 			}
 
 			loading = false;
@@ -378,6 +458,51 @@ namespace DenshaDeGoInput
 			{
 				ButtonProperties[5].Timer = 0;
 				ButtonProperties[5].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Up == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[6].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[6].Timer = 0;
+				ButtonProperties[6].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Down == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[7].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[7].Timer = 0;
+				ButtonProperties[7].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Left == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[8].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[8].Timer = 0;
+				ButtonProperties[8].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Right == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[9].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[9].Timer = 0;
+				ButtonProperties[9].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Pedal == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[10].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[10].Timer = 0;
+				ButtonProperties[10].Repeats = false;
 			}
 		}
 
@@ -622,6 +747,51 @@ namespace DenshaDeGoInput
 												}
 											}
 											break;
+										case "up":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[6].Command = a;
+												}
+											}
+											break;
+										case "down":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[7].Command = a;
+												}
+											}
+											break;
+										case "left":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[8].Command = a;
+												}
+											}
+											break;
+										case "right":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[9].Command = a;
+												}
+											}
+											break;
+										case "pedal":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[10].Command = a;
+												}
+											}
+											break;
 									}
 									break;
 								case "classic":
@@ -847,6 +1017,11 @@ namespace DenshaDeGoInput
 				Builder.AppendLine("b = " + ButtonProperties[3].Command.ToString(Culture));
 				Builder.AppendLine("c = " + ButtonProperties[4].Command.ToString(Culture));
 				Builder.AppendLine("d = " + ButtonProperties[5].Command.ToString(Culture));
+				Builder.AppendLine("up = " + ButtonProperties[6].Command.ToString(Culture));
+				Builder.AppendLine("down = " + ButtonProperties[7].Command.ToString(Culture));
+				Builder.AppendLine("left = " + ButtonProperties[8].Command.ToString(Culture));
+				Builder.AppendLine("right = " + ButtonProperties[9].Command.ToString(Culture));
+				Builder.AppendLine("pedal = " + ButtonProperties[10].Command.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[classic]");
 				Builder.AppendLine("hat = " + ControllerClassic.usesHat.ToString(Culture).ToLower());

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -41,8 +41,7 @@ namespace DenshaDeGoInput
 
 		public InputControl[] Controls { get; private set; }
 
-		private static FileSystem FileSystem;
-		public static string currentLanguage;
+		internal static FileSystem FileSystem;
 
 		private Config configForm;
 
@@ -77,9 +76,19 @@ namespace DenshaDeGoInput
 		internal static int[] powerCommands = new int[6];
 
 		/// <summary>
-		/// An array with the command indices configured for each button.
+		/// Class for the properties of the buttons.
 		/// </summary>
-		internal static int[] buttonCommands = new int[5];
+		internal class ButtonProp
+		{
+			internal int Command;
+			internal double Timer;
+			internal bool Repeats;
+		}
+
+		/// <summary>
+		/// An array with the properties for each button.
+		/// </summary>
+		internal static ButtonProp[] ButtonProperties = new ButtonProp[5];
 
 
 		/// <summary>
@@ -98,6 +107,16 @@ namespace DenshaDeGoInput
 		internal static bool mapHoldBrake;
 
 		/// <summary>
+		/// Initial delay when repeating a button press.
+		/// </summary>
+		internal static int repeatDelay = 500;
+
+		/// <summary>
+		/// Internval for repeating a button press.
+		/// </summary>
+		internal static int repeatInterval = 100;
+
+		/// <summary>
 		/// A function call when the Config button is pressed.
 		/// </summary>
 		/// <param name="owner">The owner of the window</param>
@@ -113,11 +132,19 @@ namespace DenshaDeGoInput
 		/// <returns>Whether the plugin has been loaded successfully.</returns>
 		public bool Load(FileSystem fileSystem)
 		{
-			configForm = new Config();
 			FileSystem = fileSystem;
+
+			// Initialize the array of button properties
+			for (int i = 0; i < ButtonProperties.Length; i++)
+			{
+				ButtonProperties[i] = new ButtonProp();
+			}
 
 			// Load settings from the config file
 			LoadConfig();
+
+			// Create the config form
+			configForm = new Config();
 
 			// Define the list of commands
 			// We allocate 50 slots per handle plus one slot per command
@@ -172,30 +199,15 @@ namespace DenshaDeGoInput
 				powerHandleMoved = false;
 			}
 			// Select button
-			//if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Released)
-			//{
-				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[0]]));
-			//}
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[0].Command]));
 			// Start button
-			if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Released)
-			{
-				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[1]]));
-			}
+            KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[1].Command]));
 			// A button
-			if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Released)
-			{
-				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[2]]));
-			}
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[2].Command]));
 			// B button
-			if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Released)
-			{
-				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[3]]));
-			}
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[3].Command]));
 			// C button
-			if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Released)
-			{
-				KeyUp(this, new InputEventArgs(Controls[100 + buttonCommands[4]]));
-			}
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
 
 			InputTranslator.Update();
 
@@ -213,30 +225,76 @@ namespace DenshaDeGoInput
 					KeyDown(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 					powerHandleMoved = true;
 				}
+
 				// Select button
-				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed && ButtonProperties[0].Timer <= 0)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[0]]));
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[0].Command]));
+					if (ButtonProperties[0].Repeats)
+					{
+						ButtonProperties[0].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[0].Timer = repeatDelay;
+						ButtonProperties[0].Repeats = true;
+					}
 				}
 				// Start button
-				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed && ButtonProperties[1].Timer <= 0)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[1]]));
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[1].Command]));
+					if (ButtonProperties[1].Repeats)
+					{
+						ButtonProperties[1].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[1].Timer = repeatDelay;
+						ButtonProperties[1].Repeats = true;
+					}
 				}
 				// A button
-				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed && ButtonProperties[2].Timer <= 0)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[2]]));
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[2].Command]));
+					if (ButtonProperties[2].Repeats)
+					{
+						ButtonProperties[2].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[2].Timer = repeatDelay;
+						ButtonProperties[2].Repeats = true;
+					}
 				}
 				// B button
-				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed && ButtonProperties[3].Timer <= 0)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[3]]));
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[3].Command]));
+					if (ButtonProperties[3].Repeats)
+					{
+						ButtonProperties[3].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[3].Timer = repeatDelay;
+						ButtonProperties[3].Repeats = true;
+					}
 				}
 				// C button
-				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
+				if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed && ButtonProperties[4].Timer <= 0)
 				{
-					KeyDown(this, new InputEventArgs(Controls[100 + buttonCommands[4]]));
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
+					if (ButtonProperties[4].Repeats)
+					{
+						ButtonProperties[4].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[4].Timer = repeatDelay;
+						ButtonProperties[4].Repeats = true;
+					}
 				}
 			}
 
@@ -249,7 +307,53 @@ namespace DenshaDeGoInput
 		/// <param name="data">Data</param>
 		public void SetElapseData(ElapseData data)
 		{
-			currentLanguage = data.CurrentLanguageCode;
+			Translations.CurrentLanguageCode = data.CurrentLanguageCode;
+
+			if (InputTranslator.ControllerButtons.Select == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[0].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[0].Timer = 0;
+				ButtonProperties[0].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.Start == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[1].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[1].Timer = 0;
+				ButtonProperties[1].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.A == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[2].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[2].Timer = 0;
+				ButtonProperties[2].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.B == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[3].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[3].Timer = 0;
+				ButtonProperties[3].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.C == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[4].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[4].Timer = 0;
+				ButtonProperties[4].Repeats = false;
+			}
 		}
 
 		public void SetMaxNotch(int powerNotch, int brakeNotch) { }
@@ -375,6 +479,7 @@ namespace DenshaDeGoInput
 			{
 				System.IO.Directory.CreateDirectory(optionsFolder);
 			}
+			// Plugin options
 			string configFile = OpenBveApi.Path.CombineFile(optionsFolder, "options_denshadego.cfg");
 			if (System.IO.File.Exists(configFile))
 			{
@@ -443,7 +548,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													buttonCommands[0] = a;
+													ButtonProperties[0].Command = a;
 												}
 											}
 											break;
@@ -452,7 +557,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													buttonCommands[1] = a;
+													ButtonProperties[1].Command = a;
 												}
 											}
 											break;
@@ -461,7 +566,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													buttonCommands[2] = a;
+													ButtonProperties[2].Command = a;
 												}
 											}
 											break;
@@ -470,7 +575,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													buttonCommands[3] = a;
+													ButtonProperties[3].Command = a;
 												}
 											}
 											break;
@@ -479,7 +584,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													buttonCommands[4] = a;
+													ButtonProperties[4].Command = a;
 												}
 											}
 											break;
@@ -615,6 +720,68 @@ namespace DenshaDeGoInput
 					}
 				}
 			}
+
+			// General OpenBVE options
+			string openbveConfigFile = OpenBveApi.Path.CombineFile(optionsFolder, "options.cfg");
+			if (System.IO.File.Exists(openbveConfigFile))
+			{
+				// load options
+				string[] Lines = System.IO.File.ReadAllLines(openbveConfigFile, new System.Text.UTF8Encoding());
+				string Section = "";
+				for (int i = 0; i < Lines.Length; i++)
+				{
+					Lines[i] = Lines[i].Trim(new char[] { });
+					if (Lines[i].Length != 0 && !Lines[i].StartsWith(";", StringComparison.OrdinalIgnoreCase))
+					{
+						if (Lines[i].StartsWith("[", StringComparison.Ordinal) &
+							Lines[i].EndsWith("]", StringComparison.Ordinal))
+						{
+							Section = Lines[i].Substring(1, Lines[i].Length - 2).Trim(new char[] { }).ToLowerInvariant();
+						}
+						else
+						{
+							int j = Lines[i].IndexOf("=", StringComparison.OrdinalIgnoreCase);
+							string Key, Value;
+							if (j >= 0)
+							{
+								Key = Lines[i].Substring(0, j).TrimEnd().ToLowerInvariant();
+								Value = Lines[i].Substring(j + 1).TrimStart(new char[] { });
+							}
+							else
+							{
+								Key = "";
+								Value = Lines[i];
+							}
+							switch (Section)
+							{
+								case "controls":
+									switch (Key)
+									{
+										case "keyrepeatdelay":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													repeatDelay = a;
+												}
+											}
+											break;
+										case "keyrepeatinterval":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													repeatInterval = a;
+												}
+											}
+											break;
+									}
+								break;
+							}
+						}
+					}
+				}
+			}
 		}
 
 		/// <summary>
@@ -640,11 +807,11 @@ namespace DenshaDeGoInput
 				Builder.AppendLine("map_hold_brake = " + mapHoldBrake.ToString(Culture).ToLower());
 				Builder.AppendLine();
 				Builder.AppendLine("[buttons]");
-				Builder.AppendLine("select = " + buttonCommands[0].ToString(Culture));
-				Builder.AppendLine("start = " + buttonCommands[1].ToString(Culture));
-				Builder.AppendLine("a = " + buttonCommands[2].ToString(Culture));
-				Builder.AppendLine("b = " + buttonCommands[3].ToString(Culture));
-				Builder.AppendLine("c = " + buttonCommands[4].ToString(Culture));
+				Builder.AppendLine("select = " + ButtonProperties[0].Command.ToString(Culture));
+				Builder.AppendLine("start = " + ButtonProperties[1].Command.ToString(Culture));
+				Builder.AppendLine("a = " + ButtonProperties[2].Command.ToString(Culture));
+				Builder.AppendLine("b = " + ButtonProperties[3].Command.ToString(Culture));
+				Builder.AppendLine("c = " + ButtonProperties[4].Command.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[playstation]");
 				Builder.AppendLine("hat = " + PSController.UsesHat.ToString(Culture).ToLower());

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -88,7 +88,7 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// An array with the properties for each button.
 		/// </summary>
-		internal static ButtonProp[] ButtonProperties = new ButtonProp[5];
+		internal static ButtonProp[] ButtonProperties = new ButtonProp[6];
 
 
 		/// <summary>
@@ -208,6 +208,8 @@ namespace DenshaDeGoInput
 			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[3].Command]));
 			// C button
 			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[4].Command]));
+			// D button
+			KeyUp(this, new InputEventArgs(Controls[100 + ButtonProperties[5].Command]));
 
 			InputTranslator.Update();
 
@@ -296,6 +298,20 @@ namespace DenshaDeGoInput
 						ButtonProperties[4].Repeats = true;
 					}
 				}
+				// D button
+				if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed && ButtonProperties[5].Timer <= 0)
+				{
+					KeyDown(this, new InputEventArgs(Controls[100 + ButtonProperties[5].Command]));
+					if (ButtonProperties[5].Repeats)
+					{
+						ButtonProperties[5].Timer = repeatInterval;
+					}
+					else
+					{
+						ButtonProperties[5].Timer = repeatDelay;
+						ButtonProperties[5].Repeats = true;
+					}
+				}
 			}
 
 			loading = false;
@@ -353,6 +369,15 @@ namespace DenshaDeGoInput
 			{
 				ButtonProperties[4].Timer = 0;
 				ButtonProperties[4].Repeats = false;
+			}
+			if (InputTranslator.ControllerButtons.D == OpenTK.Input.ButtonState.Pressed)
+			{
+				ButtonProperties[5].Timer -= data.ElapsedTime.Milliseconds;
+			}
+			else
+			{
+				ButtonProperties[5].Timer = 0;
+				ButtonProperties[5].Repeats = false;
 			}
 		}
 
@@ -588,92 +613,29 @@ namespace DenshaDeGoInput
 												}
 											}
 											break;
+										case "d":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ButtonProperties[5].Command = a;
+												}
+											}
+											break;
 									}
 									break;
-								case "playstation":
+								case "classic":
 									switch (Key)
 									{
 										case "hat":
-											PSController.UsesHat = string.Compare(Value, "false", StringComparison.OrdinalIgnoreCase) != 0;
+											ControllerClassic.usesHat = string.Compare(Value, "false", StringComparison.OrdinalIgnoreCase) != 0;
 											break;
 										case "hat_index":
 											{
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													PSController.hatIndex = a;
-												}
-											}
-											break;
-										case "cross":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.Cross = a;
-												}
-											}
-											break;
-										case "square":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.Square = a;
-												}
-											}
-											break;
-										case "triangle":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.Triangle = a;
-												}
-											}
-											break;
-										case "circle":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.Circle = a;
-												}
-											}
-											break;
-										case "l1":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.L1 = a;
-												}
-											}
-											break;
-										case "l2":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.L2 = a;
-												}
-											}
-											break;
-										case "r1":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.R1 = a;
-												}
-											}
-											break;
-										case "r2":
-											{
-												int a;
-												if (int.TryParse(Value, out a))
-												{
-													PSController.ButtonIndex.R2 = a;
+													ControllerClassic.hatIndex = a;
 												}
 											}
 											break;
@@ -682,7 +644,7 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													PSController.ButtonIndex.Select = a;
+													ControllerClassic.ButtonIndex.Select = a;
 												}
 											}
 											break;
@@ -691,25 +653,97 @@ namespace DenshaDeGoInput
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													PSController.ButtonIndex.Start = a;
+													ControllerClassic.ButtonIndex.Start = a;
 												}
 											}
 											break;
-										case "left":
+										case "a":
 											{
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													PSController.ButtonIndex.Left = a;
+													ControllerClassic.ButtonIndex.A = a;
 												}
 											}
 											break;
-										case "right":
+										case "b":
 											{
 												int a;
 												if (int.TryParse(Value, out a))
 												{
-													PSController.ButtonIndex.Right = a;
+													ControllerClassic.ButtonIndex.B = a;
+												}
+											}
+											break;
+										case "c":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.C = a;
+												}
+											}
+											break;
+										case "power1":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Power1 = a;
+												}
+											}
+											break;
+										case "power2":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Power2 = a;
+												}
+											}
+											break;
+										case "power3":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Power3 = a;
+												}
+											}
+											break;
+										case "brake1":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Brake1 = a;
+												}
+											}
+											break;
+										case "brake2":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Brake2 = a;
+												}
+											}
+											break;
+										case "brake3":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Brake3 = a;
+												}
+											}
+											break;
+										case "brake4":
+											{
+												int a;
+												if (int.TryParse(Value, out a))
+												{
+													ControllerClassic.ButtonIndex.Brake4 = a;
 												}
 											}
 											break;
@@ -812,22 +846,24 @@ namespace DenshaDeGoInput
 				Builder.AppendLine("a = " + ButtonProperties[2].Command.ToString(Culture));
 				Builder.AppendLine("b = " + ButtonProperties[3].Command.ToString(Culture));
 				Builder.AppendLine("c = " + ButtonProperties[4].Command.ToString(Culture));
+				Builder.AppendLine("d = " + ButtonProperties[5].Command.ToString(Culture));
 				Builder.AppendLine();
-				Builder.AppendLine("[playstation]");
-				Builder.AppendLine("hat = " + PSController.UsesHat.ToString(Culture).ToLower());
-				Builder.AppendLine("hat_index = " + PSController.hatIndex.ToString(Culture));
-				Builder.AppendLine("cross = " + PSController.ButtonIndex.Cross.ToString(Culture));
-				Builder.AppendLine("square = " + PSController.ButtonIndex.Square.ToString(Culture));
-				Builder.AppendLine("triangle = " + PSController.ButtonIndex.Triangle.ToString(Culture));
-				Builder.AppendLine("circle = " + PSController.ButtonIndex.Circle.ToString(Culture));
-				Builder.AppendLine("l1 = " + PSController.ButtonIndex.L1.ToString(Culture));
-				Builder.AppendLine("l2 = " + PSController.ButtonIndex.L2.ToString(Culture));
-				Builder.AppendLine("r1 = " + PSController.ButtonIndex.R1.ToString(Culture));
-				Builder.AppendLine("r2 = " + PSController.ButtonIndex.R2.ToString(Culture));
-				Builder.AppendLine("select = " + PSController.ButtonIndex.Select.ToString(Culture));
-				Builder.AppendLine("start = " + PSController.ButtonIndex.Start.ToString(Culture));
-				Builder.AppendLine("left = " + PSController.ButtonIndex.Left.ToString(Culture));
-				Builder.AppendLine("right = " + PSController.ButtonIndex.Right.ToString(Culture));
+				Builder.AppendLine("[classic]");
+				Builder.AppendLine("hat = " + ControllerClassic.usesHat.ToString(Culture).ToLower());
+				Builder.AppendLine("hat_index = " + ControllerClassic.hatIndex.ToString(Culture));
+				Builder.AppendLine("select = " + ControllerClassic.ButtonIndex.Select.ToString(Culture));
+				Builder.AppendLine("start = " + ControllerClassic.ButtonIndex.Start.ToString(Culture));
+				Builder.AppendLine("a = " + ControllerClassic.ButtonIndex.A.ToString(Culture));
+				Builder.AppendLine("b = " + ControllerClassic.ButtonIndex.B.ToString(Culture));
+				Builder.AppendLine("c = " + ControllerClassic.ButtonIndex.C.ToString(Culture));
+				Builder.AppendLine("power1 = " + ControllerClassic.ButtonIndex.Power1.ToString(Culture));
+				Builder.AppendLine("power2 = " + ControllerClassic.ButtonIndex.Power2.ToString(Culture));
+				Builder.AppendLine("power3 = " + ControllerClassic.ButtonIndex.Power3.ToString(Culture));
+				Builder.AppendLine("brake1 = " + ControllerClassic.ButtonIndex.Brake1.ToString(Culture));
+				Builder.AppendLine("brake2 = " + ControllerClassic.ButtonIndex.Brake2.ToString(Culture));
+				Builder.AppendLine("brake3 = " + ControllerClassic.ButtonIndex.Brake3.ToString(Culture));
+				Builder.AppendLine("brake4 = " + ControllerClassic.ButtonIndex.Brake4.ToString(Culture));
+
 				string optionsFolder = OpenBveApi.Path.CombineDirectory(FileSystem.SettingsFolder, "1.5.0");
 				string configFile = OpenBveApi.Path.CombineFile(optionsFolder, "options_denshadego.cfg");
 				System.IO.File.WriteAllText(configFile, Builder.ToString(), new System.Text.UTF8Encoding(true));

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
@@ -55,7 +55,8 @@
     <Compile Include="DenshaDeGoInput.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InputTranslator.cs" />
-    <Compile Include="PSController.cs" />
+    <Compile Include="ControllerClassic.cs" />
+    <Compile Include="ControllerUnbalance.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Config.resx">

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F6FBD153-9D9F-4D6C-B08D-0C798F106B32}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DenshaDeGoInput</RootNamespace>
+    <AssemblyName>DenshaDeGoInput</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin_debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin_release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="OpenTK">
+      <HintPath>..\..\..\packages\OpenTK.3.2\lib\net20\OpenTK.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Config.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Config.Designer.cs">
+      <DependentUpon>Config.cs</DependentUpon>
+    </Compile>
+    <Compile Include="DenshaDeGoInput.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="InputTranslator.cs" />
+    <Compile Include="PSController.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Config.resx">
+      <DependentUpon>Config.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenBveApi\OpenBveApi.csproj">
+      <Project>{27134980-4415-4375-a564-40a9014dfa5f}</Project>
+      <Name>OpenBveApi</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="OpenTK.dll.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <OutputFiles Include="$(TargetDir)$(TargetName).*" />
+    </ItemGroup>
+    <Move SourceFiles="@(OutputFiles)" DestinationFolder="$(TargetDir)Data\InputDevicePlugins\" />
+  </Target>
+</Project>

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="OpenTK">
-      <HintPath>..\..\..\packages\OpenTK.3.2\lib\net20\OpenTK.dll</HintPath>
+      <HintPath>..\..\..\packages\OpenTK.3.3.1\lib\net20\OpenTK.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,4 +1,4 @@
-﻿//Simplified BSD License (BSD-2-Clause)
+//Simplified BSD License (BSD-2-Clause)
 //
 //Copyright (c) 2020, Marc Riera, The OpenBVE Project
 //
@@ -46,36 +46,92 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Enumeration representing brake notches.
 		/// </summary>
+		[Flags]
 		internal enum BrakeNotches
 		{
-			Released = 0,
-			B1 = 1,
-			B2 = 2,
-			B3 = 3,
-			B4 = 4,
-			B5 = 5,
-			B6 = 6,
-			B7 = 7,
-			B8 = 8,
-			Emergency = 9,
+			// The controller has 4 physical buttons.
+			// These do *not* map directly to the simulation
+
+			/// <summary>No buttons are pressed on the controller</summary>
+			None = 0,
+			/// <summary>The Brake1 button is pressed</summary>
+			Brake1 = 1,
+			/// <summary>The Brake2 button is pressed</summary>
+			Brake2 = 2,
+			/// <summary>The Brake3 button is pressed</summary>
+			Brake3 = 4,
+			/// <summary>The Brake4 button is pressed</summary>
+			Brake4 = 8,
+
+			// Our returned notches to the simulation are a bitflag button combination
+
+			/// <summary>Brakes are released</summary>
+			Released = Brake2 | Brake3 | Brake4,
+			/// <summary>Brake Notch B1</summary>
+			B1 = Brake1 | Brake3 | Brake4,
+			/// <summary>Brake Notch B2</summary>
+			B2 = Brake3 | Brake4,
+			/// <summary>Brake Notch B3</summary>
+			B3 = Brake1 | Brake2 | Brake4,
+			/// <summary>Brake Notch B4</summary>
+			B4 = Brake2 | Brake4,
+			/// <summary>Brake Notch B5</summary>
+			B5 = Brake1 | Brake4,
+			/// <summary>Brake Notch B6</summary>
+			B6 = Brake4,
+			/// <summary>Brake Notch B7</summary>
+			B7 = Brake1 | Brake2 | Brake3,
+			/// <summary>Brake Notch B8</summary>
+			B8 = Brake2 | Brake3,
+			/// <summary>Emergency</summary>
+			Emergency = Brake1 | Brake2 | Brake3 | Brake4,
 		};
 
 		/// <summary>
 		/// Enumeration representing power notches.
 		/// </summary>
+		[Flags]
 		internal enum PowerNotches
 		{
-			N = 0,
-			P1 = 1,
-			P2 = 2,
-			P3 = 3,
-			P4 = 4,
-			P5 = 5,
+			// The controller has 3 physical buttons.
+			// These do *not* map directly to the simulation
+
+			/// <summary>No buttons are pressed on the controller</summary>
+			None = 0,
+			/// <summary>The Power1 button is pressed</summary>
+			Power1 = 1,
+			/// <summary>The Power2 button is pressed</summary>
+			Power2 = 2,
+			/// <summary>The Power3 button is pressed</summary>
+			Power3 = 4,
+			
+			// Our returned notches to the simulation are a bitflag button combination
+
+			/// <summary>Power is in N</summary>
+			N = Power2 | Power3,
+			/// <summary>Power notch P1</summary>
+			P1 = Power1 | Power3,
+			/// <summary>Power notch P2</summary>
+			P2 = Power3,
+			/// <summary>Power notch P3</summary>
+			P3 = Power1 | Power2,
+			/// <summary>Power notch P4</summary>
+			P4 = Power2,
+			/// <summary>Power notch P5</summary>
+			P5 = Power1,
 		};
 
-		/// <summary>
-		/// Class with the state of the buttons.
-		/// </summary>
+		[Flags]
+		internal enum ControllerFunctionButtons
+		{
+			None = 0,
+			Start = 1,
+			Select = 2,
+			A = 4,
+			B = 8,
+			C = 16
+		}
+
 		internal class ButtonState
 		{
 			internal OpenTK.Input.ButtonState Select;
@@ -213,7 +269,7 @@ namespace DenshaDeGoInput
 			switch (ControllerModel)
 			{
 				case ControllerModels.Classic:
-					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex));
+					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex), out PowerNotch, out BrakeNotch);
 					return;
 				case ControllerModels.Unbalance:
 					ControllerUnbalance.ReadInput(Joystick.GetState(activeControllerIndex));

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -13,7 +13,7 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal enum ControllerModels
 		{
-			None = 0,
+			Unsupported = 0,
 			PlayStation = 1,
 		};
 
@@ -99,13 +99,13 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Gets the controller model.
 		/// </summary>
-		internal static ControllerModels GetControllerModel(JoystickState state)
+		internal static ControllerModels GetControllerModel(JoystickState state, JoystickCapabilities capabilities)
 		{
-			if (PSController.IsPSController(state))
+			if (PSController.IsPSController(capabilities))
 			{
 				return ControllerModels.PlayStation;
 			}
-			return ControllerModels.None;
+			return ControllerModels.Unsupported;
 		}
 
 		/// <summary>
@@ -117,14 +117,13 @@ namespace DenshaDeGoInput
 			{
 				JoystickState state = Joystick.GetState(activeControllerIndex);
 				JoystickCapabilities capabilities = Joystick.GetCapabilities(activeControllerIndex);
+				ControllerModel = GetControllerModel(state, capabilities);
 				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
-				if (capabilities.ButtonCount > 0 && PSController.IsPSController(state))
+				if (capabilities.ButtonCount > 0 && ControllerModel != ControllerModels.Unsupported)
 				{
 					IsControllerConnected = true;
-					ControllerModel = ControllerModels.PlayStation;
 					return;
 				}
-				ControllerModel = ControllerModels.None;
 				activeControllerIndex = -1;
 			}
 			else

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,0 +1,223 @@
+﻿using System.Collections.Generic;
+using OpenTK.Input;
+
+namespace DenshaDeGoInput
+{
+	/// <summary>
+	/// The class which converts the input from the controller
+	/// </summary>
+	internal class InputTranslator
+	{
+		/// <summary>
+		/// Enumeration representing controller models.
+		/// </summary>
+		internal enum ControllerModels
+		{
+			None = 0,
+			PlayStation = 1,
+		};
+
+		/// <summary>
+		/// Enumeration representing brake notches.
+		/// </summary>
+		internal enum BrakeNotches
+		{
+			Released = 0,
+			B1 = 1,
+			B2 = 2,
+			B3 = 3,
+			B4 = 4,
+			B5 = 5,
+			B6 = 6,
+			B7 = 7,
+			B8 = 8,
+			Emergency = 9,
+		};
+
+		/// <summary>
+		/// Enumeration representing power notches.
+		/// </summary>
+		internal enum PowerNotches
+		{
+			N = 0,
+			P1 = 1,
+			P2 = 2,
+			P3 = 3,
+			P4 = 4,
+			P5 = 5,
+		};
+
+		/// <summary>
+		/// Class with the state of the buttons.
+		/// </summary>
+		internal class ButtonState
+		{
+			internal OpenTK.Input.ButtonState A;
+			internal OpenTK.Input.ButtonState B;
+			internal OpenTK.Input.ButtonState C;
+			internal OpenTK.Input.ButtonState Start;
+			internal OpenTK.Input.ButtonState Select;
+		}
+
+		/// <summary>
+		/// The index of the active controller, or -1 if not set.
+		/// </summary>
+		public static int activeControllerIndex = -1;
+
+		/// <summary>
+		/// Whether a supported controller is connected or not.
+		/// </summary>
+		internal static bool IsControllerConnected;
+
+		/// <summary>
+		/// The controller model.
+		/// </summary>
+		internal static ControllerModels ControllerModel;
+
+		/// <summary>
+		/// The current brake notch reported by the controller.
+		/// </summary>
+		internal static BrakeNotches BrakeNotch;
+
+		/// <summary>
+		/// The current power notch reported by the controller.
+		/// </summary>
+		internal static PowerNotches PowerNotch;
+
+		/// <summary>
+		/// The previous brake notch reported by the controller.
+		/// </summary>
+		internal static BrakeNotches PreviousBrakeNotch;
+
+		/// <summary>
+		/// The previous power notch reported by the controller.
+		/// </summary>
+		internal static PowerNotches PreviousPowerNotch;
+
+		internal static ButtonState ControllerButtons = new ButtonState();
+
+		/// <summary>
+		/// Gets the controller model.
+		/// </summary>
+		internal static ControllerModels GetControllerModel(JoystickState state)
+		{
+			if (PSController.IsPSController(state))
+			{
+				return ControllerModels.PlayStation;
+			}
+			return ControllerModels.None;
+		}
+
+		/// <summary>
+		/// Updates the status of the controller.
+		/// </summary>
+		public static void Update()
+		{
+			if (!IsControllerConnected)
+			{
+				JoystickState state = Joystick.GetState(activeControllerIndex);
+				JoystickCapabilities capabilities = Joystick.GetCapabilities(activeControllerIndex);
+				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
+				if (capabilities.ButtonCount > 0 && PSController.IsPSController(state))
+				{
+					IsControllerConnected = true;
+					ControllerModel = ControllerModels.PlayStation;
+					return;
+				}
+				ControllerModel = ControllerModels.None;
+				activeControllerIndex = -1;
+			}
+			else
+			{
+				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
+				if (Joystick.GetCapabilities(activeControllerIndex).ButtonCount == 0)
+				{
+					IsControllerConnected = false;
+					return;
+				}
+				GetInput();
+			}
+		}
+
+		/// <summary>
+		/// Gets the input from the controller.
+		/// </summary>
+		internal static void GetInput()
+		{
+			PreviousBrakeNotch = BrakeNotch;
+			PreviousPowerNotch = PowerNotch;
+
+			switch (ControllerModel)
+			{
+				case ControllerModels.PlayStation:
+					PSController.ReadButtons(Joystick.GetState(activeControllerIndex));
+					return;
+			}
+		}
+
+		/// <summary>
+		/// Gets the state of the buttons of the current controller
+		/// </summary>
+		/// <returns>State of the buttons of the current controller</returns>
+		internal static List<OpenTK.Input.ButtonState> GetButtonsState()
+		{
+			List<OpenTK.Input.ButtonState> buttonsState = new List<OpenTK.Input.ButtonState>();
+
+			if (IsControllerConnected)
+			{
+				for (int i = 0; i < Joystick.GetCapabilities(activeControllerIndex).ButtonCount; i++)
+				{
+					buttonsState.Add(Joystick.GetState(activeControllerIndex).GetButton(i));
+				}
+			}
+			return buttonsState;
+		}
+
+		/// <summary>
+		/// Gets the position of the hats of the current controller
+		/// </summary>
+		/// <returns>Position of the hats of the current controller</returns>
+		internal static List<HatPosition> GetHatPositions()
+		{
+			List<HatPosition> hatPositions = new List<HatPosition>();
+
+			if (IsControllerConnected)
+			{
+				for (int i = 0; i < Joystick.GetCapabilities(activeControllerIndex).ButtonCount; i++)
+				{
+					hatPositions.Add(Joystick.GetState(activeControllerIndex).GetHat((JoystickHat)i).Position);
+				}
+			}
+			return hatPositions;
+		}
+
+		/// <summary>
+		/// Compares two button states to find the index of the button that has been pressed.
+		/// </summary>
+		/// <returns>Index of the button that has been pressed.</returns>
+		internal static int GetDifferentPressedIndex(List<OpenTK.Input.ButtonState> previousState, List<OpenTK.Input.ButtonState> newState, List<int> ignored)
+		{
+			for (int i = 0; i < newState.Count; i++)
+			{
+				if (!ignored.Contains(i) && newState[i] != previousState[i])
+					return i;
+			}
+			return -1;
+		}
+
+		/// <summary>
+		/// Compares two hat states to find the index of the hat that has changed.
+		/// </summary>
+		/// <returns>Index of the hat that has changed.</returns>
+		internal static int GetChangedHat(List<HatPosition> previousPosition, List<HatPosition> newPosition)
+		{
+			for (int i = 0; i < newPosition.Count; i++)
+			{
+				if (newPosition[i] != previousPosition[i])
+					return i;
+			}
+			return -1;
+		}
+
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,4 +1,28 @@
-﻿using System.Collections.Generic;
+﻿//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System.Collections.Generic;
 using OpenTK.Input;
 
 namespace DenshaDeGoInput

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -89,25 +89,44 @@ namespace DenshaDeGoInput
 			P5 = 5,
 		};
 
-		internal class ButtonState
+		/// <summary>
+		/// Enumeration representing controller buttons.
+		/// </summary>
+		internal enum ControllerButton
 		{
-			internal OpenTK.Input.ButtonState Select;
-			internal OpenTK.Input.ButtonState Start;
-			internal OpenTK.Input.ButtonState A;
-			internal OpenTK.Input.ButtonState B;
-			internal OpenTK.Input.ButtonState C;
-			internal OpenTK.Input.ButtonState D;
-			internal OpenTK.Input.ButtonState Up;
-			internal OpenTK.Input.ButtonState Down;
-			internal OpenTK.Input.ButtonState Left;
-			internal OpenTK.Input.ButtonState Right;
-			internal OpenTK.Input.ButtonState Pedal;
+			/// <summary>Select button</summary>
+			Select = 0,
+			/// <summary>Start button</summary>
+			Start = 1,
+			/// <summary>A button</summary>
+			A = 2,
+			/// <summary>B button</summary>
+			B = 3,
+			/// <summary>C button</summary>
+			C = 4,
+			/// <summary>D button</summary>
+			D = 5,
+			/// <summary>Up button</summary>
+			Up = 6,
+			/// <summary>Down button</summary>
+			Down = 7,
+			/// <summary>Left button</summary>
+			Left = 8,
+			/// <summary>Right button</summary>
+			Right = 9,
+			/// <summary>Pedal button</summary>
+			Pedal = 10,
 		}
+
+		/// <summary>
+		/// An array with the state of the controller's buttons.
+		/// </summary>
+		internal static ButtonState[] ControllerButtons = new ButtonState[11];
 
 		/// <summary>
 		/// The index of the active controller, or -1 if not set.
 		/// </summary>
-		public static int activeControllerIndex = -1;
+		internal static int activeControllerIndex = -1;
 
 		/// <summary>
 		/// Whether a supported controller is connected or not.
@@ -138,11 +157,6 @@ namespace DenshaDeGoInput
 		/// The previous power notch reported by the controller.
 		/// </summary>
 		internal static PowerNotches PreviousPowerNotch;
-
-		/// <summary>
-		/// The state of the controller's buttons.
-		/// </summary>
-		internal static ButtonState ControllerButtons = new ButtonState();
 
 		/// <summary>
 		/// Gets the controller model.
@@ -190,9 +204,7 @@ namespace DenshaDeGoInput
 				// The controller is apparently not connected; try to connect to it
 				ControllerModel = GetControllerModel(activeControllerIndex);
 
-				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
-				JoystickCapabilities capabilities = Joystick.GetCapabilities(activeControllerIndex);
-				if (capabilities.ButtonCount > 0 && ControllerModel != ControllerModels.Unsupported)
+				if (Joystick.GetState(activeControllerIndex).IsConnected && ControllerModel != ControllerModels.Unsupported)
 				{
 					// The controller is valid and can be used
 					IsControllerConnected = true;
@@ -201,8 +213,7 @@ namespace DenshaDeGoInput
 			}
 			else
 			{
-				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
-				if (Joystick.GetCapabilities(activeControllerIndex).ButtonCount == 0)
+				if (!Joystick.GetState(activeControllerIndex).IsConnected)
 				{
 					// The controller is apparently not connected
 					IsControllerConnected = false;

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -134,6 +134,7 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Gets the controller model.
 		/// </summary>
+		/// <param name="index">The index of the joystick.</param>
 		internal static ControllerModels GetControllerModel(int index)
 		{
 			JoystickCapabilities capabilities = Joystick.GetCapabilities(index);
@@ -154,8 +155,10 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Gets a string representing the vendor and product ID.
+		/// Gets a string representing a controller's vendor and product ID.
 		/// </summary>
+		/// <param name="index">The index of the joystick.</param>
+		/// <returns>String representing the controller's vendor and product ID.</returns>
 		internal static string GetControllerID(int index)
 		{
 			string guid = Joystick.GetGuid(index).ToString("N");
@@ -257,6 +260,9 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Compares two button states to find the index of the button that has been pressed.
 		/// </summary>
+		/// <param name="previousState">The previous state of the buttons.</param>
+		/// <param name="newState">The new state of the buttons.</param>
+		/// <param name="ignored">The list of ignored buttons.</param>
 		/// <returns>Index of the button that has been pressed.</returns>
 		internal static int GetDifferentPressedIndex(List<OpenTK.Input.ButtonState> previousState, List<OpenTK.Input.ButtonState> newState, List<int> ignored)
 		{
@@ -271,6 +277,8 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Compares two hat states to find the index of the hat that has changed.
 		/// </summary>
+		/// <param name="previousPosition">The previous position of the hat.</param>
+		/// <param name="newPosition">The new position of the hat.</param>
 		/// <returns>Index of the hat that has changed.</returns>
 		internal static int GetChangedHat(List<HatPosition> previousPosition, List<HatPosition> newPosition)
 		{

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -30,7 +30,7 @@ namespace DenshaDeGoInput
 	/// <summary>
 	/// Class which holds generic controller input.
 	/// </summary>
-	internal class InputTranslator
+	internal static class InputTranslator
 	{
 		/// <summary>
 		/// Enumeration representing controller models.
@@ -38,7 +38,8 @@ namespace DenshaDeGoInput
 		internal enum ControllerModels
 		{
 			Unsupported = 0,
-			PlayStation = 1,
+			Classic = 1,
+			Unbalance = 2,
 		};
 
 		/// <summary>
@@ -76,11 +77,16 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal class ButtonState
 		{
+			internal OpenTK.Input.ButtonState Select;
+			internal OpenTK.Input.ButtonState Start;
 			internal OpenTK.Input.ButtonState A;
 			internal OpenTK.Input.ButtonState B;
 			internal OpenTK.Input.ButtonState C;
-			internal OpenTK.Input.ButtonState Start;
-			internal OpenTK.Input.ButtonState Select;
+			internal OpenTK.Input.ButtonState D;
+			internal OpenTK.Input.ButtonState Up;
+			internal OpenTK.Input.ButtonState Down;
+			internal OpenTK.Input.ButtonState Left;
+			internal OpenTK.Input.ButtonState Right;
 		}
 
 		/// <summary>
@@ -128,9 +134,13 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static ControllerModels GetControllerModel(JoystickState state, JoystickCapabilities capabilities)
 		{
-			if (PSController.IsPSController(capabilities))
+			if (ControllerUnbalance.IsCompatibleController(capabilities))
 			{
-				return ControllerModels.PlayStation;
+				return ControllerModels.Unbalance;
+			}
+			if (ControllerClassic.IsCompatibleController(capabilities))
+			{
+				return ControllerModels.Classic;
 			}
 			return ControllerModels.Unsupported;
 		}
@@ -182,8 +192,11 @@ namespace DenshaDeGoInput
 			// Read the input from the controller according to the type
 			switch (ControllerModel)
 			{
-				case ControllerModels.PlayStation:
-					PSController.ReadButtons(Joystick.GetState(activeControllerIndex));
+				case ControllerModels.Classic:
+					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex));
+					return;
+				case ControllerModels.Unbalance:
+					ControllerUnbalance.ReadInput(Joystick.GetState(activeControllerIndex));
 					return;
 			}
 		}

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -46,91 +46,48 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Enumeration representing brake notches.
 		/// </summary>
-		[Flags]
 		internal enum BrakeNotches
 		{
-			// The controller has 4 physical buttons.
-			// These do *not* map directly to the simulation
-
-			/// <summary>No buttons are pressed on the controller</summary>
-			None = 0,
-			/// <summary>The Brake1 button is pressed</summary>
-			Brake1 = 1,
-			/// <summary>The Brake2 button is pressed</summary>
-			Brake2 = 2,
-			/// <summary>The Brake3 button is pressed</summary>
-			Brake3 = 4,
-			/// <summary>The Brake4 button is pressed</summary>
-			Brake4 = 8,
-
-			// Our returned notches to the simulation are a bitflag button combination
-
 			/// <summary>Brakes are released</summary>
-			Released = Brake2 | Brake3 | Brake4,
+			Released = 0,
 			/// <summary>Brake Notch B1</summary>
-			B1 = Brake1 | Brake3 | Brake4,
+			B1 = 1,
 			/// <summary>Brake Notch B2</summary>
-			B2 = Brake3 | Brake4,
+			B2 = 2,
 			/// <summary>Brake Notch B3</summary>
-			B3 = Brake1 | Brake2 | Brake4,
+			B3 = 3,
 			/// <summary>Brake Notch B4</summary>
-			B4 = Brake2 | Brake4,
+			B4 = 4,
 			/// <summary>Brake Notch B5</summary>
-			B5 = Brake1 | Brake4,
+			B5 = 5,
 			/// <summary>Brake Notch B6</summary>
-			B6 = Brake4,
+			B6 = 6,
 			/// <summary>Brake Notch B7</summary>
-			B7 = Brake1 | Brake2 | Brake3,
+			B7 = 7,
 			/// <summary>Brake Notch B8</summary>
-			B8 = Brake2 | Brake3,
+			B8 = 8,
 			/// <summary>Emergency</summary>
-			Emergency = Brake1 | Brake2 | Brake3 | Brake4,
+			Emergency = 9,
 		};
 
 		/// <summary>
 		/// Enumeration representing power notches.
 		/// </summary>
-		[Flags]
 		internal enum PowerNotches
 		{
-			// The controller has 3 physical buttons.
-			// These do *not* map directly to the simulation
-
-			/// <summary>No buttons are pressed on the controller</summary>
-			None = 0,
-			/// <summary>The Power1 button is pressed</summary>
-			Power1 = 1,
-			/// <summary>The Power2 button is pressed</summary>
-			Power2 = 2,
-			/// <summary>The Power3 button is pressed</summary>
-			Power3 = 4,
-			
-			// Our returned notches to the simulation are a bitflag button combination
-
 			/// <summary>Power is in N</summary>
-			N = Power2 | Power3,
+			N = 0,
 			/// <summary>Power notch P1</summary>
-			P1 = Power1 | Power3,
+			P1 = 1,
 			/// <summary>Power notch P2</summary>
-			P2 = Power3,
+			P2 = 2,
 			/// <summary>Power notch P3</summary>
-			P3 = Power1 | Power2,
+			P3 = 3,
 			/// <summary>Power notch P4</summary>
-			P4 = Power2,
+			P4 = 4,
 			/// <summary>Power notch P5</summary>
-			P5 = Power1,
+			P5 = 5,
 		};
-
-		[Flags]
-		internal enum ControllerFunctionButtons
-		{
-			None = 0,
-			Start = 1,
-			Select = 2,
-			A = 4,
-			B = 8,
-			C = 16
-		}
 
 		internal class ButtonState
 		{
@@ -269,7 +226,7 @@ namespace DenshaDeGoInput
 			switch (ControllerModel)
 			{
 				case ControllerModels.Classic:
-					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex), out PowerNotch, out BrakeNotch);
+					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex));
 					return;
 				case ControllerModels.Unbalance:
 					ControllerUnbalance.ReadInput(Joystick.GetState(activeControllerIndex));

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -28,7 +28,7 @@ using OpenTK.Input;
 namespace DenshaDeGoInput
 {
 	/// <summary>
-	/// The class which converts the input from the controller
+	/// Class which holds generic controller input.
 	/// </summary>
 	internal class InputTranslator
 	{
@@ -118,6 +118,9 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static PowerNotches PreviousPowerNotch;
 
+		/// <summary>
+		/// The state of the controller's buttons.
+		/// </summary>
 		internal static ButtonState ControllerButtons = new ButtonState();
 
 		/// <summary>
@@ -139,15 +142,19 @@ namespace DenshaDeGoInput
 		{
 			if (!IsControllerConnected)
 			{
+				// The controller is apparently not connected; try to connect to it
 				JoystickState state = Joystick.GetState(activeControllerIndex);
 				JoystickCapabilities capabilities = Joystick.GetCapabilities(activeControllerIndex);
 				ControllerModel = GetControllerModel(state, capabilities);
+
 				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
 				if (capabilities.ButtonCount > 0 && ControllerModel != ControllerModels.Unsupported)
 				{
+					// The controller is valid and can be used
 					IsControllerConnected = true;
 					return;
 				}
+				// The controller is not valid; temporarily discard input from the device
 				activeControllerIndex = -1;
 			}
 			else
@@ -155,6 +162,7 @@ namespace DenshaDeGoInput
 				// HACK: IsConnected seems to be broken on Mono, so we use the button count instead
 				if (Joystick.GetCapabilities(activeControllerIndex).ButtonCount == 0)
 				{
+					// The controller is apparently not connected
 					IsControllerConnected = false;
 					return;
 				}
@@ -167,9 +175,11 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static void GetInput()
 		{
+			// Store the current notches so we can later tell if they have been moved
 			PreviousBrakeNotch = BrakeNotch;
 			PreviousPowerNotch = PowerNotch;
 
+			// Read the input from the controller according to the type
 			switch (ControllerModel)
 			{
 				case ControllerModels.PlayStation:

--- a/source/InputDevicePlugins/DenshaDeGoInput/OpenTK.dll.config
+++ b/source/InputDevicePlugins/DenshaDeGoInput/OpenTK.dll.config
@@ -1,0 +1,25 @@
+<configuration>
+  <dllmap os="linux" dll="opengl32.dll" target="libGL.so.1"/>
+  <dllmap os="linux" dll="glu32.dll" target="libGLU.so.1"/>
+  <dllmap os="linux" dll="openal32.dll" target="libopenal.so.1"/>
+  <dllmap os="linux" dll="alut.dll" target="libalut.so.0"/>
+  <dllmap os="linux" dll="opencl.dll" target="libOpenCL.so"/>
+  <dllmap os="linux" dll="libX11" target="libX11.so.6"/>
+  <dllmap os="linux" dll="libXi" target="libXi.so.6"/>
+  <dllmap os="linux" dll="SDL2.dll" target="libSDL2-2.0.so.0"/>
+  <dllmap os="osx" dll="opengl32.dll" target="/System/Library/Frameworks/OpenGL.framework/OpenGL"/>
+  <dllmap os="osx" dll="openal32.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="alut.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="libGLES.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv1_CM.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv2.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="opencl.dll" target="/System/Library/Frameworks/OpenCL.framework/OpenCL"/>
+  <dllmap os="osx" dll="SDL2.dll" target="libSDL2.dylib"/>
+  <!-- XQuartz compatibility (X11 on Mac) -->
+  <dllmap os="osx" dll="libGL.so.1" target="/usr/X11/lib/libGL.dylib"/>
+  <dllmap os="osx" dll="libX11" target="/usr/X11/lib/libX11.dylib"/>
+  <dllmap os="osx" dll="libXcursor.so.1" target="/usr/X11/lib/libXcursor.dylib"/>
+  <dllmap os="osx" dll="libXi" target="/usr/X11/lib/libXi.dylib"/>
+  <dllmap os="osx" dll="libXinerama" target="/usr/X11/lib/libXinerama.dylib"/>
+  <dllmap os="osx" dll="libXrandr.so.2" target="/usr/X11/lib/libXrandr.dylib"/>
+</configuration>

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -1,4 +1,28 @@
-﻿using System.Collections.Generic;
+﻿//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System.Collections.Generic;
 using System.Windows.Forms;
 using OpenTK.Input;
 namespace DenshaDeGoInput

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -205,11 +205,11 @@ namespace DenshaDeGoInput
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
 			}
 
+			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
+			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
 			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.Square ? 1 : 0);
 			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.Cross ? 1 : 0);
 			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.Circle ? 1 : 0);
-			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
-			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
 		}
 
 		/// <summary>

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -76,7 +76,7 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public static bool IsPSController(JoystickCapabilities joystick)
 		{
-			if (joystick.ButtonCount >= 10 && joystick.ButtonCount <= 20)
+			if ((joystick.ButtonCount >= 12 || (joystick.ButtonCount >= 10 && joystick.HatCount > 0)) && joystick.ButtonCount <= 20)
 			{
 				return true;
 			}

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -1,0 +1,279 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using OpenTK.Input;
+namespace DenshaDeGoInput
+{
+	/// <summary>
+	/// Class for Densha de GO! controllers for the Sony PlayStation
+	/// </summary>
+	internal class PSController
+	{
+		internal static bool UsesHat = false;
+
+		internal static int hatIndex;
+
+		internal class ButtonIndices
+		{
+			internal int Cross = -1;
+			internal int Circle = -1;
+			internal int Square = -1;
+			internal int Triangle = -1;
+			internal int L1 = -1;
+			internal int R1 = -1;
+			internal int L2 = -1;
+			internal int R2 = -1;
+			internal int Select = -1;
+			internal int Start = -1;
+			internal int Left = -1;
+			internal int Right = -1;
+		}
+
+		internal class PressedButtons
+		{
+			internal bool Cross;
+			internal bool Circle;
+			internal bool Square;
+			internal bool Triangle;
+			internal bool L1;
+			internal bool R1;
+			internal bool L2;
+			internal bool R2;
+			internal bool Select;
+			internal bool Start;
+			internal bool Left;
+			internal bool Right;
+		}
+
+		internal static ButtonIndices ButtonIndex = new ButtonIndices();
+		internal static PressedButtons ButtonPressed = new PressedButtons();
+
+		/// <summary>
+		/// Checks if a joystick is a Sony PlayStation controller
+		/// </summary>
+		public static bool IsPSController(JoystickState joystick)
+		{
+			return true;
+		}
+
+		/// <summary>
+		/// Reads the buttons from the controller
+		/// </summary>
+		public static void ReadButtons(JoystickState joystick)
+		{
+			ButtonPressed.Cross = joystick.IsButtonDown(ButtonIndex.Cross);
+			ButtonPressed.Circle = joystick.IsButtonDown(ButtonIndex.Circle);
+			ButtonPressed.Square = joystick.IsButtonDown(ButtonIndex.Square);
+			ButtonPressed.Triangle = joystick.IsButtonDown(ButtonIndex.Triangle);
+			ButtonPressed.L1 = joystick.IsButtonDown(ButtonIndex.L1);
+			ButtonPressed.L2 = joystick.IsButtonDown(ButtonIndex.L2);
+			ButtonPressed.R1 = joystick.IsButtonDown(ButtonIndex.R1);
+			ButtonPressed.R2 = joystick.IsButtonDown(ButtonIndex.R2);
+			ButtonPressed.Select = joystick.IsButtonDown(ButtonIndex.Select);
+			ButtonPressed.Start = joystick.IsButtonDown(ButtonIndex.Start);
+
+			if (UsesHat)
+			{
+				ButtonPressed.Left = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
+				ButtonPressed.Right = joystick.GetHat((JoystickHat)hatIndex).IsRight;
+			}
+			else
+			{
+				ButtonPressed.Left = joystick.IsButtonDown(ButtonIndex.Left);
+				ButtonPressed.Right = joystick.IsButtonDown(ButtonIndex.Right);
+			}
+
+			if (!ButtonPressed.L2 && !ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
+			}
+			if (ButtonPressed.L2 && !ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
+			}
+			if (ButtonPressed.L2 && !ButtonPressed.R2 && ButtonPressed.L1 && ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
+			}
+			if (!ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
+			}
+			if (!ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && !ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
+			}
+			if (ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && !ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
+			}
+			if (ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && !ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
+			}
+			if (!ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
+			}
+			if (!ButtonPressed.L2 && ButtonPressed.R2 && ButtonPressed.L1 && ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
+			}
+			if (ButtonPressed.L2 && ButtonPressed.R2 && !ButtonPressed.L1 && ButtonPressed.R1)
+			{
+				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
+			}
+
+			if (ButtonPressed.Right && ButtonPressed.Left && !ButtonPressed.Triangle)
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+			}
+			if (ButtonPressed.Right && !ButtonPressed.Left && ButtonPressed.Triangle)
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
+			}
+			if (ButtonPressed.Right && !ButtonPressed.Left && !ButtonPressed.Triangle)
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
+			}
+			if (!ButtonPressed.Right && ButtonPressed.Left && ButtonPressed.Triangle)
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
+			}
+			if (!ButtonPressed.Right && ButtonPressed.Left && !ButtonPressed.Triangle)
+			{
+				if (UsesHat && InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
+				{
+					// Hack for adapters which map the direction buttons to a hat and confuse N with P4
+					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+				}
+				else
+				{
+					InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
+				}
+			}
+			if (!ButtonPressed.Right && !ButtonPressed.Left && ButtonPressed.Triangle)
+			{
+				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
+			}
+
+			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.Square ? 1 : 0);
+			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.Cross ? 1 : 0);
+			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.Circle ? 1 : 0);
+			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
+			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
+		}
+
+		public static void Calibrate()
+		{
+			string[] input = { "A", "B", "C", "SELECT", "START", "EMG", "B6", "B5", "B4", "B8", "P5", "N", "P2", "P1", "P5" };
+			List<OpenTK.Input.ButtonState> ButtonState = InputTranslator.GetButtonsState();
+			List<OpenTK.Input.ButtonState> PreviousButtonState;
+			List<HatPosition> HatPositions = InputTranslator.GetHatPositions();
+			List<HatPosition> PreviousHatPositions;
+			List<int> ignored = new List<int>();
+
+			// Button calibration
+			for (int i = 0; i < 5; i++)
+			{
+				MessageBox.Show($"Hold the {input[i]} button in the controller and press OK.");
+				PreviousButtonState = ButtonState;
+				ButtonState = InputTranslator.GetButtonsState();
+				int index = InputTranslator.GetDifferentPressedIndex(PreviousButtonState, ButtonState, ignored);
+				ignored.Add(index);
+				switch (i)
+				{
+					case 0:
+						ButtonIndex.Square = index;
+						break;
+					case 1:
+						ButtonIndex.Cross = index;
+						break;
+					case 2:
+						ButtonIndex.Circle = index;
+						break;
+					case 3:
+						ButtonIndex.Select = index;
+						break;
+					case 4:
+						ButtonIndex.Start = index;
+						break;
+				}
+			}
+
+			// The brake handle needs to be moved to EMG to initialise properly
+			MessageBox.Show($"Move the brake handle to {input[5]} and press OK.");
+
+			// Brake handle calibration
+			for (int i = 6; i < 10; i++)
+			{
+				MessageBox.Show($"Move the brake handle to {input[i]} and press OK.");
+				PreviousButtonState = ButtonState;
+				ButtonState = InputTranslator.GetButtonsState();
+				int index = InputTranslator.GetDifferentPressedIndex(PreviousButtonState, ButtonState, ignored);
+				ignored.Add(index);
+				switch (i)
+				{
+					case 6:
+						ButtonIndex.R2 = index;
+						break;
+					case 7:
+						ButtonIndex.L1 = index;
+						break;
+					case 8:
+						ButtonIndex.L2 = index;
+						break;
+					case 9:
+						ButtonIndex.R1 = index;
+						break;
+				}
+			}
+
+			// The power handle needs to be moved to P5 and N to initialise properly
+			MessageBox.Show($"Move the power handle to {input[10]} and press OK.");
+			MessageBox.Show($"Move the power handle to {input[11]} and press OK.");
+
+			// Clear previous data before calibrating the power handle
+			ignored.Clear();
+			ButtonState = InputTranslator.GetButtonsState();
+			HatPositions = InputTranslator.GetHatPositions();
+
+			// Power handle calibration
+			for (int i = 12; i < 15; i++)
+			{
+				MessageBox.Show($"Move the power handle to {input[i]} and press OK.");
+				PreviousButtonState = ButtonState;
+				PreviousHatPositions = HatPositions;
+				ButtonState = InputTranslator.GetButtonsState();
+				HatPositions = InputTranslator.GetHatPositions();
+				int index = InputTranslator.GetDifferentPressedIndex(PreviousButtonState, ButtonState, ignored);
+				ignored.Add(index);
+
+				int hat = InputTranslator.GetChangedHat(PreviousHatPositions, HatPositions);
+				if (hat != -1 && i != 13)
+				{
+					// If a hat has changed, it means the converter is mapping the direction buttons 
+					UsesHat = true;
+					hatIndex = hat;
+				}
+				else
+				{
+					UsesHat = false;
+				}
+
+				switch (i)
+				{
+					case 12:
+						ButtonIndex.Left = index;
+						break;
+					case 13:
+						ButtonIndex.Triangle = index;
+						break;
+					case 14:
+						ButtonIndex.Right = index;
+						break;
+				}
+			}
+		}
+
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -28,14 +28,23 @@ using OpenTK.Input;
 namespace DenshaDeGoInput
 {
 	/// <summary>
-	/// Class for Densha de GO! controllers for the Sony PlayStation
+	/// Class for Densha de GO! controllers for the Sony PlayStation.
 	/// </summary>
 	internal class PSController
 	{
+		/// <summary>
+		/// Whether the adapter uses a hat to map the direction buttons.
+		/// </summary>
 		internal static bool UsesHat = false;
 
+		/// <summary>
+		/// The index of the hat used to map the direction buttons.
+		/// </summary>
 		internal static int hatIndex;
 
+		/// <summary>
+		/// Class for the indices of the buttons used by the controller.
+		/// </summary>
 		internal class ButtonIndices
 		{
 			internal int Cross = -1;
@@ -52,6 +61,9 @@ namespace DenshaDeGoInput
 			internal int Right = -1;
 		}
 
+		/// <summary>
+		/// Class for the pressed state of the buttons used by the controller.
+		/// </summary>
 		internal class PressedButtons
 		{
 			internal bool Cross;
@@ -68,11 +80,18 @@ namespace DenshaDeGoInput
 			internal bool Right;
 		}
 
+		/// <summary>
+		/// The button indices of the buttons used by the controller.
+		/// </summary>
 		internal static ButtonIndices ButtonIndex = new ButtonIndices();
+
+		/// <summary>
+		/// The pressed state of the buttons used by the controller.
+		/// </summary>
 		internal static PressedButtons ButtonPressed = new PressedButtons();
 
 		/// <summary>
-		/// Checks if a joystick is a Sony PlayStation controller
+		/// Checks whether a joystick is a Sony PlayStation controller.
 		/// </summary>
 		public static bool IsPSController(JoystickCapabilities joystick)
 		{
@@ -84,7 +103,7 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Reads the buttons from the controller
+		/// Reads the buttons from the controller.
 		/// </summary>
 		public static void ReadButtons(JoystickState joystick)
 		{
@@ -101,11 +120,13 @@ namespace DenshaDeGoInput
 
 			if (UsesHat)
 			{
+				// The adapter uses the hat to map the direction buttons.
 				ButtonPressed.Left = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
 				ButtonPressed.Right = joystick.GetHat((JoystickHat)hatIndex).IsRight;
 			}
 			else
 			{
+				// The adapter maps the direction buttons to independent buttons.
 				ButtonPressed.Left = joystick.IsButtonDown(ButtonIndex.Left);
 				ButtonPressed.Right = joystick.IsButtonDown(ButtonIndex.Right);
 			}
@@ -191,6 +212,9 @@ namespace DenshaDeGoInput
 			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
 		}
 
+		/// <summary>
+		/// Launches the calibration wizard to guess the button indices used by the adapter.
+		/// </summary>
 		public static void Calibrate()
 		{
 			string[] input = { "A", "B", "C", "SELECT", "START", "EMG", "B6", "B5", "B4", "B8", "P5", "N", "P2", "P1", "P5" };

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -25,6 +25,7 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
 using OpenTK.Input;
+using OpenBveApi.Interface;
 namespace DenshaDeGoInput
 {
 	/// <summary>
@@ -217,7 +218,7 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public static void Calibrate()
 		{
-			string[] input = { "A", "B", "C", "SELECT", "START", "EMG", "B6", "B5", "B4", "B8", "P5", "N", "P2", "P1", "P5" };
+			string[] input = { "SELECT", "START", "A", "B", "C", "EMG", "B6", "B5", "B4", "B8", "P5", "N", "P2", "P1", "P5" };
 			List<OpenTK.Input.ButtonState> ButtonState = InputTranslator.GetButtonsState();
 			List<OpenTK.Input.ButtonState> PreviousButtonState;
 			List<HatPosition> HatPositions = InputTranslator.GetHatPositions();
@@ -227,7 +228,7 @@ namespace DenshaDeGoInput
 			// Button calibration
 			for (int i = 0; i < 5; i++)
 			{
-				MessageBox.Show($"Hold the {input[i]} button in the controller and press OK.");
+				MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_button").Replace("[button]", input[i]));
 				PreviousButtonState = ButtonState;
 				ButtonState = InputTranslator.GetButtonsState();
 				int index = InputTranslator.GetDifferentPressedIndex(PreviousButtonState, ButtonState, ignored);
@@ -235,30 +236,30 @@ namespace DenshaDeGoInput
 				switch (i)
 				{
 					case 0:
-						ButtonIndex.Square = index;
-						break;
-					case 1:
-						ButtonIndex.Cross = index;
-						break;
-					case 2:
-						ButtonIndex.Circle = index;
-						break;
-					case 3:
 						ButtonIndex.Select = index;
 						break;
-					case 4:
+					case 1:
 						ButtonIndex.Start = index;
+						break;
+					case 2:
+						ButtonIndex.Square = index;
+						break;
+					case 3:
+						ButtonIndex.Cross = index;
+						break;
+					case 4:
+						ButtonIndex.Circle = index;
 						break;
 				}
 			}
 
 			// The brake handle needs to be moved to EMG to initialise properly
-			MessageBox.Show($"Move the brake handle to {input[5]} and press OK.");
+			MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_brake").Replace("[notch]", input[5]));
 
 			// Brake handle calibration
 			for (int i = 6; i < 10; i++)
 			{
-				MessageBox.Show($"Move the brake handle to {input[i]} and press OK.");
+				MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_brake").Replace("[notch]", input[i]));
 				PreviousButtonState = ButtonState;
 				ButtonState = InputTranslator.GetButtonsState();
 				int index = InputTranslator.GetDifferentPressedIndex(PreviousButtonState, ButtonState, ignored);
@@ -281,8 +282,8 @@ namespace DenshaDeGoInput
 			}
 
 			// The power handle needs to be moved to P5 and N to initialise properly
-			MessageBox.Show($"Move the power handle to {input[10]} and press OK.");
-			MessageBox.Show($"Move the power handle to {input[11]} and press OK.");
+			MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_power").Replace("[notch]", input[10]));
+			MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_power").Replace("[notch]", input[11]));
 
 			// Clear previous data before calibrating the power handle
 			ignored.Clear();
@@ -292,7 +293,7 @@ namespace DenshaDeGoInput
 			// Power handle calibration
 			for (int i = 12; i < 15; i++)
 			{
-				MessageBox.Show($"Move the power handle to {input[i]} and press OK.");
+				MessageBox.Show(Translations.GetInterfaceString("denshadego_calibrate_power").Replace("[notch]", input[i]));
 				PreviousButtonState = ButtonState;
 				PreviousHatPositions = HatPositions;
 				ButtonState = InputTranslator.GetButtonsState();

--- a/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/PSController.cs
@@ -50,9 +50,13 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Checks if a joystick is a Sony PlayStation controller
 		/// </summary>
-		public static bool IsPSController(JoystickState joystick)
+		public static bool IsPSController(JoystickCapabilities joystick)
 		{
-			return true;
+			if (joystick.ButtonCount >= 10 && joystick.ButtonCount <= 20)
+			{
+				return true;
+			}
+			return false;
 		}
 
 		/// <summary>

--- a/source/InputDevicePlugins/DenshaDeGoInput/Properties/AssemblyInfo.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Densha de GO! controller plugin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DenshaDeGoInput")]
+[assembly: AssemblyCopyright("Marc Riera, The OpenBVE Project")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("473444ad-286e-42ef-8d70-ad8880bc12ef")]
+
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0")]

--- a/source/InputDevicePlugins/DenshaDeGoInput/app.config
+++ b/source/InputDevicePlugins/DenshaDeGoInput/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/source/InputDevicePlugins/DenshaDeGoInput/packages.config
+++ b/source/InputDevicePlugins/DenshaDeGoInput/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="OpenTK" version="3.2" targetFramework="net461" />
+</packages>

--- a/source/InputDevicePlugins/DenshaDeGoInput/packages.config
+++ b/source/InputDevicePlugins/DenshaDeGoInput/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTK" version="3.2" targetFramework="net461" />
+  <package id="OpenTK" version="3.2.0" targetFramework="net461" />
 </packages>

--- a/source/InputDevicePlugins/DenshaDeGoInput/packages.config
+++ b/source/InputDevicePlugins/DenshaDeGoInput/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTK" version="3.2.0" targetFramework="net461" />
+  <package id="OpenTK" version="3.3.1" targetFramework="net461" />
 </packages>

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1387,6 +1387,7 @@ namespace OpenBve
 									case Translations.Command.HoldBrake:
 										if (TrainManager.PlayerTrain.Handles.HasHoldBrake && (TrainManager.PlayerTrain.Handles.Brake.Driver == 0 || TrainManager.PlayerTrain.Handles.Brake.Driver == 1) && !TrainManager.PlayerTrain.Handles.HoldBrake.Driver)
 										{
+											TrainManager.PlayerTrain.ApplyNotch(0, !TrainManager.PlayerTrain.Handles.SingleHandle, 0, false);
 											TrainManager.PlayerTrain.ApplyHoldBrake(true);
 										}
 										break;

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -498,7 +498,7 @@ namespace OpenBve {
 						TrainManager.Trains[i].LoadDefaultPlugin(TrainManager.Trains[i].TrainFolder);
 					}
 					for (int j = 0; j < InputDevicePlugin.AvailablePluginInfos.Count; j++) {
-						if (InputDevicePlugin.AvailablePluginInfos[j].Status == InputDevicePlugin.PluginInfo.PluginStatus.Enable && InputDevicePlugin.AvailablePluginInfos[j] is ITrainInputDevice)
+						if (InputDevicePlugin.AvailablePluginInfos[j].Status == InputDevicePlugin.PluginInfo.PluginStatus.Enable && InputDevicePlugin.AvailablePlugins[j] is ITrainInputDevice)
 						{
 							ITrainInputDevice trainInputDevice = (ITrainInputDevice)InputDevicePlugin.AvailablePlugins[j];
 							trainInputDevice.SetVehicleSpecs(TrainManager.Trains[i].vehicleSpecs());


### PR DESCRIPTION
This pull request implements an input device plugin for Densha de GO! controllers, as mentioned in #528. Technical documentation on the controllers can be found [here](https://gist.github.com/MarcRiera/075b5651039942b2380dc51f0ec1cbc9).

![image](https://user-images.githubusercontent.com/12414284/97803873-555a3700-1c4c-11eb-9783-ace227791749.png)

## Features
* Compatible with classic (non-USB) Densha de GO! controllers for consoles: Nintendo 64 (TCPP-20003), Sega Dreamcast (TCPP-20003), Sega Saturn (TC-5175290) and Sony PlayStation (SCPH-00051, TCPP-20001, TCPP-20002, TCPP-20008). Naturally, **a USB adapter is required**.
* Initial (untested) compatibility with DGOC-44U and DGC-255 (USB controllers by Unbalance).
* Automatic calibration via a wizard. The user is asked to follow a sequence of button presses and the plugin automatically detects the configuration for the adapter. This only needs to be done once or after changing the adapter.
* Several options regarding how the power and brake notches are mapped between the physical and virtual handles.
* Command mapping to physical buttons.
* Localization support.

## Limitations
* The controllers have their own way of being detected on consoles but this is lost when using adapters. For this reason, autodetection is not possible and the plugin will accept any USB controller. Disable the plugin when not in use to avoid interference.
* Some adapters map the direction buttons on a standard PlayStation controller to a hat. Due to how the Densha de GO! controllers work, **N** and **P4** on the power handle become undistinguishable. The plugin takes this into account and will guess the correct notch most times, but can become confused specially when changing notch too fast.
* For a similar reason, because the Dreamcast controller needs to press the four direction buttons at the same time, it will not work with adapters which map them to a hat. Only adapters mapping them to independent buttons will work with OpenBVE.

## Future work
* Confirm compatibility with USB controllers by Unbalance.
* Add support for USB controllers for the Sony PlayStation 2.