### PR TITLE
Improvements to Panel Parsers

### DIFF
--- a/OpenBVE.sln
+++ b/OpenBVE.sln
@@ -163,6 +163,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrainManager", "source\Trai
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Train.OpenBve", "source\Plugins\Train.OpenBve\Train.OpenBve.csproj", "{D3710390-CD0E-4E14-8E4F-80302D797D5E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Formats.OpenBve", "Source\Plugins\Formats.OpenBve\Formats.OpenBve.csproj", "{60ADCB15-1E0E-4708-93A5-F1248DF73A03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -593,6 +595,18 @@ Global
 		{D3710390-CD0E-4E14-8E4F-80302D797D5E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D3710390-CD0E-4E14-8E4F-80302D797D5E}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3710390-CD0E-4E14-8E4F-80302D797D5E}.Release|x86.Build.0 = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Debug|x86.Build.0 = Debug|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|x86.ActiveCfg = Release|Any CPU
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -626,6 +640,7 @@ Global
 		{8D21C5C6-73E9-42E0-92FB-63500E321836} = {16553295-E70F-4596-AA78-848EEA576C4A}
 		{F49789F2-97F3-45B3-BC85-F4E09C0D120D} = {16553295-E70F-4596-AA78-848EEA576C4A}
 		{D3710390-CD0E-4E14-8E4F-80302D797D5E} = {F49789F2-97F3-45B3-BC85-F4E09C0D120D}
+		{60ADCB15-1E0E-4708-93A5-F1248DF73A03} = {F49789F2-97F3-45B3-BC85-F4E09C0D120D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {50B52A67-69B1-4B19-A59C-FF058FD9EBDF}

--- a/source/Plugins/Formats.OpenBve/Formats.OpenBve.csproj
+++ b/source/Plugins/Formats.OpenBve/Formats.OpenBve.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{60ADCB15-1E0E-4708-93A5-F1248DF73A03}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Formats.OpenBve</RootNamespace>
+    <AssemblyName>Formats.OpenBve</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin_debug\Data\Formats\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin_release\Data\Formats\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Plugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenBveApi\OpenBveApi.csproj">
+      <Project>{27134980-4415-4375-a564-40a9014dfa5f}</Project>
+      <Name>OpenBveApi</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/source/Plugins/Formats.OpenBve/Plugin.cs
+++ b/source/Plugins/Formats.OpenBve/Plugin.cs
@@ -1,0 +1,506 @@
+//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2021, Christopher Lees, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+using OpenBveApi.Colors;
+using OpenBveApi.Hosts;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using OpenBveApi.Textures;
+using Path = OpenBveApi.Path;
+
+namespace Formats.OpenBve
+{
+    /// <summary>An abstract block of data</summary>
+	public abstract class Block
+    {
+		/// <summary>The host application</summary>
+		internal readonly HostInterface currentHost;
+
+		/// <summary>The filename the data was loaded from</summary>
+		internal string FileName;
+
+		/// <summary>The token that identifies the contents of this block</summary>
+		public object Token;
+
+		/// <summary>The label of this block</summary>
+		/// <remarks>Normally blank</remarks>
+		public string Label;
+
+		/// <summary>Reads an signed 32-bit integer from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract int ReadInt<T>(T Key, int defaultValue = 0) where T : struct, Enum;
+		
+		/// <summary>Reads a double-bit precision floating point number from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract double ReadDouble<T>(T Key, double defaultValue = 0) where T : struct, Enum;
+
+		/// <summary>Reads a string from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract string ReadString<T>(T Key, string defaultValue = "") where T : struct, Enum;
+
+		/// <summary>Reads a 2D vector from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract Vector2 ReadVector2<T>(T Key, Vector2 defaultValue = new Vector2()) where T : struct, Enum;
+
+		/// <summary>Reads a 3D vector from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract Vector3 ReadVector3<T>(T Key, Vector3 defaultValue = new Vector3()) where T : struct, Enum;
+
+		/// <summary>Reads a 24-bit color from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="defaultValue">An optional non-standard default value</param>
+		public abstract Color24 ReadColor24<T>(T Key, Color24? defaultValue = null) where T : struct, Enum;
+
+		/// <summary>Reads a 32-bit color from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		public abstract Color32 ReadColor32<T>(T Key) where T : struct, Enum;
+
+		/// <summary>Reads a string from the block</summary>
+		/// <param name="Key">The key of the KVP pair</param>
+		/// <param name="texturePath">The texture search path</param>
+		/// <param name="textureParameters">The texture parameters to apply</param>
+		/// <param name="loadTexture">Whether the texture should be preloaded</param>
+		public abstract Texture LoadTexture<T>(T Key, string texturePath, TextureParameters textureParameters, bool loadTexture = false) where T : struct, Enum;
+
+		/// <summary>Creates a new block from the supplied XDocument</summary>
+		/// <param name="fileName">The filename</param>
+		/// <param name="document">The XDocument</param>
+		/// <param name="token">The token for the new block</param>
+		/// <returns>The new block</returns>
+		/// <remarks>Always creates a XmlBlock</remarks>
+		public Block ReadBlock<T>(string fileName, XElement document, T token) where T : struct, Enum
+		{
+			return new XmlBlock(currentHost, fileName, document, token);
+		}
+
+		/// <summary>Creates a new block from the supplied string</summary>
+		/// <param name="text">The string</param>
+		/// <param name="token">The token for the new block</param>
+		/// <returns>The new block</returns>
+		/// <remarks>Always creates a TextualBlock</remarks>
+		public static Block ReadBlock<T>(string text, T token) where T : struct, Enum
+		{
+			throw new NotImplementedException();
+			//return new TextualBlock(text, token);
+		}
+
+		/// <summary>Reads a sub-block from the enclosing block</summary>
+		/// <param name="newToken">The expected token for the new block</param>
+		/// <returns>The new block</returns>
+		/// <remarks>The type of the new block will always match that of the base block</remarks>
+		public abstract Block ReadSubBlock<T>(T newToken) where T : struct, Enum;
+
+		public Block(HostInterface host)
+		{
+			currentHost = host;
+		}
+    }
+
+    public class XmlBlock : Block
+    {
+	    private readonly XElement blockDocument;
+
+		public XmlBlock(HostInterface host, string fileName, XElement document, object token) : base(host)
+		{
+			FileName = fileName;
+		    blockDocument = document;
+		    Token = token;
+	    }
+
+
+		public override int ReadInt<T>(T Key, int defaultValue = 0)
+		{
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					if (!NumberFormats.TryParseIntVb6(e.Value, out var i))
+					{
+						currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						return defaultValue;
+					}
+					return i;
+				}
+			}
+			return defaultValue;
+		}
+
+		public override double ReadDouble<T>(T Key, double defaultValue = 0)
+		{
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					if (!NumberFormats.TryParseDoubleVb6(e.Value, out var d))
+					{
+						currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						return defaultValue;
+					}
+					return d;
+				}
+			}
+			return defaultValue;
+		}
+
+		public override string ReadString<T>(T Key, string defaultValue = "")
+	    {
+		    foreach(XElement e in blockDocument.Elements())
+		    {
+			    T parsedElement;
+			    Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+			    if (parsedElement.Equals(Key))
+			    {
+				    return e.Value;
+			    }
+		    }
+		    return defaultValue;
+	    }
+
+		public override Vector2 ReadVector2<T>(T Key, Vector2 defaultValue = new Vector2())
+		{
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					Vector2 newVector = new Vector2();
+					string[] splitString = e.Value.Split(',');
+					if (splitString.Length != 2)
+					{
+						currentHost.AddMessage(MessageType.Error, false, "Value should have exactly two arguments in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+					}
+					for (int i = 0; i < splitString.Length; i++)
+					{
+						switch (i)
+						{
+							case 0:
+								if (!NumberFormats.TryParseDoubleVb6(splitString[i], out newVector.X))
+								{
+									currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								}
+								break;
+							case 1:
+								if (!NumberFormats.TryParseDoubleVb6(splitString[i], out newVector.Y))
+								{
+									currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								}
+								break;
+						}
+					}
+					return newVector;
+				}
+			}
+			return defaultValue;
+		}
+
+		public override Vector3 ReadVector3<T>(T Key, Vector3 defaultValue = new Vector3())
+		{
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				
+				if (parsedElement.Equals(Key))
+				{
+					Vector3 newVector = new Vector3();
+					string[] splitString = e.Value.Split(',');
+					if (splitString.Length != 3)
+					{
+						currentHost.AddMessage(MessageType.Error, false, "Value should have exactly three arguments in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+					}
+					for (int i = 0; i < splitString.Length; i++)
+					{
+						switch (i)
+						{
+							case 0:
+								if (!NumberFormats.TryParseDoubleVb6(splitString[i], out newVector.X))
+								{
+									currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								}
+								break;
+							case 1:
+								if (!NumberFormats.TryParseDoubleVb6(splitString[i], out newVector.Y))
+								{
+									currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								}
+								break;
+							case 2:
+								if (!NumberFormats.TryParseDoubleVb6(splitString[i], out newVector.Z))
+								{
+									currentHost.AddMessage(MessageType.Error, false, "Z is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								}
+								break;
+						}
+					}
+					return newVector;
+				}
+			}
+			return defaultValue;
+		}
+
+		public override Color24 ReadColor24<T>(T Key, Color24? defaultValue = null)
+		{
+			Color24 parsedColor = Color24.White;
+			if (defaultValue != null)
+			{
+				// HACK: We can't easily pass a struct as a default value, so use null instead
+				// and set the default value if non-null
+				parsedColor = (Color24)defaultValue;
+			}
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					string[] splitString = e.Value.Split(',');
+					if (splitString.Length > 1)
+					{
+						//Must be RGB / partial
+						if (splitString.Length != 3)
+						{
+							currentHost.AddMessage(MessageType.Error, false, "Value should have exactly three arguments in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						}
+
+						int r = 0, g = 0, b = 0;
+						for (int i = 0; i < splitString.Length; i++)
+						{
+							switch (i)
+							{
+								case 0:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out r))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Red is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (r < 0 | r > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Red is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										r = r < 0 ? 0 : 255;
+									}
+									break;
+								case 1:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out g))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Green is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (g < 0 | g > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Green is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										g = g < 0 ? 0 : 255;
+									}
+									break;
+								case 2:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out b))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Blue is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (b < 0 | b > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Blue is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										b = b < 0 ? 0 : 255;
+									}
+									break;
+							}
+						}
+						parsedColor = new Color24((byte) r, (byte) g, (byte) b);
+					}
+					else
+					{
+						//Hex color
+						if (!Color24.TryParseHexColor(e.Value, out parsedColor))
+						{
+							currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						}
+					}
+					return parsedColor;
+				}
+			}
+			return parsedColor;
+		}
+
+		public override Color32 ReadColor32<T>(T Key)
+		{
+			Color32 parsedColor = Color32.White;
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					string[] splitString = e.Value.Split(',');
+					if (splitString.Length > 1)
+					{
+						//Must be RGB / partial
+						if (splitString.Length != 4)
+						{
+							currentHost.AddMessage(MessageType.Error, false, "Value should have exactly three arguments in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						}
+
+						int r = 0, g = 0, b = 0, a = 0;
+						for (int i = 0; i < splitString.Length; i++)
+						{
+							switch (i)
+							{
+								case 0:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out r))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Red is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (r < 0 | r > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Red is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										r = r < 0 ? 0 : 255;
+									}
+									break;
+								case 1:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out g))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Green is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (g < 0 | g > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Green is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										g = g < 0 ? 0 : 255;
+									}
+									break;
+								case 2:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out b))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Blue is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (b < 0 | b > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Blue is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										b = b < 0 ? 0 : 255;
+									}
+									break;
+								case 3:
+									if (!NumberFormats.TryParseIntVb6(splitString[i], out a))
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Alpha is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+									}
+									else if (a < 0 | a > 255) 
+									{
+										currentHost.AddMessage(MessageType.Error, false, "Alpha is required to be within the range of 0 to 255 in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+										a = a < 0 ? 0 : 255;
+									}
+									break;
+							}
+						}
+						parsedColor = new Color32((byte) r, (byte) g, (byte) b, (byte) a);
+					}
+					else
+					{
+						//Hex color
+						if (!Color32.TryParseHexColor(e.Value, out parsedColor))
+						{
+							currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						}
+					}
+					return parsedColor;
+				}
+			}
+			return parsedColor;
+		}
+
+		public override Texture LoadTexture<T>(T Key, string texturePath, TextureParameters textureParameters, bool loadTexture = false)
+		{
+			foreach(XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(Key))
+				{
+					if (Path.ContainsInvalidChars(e.Value))
+					{
+						currentHost.AddMessage(MessageType.Error, false, "Texture path " + e.Value + " contains invalid characters in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						return null;
+					}
+
+					try
+					{
+						string finalPath = Path.CombineFile(texturePath, e.Value);
+						if (!File.Exists(finalPath) && !System.IO.Path.HasExtension(finalPath))
+						{
+							string candidatePath = Path.CombineFile(finalPath, ".bmp");
+							if (!File.Exists(candidatePath))
+							{
+								candidatePath = Path.CombineFile(finalPath, ".png");
+							}
+						
+							if (File.Exists(candidatePath))
+							{
+								finalPath = candidatePath;
+							}
+							else
+							{
+								currentHost.AddMessage(MessageType.Error, false, "Texture file " + e.Value + " was not found in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+								return null;
+							}
+						}
+						Texture loadedTexture;
+						currentHost.RegisterTexture(finalPath, textureParameters, out loadedTexture, loadTexture);
+						return loadedTexture;
+					}
+					catch
+					{
+						currentHost.AddMessage(MessageType.Error, false, "An unexpected error occured whilst loading texture file " + e.Value + " in " + Key + " in " + blockDocument.Name + " at line " + ((IXmlLineInfo)e).LineNumber + " in " + FileName);
+						return null;
+					}
+				}
+			}
+			return null;
+		}
+
+
+		public override Block ReadSubBlock<T>(T newToken)
+		{
+			foreach (XElement e in blockDocument.Elements())
+			{
+				T parsedElement;
+				Enum.TryParse(e.Name.LocalName, true, out parsedElement);
+				if (parsedElement.Equals(newToken))
+				{
+					e.Remove();
+					return new XmlBlock(currentHost, FileName, e, newToken);
+				}
+			}
+			return null;
+		}
+    }
+}

