### PR TITLE
Change: Alter travis file [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ linuxbuild.*
 macbuild.*
 /mac/
 installers/debian.deb
+OpenBVE-*.zip
+OpenBVE-*.deb
+OpenBVE-*.dmg
 
 #Debian Build directory
 installers/debian/usr/lib/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,10 @@ matrix:
       script: make debian
       if: tag IS present
 
-    #Test builds
-    ##Use makefile##
+    #Further test builds on different Ubuntu / Mono versions and using the SLN file directly
     
-    #Note: Only run upload builds on MacOS https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
-    #Let's test all variations on Linux, but can probably get away with only running an upload build on OS-X
-    #TODO: Consider possible alternatives
-    - os: linux
-      dist: xenial
-      mono: latest
-      script: make all-release
-    - os: linux
-      dist: trusty
-      mono: 5.20.1
-      script: make all-release
-    ##Use .sln file##
+    #Note: Only run the single uploading build on MacOS https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    #Let's test all variations on Linux. This will (probably) ensure that things go OK
     - os: linux
       dist: trusty
       mono: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ matrix:
 
     #Test builds
     ##Use makefile##
+    
+    #Note: Only run upload builds on MacOS https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    #Let's test all variations on Linux, but can probably get away with only running an upload build on OS-X
+    #TODO: Consider possible alternatives
     - os: linux
       dist: xenial
-      mono: latest
-      script: make all-release
-    - os: osx
       mono: latest
       script: make all-release
     - os: linux
@@ -36,9 +37,6 @@ matrix:
       solution: OpenBVE.sln
     - os: linux
       dist: xenial
-      mono: latest
-      solution: OpenBVE.sln
-    - os: osx
       mono: latest
       solution: OpenBVE.sln
     - os: linux

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ MONO_VERSION:= $(shell mono --version | awk '/version/ { print $$5 }')
 MIN_NUGET_VERSION:= "2.16.0"
 NUGET_VERSION:= $(shell nuget help 2> /dev/null | awk '/Version:/ { print $$3; exit 0}')
 GreaterVersion = $(shell printf '%s\n' $(1) $(2) | sort -t. -k 1,1nr -k 2,2nr -k 3,3nr -k 4,4nr | head -n 1)
+PROGRAM_VERSION = $(shell git describe --tags --exact-match 2> /dev/null)
 
 # Directories
 DEBUG_DIR   := bin_debug
@@ -157,11 +158,31 @@ $(MAC_BUILD_RESULT): all-release
 
 	@echo $(COLOR_RED)Creating $(COLOR_CYAN)$(MAC_BUILD_RESULT)$(COLOR_END)
 	@hdiutil create $(MAC_BUILD_RESULT) -volname "OpenBVE" -fs HFS+ -srcfolder "mac/OpenBVE.app"
+	@echo Renaming final output file
+ifeq (, $(PROGRAM_VERSION))
+	@echo This is a $(COLOR_BLUE)Daily build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$$(date '+%F').dmg$(COLOR_END)
+	@mv macbuild.dmg OpenBVE-$$(date '+%F').dmg
+else
+	@echo This is a $(COLOR_YELLOW)Tagged Release build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$(PROGRAM_VERSION).dmg$(COLOR_END)
+	@mv macbuild.dmg OpenBVE-$(PROGRAM_VERSION).dmg
+endif
 
 $(LINUX_BUILD_RESULT): all-release
 	@rm -rf bin_release/DevTools/
 	@echo $(COLOR_RED)Compressing $(COLOR_CYAN)$(LINUX_BUILD_RESULT)$(COLOR_END)
 	@cd $(RELEASE_DIR); zip -qr9Z deflate ../$(LINUX_BUILD_RESULT) *
+	@echo Renaming final output file
+ifeq (, $(PROGRAM_VERSION))
+	@echo This is a $(COLOR_BLUE)Daily build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$$(date '+%F').zip$(COLOR_END)
+	@mv linuxbuild.zip OpenBVE-$$(date '+%F').zip
+else
+	@echo This is a $(COLOR_YELLOW)Tagged Release build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$(PROGRAM_VERSION).zip$(COLOR_END)
+	@mv linuxbuild.zip OpenBVE-$(PROGRAM_VERSION).zip
+endif
 
 $(DEBIAN_BUILD_RESULT): all-release
 	@rm -rf bin_release/DevTools/
@@ -174,3 +195,13 @@ $(DEBIAN_BUILD_RESULT): all-release
 	@cp -r -f $(CP_UPDATE_FLAG) $(RELEASE_DIR)/* installers/debian/usr/lib/openbve
 	@echo $(COLOR_RED)Compressing $(COLOR_CYAN)$(DEBIAN_BUILD_RESULT)$(COLOR_END)
 	@fakeroot dpkg-deb --build installers/debian
+	@echo Renaming final output file
+ifeq (, $(PROGRAM_VERSION))
+	@echo This is a $(COLOR_BLUE)Daily build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$$(date '+%F').deb$(COLOR_END)
+	@mv debianbuild.deb OpenBVE-$$(date '+%F').deb
+else
+	@echo This is a $(COLOR_YELLOW)Tagged Release build$(COLOR_END)
+	@echo Final filename: $(COLOR_RED)OpenBVE-$$(date '+%F').deb$(COLOR_END)
+	@mv debianbuild.deb OpenBVE-$(PROGRAM_VERSION).deb
+endif


### PR DESCRIPTION
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

We'll hit this whenever it comes in....
Can probably get away with running only the upload build on OS-X as the testing itself will be done on Linux.

Possible alternatives to investigate:
* CircleCI
* Github Actions

Other potential changes to make:
* Cut back further on builds triggered. We can probably loose the makefile test builds (as the publish builds are roughly equivialant)
* Chase Travis for OSS credits. Very unclear as to how this will actually work in practice.

---

As a rough rule of thumb, let's assume 1 commit per day (averaged out including PR builds etc).
It's unclear as to what exactly they're going to charge for, as 90% of the build time is setup of their image (not our code running)

A typical build takes anywhere from 10min to 30min, depending on the Travis load. 
Of this ~1min is the actual build time & the rest is setup, which is somewhat mad, especially as it looks like they're going to charge credits for the whole shebang.

Therefore taking a median travis build time of 15min & currently the single build change from this:
* 750 credits per build * 30 days in month = ~22,500 credits per month just for OS-X
* 900 credits for the rest of the builds * 30 days in month = ~27,000 credits per month
TOTAL: ~50,000 credits per month.