--- a/source/Plugins/Formats.OpenBve/Properties/AssemblyInfo.cs
+++ b/source/Plugins/Formats.OpenBve/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Formats.OpenBve")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Formats.OpenBve")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60adcb15-1e0e-4708-93a5-f1248df73a03")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Plugins/Train.OpenBve/Panel/Common/Panel.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Common/Panel.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using LibRender2.Trains;
+using OpenBveApi.Colors;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using OpenBveApi.Objects;
+using OpenBveApi.Textures;
+using TrainManager.Trains;
+
+namespace Train.OpenBve
+{
+	internal class Panel
+	{
+		private readonly Plugin Plugin;
+		/// <summary>The distance between animated layer stacks</summary>
+		/// <remarks>Required to prevent openGL z-fighting</remarks>
+		private const double StackDistance = 0.000001;
+		/// <remarks>EyeDistance is required to be 1.0 by UpdateCarSectionElement and by UpdateCameraRestriction, thus cannot be easily changed.</remarks>
+		internal const double EyeDistance = 1.0;
+		/// <summary>The resolution of the panel image in px</summary>
+		internal static double Resolution = 1024.0;
+		/// <summary>The top left of the default shown area in px</summary>
+		internal static Vector2 TopLeft = new Vector2(0,0);
+		/// <summary>The bottom right of the default shown area in px</summary>
+		internal static Vector2 BottomRight = new Vector2(1024, 1024);
+		/// <summary>The center of the shown area in px</summary>
+		internal static Vector2 Center = new Vector2(0, 512);
+		/// <summary>The origin of the panel in px</summary>
+		internal static Vector2 Origin = new Vector2(0, 512);
+
+		internal Panel(Plugin plugin)
+		{
+			Plugin = plugin;
+		}
+
+		internal int CreateElement(ref ElementsGroup Group, double Left, double Top, Vector2 RelativeRotationCenter, double Distance, Vector3 Driver, Texture DaytimeTexture, Texture NighttimeTexture, bool AddStateToLastElement = false)
+		{
+			return CreateElement(ref Group, Left, Top, DaytimeTexture.Width, DaytimeTexture.Height, RelativeRotationCenter, Distance, Driver, DaytimeTexture, NighttimeTexture, Color32.White, AddStateToLastElement);
+		}
+
+		internal int CreateElement(ref ElementsGroup Group, double Left, double Top, double Width, double Height, Vector2 RelativeRotationCenter, double Distance, Vector3 Driver, Texture DaytimeTexture, Texture NighttimeTexture, Color32 Color, bool AddStateToLastElement = false)
+		{
+			if (Width == 0 || Height == 0)
+			{
+				Plugin.currentHost.AddMessage(MessageType.Error, false, "Attempted to create an invalid size element");
+			}
+
+			Distance *= StackDistance;
+			double WorldWidth, WorldHeight;
+			if (Plugin.Renderer.Screen.Width >= Plugin.Renderer.Screen.Height) {
+				WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
+				WorldHeight = WorldWidth / Plugin.Renderer.Screen.AspectRatio;
+			} else {
+				WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance / Plugin.Renderer.Screen.AspectRatio;
+				WorldWidth = WorldHeight * Plugin.Renderer.Screen.AspectRatio;
+			}
+			double x0 = Left / Resolution;
+			double x1 = (Left + Width) / Resolution;
+			double y0 = (BottomRight.Y - Top) / Resolution * Plugin.Renderer.Screen.AspectRatio;
+			double y1 = (BottomRight.Y - (Top + Height)) / Resolution * Plugin.Renderer.Screen.AspectRatio;
+			double xd = 0.5 - Center.X / Resolution;
+			x0 += xd; x1 += xd;
+			double yt = BottomRight.Y - Resolution / Plugin.Renderer.Screen.AspectRatio;
+			double yd = (Center.Y - yt) / (BottomRight.Y - yt) - 0.5;
+			y0 += yd; y1 += yd;
+			x0 = (x0 - 0.5) * WorldWidth;
+			x1 = (x1 - 0.5) * WorldWidth;
+			y0 = (y0 - 0.5) * WorldHeight;
+			y1 = (y1 - 0.5) * WorldHeight;
+			double xm = x0 * (1.0 - RelativeRotationCenter.X) + x1 * RelativeRotationCenter.X;
+			double ym = y0 * (1.0 - RelativeRotationCenter.Y) + y1 * RelativeRotationCenter.Y;
+			Vector3[] v = new Vector3[4];
+			v[0] = new Vector3(x0 - xm, y1 - ym, 0);
+			v[1] = new Vector3(x0 - xm, y0 - ym, 0);
+			v[2] = new Vector3(x1 - xm, y0 - ym, 0);
+			v[3] = new Vector3(x1 - xm, y1 - ym, 0);
+			Vertex t0 = new Vertex(v[0], new Vector2(0.0f, 1.0f));
+			Vertex t1 = new Vertex(v[1], new Vector2(0.0f, 0.0f));
+			Vertex t2 = new Vertex(v[2], new Vector2(1.0f, 0.0f));
+			Vertex t3 = new Vertex(v[3], new Vector2(1.0f, 1.0f));
+			StaticObject Object = new StaticObject(Plugin.currentHost);
+			Object.Mesh.Vertices = new VertexTemplate[] { t0, t1, t2, t3 };
+			Object.Mesh.Faces = new[] { new MeshFace(new[] { 0, 1, 2, 3 }) };
+			Object.Mesh.Materials = new MeshMaterial[1];
+			Object.Mesh.Materials[0].Flags = new MaterialFlags();
+			if (DaytimeTexture != null)
+			{
+				Object.Mesh.Materials[0].Flags |= MaterialFlags.TransparentColor;
+
+				if (NighttimeTexture != null)
+				{
+					// In BVE4 and versions of OpenBVE prior to v1.7.1.0, elements with NighttimeImage defined are rendered with lighting disabled.
+					Object.Mesh.Materials[0].Flags |= MaterialFlags.DisableLighting;
+				}
+			}
+			Object.Mesh.Materials[0].Color = Color;
+			Object.Mesh.Materials[0].TransparentColor = Color24.Blue;
+			Object.Mesh.Materials[0].DaytimeTexture = DaytimeTexture;
+			Object.Mesh.Materials[0].NighttimeTexture = NighttimeTexture;
+			Object.Dynamic = true;
+			// calculate offset
+			Vector3 o;
+			o.X = xm + Driver.X;
+			o.Y = ym + Driver.Y;
+			o.Z = EyeDistance - Distance + Driver.Z;
+			// add object
+			if (AddStateToLastElement) {
+				int n = Group.Elements.Length - 1;
+				int j = Group.Elements[n].States.Length;
+				Array.Resize(ref Group.Elements[n].States, j + 1);
+				Group.Elements[n].States[j] = new ObjectState
+				{
+					Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z),
+					Prototype = Object
+				};
+				return n;
+			} else {
+				int n = Group.Elements.Length;
+				Array.Resize(ref Group.Elements, n + 1);
+				Group.Elements[n] = new AnimatedObject(Plugin.currentHost);
+				Group.Elements[n].States = new[] { new ObjectState() };
+				Group.Elements[n].States[0].Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z);
+				Group.Elements[n].States[0].Prototype = Object;
+				Group.Elements[n].CurrentState = 0;
+				Group.Elements[n].internalObject = new ObjectState { Prototype = Object };
+				Plugin.currentHost.CreateDynamicObject(ref Group.Elements[n].internalObject);
+				return n;
+			}
+		}
+
+		internal void CreateTouchElement(ElementsGroup Group, Vector2 Location, Vector2 Size, int ScreenIndex, int[] SoundIndices, CommandEntry[] CommandEntries, Vector2 RelativeRotationCenter, double Distance, Vector3 Driver)
+		{
+			Distance *= StackDistance;
+			double WorldWidth, WorldHeight;
+			if (Plugin.Renderer.Screen.Width >= Plugin.Renderer.Screen.Height)
+			{
+				WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
+				WorldHeight = WorldWidth / Plugin.Renderer.Screen.AspectRatio;
+			}
+			else
+			{
+				WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance / Plugin.Renderer.Screen.AspectRatio;
+				WorldWidth = WorldHeight * Plugin.Renderer.Screen.AspectRatio;
+			}
+			double x0 = Location.X / Resolution;
+			double x1 = (Location.X + Size.X) / Resolution;
+			double y0 = (BottomRight.Y - Location.Y) / Resolution * Plugin.Renderer.Screen.AspectRatio;
+			double y1 = (BottomRight.Y - (Location.Y + Size.Y)) / Resolution * Plugin.Renderer.Screen.AspectRatio;
+			double xd = 0.5 - Center.X / Resolution;
+			x0 += xd;
+			x1 += xd;
+			double yt = BottomRight.Y - Resolution / Plugin.Renderer.Screen.AspectRatio;
+			double yd = (Center.Y - yt) / (BottomRight.Y - yt) - 0.5;
+			y0 += yd;
+			y1 += yd;
+			x0 = (x0 - 0.5) * WorldWidth;
+			x1 = (x1 - 0.5) * WorldWidth;
+			y0 = (y0 - 0.5) * WorldHeight;
+			y1 = (y1 - 0.5) * WorldHeight;
+			double xm = x0 * (1.0 - RelativeRotationCenter.X) + x1 * RelativeRotationCenter.X;
+			double ym = y0 * (1.0 - RelativeRotationCenter.Y) + y1 * RelativeRotationCenter.Y;
+			Vector3[] v = new Vector3[4];
+			v[0] = new Vector3(x0 - xm, y1 - ym, 0);
+			v[1] = new Vector3(x0 - xm, y0 - ym, 0);
+			v[2] = new Vector3(x1 - xm, y0 - ym, 0);
+			v[3] = new Vector3(x1 - xm, y1 - ym, 0);
+			Vertex t0 = new Vertex(v[0], new Vector2(0.0f, 1.0f));
+			Vertex t1 = new Vertex(v[1], new Vector2(0.0f, 0.0f));
+			Vertex t2 = new Vertex(v[2], new Vector2(1.0f, 0.0f));
+			Vertex t3 = new Vertex(v[3], new Vector2(1.0f, 1.0f));
+			StaticObject Object = new StaticObject(Plugin.currentHost);
+			Object.Mesh.Vertices = new VertexTemplate[] { t0, t1, t2, t3 };
+			Object.Mesh.Faces = new[] { new MeshFace(new[] { 0, 1, 2, 3 }) };
+			Object.Mesh.Materials = new MeshMaterial[1];
+			Object.Mesh.Materials[0].Flags = 0;
+			Object.Mesh.Materials[0].Color = Color32.White;
+			Object.Mesh.Materials[0].TransparentColor = Color24.Blue;
+			Object.Mesh.Materials[0].DaytimeTexture = null;
+			Object.Mesh.Materials[0].NighttimeTexture = null;
+			Object.Dynamic = true;
+			// calculate offset
+			Vector3 o;
+			o.X = xm + Driver.X;
+			o.Y = ym + Driver.Y;
+			o.Z = EyeDistance - Distance + Driver.Z;
+			if (Group.TouchElements == null)
+			{
+				Group.TouchElements = new TouchElement[0];
+			}
+			int n = Group.TouchElements.Length;
+			Array.Resize(ref Group.TouchElements, n + 1);
+			Group.TouchElements[n] = new TouchElement
+			{
+				Element = new AnimatedObject(Plugin.currentHost),
+				JumpScreenIndex = ScreenIndex,
+				SoundIndices = SoundIndices,
+				ControlIndices = new int[CommandEntries.Length]
+			};
+			Group.TouchElements[n].Element.States = new[] { new ObjectState() };
+			Group.TouchElements[n].Element.States[0].Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z);
+			Group.TouchElements[n].Element.States[0].Prototype = Object;
+			Group.TouchElements[n].Element.CurrentState = 0;
+			Group.TouchElements[n].Element.internalObject = new ObjectState(Object);
+			Plugin.currentHost.CreateDynamicObject(ref Group.TouchElements[n].Element.internalObject);
+			int m = Plugin.CurrentControls.Length;
+			Array.Resize(ref Plugin.CurrentControls, m + CommandEntries.Length);
+			for (int i = 0; i < CommandEntries.Length; i++)
+			{
+				Plugin.CurrentControls[m + i].Command = CommandEntries[i].Command;
+				Plugin.CurrentControls[m + i].Method = ControlMethod.Touch;
+				Plugin.CurrentControls[m + i].Option = CommandEntries[i].Option;
+				Group.TouchElements[n].ControlIndices[i] = m + i;
+			}
+		}
+	}
+}

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Keys.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Keys.cs
@@ -94,6 +94,24 @@
 		/// <summary>Sets the bottom edge of the main panel element relative to the texture</summary>
 		Bottom = 40,
 		/// <summary>Sets the center of the main panel element relative to the texture</summary>
-		Center = 41
+		Center = 41,
+		/// <summary>The element is a numerical value used when activated</summary>
+		/// <remarks>Screen switch, touch etc.</remarks>
+		Number = 42,
+		/// <summary>The element contains a size</summary>
+		Size = 43,
+		/// <summary>The element triggers a screen jump</summary>
+		JumpScreen = 44,
+		/// <summary>The element contains a sound index used when activated</summary>
+		SoundIndex = 45,
+		/// <summary>The element contains a list of sound indicies corresponding to states</summary>
+		SoundEntries = 46,
+		/// <summary>The element contains the command used when activated</summary>
+		Command = 47,
+		/// <summary>The element contains a list of command entries corresponding to states</summary>
+		CommandEntries = 48,
+		/// <summary>The option to be supplied to the command</summary>
+		/// <remarks>e.g. Power notch etc.</remarks>
+		CommandOption = 49
 	}
 }

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Keys.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Keys.cs
@@ -1,0 +1,99 @@
+﻿namespace Train.OpenBve.Panel2Cfg
+{
+	/// <summary>The different keys which can be found within a Panel2.cfg section</summary>
+	internal enum Key
+	{
+		/// <summary>Invalid</summary>
+		Invalid = 0,
+		/// <summary>Sets the controlling animation subject</summary>
+		Subject = 1,
+		/// <summary>Sets the location of the element relative to the panel bitmap</summary>
+		Location = 2,
+		/// <summary>Sets the daytime texture for the element</summary>
+		DaytimeImage = 3,
+		/// <summary>Sets the nighttime texture for the element</summary>
+		NighttimeImage = 4,
+		/// <summary>Sets the transparent color used for the element's texture</summary>
+		TransparentColor = 5,
+		TransparentColour = 5,
+		/// <summary>Sets the layer within the panel stack the element is created on</summary>
+		Layer = 6,
+		/// <summary>Sets the radius of a needle element</summary>
+		Radius = 7,
+		/// <summary>Sets the origin of a needle element</summary>
+		Origin = 8,
+		/// <summary>Sets the inital angle of a needle element</summary>
+		/// <remarks>When the subject is at minimum</remarks>
+		InitialAngle = 9,
+		/// <summary>Sets the last angle of a needle element</summary>
+		/// <remarks>When the subject is at maximum</remarks>
+		LastAngle = 10,
+		/// <summary>Sets the minimum value for angle calculations</summary>
+		Minimum = 11,
+		/// <summary>Sets the maximum value for angle calculations</summary>
+		Maximum = 12,
+		/// <summary>Sets the natural frequency for needle rotations</summary>
+		NaturalFreq = 13,
+		NaturalFrequency = 13,
+		/// <summary>Sets the damping ratio for needle rotations</summary>
+		DampingRatio = 14,
+		/// <summary>Whether a needle has a backstop</summary>
+		/// <remarks>If no backstop is present, then the needle will rotate past the minimum / maximum angles</remarks>
+		Backstop = 15,
+		/// <summary>Sets the width of an element</summary>
+		Width = 16,
+		/// <summary>Sets the height of an element</summary>
+		Height = 17,
+		/// <summary>Sets the movement / rotation direction</summary>
+		Direction = 18,
+		/// <summary>Sets the interval for DigitalNumber elements</summary>
+		Interval = 19,
+		/// <summary>Sets the step for DigitalNumber elements</summary>
+		Step = 20,
+		/// <summary>Sets the top left of the windscreen area</summary>
+		TopLeft = 21,
+		/// <summary>Sets the bottom right of the windscreen area</summary>
+		BottomRight = 22,
+		/// <summary>Sets the number of drops to be generated on the windscreen</summary>
+		NumberOfDrops = 23,
+		/// <summary>Sets the size in pixels of a drop</summary>
+		DropSize = 24,
+		/// <summary>Loads the daytime drop textures</summary>
+		DaytimeDrops = 25,
+		/// <summary>Loads the nighttime drop textures</summary>
+		NighttimeDrops = 26,
+		/// <summary>Loads the daytime snowflake textures</summary>
+		DaytimeFlakes = 27,
+		/// <summary>Loads the nighttime snowflake textures</summary>
+		NighttimeFlakes = 28,
+		/// <summary>Sets the speed at which the windscreen wipers sweep the screen</summary>
+		WipeSpeed = 29,
+		/// <summary>Sets the time for which the wipers hold at the rest position</summary>
+		WiperHoldTime = 30,
+		/// <summary>Sets the wiper rest position</summary>
+		RestPosition = 31,
+		WiperRestPosition = 31,
+		/// <summary>Sets the wiper hold position</summary>
+		HoldPosition = 32,
+		WiperHoldPosition = 32,
+		/// <summary>Sets the lifetime for a raindrop</summary>
+		DropLife = 33,
+		/// <summary>Sets the color of an element</summary>
+		Color = 34,
+		Colour = 34,
+		/// <summary>Whether the rotation of an element is smoothed</summary>
+		Smoothed = 35,
+		/// <summary>Sets the resolution of the main panel element</summary>
+		Resolution = 36,
+		/// <summary>Sets the left edge of the main panel element relative to the texture</summary>
+		Left = 37,
+		/// <summary>Sets the right edge of the main panel element relative to the texture</summary>
+		Right = 38,
+		/// <summary>Sets the top edge of the main panel element relative to the texture</summary>
+		Top = 39,
+		/// <summary>Sets the bottom edge of the main panel element relative to the texture</summary>
+		Bottom = 40,
+		/// <summary>Sets the center of the main panel element relative to the texture</summary>
+		Center = 41
+	}
+}

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Sections.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Sections.cs
@@ -18,6 +18,10 @@
 		/// <summary>A timetable bitmap overlay</summary>
 		Timetable,
 		/// <summary>The windscreen and wipers overlays</summary>
-		Windscreen
+		Windscreen,
+		/// <summary>A screen switch element</summary>
+		Screen,
+		/// <summary>A touch element</summary>
+		Touch,
 	}
 }

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Sections.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.Sections.cs
@@ -1,0 +1,23 @@
+﻿namespace Train.OpenBve.Panel2Cfg
+{
+	/// <summary>The different sections available for a Panel2.cfg</summary>
+	internal enum Section
+	{
+		/// <summary>The panel bitmap</summary>
+		This,
+		/// <summary>An on-off lamp bound to an available subject</summary>
+		PilotLamp,
+		/// <summary>A needle type gauge bound to an available subject</summary>
+		Needle,
+		/// <summary>A linear type gauge bound to an available subject</summary>
+		LinearGauge,
+		/// <summary>A digital-strip gauge bound to an available subject</summary>
+		DigitalNumber,
+		/// <summary>A digital type gauge bound to an available subject</summary>
+		DigitalGauge,
+		/// <summary>A timetable bitmap overlay</summary>
+		Timetable,
+		/// <summary>The windscreen and wipers overlays</summary>
+		Windscreen
+	}
+}

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.cs
@@ -28,10 +28,7 @@ namespace Train.OpenBve
 			Plugin = plugin;
 		}
 
-		// constants
-		private  double StackDistance = 0.000001;
-		/// <remarks>EyeDistance is required to be 1.0 by UpdateCarSectionElement and by UpdateCameraRestriction, thus cannot be easily changed.</remarks>
-		private const double EyeDistance = 1.0;
+		
 
 		/// <summary>Parses a BVE2 / openBVE panel.cfg file</summary>
 		/// <param name="PanelFile">The relative path of the panel configuration file from the train</param>
@@ -55,11 +52,7 @@ namespace Train.OpenBve
 				}
 			}
 			// initialize
-			double PanelResolution = 1024.0;
-			double PanelLeft = 0.0, PanelRight = 1024.0;
-			double PanelTop = 0.0, PanelBottom = 1024.0;
-			Vector2 PanelCenter = new Vector2(0, 512);
-			Vector2 PanelOrigin = new Vector2(0, 512);
+			
 			string PanelDaytimeImage = null;
 			string PanelNighttimeImage = null;
 			Color24 PanelTransparentColor = Color24.Blue;
@@ -91,7 +84,7 @@ namespace Train.OpenBve
 												}
 												if (pr > 100)
 												{
-													PanelResolution = pr;
+													Panel.Resolution = pr;
 												}
 												else
 												{
@@ -101,33 +94,33 @@ namespace Train.OpenBve
 												}
 												break;
 											case Key.Left:
-												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out PanelLeft)) {
+												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.TopLeft.X)) {
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line" + (i + 1).ToString(Culture) + " in " + FileName);
 												} break;
 											case Key.Right:
-												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out PanelRight)) {
+												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.BottomRight.X)) {
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 												}
 
 												if (Plugin.CurrentOptions.EnableBveTsHacks)
 												{
-													switch ((int) PanelRight)
+													switch ((int)Panel.BottomRight.X)
 													{
 														case 1696:
-															if (PanelResolution == 1024 && trainName == "TOQ2000CN1EXP10" || trainName == "TOQ8500CS8EXP10")
+															if (Panel.Resolution == 1024 && trainName == "TOQ2000CN1EXP10" || trainName == "TOQ8500CS8EXP10")
 															{
-																PanelRight = 1024;
+																Panel.BottomRight.X = 1024;
 															}
 															break;
 													}
 												}
 												break;
 											case Key.Top:
-												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out PanelTop)) {
+												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.TopLeft.Y)) {
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 												} break;
 											case Key.Bottom:
-												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out PanelBottom)) {
+												if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.BottomRight.Y)) {
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 												} break;
 											case Key.DaytimeImage:
@@ -165,15 +158,15 @@ namespace Train.OpenBve
 													{
 														string a = Value.Substring(0, k).TrimEnd();
 														string b = Value.Substring(k + 1).TrimStart();
-														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out PanelCenter.X)) {
+														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Panel.Center.X)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
-														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out PanelCenter.Y)) {
+														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Panel.Center.Y)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
 														if (Plugin.CurrentOptions.EnableBveTsHacks)
 														{
-															switch ((int)PanelCenter.Y)
+															switch ((int)Panel.Center.Y)
 															{
 																case 180:
 																	switch (trainName.ToUpperInvariant())
@@ -181,7 +174,7 @@ namespace Train.OpenBve
 																		case "LT_C69_77":
 																		case "LT_C69_77_V2":
 																			// Broken initial zoom
-																			PanelCenter.Y = 350;
+																			Panel.Center.Y = 350;
 																			break;
 																	}
 																	break;
@@ -190,19 +183,19 @@ namespace Train.OpenBve
 																	{
 																		case "HM05":
 																			// Broken initial zoom
-																			PanelCenter.Y = 350;
+																			Panel.Center.Y = 350;
 																			break;
 																	}
 																	break;
 																case 229:
-																	if (PanelBottom == 768 && PanelResolution == 1024)
+																	if (Panel.BottomRight.Y == 768 && Panel.Resolution == 1024)
 																	{
 																		// Martin Finken's BVE4 trams: Broken initial zoom
-																		PanelCenter.Y = 350;
+																		Panel.Center.Y = 350;
 																	}
 																	break;
 																case 255:
-																	if (PanelBottom == 1024 && PanelResolution == 1024)
+																	if (Panel.BottomRight.Y == 1024 && Panel.Resolution == 1024)
 																	{
 																		switch (trainName.ToUpperInvariant())
 																		{
@@ -214,13 +207,13 @@ namespace Train.OpenBve
 																			case "LT1938":
 																			case "LT1973 UNREFURB":
 																				// Broken initial zoom
-																				PanelCenter.Y = 350;
+																				Panel.Center.Y = 350;
 																				break;
 																			case "LT_A60_62":
 																			case "LT1972 MKII":
 																				// Broken initial zoom and black patch at bottom of panel
-																				PanelCenter.Y = 350;
-																				PanelBottom = 792;
+																				Panel.Center.Y = 350;
+																				Panel.BottomRight.Y = 792;
 																				break;
 																		}
 																	}
@@ -239,10 +232,10 @@ namespace Train.OpenBve
 													{
 														string a = Value.Substring(0, k).TrimEnd();
 														string b = Value.Substring(k + 1).TrimStart();
-														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out PanelOrigin.X)) {
+														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Panel.Origin.X)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
-														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out PanelOrigin.Y)) {
+														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Panel.Origin.Y)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
 														if (Plugin.CurrentOptions.EnableBveTsHacks)
@@ -250,10 +243,10 @@ namespace Train.OpenBve
 															switch (trainName)
 															{
 																case "8171BETA":
-																	if (PanelResolution == 768 && PanelOrigin.Y == 256)
+																	if (Panel.Resolution == 768 && Panel.Origin.Y == 256)
 																	{
 																		// 81-71: Bust panel origin means a flying cab....
-																		PanelOrigin.Y = 0;
+																		Panel.Origin.Y = 0;
 																	}
 																	break;
 															}
@@ -272,20 +265,20 @@ namespace Train.OpenBve
 			{ // camera restriction
 				double WorldWidth, WorldHeight;
 				if (Plugin.Renderer.Screen.Width >= Plugin.Renderer.Screen.Height) {
-					WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
+					WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * Panel.EyeDistance;
 					WorldHeight = WorldWidth / Plugin.Renderer.Screen.AspectRatio;
 				} else {
-					WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance / Plugin.Renderer.Screen.AspectRatio;
+					WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * Panel.EyeDistance / Plugin.Renderer.Screen.AspectRatio;
 					WorldWidth = WorldHeight * Plugin.Renderer.Screen.AspectRatio;
 				}
-				double x0 = (PanelLeft - PanelCenter.X) / PanelResolution;
-				double x1 = (PanelRight - PanelCenter.X) / PanelResolution;
-				double y0 = (PanelCenter.Y - PanelBottom) / PanelResolution * Plugin.Renderer.Screen.AspectRatio;
-				double y1 = (PanelCenter.Y - PanelTop) / PanelResolution * Plugin.Renderer.Screen.AspectRatio;
-				Car.CameraRestriction.BottomLeft = new Vector3(x0 * WorldWidth, y0 * WorldHeight, EyeDistance);
-				Car.CameraRestriction.TopRight = new Vector3(x1 * WorldWidth, y1 * WorldHeight, EyeDistance);
-				Car.DriverYaw = Math.Atan((PanelCenter.X - PanelOrigin.X) * WorldWidth / PanelResolution);
-				Car.DriverPitch = Math.Atan((PanelOrigin.Y - PanelCenter.Y) * WorldWidth / PanelResolution);
+				double x0 = (Panel.TopLeft.X - Panel.Center.X) / Panel.Resolution;
+				double x1 = (Panel.BottomRight.X - Panel.Center.X) / Panel.Resolution;
+				double y0 = (Panel.Center.Y - Panel.BottomRight.Y) / Panel.Resolution * Plugin.Renderer.Screen.AspectRatio;
+				double y1 = (Panel.Center.Y - Panel.TopLeft.Y) / Panel.Resolution * Plugin.Renderer.Screen.AspectRatio;
+				Car.CameraRestriction.BottomLeft = new Vector3(x0 * WorldWidth, y0 * WorldHeight, Panel.EyeDistance);
+				Car.CameraRestriction.TopRight = new Vector3(x1 * WorldWidth, y1 * WorldHeight, Panel.EyeDistance);
+				Car.DriverYaw = Math.Atan((Panel.Center.X - Panel.Origin.X) * WorldWidth / Panel.Resolution);
+				Car.DriverPitch = Math.Atan((Panel.Origin.Y - Panel.Center.Y) * WorldWidth / Panel.Resolution);
 			}
 			// create panel
 			if (PanelDaytimeImage != null) {
@@ -302,7 +295,7 @@ namespace Train.OpenBve
 							Plugin.currentHost.RegisterTexture(PanelNighttimeImage, new TextureParameters(null, PanelTransparentColor), out tnight, true);
 						}
 					}
-					CreateElement(ref Car.CarSections[0].Groups[0], 0.0, 0.0, new Vector2(0.5, 0.5), 0.0, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight);
+					Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[0], 0.0, 0.0, new Vector2(0.5, 0.5), 0.0, Car.Driver, tday, tnight);
 				}
 			}
 
@@ -416,7 +409,7 @@ namespace Train.OpenBve
 										}
 										int w = tday.Width;
 										int h = tday.Height;
-										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, w, h, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight, Color32.White);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, w, h, new Vector2(0.5, 0.5), Layer, Car.Driver, tday, tnight, Color32.White);
 										string f = GetStackLanguageFromSubject(Car.baseTrain, Subject, Section + " in " + FileName);
 										try
 										{
@@ -603,7 +596,7 @@ namespace Train.OpenBve
 										double n = Radius == 0.0 | OriginY == 0.0 ? 1.0 : Radius / OriginY;
 										double nx = n * tday.Width;
 										double ny = n * tday.Height;
-										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX - ox * nx, LocationY - oy * ny, nx, ny, new Vector2(ox, oy), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight, Color);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX - ox * nx, LocationY - oy * ny, nx, ny, new Vector2(ox, oy), Layer, Car.Driver, tday, tnight, Color);
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateZDirection = Vector3.Backward;
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateXDirection = Vector3.Right;
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateYDirection = Vector3.Cross(Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateZDirection, Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateXDirection);
@@ -772,7 +765,7 @@ namespace Train.OpenBve
 										if (NighttimeImage != null) {
 											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight, true);
 										}
-										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, tday.Width, tday.Height, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight, Color32.White);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, tday.Width, tday.Height, new Vector2(0.5, 0.5), Layer, Car.Driver, tday, tnight, Color32.White);
 										if (Maximum < Minimum)
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Maximum value must be greater than minimum value " + Section + " in " + FileName);
@@ -957,7 +950,7 @@ namespace Train.OpenBve
 											}
 											int j = -1;
 											for (int k = 0; k < tday.Length; k++) {
-												int l = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, wday, Interval, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday[k], tnight[k], Color32.White, k != 0);
+												int l = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, wday, Interval, new Vector2(0.5, 0.5), Layer, Car.Driver, tday[k], tnight[k], Color32.White, k != 0);
 												if (k == 0) j = l;
 											}
 											string f = GetStackLanguageFromSubject(Car.baseTrain, Subject, Section + " in " + FileName);
@@ -976,20 +969,20 @@ namespace Train.OpenBve
 												{
 													if (Subject == "power")
 													{
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.PowerDecrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.PowerIncrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.PowerDecrease } }, new Vector2(0.5, 0.5), 0, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.PowerIncrease } }, new Vector2(0.5, 0.5), 0, Car.Driver);
 													}
 
 													if (Subject == "brake")
 													{
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.BrakeIncrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.BrakeDecrease } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.BrakeIncrease } }, new Vector2(0.5, 0.5), 0, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.BrakeDecrease } }, new Vector2(0.5, 0.5), 0, Car.Driver);
 													}
 
 													if (Subject == "reverser")
 													{
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.ReverserForward } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
-														Plugin.PanelXmlParser.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.ReverserBackward } }, new Vector2(0.5, 0.5), 0, PanelResolution, PanelBottom, PanelCenter, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.ReverserForward } }, new Vector2(0.5, 0.5), 0, Car.Driver);
+														Plugin.Panel.CreateTouchElement(Car.CarSections[0].Groups[GroupIndex], new Vector2(LocationX, LocationY + Interval / 2.0), new Vector2(wday, Interval / 2.0), GroupIndex - 1, new int[0], new[] { new CommandEntry { Command = Translations.Command.ReverserBackward } }, new Vector2(0.5, 0.5), 0, Car.Driver);
 													}
 												}
 											}
@@ -1105,7 +1098,7 @@ namespace Train.OpenBve
 									}
 									if (Radius != 0.0) {
 										// create element
-										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX - Radius, LocationY - Radius, 2.0 * Radius, 2.0 * Radius, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, null, null, Color);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX - Radius, LocationY - Radius, 2.0 * Radius, 2.0 * Radius, new Vector2(0.5, 0.5), Layer, Car.Driver, null, null, Color);
 										InitialAngle = InitialAngle + Math.PI;
 										LastAngle = LastAngle + Math.PI;
 										double x0 = Car.CarSections[0].Groups[GroupIndex].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.X;
@@ -1236,7 +1229,7 @@ namespace Train.OpenBve
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "Height is required to be specified in " + Section + " in " + FileName);
 									}
 									if (Width > 0.0 & Height > 0.0) {
-										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, Width, Height, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, null, null, Color32.White);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, Width, Height, new Vector2(0.5, 0.5), Layer, Car.Driver, null, null, Color32.White);
 										try
 										{
 											Car.CarSections[0].Groups[GroupIndex].Elements[j].StateFunction = new FunctionScript(Plugin.currentHost, "panel2timetable", false);
@@ -1252,8 +1245,8 @@ namespace Train.OpenBve
 							case Panel2Cfg.Section.Windscreen:
 								{
 									i++;
-									Vector2 topLeft = new Vector2(PanelLeft, PanelTop);
-									Vector2 bottomRight = new Vector2(PanelRight, PanelBottom);
+									Vector2 topLeft = new Vector2(Panel.TopLeft);
+									Vector2 bottomRight = new Vector2(Panel.BottomRight);
 									int numberOfDrops = 16, Layer = 0, dropSize = 16;
 									WiperPosition restPosition = WiperPosition.Left, holdPosition = WiperPosition.Left;
 									List<string> daytimeDropFiles, nighttimeDropFiles, daytimeFlakeFiles, nighttimeFlakeFiles;
@@ -1481,8 +1474,8 @@ namespace Train.OpenBve
 										int DropTexture = Plugin.RandomNumberGenerator.Next(daytimeDrops.Count);
 										double currentDropY = Plugin.RandomNumberGenerator.NextDouble() * (bottomRight.Y - topLeft.Y) + topLeft.Y;
 										//Create both a drop and a snowflake at the same position, the windscreen code will determine which is shown
-										int panelDropIndex = CreateElement(ref Car.CarSections[0].Groups[0], currentDropX, currentDropY, dropSize, dropSize, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, daytimeDrops[DropTexture], nighttimeDrops[DropTexture], Color32.White);
-										int panelFlakeIndex = CreateElement(ref Car.CarSections[0].Groups[0], currentDropX, currentDropY, dropSize, dropSize, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, daytimeFlakes[DropTexture], nighttimeFlakes[DropTexture], Color32.White);
+										int panelDropIndex = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[0], currentDropX, currentDropY, dropSize, dropSize, new Vector2(0.5, 0.5), Layer,  Car.Driver, daytimeDrops[DropTexture], nighttimeDrops[DropTexture], Color32.White);
+										int panelFlakeIndex = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[0], currentDropX, currentDropY, dropSize, dropSize, new Vector2(0.5, 0.5), Layer, Car.Driver, daytimeFlakes[DropTexture], nighttimeFlakes[DropTexture], Color32.White);
 										string f = drop + " raindrop";
 										string f2 = drop + " snowflake";
 										try
@@ -1719,98 +1712,7 @@ namespace Train.OpenBve
 			return Code + Suffix;
 		}
 
-		internal int CreateElement(ref ElementsGroup Group, double Left, double Top, Vector2 RelativeRotationCenter, double Distance, double PanelResolution, double PanelBottom, Vector2 PanelCenter, Vector3 Driver, Texture DaytimeTexture, Texture NighttimeTexture, bool AddStateToLastElement = false)
-		{
-			return CreateElement(ref Group, Left, Top, DaytimeTexture.Width, DaytimeTexture.Height, RelativeRotationCenter, Distance, PanelResolution, PanelBottom, PanelCenter, Driver, DaytimeTexture, NighttimeTexture, Color32.White, AddStateToLastElement);
-		}
-
-		internal int CreateElement(ref ElementsGroup Group, double Left, double Top, double Width, double Height, Vector2 RelativeRotationCenter, double Distance, double PanelResolution, double PanelBottom, Vector2 PanelCenter, Vector3 Driver, Texture DaytimeTexture, Texture NighttimeTexture, Color32 Color, bool AddStateToLastElement = false)
-		{
-			if (Width == 0 || Height == 0)
-			{
-				Plugin.currentHost.AddMessage(MessageType.Error, false, "Attempted to create an invalid size element");
-			}
-			double WorldWidth, WorldHeight;
-			if (Plugin.Renderer.Screen.Width >= Plugin.Renderer.Screen.Height) {
-				WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
-				WorldHeight = WorldWidth / Plugin.Renderer.Screen.AspectRatio;
-			} else {
-				WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance / Plugin.Renderer.Screen.AspectRatio;
-				WorldWidth = WorldHeight * Plugin.Renderer.Screen.AspectRatio;
-			}
-			double x0 = Left / PanelResolution;
-			double x1 = (Left + Width) / PanelResolution;
-			double y0 = (PanelBottom - Top) / PanelResolution * Plugin.Renderer.Screen.AspectRatio;
-			double y1 = (PanelBottom - (Top + Height)) / PanelResolution * Plugin.Renderer.Screen.AspectRatio;
-			double xd = 0.5 - PanelCenter.X / PanelResolution;
-			x0 += xd; x1 += xd;
-			double yt = PanelBottom - PanelResolution / Plugin.Renderer.Screen.AspectRatio;
-			double yd = (PanelCenter.Y - yt) / (PanelBottom - yt) - 0.5;
-			y0 += yd; y1 += yd;
-			x0 = (x0 - 0.5) * WorldWidth;
-			x1 = (x1 - 0.5) * WorldWidth;
-			y0 = (y0 - 0.5) * WorldHeight;
-			y1 = (y1 - 0.5) * WorldHeight;
-			double xm = x0 * (1.0 - RelativeRotationCenter.X) + x1 * RelativeRotationCenter.X;
-			double ym = y0 * (1.0 - RelativeRotationCenter.Y) + y1 * RelativeRotationCenter.Y;
-			Vector3[] v = new Vector3[4];
-			v[0] = new Vector3(x0 - xm, y1 - ym, 0);
-			v[1] = new Vector3(x0 - xm, y0 - ym, 0);
-			v[2] = new Vector3(x1 - xm, y0 - ym, 0);
-			v[3] = new Vector3(x1 - xm, y1 - ym, 0);
-			Vertex t0 = new Vertex(v[0], new Vector2(0.0f, 1.0f));
-			Vertex t1 = new Vertex(v[1], new Vector2(0.0f, 0.0f));
-			Vertex t2 = new Vertex(v[2], new Vector2(1.0f, 0.0f));
-			Vertex t3 = new Vertex(v[3], new Vector2(1.0f, 1.0f));
-			StaticObject Object = new StaticObject(Plugin.currentHost);
-			Object.Mesh.Vertices = new VertexTemplate[] { t0, t1, t2, t3 };
-			Object.Mesh.Faces = new[] { new MeshFace(new[] { 0, 1, 2, 3 }) };
-			Object.Mesh.Materials = new MeshMaterial[1];
-			Object.Mesh.Materials[0].Flags = new MaterialFlags();
-			if (DaytimeTexture != null)
-			{
-				Object.Mesh.Materials[0].Flags |= MaterialFlags.TransparentColor;
-
-				if (NighttimeTexture != null)
-				{
-					// In BVE4 and versions of OpenBVE prior to v1.7.1.0, elements with NighttimeImage defined are rendered with lighting disabled.
-					Object.Mesh.Materials[0].Flags |= MaterialFlags.DisableLighting;
-				}
-			}
-			Object.Mesh.Materials[0].Color = Color;
-			Object.Mesh.Materials[0].TransparentColor = Color24.Blue;
-			Object.Mesh.Materials[0].DaytimeTexture = DaytimeTexture;
-			Object.Mesh.Materials[0].NighttimeTexture = NighttimeTexture;
-			Object.Dynamic = true;
-			// calculate offset
-			Vector3 o;
-			o.X = xm + Driver.X;
-			o.Y = ym + Driver.Y;
-			o.Z = EyeDistance - Distance + Driver.Z;
-			// add object
-			if (AddStateToLastElement) {
-				int n = Group.Elements.Length - 1;
-				int j = Group.Elements[n].States.Length;
-				Array.Resize(ref Group.Elements[n].States, j + 1);
-				Group.Elements[n].States[j] = new ObjectState
-				{
-					Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z),
-					Prototype = Object
-				};
-				return n;
-			} else {
-				int n = Group.Elements.Length;
-				Array.Resize(ref Group.Elements, n + 1);
-				Group.Elements[n] = new AnimatedObject(Plugin.currentHost);
-				Group.Elements[n].States = new[] { new ObjectState() };
-				Group.Elements[n].States[0].Translation = Matrix4D.CreateTranslation(o.X, o.Y, -o.Z);
-				Group.Elements[n].States[0].Prototype = Object;
-				Group.Elements[n].CurrentState = 0;
-				Group.Elements[n].internalObject = new ObjectState { Prototype = Object };
-				Plugin.currentHost.CreateDynamicObject(ref Group.Elements[n].internalObject);
-				return n;
-			}
-		}
+		
 
 	}
 }

--- a/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2Cfg/Panel2CfgParser.cs
@@ -328,7 +328,7 @@ namespace Train.OpenBve
 							case Panel2Cfg.Section.PilotLamp:
 								{
 									string Subject = "true";
-									double LocationX = 0.0, LocationY = 0.0;
+									Vector2 Location = new Vector2();
 									string DaytimeImage = null, NighttimeImage = null;
 									Color24 TransparentColor = Color24.Blue;
 									int Layer = 0;
@@ -352,10 +352,10 @@ namespace Train.OpenBve
 													{
 														string a = Value.Substring(0, k).TrimEnd();
 														string b = Value.Substring(k + 1).TrimStart();
-														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX)) {
+														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
-														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY)) {
+														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "Top is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
 													} else {
@@ -409,7 +409,7 @@ namespace Train.OpenBve
 										}
 										int w = tday.Width;
 										int h = tday.Height;
-										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, w, h, new Vector2(0.5, 0.5), Layer, Car.Driver, tday, tnight, Color32.White);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], Location.X, Location.Y, w, h, new Vector2(0.5, 0.5), Layer, Car.Driver, tday, tnight, Color32.White);
 										string f = GetStackLanguageFromSubject(Car.baseTrain, Subject, Section + " in " + FileName);
 										try
 										{
@@ -425,11 +425,11 @@ namespace Train.OpenBve
 							case Panel2Cfg.Section.Needle:
 								{
 									string Subject = "true";
-									double LocationX = 0.0, LocationY = 0.0;
+									Vector2 Location = new Vector2();
 									string DaytimeImage = null, NighttimeImage = null;
 									Color32 Color = Color32.White;
 									Color24 TransparentColor = Color24.Blue;
-									double OriginX = -1.0, OriginY = -1.0;
+									Vector2 Origin = new Vector2(-1, -1);
 									bool OriginDefined = false;
 									double Layer = 0.0, Radius = 0.0;
 									double InitialAngle = -2.0943951023932, LastAngle = 2.0943951023932;
@@ -457,10 +457,10 @@ namespace Train.OpenBve
 														{
 															string a = Value.Substring(0, k).TrimEnd();
 															string b = Value.Substring(k + 1).TrimStart();
-															if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX)) {
+															if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X)) {
 																Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterX is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 															}
-															if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY)) {
+															if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y)) {
 																Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterY is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 															}
 														} else {
@@ -513,12 +513,12 @@ namespace Train.OpenBve
 														{
 															string a = Value.Substring(0, k).TrimEnd();
 															string b = Value.Substring(k + 1).TrimStart();
-															if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out OriginX)) {
+															if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Origin.X)) {
 																Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 															}
-															if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out OriginY)) {
+															if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Origin.Y)) {
 																Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
-																OriginX = -OriginX;
+																Origin.X = -Origin.X;
 															}
 															OriginDefined = true;
 														} else {
@@ -588,15 +588,15 @@ namespace Train.OpenBve
 											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight, true);
 										}
 										if (!OriginDefined) {
-											OriginX = 0.5 * tday.Width;
-											OriginY = 0.5 * tday.Height;
+											Origin.X = 0.5 * tday.Width;
+											Origin.Y = 0.5 * tday.Height;
 										}
-										double ox = OriginX / tday.Width;
-										double oy = OriginY / tday.Height;
-										double n = Radius == 0.0 | OriginY == 0.0 ? 1.0 : Radius / OriginY;
+										double ox = Origin.X / tday.Width;
+										double oy = Origin.Y / tday.Height;
+										double n = Radius == 0.0 | Origin.Y == 0.0 ? 1.0 : Radius / Origin.Y;
 										double nx = n * tday.Width;
 										double ny = n * tday.Height;
-										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX - ox * nx, LocationY - oy * ny, nx, ny, new Vector2(ox, oy), Layer, Car.Driver, tday, tnight, Color);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], Location.X - ox * nx, Location.Y - oy * ny, nx, ny, new Vector2(ox, oy), Layer, Car.Driver, tday, tnight, Color);
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateZDirection = Vector3.Backward;
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateXDirection = Vector3.Right;
 										Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateYDirection = Vector3.Cross(Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateZDirection, Car.CarSections[0].Groups[GroupIndex].Elements[j].RotateXDirection);
@@ -1165,7 +1165,7 @@ namespace Train.OpenBve
 								// timetable
 							case Panel2Cfg.Section.Timetable:
 								{
-									double LocationX = 0.0, LocationY = 0.0;
+									Vector2 Location = new Vector2();
 									double Width = 0.0, Height = 0.0;
 									//We read the transparent color for the timetable from the config file, but it is never used
 									//TODO: Fix or depreciate??
@@ -1189,10 +1189,10 @@ namespace Train.OpenBve
 													{
 														string a = Value.Substring(0, k).TrimEnd();
 														string b = Value.Substring(k + 1).TrimStart();
-														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX)) {
+														if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
-														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY)) {
+														if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y)) {
 															Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 														}
 													} else {
@@ -1229,7 +1229,7 @@ namespace Train.OpenBve
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "Height is required to be specified in " + Section + " in " + FileName);
 									}
 									if (Width > 0.0 & Height > 0.0) {
-										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, Width, Height, new Vector2(0.5, 0.5), Layer, Car.Driver, null, null, Color32.White);
+										int j = Plugin.Panel.CreateElement(ref Car.CarSections[0].Groups[GroupIndex], Location.X, Location.Y, Width, Height, new Vector2(0.5, 0.5), Layer, Car.Driver, null, null, Color32.White);
 										try
 										{
 											Car.CarSections[0].Groups[GroupIndex].Elements[j].StateFunction = new FunctionScript(Plugin.currentHost, "panel2timetable", false);

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfg.Keys.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfg.Keys.cs
@@ -1,0 +1,79 @@
+﻿namespace Train.OpenBve.PanelCfg
+{
+	/// <summary>The different keys which can be found within a Panel.cfg section</summary>
+	internal enum Key
+	{
+		/// <summary>Invalid</summary>
+		Invalid = 0,
+		/// <summary>Sets the yaw for the panel element</summary>
+		Yaw = 1,
+		/// <summary>Sets the pitch for the panel element</summary>
+		Pitch = 2,
+		/// <summary>The type of element</summary>
+		Type = 3,
+		形態 = 3,
+		/// <summary>A lower needle / hand element</summary>
+		LowerNeedle = 4,
+		LowerHand = 4,
+		下針 = 4,
+		/// <summary>An upper needle / hand element</summary>
+		UpperNeedle = 5,
+		UppperHand = 5,
+		上針 = 5,
+		/// <summary>Sets the center of an element</summary>
+		Center = 6,
+		中心 = 6,
+		/// <summary>Sets the radius of a needle / hand element</summary>
+		Radius = 7,
+		半径 = 7,
+		/// <summary>Sets the cover texture of an element</summary>
+		Cover = 8,
+		ふた = 8,
+		/// <summary>Sets the units for an element's subject</summary>
+		Unit = 9,
+		単位 = 9,
+		/// <summary>Sets the maximum for a needle / hand element</summary>
+		Maximum = 10,
+		最大 = 10,
+		/// <summary>Sets the minimum for a needle / hand element</summary>
+		Minimum = 11,
+		最小 = 11,
+		/// <summary>Sets the angle for a needle / hand element</summary>
+		Angle = 12,
+		角度 = 12,
+		/// <summary>A generic needle / hand element</summary>
+		Needle = 13,
+		Hand = 13,
+		針 = 13,
+		/// <summary>An ATC lamp element</summary>
+		/// <remarks>No SHIFT_JIS equivilant</remarks>
+		ATC = 14,
+		/// <summary>Sets the radius of the ATC speed display</summary>
+		ATCRadius = 15,
+		ATC半径 = 15,
+		/// <summary>A number strip element</summary>
+		Number = 16,
+		数字 = 16,
+		/// <summary>Sets the upper left corner of an element</summary>
+		Corner = 17,
+		左上 = 17,
+		/// <summary>Sets the size of an element</summary>
+		Size = 18,
+		サイズ = 18,
+		/// <summary>Sets the width of an element</summary>
+		Width = 19,
+		幅 = 19,
+		/// <summary>Sets the texture to be displayed when a PilotLamp turns on</summary>
+		TurnOn = 20,
+		点灯 = 20,
+		/// <summary>Sets the texture to be displayed when a PilotLamp turns off</summary>
+		TurnOff = 21,
+		消灯 = 21,
+		/// <summary>Sets the texture for an element</summary>
+		Image = 22,
+		画像 = 22,
+		/// <summary>Sets the background texture for an element</summary>
+		Background = 23,
+		背景 = 23,
+	}
+}

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfg.Sections.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfg.Sections.cs
@@ -1,0 +1,32 @@
+﻿namespace Train.OpenBve.PanelCfg
+{
+	/// <summary>The different sections available for a Panel.cfg</summary>
+	internal enum Section
+	{
+		/// <summary>The panel bitmap</summary>
+		Panel = 0,
+		/// <summary>Sets up the pitch and yaw of the panel</summary>
+		View = 1,
+		/// <summary>A dial type gauge indicating brake pressure</summary>
+		PressureGauge = 2,
+		PressureMeter = 2,
+		PressureIndicator = 2,
+		圧力計 = 2,
+		/// <summary>A dial type gauge indicating speed</summary>
+		Speedometer = 3,
+		SpeedIndicator = 3,
+		速度計 = 3,
+		/// <summary>A digital-strip gauge bound to an available subject</summary>
+		DigitalIndicator = 4,
+		デジタル速度計 = 4,
+		/// <summary>A lamp lit when the train is ready to start</summary>
+		PilotLamp = 5,
+		知らせ灯 = 5,
+		/// <summary>A dial type gauge indicating time</summary>
+		Watch = 6,
+		時計 = 7,
+		/// <summary>A digital-strip gauge indicating the current brake value</summary>
+		BrakeIndicator = 7,
+		ハンドルの段表示 = 7
+	}
+}

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfgParser.cs
@@ -27,7 +27,6 @@ namespace Train.OpenBve
 		/// <remarks>EyeDistance is required to be 1.0 by UpdateCarSectionElement and by UpdateCameraRestriction, thus cannot be easily changed</remarks>
 		private const double EyeDistance = 1.0;
 
-		private double WorldWidth, WorldHeight, WorldLeft, WorldTop;
 		private double FullWidth = 480, FullHeight = 440, SemiHeight = 240;
 
 		/// <summary>Parses a BVE1 panel.cfg file</summary>
@@ -55,19 +54,19 @@ namespace Train.OpenBve
 
 			if (Plugin.Renderer.Screen.Width >= Plugin.Renderer.Screen.Height)
 			{
-				WorldWidth = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
-				WorldHeight = WorldWidth / AspectRatio;
+				Panel.BottomRight.X = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.HorizontalViewingAngle) * EyeDistance;
+				Panel.BottomRight.Y = Panel.BottomRight.X / AspectRatio;
 			}
 			else
 			{
-				WorldHeight = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance;
-				WorldWidth = WorldHeight * AspectRatio;
+				Panel.BottomRight.Y = 2.0 * Math.Tan(0.5 * Plugin.Renderer.Camera.VerticalViewingAngle) * EyeDistance;
+				Panel.BottomRight.X = Panel.BottomRight.Y * AspectRatio;
 			}
 
-			Car.CameraRestriction.BottomLeft = new Vector3(-0.5 * WorldWidth, -0.5 * WorldHeight, EyeDistance);
-			Car.CameraRestriction.TopRight = new Vector3(0.5 * WorldWidth, 0.5 * WorldHeight, EyeDistance);
-			WorldLeft = Car.Driver.X - 0.5 * WorldWidth;
-			WorldTop = Car.Driver.Y + 0.5 * WorldHeight;
+			Car.CameraRestriction.BottomLeft = new Vector3(-0.5 * Panel.BottomRight.X, -0.5 * Panel.BottomRight.Y, EyeDistance);
+			Car.CameraRestriction.TopRight = new Vector3(0.5 * Panel.BottomRight.X, 0.5 * Panel.BottomRight.Y, EyeDistance);
+			Panel.TopLeft.X = Car.Driver.X - 0.5 * Panel.BottomRight.X;
+			Panel.TopLeft.Y = Car.Driver.Y + 0.5 * Panel.BottomRight.Y;
 			double WorldZ = Car.Driver.Z;
 			const double UpDownAngleConstant = -0.191986217719376;
 			double PanelYaw = 0.0;
@@ -1533,8 +1532,8 @@ namespace Train.OpenBve
 			// create object
 			StaticObject Object = new StaticObject(Plugin.currentHost);
 			Vector3[] v = new Vector3[4];
-			double sx = 0.5 * WorldWidth * Width / FullWidth;
-			double sy = 0.5 * WorldHeight * Height / FullHeight;
+			double sx = 0.5 * Panel.BottomRight.X * Width / FullWidth;
+			double sy = 0.5 * Panel.BottomRight.Y * Height / FullHeight;
 			v[0] = new Vector3(-sx, -sy, 0);
 			v[1] = new Vector3(-sx, sy, 0);
 			v[2] = new Vector3(sx, sy, 0);
@@ -1559,8 +1558,8 @@ namespace Train.OpenBve
 			Object.Dynamic = true;
 			// calculate offset
 			Vector3 o;
-			o.X = WorldLeft + sx + WorldWidth * Left / FullWidth;
-			o.Y = WorldTop - sy - WorldHeight * Top / FullHeight;
+			o.X = Panel.TopLeft.X + sx + Panel.BottomRight.X * Left / FullWidth;
+			o.Y = Panel.TopLeft.Y - sy - Panel.BottomRight.Y * Top / FullHeight;
 			o.Z = WorldZ;
 			// add object
 			if (AddStateToLastElement)

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfg/PanelCfgParser.cs
@@ -6,6 +6,7 @@ using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Textures;
+using Train.OpenBve.PanelCfg;
 using TrainManager.Car;
 using TrainManager.Handles;
 
@@ -80,21 +81,29 @@ namespace Train.OpenBve
 					if (Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal))
 					{
 						string Section = Lines[i].Substring(1, Lines[i].Length - 2).Trim();
-						switch (Section.ToLowerInvariant())
+						if (!Enum.TryParse(Section, true, out Section section))
+						{
+							Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised section " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+						}
+						switch (section)
 						{
 							// panel
-							case "panel":
+							case PanelCfg.Section.Panel:
 								i++;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal)))
 								{
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
-										string Value = Lines[i].Substring(j + 1).TrimStart();
-										switch (Key.ToLowerInvariant())
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
 										{
-											case "background":
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
+										string Value = Lines[i].Substring(j + 1).TrimStart();
+										switch (Key)
+										{
+											case Key.Background:
 												if (Path.ContainsInvalidChars(Value))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "FileName contains illegal characters in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -119,18 +128,22 @@ namespace Train.OpenBve
 								i--;
 								break;
 							// view
-							case "view":
+							case PanelCfg.Section.View:
 								i++;
 								while (i < Lines.Length && !(Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal)))
 								{
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
-										string Value = Lines[i].Substring(j + 1).TrimStart();
-										switch (Key.ToLowerInvariant())
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
 										{
-											case "yaw":
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
+										string Value = Lines[i].Substring(j + 1).TrimStart();
+										switch (Key)
+										{
+											case Key.Yaw:
 											{
 												double yaw = 0.0;
 												if (Value.Length > 0 && !NumberFormats.TryParseDoubleVb6(Value, out yaw))
@@ -142,7 +155,7 @@ namespace Train.OpenBve
 												PanelYaw = Math.Atan(yaw);
 											}
 												break;
-											case "pitch":
+											case Key.Pitch:
 											{
 												double pitch = 0.0;
 												if (Value.Length > 0 && !NumberFormats.TryParseDoubleVb6(Value, out pitch))
@@ -198,17 +211,18 @@ namespace Train.OpenBve
 					if (Lines[i].StartsWith("[", StringComparison.Ordinal) & Lines[i].EndsWith("]", StringComparison.Ordinal))
 					{
 						string Section = Lines[i].Substring(1, Lines[i].Length - 2).Trim();
-						switch (Section.ToLowerInvariant())
+						if (!Enum.TryParse(Section, true, out Section section))
+						{
+							Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised section " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+						}
+						switch (section)
 						{
 							// pressuregauge
-							case "pressuregauge":
-							case "pressuremeter":
-							case "pressureindicator":
-							case "圧力計":
+							case PanelCfg.Section.PressureGauge:
 							{
 								int Type = 0;
-								Color32[] NeedleColor = new Color32[] {Color32.Black, Color32.Black};
-								int[] NeedleType = new int[] {0, 0};
+								Color32[] NeedleColor = {Color32.Black, Color32.Black};
+								int[] NeedleType = {0, 0};
 								double CenterX = 0.0, CenterY = 0.0, Radius = 16.0;
 								string Background = null, Cover = null;
 								double Angle = 0.785398163397449, Minimum = 0.0, Maximum = 1000.0;
@@ -219,13 +233,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "type":
-											case "形態":
+											case Key.Type:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out Type))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Type is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -238,13 +255,9 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "lowerneedle":
-											case "lowerhand":
-											case "下針":
-											case "upperneedle":
-											case "upperhand":
-											case "上針":
-												int k = Key.ToLowerInvariant() == "lowerneedle" | Key.ToLowerInvariant() == "lowerhand" | Key == "下針" ? 0 : 1;
+											case Key.LowerNeedle:
+											case Key.UpperNeedle:
+												int k = Key == Key.LowerNeedle ? 0 : 1;
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0)
 												{
 													switch (Arguments[0].ToLowerInvariant())
@@ -324,8 +337,7 @@ namespace Train.OpenBve
 
 												NeedleColor[k] = new Color32((byte) r, (byte) g, (byte) b, 255);
 												break;
-											case "center":
-											case "中心":
+											case Key.Center:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CenterX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -338,8 +350,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "radius":
-											case "半径":
+											case Key.Radius:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Radius))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -347,8 +358,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "background":
-											case "背景":
+											case Key.Background:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -365,8 +375,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "cover":
-											case "ふた":
+											case Key.Cover:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -383,8 +392,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "unit":
-											case "単位":
+											case Key.Unit:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0)
 												{
 													string a = Arguments[0].ToLowerInvariant();
@@ -408,8 +416,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "maximum":
-											case "最大":
+											case Key.Maximum:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Maximum))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "PressureValue is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -417,8 +424,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "minimum":
-											case "最小":
+											case Key.Minimum:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Minimum))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "PressureValue is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -426,8 +432,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "angle":
-											case "角度":
+											case Key.Angle:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Angle))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -582,9 +587,7 @@ namespace Train.OpenBve
 							}
 								break;
 							// speedometer
-							case "speedometer":
-							case "speedindicator":
-							case "速度計":
+							case PanelCfg.Section.Speedometer:
 							{
 								int Type = 0;
 								Color32 Needle = Color32.White;
@@ -598,13 +601,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "type":
-											case "形態":
+											case Key.Type:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out Type))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -617,8 +623,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "background":
-											case "背景":
+											case Key.Background:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -635,9 +640,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "needle":
-											case "hand":
-											case "針":
+											case Key.Needle:
 											{
 												int r = 0, g = 0, b = 0;
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out r))
@@ -677,8 +680,7 @@ namespace Train.OpenBve
 												NeedleOverridden = true;
 											}
 												break;
-											case "cover":
-											case "ふた":
+											case Key.Cover:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												Cover = Path.CombineFile(TrainPath, Value);
 												if (!System.IO.File.Exists(Cover))
@@ -686,9 +688,8 @@ namespace Train.OpenBve
 													Plugin.currentHost.AddMessage(MessageType.Error, true, "FileName" + Cover + " could not be found in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													Cover = null;
 												}
-
 												break;
-											case "atc":
+											case Key.ATC:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												Atc = Path.CombineFile(TrainPath, Value);
 												if (!System.IO.File.Exists(Atc))
@@ -696,19 +697,15 @@ namespace Train.OpenBve
 													Plugin.currentHost.AddMessage(MessageType.Error, true, "FileName" + Atc + " could not be found in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													Atc = null;
 												}
-
 												break;
-											case "atcradius":
-											case "atc半径":
+											case Key.ATCRadius:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out AtcRadius))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													AtcRadius = 0.0;
 												}
-
 												break;
-											case "center":
-											case "中心":
+											case Key.Center:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CenterX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -719,19 +716,15 @@ namespace Train.OpenBve
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													CenterY = 0.0;
 												}
-
 												break;
-											case "radius":
-											case "半径":
+											case Key.Radius:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Radius))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													Radius = 0.0;
 												}
-
 												break;
-											case "angle":
-											case "角度":
+											case Key.Angle:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Angle))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -741,10 +734,8 @@ namespace Train.OpenBve
 												{
 													Angle = Angle.ToRadians();
 												}
-
 												break;
-											case "maximum":
-											case "最大":
+											case Key.Maximum:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Maximum))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "SpeedValue is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -754,7 +745,6 @@ namespace Train.OpenBve
 												{
 													Maximum *= 0.277777777777778;
 												}
-
 												break;
 										}
 									}
@@ -924,8 +914,7 @@ namespace Train.OpenBve
 							}
 								break;
 							// digitalindicator
-							case "digitalindicator":
-							case "デジタル速度計":
+							case PanelCfg.Section.DigitalIndicator:
 							{
 								string Number = null;
 								double CornerX = 0.0, CornerY = 0.0;
@@ -937,13 +926,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "number":
-											case "数字":
+											case Key.Number:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -960,8 +952,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "corner":
-											case "左上":
+											case Key.Corner:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CornerX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -974,8 +965,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "size":
-											case "サイズ":
+											case Key.Size:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out Width))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Width is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -988,7 +978,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "unit":
+											case Key.Unit:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0)
 												{
 													string a = Arguments[0].ToLowerInvariant();
@@ -1138,8 +1128,7 @@ namespace Train.OpenBve
 							}
 								break;
 							// pilotlamp
-							case "pilotlamp":
-							case "知らせ灯":
+							case PanelCfg.Section.PilotLamp:
 							{
 								double CornerX = 0.0, CornerY = 0.0;
 								string TurnOn = null, TurnOff = null;
@@ -1149,13 +1138,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "turnon":
-											case "点灯":
+											case Key.TurnOn:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -1170,10 +1162,8 @@ namespace Train.OpenBve
 														TurnOn = null;
 													}
 												}
-
 												break;
-											case "turnoff":
-											case "消灯":
+											case Key.TurnOff:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -1188,10 +1178,8 @@ namespace Train.OpenBve
 														TurnOff = null;
 													}
 												}
-
 												break;
-											case "corner":
-											case "左上":
+											case Key.Corner:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CornerX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -1202,7 +1190,6 @@ namespace Train.OpenBve
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Top is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													CornerY = 0.0;
 												}
-
 												break;
 										}
 									}
@@ -1222,8 +1209,7 @@ namespace Train.OpenBve
 							}
 								break;
 							// watch
-							case "watch":
-							case "時計":
+							case PanelCfg.Section.Watch:
 							{
 								Color32 Needle = Color32.Black;
 								double CenterX = 0.0, CenterY = 0.0, Radius = 16.0;
@@ -1234,13 +1220,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "background":
-											case "背景":
+											case Key.Background:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -1255,11 +1244,8 @@ namespace Train.OpenBve
 														Background = null;
 													}
 												}
-
 												break;
-											case "needle":
-											case "hand":
-											case "針":
+											case Key.Needle:
 											{
 												int r = 0, g = 0, b = 0;
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out r))
@@ -1298,8 +1284,7 @@ namespace Train.OpenBve
 												Needle = new Color32((byte) r, (byte) g, (byte) b, 255);
 											}
 												break;
-											case "center":
-											case "中心":
+											case Key.Center:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CenterX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -1310,16 +1295,13 @@ namespace Train.OpenBve
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													CenterY = 0.0;
 												}
-
 												break;
-											case "radius":
-											case "半径":
+											case Key.Radius:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out Radius))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
 													Radius = 16.0;
 												}
-
 												break;
 										}
 									}
@@ -1371,8 +1353,7 @@ namespace Train.OpenBve
 							}
 								break;
 							// brakeindicator
-							case "brakeindicator":
-							case "ハンドルの段表示":
+							case PanelCfg.Section.BrakeIndicator:
 							{
 								double CornerX = 0.0, CornerY = 0.0;
 								string Image = null;
@@ -1383,13 +1364,16 @@ namespace Train.OpenBve
 									int j = Lines[i].IndexOf('=');
 									if (j >= 0)
 									{
-										string Key = Lines[i].Substring(0, j).TrimEnd();
+										string key = Lines[i].Substring(0, j).TrimEnd();
+										if (!Enum.TryParse(key, true, out Key Key))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
+										}
 										string Value = Lines[i].Substring(j + 1).TrimStart();
 										string[] Arguments = GetArguments(Value);
-										switch (Key.ToLowerInvariant())
+										switch (Key)
 										{
-											case "image":
-											case "画像":
+											case Key.Image:
 												if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 												if (Path.ContainsInvalidChars(Value))
 												{
@@ -1406,8 +1390,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "corner":
-											case "左上":
+											case Key.Corner:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out CornerX))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);
@@ -1420,8 +1403,7 @@ namespace Train.OpenBve
 												}
 
 												break;
-											case "width":
-											case "幅":
+											case Key.Width:
 												if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[0], out Width))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "Width is invalid in " + Key + " in " + Section + " at line " + (i + 1).ToString(Culture) + " in " + FileName);

--- a/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
@@ -14,6 +14,7 @@ using OpenBveApi.Textures;
 using TrainManager.Car;
 using TrainManager.Trains;
 using Path = OpenBveApi.Path;
+using Train.OpenBve.Panel2Cfg;
 
 namespace Train.OpenBve
 {
@@ -77,20 +78,25 @@ namespace Train.OpenBve
 
 				foreach (XElement SectionElement in Element.Elements())
 				{
-					string Section = SectionElement.Name.LocalName;
-
-					switch (Section.ToLowerInvariant())
+					if (!Enum.TryParse(SectionElement.Name.LocalName, true, out Section Section))
 					{
-						case "this":
+						Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised section " + SectionElement.Name.LocalName + " at line " + ((IXmlLineInfo)SectionElement).LineNumber.ToString(Culture) + " in " + FileName);
+					}
+					switch (Section)
+					{
+						case Section.This:
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
 								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "resolution":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+								
+								switch (Key)
+								{
+									case Key.Resolution:
 										double pr = 0.0;
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out pr))
 										{
@@ -107,31 +113,31 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "A panel resolution of less than 100px was given at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "left":
+									case Key.Left:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.TopLeft.X))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line" + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "right":
+									case Key.Right:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.BottomRight.X))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "top":
+									case Key.Top:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.TopLeft.Y))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "bottom":
+									case Key.Bottom:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Panel.BottomRight.Y))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "daytimeimage":
+									case Key.DaytimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -147,7 +153,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "nighttimeimage":
+									case Key.NighttimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -163,14 +169,14 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out PanelTransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 
 										break;
-									case "center":
+									case Key.Center:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -192,7 +198,7 @@ namespace Train.OpenBve
 											}
 											break;
 										}
-									case "origin":
+									case Key.Origin:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -280,12 +286,14 @@ namespace Train.OpenBve
 					System.Threading.Thread.Sleep(1);
 					if (Plugin.Cancel) return;
 				}
-
-				string Section = SectionElement.Name.LocalName;
-
-				switch (SectionElement.Name.LocalName.ToLowerInvariant())
+				if (!Enum.TryParse(SectionElement.Name.LocalName, true, out Section Section))
 				{
-					case "screen":
+					Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised section " + SectionElement.Name.LocalName + " at line " + ((IXmlLineInfo)SectionElement).LineNumber.ToString(Culture) + " in " + FileName);
+				}
+				
+				switch (Section)
+				{
+					case Section.Screen:
 						if (GroupIndex == 0)
 						{
 							int n = 0;
@@ -293,19 +301,22 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
 								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "number":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Number:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out n))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -323,7 +334,7 @@ namespace Train.OpenBve
 							ParsePanelNode(SectionElement, FileName, Train, Car, ref CarSection, n + 1, Layer);
 						}
 						break;
-					case "touch":
+					case Section.Touch:
 						if(GroupIndex > 0)
 						{
 							Vector2 Location = new Vector2();
@@ -336,13 +347,16 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "location":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Location:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -364,7 +378,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "size":
+									case Key.Size:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -386,13 +400,13 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "jumpscreen":
+									case Key.JumpScreen:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out JumpScreen))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "soundindex":
+									case Key.SoundIndex:
 										if (Value.Length != 0)
 										{
 											if (!NumberFormats.TryParseIntVb6(Value, out var SoundIndex))
@@ -403,7 +417,7 @@ namespace Train.OpenBve
 											SoundIndices.Add(SoundIndex);
 										}
 										break;
-									case "command":
+									case Key.Command:
 										{
 											if (!CommandEntries.Contains(CommandEntry))
 											{
@@ -431,7 +445,7 @@ namespace Train.OpenBve
 											CommandEntry.Command = Translations.CommandInfos[i].Command;
 										}
 										break;
-									case "commandoption":
+									case Key.CommandOption:
 										if (!CommandEntries.Contains(CommandEntry))
 										{
 											CommandEntries.Add(CommandEntry);
@@ -442,7 +456,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "soundentries":
+									case Key.SoundEntries:
 										if (!KeyNode.HasElements)
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, $"An empty list of touch sound indices was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
@@ -451,7 +465,7 @@ namespace Train.OpenBve
 
 										ParseTouchSoundEntryNode(FileName, KeyNode, SoundIndices);
 										break;
-									case "commandentries":
+									case Key.CommandEntries:
 										if (!KeyNode.HasElements)
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, $"An empty list of touch commands was defined at line {((IXmlLineInfo)KeyNode).LineNumber} in XML file {FileName}");
@@ -460,7 +474,7 @@ namespace Train.OpenBve
 
 										ParseTouchCommandEntryNode(FileName, KeyNode, CommandEntries);
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -471,7 +485,7 @@ namespace Train.OpenBve
 							Plugin.Panel.CreateTouchElement(CarSection.Groups[GroupIndex], Location, Size, JumpScreen, SoundIndices.ToArray(), CommandEntries.ToArray(), new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver);
 						}
 						break;
-					case "pilotlamp":
+					case Section.PilotLamp:
 						{
 							string Subject = "true";
 							double LocationX = 0.0, LocationY = 0.0;
@@ -481,16 +495,19 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "subject":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Subject:
 										Subject = Value;
 										break;
-									case "location":
+									case Key.Location:
 										int k = Value.IndexOf(',');
 										if (k >= 0)
 										{
@@ -510,7 +527,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "daytimeimage":
+									case Key.DaytimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -526,7 +543,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "nighttimeimage":
+									case Key.NighttimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -542,13 +559,13 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -577,7 +594,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "needle":
+					case Section.Needle:
 						{
 							string Subject = "true";
 							double LocationX = 0.0, LocationY = 0.0;
@@ -594,16 +611,19 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
 								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "subject":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Subject:
 										Subject = Value;
 										break;
-									case "location":
+									case Key.Location:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -625,7 +645,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "radius":
+									case Key.Radius:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Radius))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -636,7 +656,7 @@ namespace Train.OpenBve
 											Radius = 16.0;
 										}
 										break;
-									case "daytimeimage":
+									case Key.DaytimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -652,7 +672,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "nighttimeimage":
+									case Key.NighttimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -668,19 +688,19 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "color":
+									case Key.Color:
 										if (Value.Length != 0 && !Color32.TryParseHexColor(Value, out Color))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "origin":
+									case Key.Origin:
 										{
 											int k = Value.IndexOf(',');
 											if (k >= 0)
@@ -704,31 +724,31 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "initialangle":
+									case Key.InitialAngle:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out InitialAngle))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "lastangle":
+									case Key.LastAngle:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out LastAngle))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "minimum":
+									case Key.Minimum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Minimum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "maximum":
+									case Key.Maximum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Maximum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "naturalfreq":
+									case Key.NaturalFreq:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out NaturalFrequency))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -739,7 +759,7 @@ namespace Train.OpenBve
 											NaturalFrequency = -NaturalFrequency;
 										}
 										break;
-									case "dampingratio":
+									case Key.DampingRatio:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out DampingRatio))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -750,19 +770,19 @@ namespace Train.OpenBve
 											DampingRatio = -DampingRatio;
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "backstop":
+									case Key.Backstop:
 										if (Value.Length != 0 && Value.ToLowerInvariant() == "true" || Value == "1")
 										{
 											Backstop = true;
 										}
 										break;
-									case "smoothed":
+									case Key.Smoothed:
 										if (Value.Length != 0 && Value.ToLowerInvariant() == "true" || Value == "1")
 										{
 											Smoothed = true;
@@ -832,7 +852,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "lineargauge":
+					case Section.LinearGauge:
 						{
 							string Subject = "true";
 							int Width = 0;
@@ -845,16 +865,19 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "subject":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Subject:
 										Subject = Value;
 										break;
-									case "location":
+									case Key.Location:
 										int k = Value.IndexOf(',');
 										if (k >= 0)
 										{
@@ -874,25 +897,25 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "minimum":
+									case Key.Minimum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Minimum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "maximum":
+									case Key.Maximum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Maximum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "width":
+									case Key.Width:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Width))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "direction":
+									case Key.Direction:
 										{
 											string[] s = Value.Split(',');
 											if (s.Length == 2)
@@ -911,7 +934,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Exactly 2 arguments are expected in LinearGauge Direction at line " + LineNumber.ToString(Culture) + " in file " + FileName);
 										}
 										break;
-									case "daytimeimage":
+									case Key.DaytimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -927,7 +950,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "nighttimeimage":
+									case Key.NighttimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -943,13 +966,13 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -988,7 +1011,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "digitalnumber":
+					case Section.DigitalNumber:
 						{
 							string Subject = "true";
 							double LocationX = 0.0, LocationY = 0.0;
@@ -999,16 +1022,19 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "subject":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Subject:
 										Subject = Value;
 										break;
-									case "location":
+									case Key.Location:
 										int k = Value.IndexOf(',');
 										if (k >= 0)
 										{
@@ -1028,7 +1054,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "daytimeimage":
+									case Key.DaytimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -1044,7 +1070,7 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "nighttimeimage":
+									case Key.NighttimeImage:
 										if (!System.IO.Path.HasExtension(Value)) Value += ".bmp";
 										if (Path.ContainsInvalidChars(Value))
 										{
@@ -1060,13 +1086,13 @@ namespace Train.OpenBve
 											}
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "interval":
+									case Key.Interval:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Interval))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Height is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1076,7 +1102,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Height is expected to be non-negative in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1188,7 +1214,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "digitalgauge":
+					case Section.DigitalGauge:
 						{
 							string Subject = "true";
 							double LocationX = 0.0, LocationY = 0.0;
@@ -1198,20 +1224,22 @@ namespace Train.OpenBve
 							double InitialAngle = -2.0943951023932, LastAngle = 2.0943951023932;
 							double Minimum = 0.0, Maximum = 1000.0;
 							double Step = 0.0;
-							int LineNumber = 0;
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "subject":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Subject:
 										Subject = Value;
 										break;
-									case "location":
+									case Key.Location:
 										int k = Value.IndexOf(',');
 										if (k >= 0)
 										{
@@ -1231,24 +1259,24 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "radius":
+									case Key.Radius:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Radius))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
-										else if (Radius == 0.0)
+										if (Radius == 0.0)
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is expected to be non-zero in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											Radius = 16.0;
 										}
 										break;
-									case "color":
+									case Key.Color:
 										if (Value.Length != 0 && !Color32.TryParseHexColor(Value, out Color))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "initialangle":
+									case Key.InitialAngle:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out InitialAngle))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1258,7 +1286,7 @@ namespace Train.OpenBve
 											InitialAngle = InitialAngle.ToRadians();
 										}
 										break;
-									case "lastangle":
+									case Key.LastAngle:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out LastAngle))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInDegrees is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1268,25 +1296,25 @@ namespace Train.OpenBve
 											LastAngle = LastAngle.ToRadians();
 										}
 										break;
-									case "minimum":
+									case Key.Minimum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Minimum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "maximum":
+									case Key.Maximum:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Maximum))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "step":
+									case Key.Step:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Step))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Value is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1295,18 +1323,14 @@ namespace Train.OpenBve
 								}
 							}
 
-							if (Radius == 0.0)
-							{
-								Plugin.currentHost.AddMessage(MessageType.Error, false, "Radius is required to be non-zero in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
-							}
 							if (Minimum == Maximum)
 							{
-								Plugin.currentHost.AddMessage(MessageType.Error, false, "Minimum and Maximum must not be equal in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								Plugin.currentHost.AddMessage(MessageType.Error, false, "Minimum and Maximum must not be equal in " + Section + " in " + FileName);
 								Radius = 0.0;
 							}
 							if (Math.Abs(InitialAngle - LastAngle) > 6.28318531)
 							{
-								Plugin.currentHost.AddMessage(MessageType.Warning, false, "The absolute difference between InitialAngle and LastAngle exceeds 360 degrees in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "The absolute difference between InitialAngle and LastAngle exceeds 360 degrees in " + Section + " in " + FileName);
 							}
 							if (Radius != 0.0)
 							{
@@ -1376,7 +1400,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "timetable":
+					case Section.Timetable:
 						{
 							double LocationX = 0.0, LocationY = 0.0;
 							double Width = 0.0, Height = 0.0;
@@ -1388,13 +1412,16 @@ namespace Train.OpenBve
 
 							foreach (XElement KeyNode in SectionElement.Elements())
 							{
-								string Key = KeyNode.Name.LocalName;
-								string Value = KeyNode.Value;
-								int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-
-								switch (Key.ToLowerInvariant())
+								int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+								if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 								{
-									case "location":
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+								}
+								string Value = KeyNode.Value;
+
+								switch (Key)
+								{
+									case Key.Location:
 										int k = Value.IndexOf(',');
 										if (k >= 0)
 										{
@@ -1414,7 +1441,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "width":
+									case Key.Width:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Width))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1424,7 +1451,7 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is required to be positive in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "height":
+									case Key.Height:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Height))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1434,13 +1461,13 @@ namespace Train.OpenBve
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "ValueInPixels is required to be positive in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "transparentcolor":
+									case Key.TransparentColor:
 										if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 										}
 										break;
-									case "layer":
+									case Key.Layer:
 										if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out Layer))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
@@ -1466,7 +1493,7 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "windscreen":
+					case Section.Windscreen:
 					{
 						Vector2 topLeft = new Vector2(Panel.TopLeft);
 						Vector2 bottomRight = new Vector2(Panel.BottomRight);
@@ -1487,13 +1514,16 @@ namespace Train.OpenBve
 
 						foreach (XElement KeyNode in SectionElement.Elements())
 						{
-							string Key = KeyNode.Name.LocalName;
-							string Value = KeyNode.Value;
-							int LineNumber = ((IXmlLineInfo) KeyNode).LineNumber;
-							int k;
-							switch (Key.ToLowerInvariant())
+							int LineNumber = ((IXmlLineInfo)KeyNode).LineNumber;
+							if (!Enum.TryParse(KeyNode.Name.LocalName, true, out Key Key))
 							{
-								case "topleft":
+								Plugin.currentHost.AddMessage(MessageType.Error, false, "Unrecognised key " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
+							}
+							string Value = KeyNode.Value;
+							int k;
+							switch (Key)
+							{
+								case Key.TopLeft:
 									k = Value.IndexOf(',');
 									if (k >= 0)
 									{
@@ -1514,7 +1544,7 @@ namespace Train.OpenBve
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "bottomright":
+								case Key.BottomRight:
 									k = Value.IndexOf(',');
 									if (k >= 0)
 									{
@@ -1535,50 +1565,49 @@ namespace Train.OpenBve
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "Two arguments are expected in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "numberofdrops":
+								case Key.NumberOfDrops:
 									if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out numberOfDrops))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "NumberOfDrops is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "dropsize":
+								case Key.DropSize:
 									if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out numberOfDrops))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "DropSize is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "daytimedrops":
+								case Key.DaytimeDrops:
 									daytimeDropFiles = Value.IndexOf(',') != -1 ? Value.Trim().Split(',').ToList() : new List<string> {Value};
 									break;
-								case "nighttimedrops":
+								case Key.NighttimeDrops:
 									nighttimeDropFiles = Value.IndexOf(',') != -1 ? Value.Trim().Split(',').ToList() : new List<string> {Value};
 									break;
-								case "transparentcolor":
+								case Key.TransparentColor:
 									if (Value.Length != 0 && !Color24.TryParseHexColor(Value, out TransparentColor))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "HexColor is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "layer":
+								case Key.Layer:
 									if (Value.Length != 0 && !NumberFormats.TryParseIntVb6(Value, out Layer))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "LayerIndex is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "wipespeed":
+								case Key.WipeSpeed:
 									if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out wipeSpeed))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "WipeSpeed is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "wiperholdtime":
+								case Key.WiperHoldTime:
 									if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out holdTime))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "WipeSpeed is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 									}
 									break;
-								case "restposition":
-								case "wiperrestposition":
+								case Key.WiperRestPosition:
 									switch (Value.ToLowerInvariant())
 									{
 										case "0":
@@ -1594,8 +1623,7 @@ namespace Train.OpenBve
 											break;
 									}
 									break;
-								case "holdposition":
-								case "wiperholdposition":
+								case Key.WiperHoldPosition:
 									switch (Value.ToLowerInvariant())
 									{
 										case "0":
@@ -1611,7 +1639,7 @@ namespace Train.OpenBve
 											break;
 									}
 									break;
-								case "droplife":
+								case Key.DropLife:
 									if (Value.Length != 0 && !NumberFormats.TryParseDoubleVb6(Value, out dropLife))
 									{
 										Plugin.currentHost.AddMessage(MessageType.Error, false, "DropLife is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);

--- a/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
@@ -488,7 +488,7 @@ namespace Train.OpenBve
 					case Section.PilotLamp:
 						{
 							string Subject = "true";
-							double LocationX = 0.0, LocationY = 0.0;
+							Vector2 Location = new Vector2();
 							string DaytimeImage = null, NighttimeImage = null;
 							Color24 TransparentColor = Color24.Blue;
 							int Layer = 0;
@@ -513,11 +513,11 @@ namespace Train.OpenBve
 										{
 											string a = Value.Substring(0, k).TrimEnd();
 											string b = Value.Substring(k + 1).TrimStart();
-											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
-											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Top is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
@@ -588,7 +588,7 @@ namespace Train.OpenBve
 								}
 								int w = tday.Width;
 								int h = tday.Height;
-								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX, LocationY, w, h, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color32.White);
+								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X, Location.Y, w, h, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color32.White);
 								string f = Plugin.Panel2CfgParser.GetStackLanguageFromSubject(Train, Subject, Section + " in " + FileName);
 								CarSection.Groups[GroupIndex].Elements[j].StateFunction = new FunctionScript(Plugin.currentHost, f + " 1 == --", false);
 							}
@@ -597,7 +597,7 @@ namespace Train.OpenBve
 					case Section.Needle:
 						{
 							string Subject = "true";
-							double LocationX = 0.0, LocationY = 0.0;
+							Vector2 Location = new Vector2();
 							string DaytimeImage = null, NighttimeImage = null;
 							Color32 Color = Color32.White;
 							Color24 TransparentColor = Color24.Blue;
@@ -630,11 +630,11 @@ namespace Train.OpenBve
 											{
 												string a = Value.Substring(0, k).TrimEnd();
 												string b = Value.Substring(k + 1).TrimStart();
-												if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+												if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterX is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 												}
-												if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+												if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 												{
 													Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterY is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 												}
@@ -814,7 +814,7 @@ namespace Train.OpenBve
 								double n = Radius == 0.0 | OriginY == 0.0 ? 1.0 : Radius / OriginY;
 								double nx = n * tday.Width;
 								double ny = n * tday.Height;
-								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX - ox * nx, LocationY - oy * ny, nx, ny, new Vector2(ox, oy), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color);
+								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X - ox * nx, Location.Y - oy * ny, nx, ny, new Vector2(ox, oy), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color);
 								CarSection.Groups[GroupIndex].Elements[j].RotateZDirection = Vector3.Backward;
 								CarSection.Groups[GroupIndex].Elements[j].RotateXDirection = Vector3.Right;
 								CarSection.Groups[GroupIndex].Elements[j].RotateYDirection = Vector3.Cross(CarSection.Groups[GroupIndex].Elements[j].RotateZDirection, CarSection.Groups[GroupIndex].Elements[j].RotateXDirection);
@@ -857,7 +857,7 @@ namespace Train.OpenBve
 							string Subject = "true";
 							int Width = 0;
 							Vector2 Direction = new Vector2(1, 0);
-							double LocationX = 0.0, LocationY = 0.0;
+							Vector2 Location = new Vector2();
 							string DaytimeImage = null, NighttimeImage = null;
 							double Minimum = 0.0, Maximum = 0.0;
 							Color24 TransparentColor = Color24.Blue;
@@ -883,11 +883,11 @@ namespace Train.OpenBve
 										{
 											string a = Value.Substring(0, k).TrimEnd();
 											string b = Value.Substring(k + 1).TrimStart();
-											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
-											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Top is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
@@ -996,7 +996,7 @@ namespace Train.OpenBve
 								}
 								int w = tday.Width;
 								int h = tday.Height;
-								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX, LocationY, w, h, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color32.White);
+								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X, Location.Y, w, h, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday, tnight, Color32.White);
 								if (Maximum < Minimum)
 								{
 									Plugin.currentHost.AddMessage(MessageType.Error, false, "Maximum value must be greater than minimum value " + Section + " in " + FileName);
@@ -1014,7 +1014,7 @@ namespace Train.OpenBve
 					case Section.DigitalNumber:
 						{
 							string Subject = "true";
-							double LocationX = 0.0, LocationY = 0.0;
+							Vector2 Location = new Vector2();
 							string DaytimeImage = null, NighttimeImage = null;
 							Color24 TransparentColor = Color24.Blue;
 							double Layer = 0.0;
@@ -1040,11 +1040,11 @@ namespace Train.OpenBve
 										{
 											string a = Value.Substring(0, k).TrimEnd();
 											string b = Value.Substring(k + 1).TrimStart();
-											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Left is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
-											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Top is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
@@ -1205,7 +1205,7 @@ namespace Train.OpenBve
 									int j = -1;
 									for (int k = 0; k < tday.Length; k++)
 									{
-										int l = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX, LocationY, wday, Interval, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday[k], tnight[k], Color32.White, k != 0);
+										int l = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X, Location.Y, wday, Interval, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, tday[k], tnight[k], Color32.White, k != 0);
 										if (k == 0) j = l;
 									}
 									string f = Plugin.Panel2CfgParser.GetStackLanguageFromSubject(Train, Subject, Section + " in " + FileName);
@@ -1217,7 +1217,7 @@ namespace Train.OpenBve
 					case Section.DigitalGauge:
 						{
 							string Subject = "true";
-							double LocationX = 0.0, LocationY = 0.0;
+							Vector2 Location = new Vector2();
 							Color32 Color = Color32.Black;
 							double Radius = 0.0;
 							int Layer = 0;
@@ -1245,11 +1245,11 @@ namespace Train.OpenBve
 										{
 											string a = Value.Substring(0, k).TrimEnd();
 											string b = Value.Substring(k + 1).TrimStart();
-											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterX is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
-											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "CenterY is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
@@ -1335,7 +1335,7 @@ namespace Train.OpenBve
 							if (Radius != 0.0)
 							{
 								// create element
-								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX - Radius, LocationY - Radius, 2.0 * Radius, 2.0 * Radius, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, null, null, Color);
+								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X - Radius, Location.Y - Radius, 2.0 * Radius, 2.0 * Radius, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, null, null, Color);
 								InitialAngle += Math.PI;
 								LastAngle += Math.PI;
 								double x0 = CarSection.Groups[GroupIndex].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.X;
@@ -1401,8 +1401,8 @@ namespace Train.OpenBve
 						}
 						break;
 					case Section.Timetable:
-						{
-							double LocationX = 0.0, LocationY = 0.0;
+					{
+							Vector2 Location = new Vector2();
 							double Width = 0.0, Height = 0.0;
 							//We read the transparent color for the timetable from the config file, but it is never used
 							//TODO: Fix or depreciate??
@@ -1427,11 +1427,11 @@ namespace Train.OpenBve
 										{
 											string a = Value.Substring(0, k).TrimEnd();
 											string b = Value.Substring(k + 1).TrimStart();
-											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out LocationX))
+											if (a.Length != 0 && !NumberFormats.TryParseDoubleVb6(a, out Location.X))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "X is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
-											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out LocationY))
+											if (b.Length != 0 && !NumberFormats.TryParseDoubleVb6(b, out Location.Y))
 											{
 												Plugin.currentHost.AddMessage(MessageType.Error, false, "Y is invalid in " + Key + " in " + Section + " at line " + LineNumber.ToString(Culture) + " in " + FileName);
 											}
@@ -1487,7 +1487,7 @@ namespace Train.OpenBve
 							}
 							if (Width > 0.0 & Height > 0.0)
 							{
-								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], LocationX, LocationY, Width, Height, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, null, null, Color32.White);
+								int j = Plugin.Panel.CreateElement(ref CarSection.Groups[GroupIndex], Location.X, Location.Y, Width, Height, new Vector2(0.5, 0.5), (OffsetLayer + Layer), Train.Cars[Car].Driver, null, null, Color32.White);
 								CarSection.Groups[GroupIndex].Elements[j].StateFunction = new FunctionScript(Plugin.currentHost, "timetable", false);
 								Plugin.currentHost.AddObjectForCustomTimeTable(CarSection.Groups[GroupIndex].Elements[j]);
 							}

--- a/source/Plugins/Train.OpenBve/Plugin.cs
+++ b/source/Plugins/Train.OpenBve/Plugin.cs
@@ -55,6 +55,8 @@ namespace Train.OpenBve
 
 	    internal Control[] CurrentControls;
 
+	    internal Panel Panel;
+
 	    internal double LastProgress;
 
 		public Plugin()
@@ -83,6 +85,7 @@ namespace Train.OpenBve
 			    Panel2CfgParser = new Panel2CfgParser(this);
 			    PanelXmlParser = new PanelXmlParser(this);
 			    PanelAnimatedXmlParser = new PanelAnimatedXmlParser(this);
+			    Panel = new Panel(this);
 		    }
 
 		    if (TrainXmlParser == null)

--- a/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
+++ b/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Panel\Common\Panel.cs" />
     <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.cs" />
     <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.Keys.cs" />
     <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.Sections.cs" />

--- a/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
+++ b/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
@@ -86,6 +86,10 @@
       <Project>{d0fca2c5-ff75-42d8-ae80-310280a61fb1}</Project>
       <Name>TrainManager</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Formats.OpenBve\Formats.OpenBve.csproj">
+      <Project>{60adcb15-1e0e-4708-93a5-f1248df73a03}</Project>
+      <Name>Formats.OpenBve</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
+++ b/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
@@ -46,9 +46,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Panel\Panel2CfgParser.cs" />
+    <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.cs" />
+    <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.Keys.cs" />
+    <Compile Include="Panel\Panel2Cfg\Panel2CfgParser.Sections.cs" />
     <Compile Include="Panel\PanelAnimatedXmlParser.cs" />
-    <Compile Include="Panel\PanelCfgParser.cs" />
+    <Compile Include="Panel\PanelCfg\PanelCfg.Keys.cs" />
+    <Compile Include="Panel\PanelCfg\PanelCfg.Sections.cs" />
+    <Compile Include="Panel\PanelCfg\PanelCfgParser.cs" />
     <Compile Include="Panel\PanelXmlParser.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
The **panel.cfg** and **panel2.cfg** parsers both make heavy use of text comparisons to determine the section / key within the section.
These can be converted into enum values for much better readability.

n.b.
This takes advantage of the C# feature that 2 members of an enum may have the same integral value. When converted to bytecode, the integral value is used as opposed to the textual representation.
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1069
May need disabling if strict code analysis is enabled (it doesn't trip ReSharper or the default VS2019 rules), or possibly the way duplicate entries are declared to match Microsoft's preferences, although personally I think it's better this way.

### CHECK / TODO:
* Very easy to get this wrong, needs testing to ensure that we don't get a duplicate somewhere and produce really unexpected results.
* Any further not found variants?
* ~~Port to Panel2 parser.~~
 