### PR TITLE
Fix: multiple issues with TFO

### DIFF
--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -122,7 +122,7 @@ namespace OpenBve
 			{
 				if (Program.CurrentHost.Plugins[i].Train != null && Program.CurrentHost.Plugins[i].Train.CanLoadTrain(TrainData))
 				{
-					//Program.CurrentHost.Plugins[i].Train.LoadTrain(Encoding.UTF8, TrainDirectory, ref currentTrain, ref Interface.CurrentControls);
+					Program.CurrentHost.Plugins[i].Train.LoadTrain(Encoding.UTF8, TrainDirectory, ref currentTrain, ref Interface.CurrentControls);
 				}
 			}
 

--- a/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
+++ b/source/OpenBVE/Parsers/Script/TrackFollowingObjectParser.cs
@@ -120,12 +120,18 @@ namespace OpenBve
 			AbstractTrain currentTrain = Train;
 			for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++)
 			{
-				if (Program.CurrentHost.Plugins[i].Train != null && Program.CurrentHost.Plugins[i].Train.CanLoadTrain(TrainDirectory))
+				if (Program.CurrentHost.Plugins[i].Train != null && Program.CurrentHost.Plugins[i].Train.CanLoadTrain(TrainData))
 				{
-						
-					Program.CurrentHost.Plugins[i].Train.LoadTrain(Encoding.UTF8, TrainDirectory, ref currentTrain, ref Interface.CurrentControls);
+					//Program.CurrentHost.Plugins[i].Train.LoadTrain(Encoding.UTF8, TrainDirectory, ref currentTrain, ref Interface.CurrentControls);
 				}
 			}
+
+			if (!Train.Cars.Any())
+			{
+				Interface.AddMessage(MessageType.Error, false, $"Failed to load the specified train in {FileName}");
+				return;
+			}
+
 			Train.AI = new TrackFollowingObjectAI(Train, Data.ToArray());
 			foreach (var Car in Train.Cars)
 			{

--- a/source/OpenBveApi/Routes/Track.TrackFollower.cs
+++ b/source/OpenBveApi/Routes/Track.TrackFollower.cs
@@ -128,10 +128,31 @@ namespace OpenBveApi.Routes
 			}
 			if (!currentHost.Tracks.ContainsKey(TrackIndex) || currentHost.Tracks[TrackIndex].Elements.Length == 0) return;
 			int i = LastTrackElement;
-			while (i >= 0 && NewTrackPosition < currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition)
+			while (i >= 0)
 			{
+				if (currentHost.Tracks[TrackIndex].Elements[i].InvalidElement)
+				{
+					var prevTrackEnded = currentHost.Tracks[TrackIndex].Elements.Select((x, j) => new { Index = j, Element = x }).Take(i + 1).LastOrDefault(x => !x.Element.InvalidElement);
+
+					if (prevTrackEnded == null)
+					{
+						break;
+					}
+
+					i = prevTrackEnded.Index;
+
+					if (i == 0)
+					{
+						break;
+					}
+				}
+
+				if (NewTrackPosition >= currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition)
+				{
+					break;
+				}
 				double ta = TrackPosition - currentHost.Tracks[TrackIndex].Elements[i].StartingTrackPosition;
-				double tb = -0.01;
+				const double tb = -0.01;
 				CheckEvents(i, -1, ta, tb);
 				i--;
 			}
@@ -186,8 +207,8 @@ namespace OpenBveApi.Routes
 						double h = s * p;
 						double b = s / System.Math.Abs(r);
 						double f = 2.0 * r * r * (1.0 - System.Math.Cos(b));
-						double c = (double) System.Math.Sign(db) * System.Math.Sqrt(f >= 0.0 ? f : 0.0);
-						double a = 0.5 * (double) System.Math.Sign(r) * b;
+						double c = (double)System.Math.Sign(db) * System.Math.Sqrt(f >= 0.0 ? f : 0.0);
+						double a = 0.5 * (double)System.Math.Sign(r) * b;
 						Vector3 D = new Vector3(currentHost.Tracks[TrackIndex].Elements[i].WorldDirection.X, 0.0, currentHost.Tracks[TrackIndex].Elements[i].WorldDirection.Z);
 						D.Normalize();
 						D.Rotate(Vector3.Down, a);

--- a/source/Plugins/Train.OpenBve/Train/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/TrainDatParser.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using LibRender2.Trains;
+using OpenBveApi;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Routes;
@@ -25,106 +27,176 @@ namespace Train.OpenBve
 			Plugin = plugin;
 		}
 
-		/// <summary>Parses a BVE2 / BVE4 / openBVE train.dat file</summary>
-		/// <param name="FileName">The train.dat file to parse</param>
-		/// <param name="Encoding">The text encoding to use</param>
-		/// <param name="Train">The train</param>
-		internal void Parse(string FileName, Encoding Encoding, TrainBase Train) {
-			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
+		/// <summary>
+		/// Read the file of the specified train.dat
+		/// </summary>
+		/// <param name="fileName">The file path of the specified train.dat</param>
+		/// <param name="encoding">The text encoding to use</param>
+		/// <returns>The array read from the specified train.dat</returns>
+		private static string[] ReadFile(string fileName, Encoding encoding)
+		{
 			//Create the array using the default compatibility train.dat
-			string[] Lines = {"BVE2000000","#CAR","1","1","1","0","1","1"};
+			string[] lines = { "BVE2000000", "#CAR", "1", "1", "1", "0", "1", "1" };
+
 			// load file
 			try
 			{
-				Lines = System.IO.File.ReadAllLines(FileName, Encoding);
+				lines = System.IO.File.ReadAllLines(fileName, encoding);
 			}
 			catch
 			{
 				//ignore and load default
 			}
-			if (Lines.Length == 1 && Encoding.Equals(Encoding.Unicode))
+			if (lines.Length == 1 && encoding.Equals(Encoding.Unicode))
 			{
 				/*
 				 * Probably not unicode after all
 				 * Stuff edited with BVE2 / BVE4 tools should either be ASCII or SHIFT_JIS
 				 * both of which should read OK with ASCII for our purposes
 				 */
-				Encoding = Encoding.ASCII;
-				Lines = System.IO.File.ReadAllLines(FileName, Encoding);
+				encoding = Encoding.ASCII;
+				lines = System.IO.File.ReadAllLines(fileName, encoding);
 			}
-			else if (Lines.Length == 0)
+			else if (lines.Length == 0)
 			{
 				//Catch zero-length train.dat files
-				throw new Exception("The train.dat file " + FileName + " is of zero length.");
+				throw new Exception("The train.dat file " + fileName + " is of zero length.");
 			}
-			
-			for (int i = 0; i < Lines.Length; i++) {
-				int j = Lines[i].IndexOf(';');
-				if (j >= 0) {
-					Lines[i] = Lines[i].Substring(0, j).Trim();
-				} else {
-					Lines[i] = Lines[i].Trim();
+
+			for (int i = 0; i < lines.Length; i++)
+			{
+				int j = lines[i].IndexOf(';');
+				if (j >= 0)
+				{
+					lines[i] = lines[i].Substring(0, j).Trim();
 				}
-				if(Lines[i].EndsWith(","))
+				else
+				{
+					lines[i] = lines[i].Trim();
+				}
+				if (lines[i].EndsWith(","))
 				{
 					//File edited with MSExcel may have additional commas at the end of a line
-					Lines[i] = Lines[i].TrimEnd(',');
+					lines[i] = lines[i].TrimEnd(',');
 				}
 			}
-			TrainDatFormats currentFormat = TrainDatFormats.openBVE;
+
+			return lines;
+		}
+
+		/// <summary>
+		/// Parse the format of the specified train.dat
+		/// </summary>
+		/// <param name="lines">The array of the specified train.dat</param>
+		/// <param name="format">The format of the specified train.dat</param>
+		/// <param name="version">The version of the specified OpenBVE train.dat</param>
+		private static void ParseFormat(IReadOnlyList<string> lines, out TrainDatFormats format, out int version)
+		{
+			format = TrainDatFormats.openBVE;
+			version = -1;
+
+			for (int i = 0; i < lines.Count; i++)
+			{
+				if (lines[i].Length <= 0)
+				{
+					continue;
+				}
+
+				string t = lines[i].ToLowerInvariant();
+				switch (t)
+				{
+					case "bve1200000":
+						format = TrainDatFormats.BVE1200000;
+						break;
+					case "bve1210000":
+						format = TrainDatFormats.BVE1210000;
+						break;
+					case "bve1220000":
+						format = TrainDatFormats.BVE1220000;
+						break;
+					case "bve2000000":
+						format = TrainDatFormats.BVE2000000;
+						break;
+					case "bve2060000":
+						format = TrainDatFormats.BVE2060000;
+						break;
+					case "openbve":
+						format = TrainDatFormats.openBVE;
+						break;
+					default:
+						if (t.ToLowerInvariant().StartsWith("openbve"))
+						{
+							format = TrainDatFormats.openBVE;
+
+							string tt = t.Substring(7, t.Length - 7);
+							if (!NumberFormats.TryParseIntVb6(tt, out version))
+							{
+								version = -1;
+							}
+						}
+						else
+						{
+							format = TrainDatFormats.Unsupported;
+						}
+						break;
+				}
+				break;
+			}
+		}
+
+		/// <summary>
+		/// Checks whether the parser can load the specified file.
+		/// </summary>
+		/// <param name="fileName">The file path of the specified train.dat</param>
+		/// <returns>Whether the parser can load the specified file.</returns>
+		internal bool CanLoad(string fileName)
+		{
+			Encoding encoding = TextEncoding.GetSystemEncodingFromFile(fileName);
+			
+			string[] lines;
+			try
+			{
+				lines = ReadFile(fileName, encoding);
+			}
+			catch
+			{
+				return false;
+			}
+
+			ParseFormat(lines, out TrainDatFormats format, out _);
+
+			return format != TrainDatFormats.Unsupported;
+		}
+
+		/// <summary>Parses a BVE2 / BVE4 / openBVE train.dat file</summary>
+		/// <param name="FileName">The train.dat file to parse</param>
+		/// <param name="Encoding">The text encoding to use</param>
+		/// <param name="Train">The train</param>
+		internal void Parse(string FileName, Encoding Encoding, TrainBase Train) {
+			System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
+
+			string[] Lines = ReadFile(FileName, Encoding);
+
+			// Check version
 			const int currentVersion = 17250;
-			int myVersion = -1;
-			for (int i = 0; i < Lines.Length; i++) {
-				if (Lines[i].Length > 0) {
-					string t = Lines[i].ToLowerInvariant();
-					switch (t)
-					{
-						case "bve1200000":
-							currentFormat = TrainDatFormats.BVE1200000;
-							break;
-						case "bve1210000":
-							currentFormat = TrainDatFormats.BVE1210000;
-							break;
-						case "bve1220000":
-							currentFormat = TrainDatFormats.BVE1220000;
-							break;
-						case "bve2000000":
-							currentFormat = TrainDatFormats.BVE2000000;
-							break;
-						case "bve2060000":
-							currentFormat = TrainDatFormats.BVE2060000;
-							break;
-						case "openbve":
-							currentFormat = TrainDatFormats.openBVE;
-							break;
-						default:
-							if (t.ToLowerInvariant().StartsWith("openbve"))
-							{
-								string tt = t.Substring(7, t.Length - 7);
-								if (NumberFormats.TryParseIntVb6(tt, out myVersion))
-								{
-									currentFormat = TrainDatFormats.openBVE;
-									if (myVersion > currentVersion)
-									{
-										Plugin.currentHost.AddMessage(MessageType.Warning, false, "The train.dat " + FileName + " was created with a newer version of openBVE. Please check for an update.");
-									}
-								}
-								else
-								{
-									currentFormat = TrainDatFormats.Unsupported;
-									Plugin.currentHost.AddMessage(MessageType.Error, false, "The train.dat version " + Lines[0].ToLowerInvariant() + " is invalid in " + FileName);
-								}
-							}
-							else
-							{
-								currentFormat = TrainDatFormats.Unsupported;
-								Plugin.currentHost.AddMessage(MessageType.Error, false, "The train.dat format " + Lines[0].ToLowerInvariant() + " is not supported in " + FileName);
-							}
-							break;
-					}
-					break;
+			ParseFormat(Lines, out TrainDatFormats currentFormat, out int myVersion);
+
+			if (currentFormat == TrainDatFormats.openBVE)
+			{
+				if (myVersion == -1)
+				{
+					Plugin.currentHost.AddMessage(MessageType.Error, false, "The train.dat version " + Lines[0].ToLowerInvariant() + " is invalid in " + FileName);
+				}
+				else if (myVersion > currentVersion)
+				{
+					Plugin.currentHost.AddMessage(MessageType.Warning, false, "The train.dat " + FileName + " was created with a newer version of openBVE. Please check for an update.");
 				}
 			}
+			else if (currentFormat == TrainDatFormats.Unsupported)
+			{
+				Plugin.currentHost.AddMessage(MessageType.Error, false, "The train.dat format " + Lines[0].ToLowerInvariant() + " is not supported in " + FileName);
+			}
+
 			// initialize
 			double BrakeCylinderServiceMaximumPressure = 440000.0;
 			double BrakeCylinderEmergencyMaximumPressure = 440000.0;

--- a/source/Plugins/Train.OpenBve/Train/TrainDatparser.Formats.cs
+++ b/source/Plugins/Train.OpenBve/Train/TrainDatparser.Formats.cs
@@ -16,6 +16,6 @@
 		/// <summary>The train.dat was written for BVE 2.0.6</summary>
 		BVE2060000 = 4,
 		/// <summary>The train.dat was written for openBVE</summary>
-		openBVE = 3,
+		openBVE = 5,
 	}
 }

--- a/source/TrainManager/TrackFollowingObject/AI/TrackFollowingObject.AI.cs
+++ b/source/TrainManager/TrackFollowingObject/AI/TrackFollowingObject.AI.cs
@@ -91,8 +91,9 @@ namespace TrainManager.Trains
 
 			if (TimeElapsed != 0.0)
 			{
+				double oldSpeed = Train.CurrentSpeed;
 				Train.CurrentSpeed = DeltaPosition / TimeElapsed;
-				Train.Specs.CurrentAverageAcceleration = Math.Sign(Train.CurrentSpeed) * Train.CurrentSpeed / TimeElapsed;
+				Train.Specs.CurrentAverageAcceleration = (int)NewDirection * (Train.CurrentSpeed - oldSpeed) / TimeElapsed;
 			}
 			else
 			{

--- a/source/TrainManager/TrackFollowingObject/AI/TravelPointData.cs
+++ b/source/TrainManager/TrackFollowingObject/AI/TravelPointData.cs
@@ -6,25 +6,13 @@
 		private double PassingTime;
 		internal override double ArrivalTime
 		{
-			get
-			{
-				return PassingTime;
-			}
-			set
-			{
-				PassingTime = value;
-			}
+			get => PassingTime;
+			set => PassingTime = value;
 		}
 		internal override double DepartureTime
 		{
-			get
-			{
-				return PassingTime;
-			}
-			set
-			{
-				PassingTime = value;
-			}
+			get => PassingTime;
+			set => PassingTime = value;
 		}
 	}
 }

--- a/source/TrainManager/TrackFollowingObject/TrackFollowingObject.cs
+++ b/source/TrainManager/TrackFollowingObject/TrackFollowingObject.cs
@@ -5,169 +5,167 @@ using OpenBveApi.Trains;
 namespace TrainManager.Trains
 {
 	/// <summary>A more advanced type of AnimatedObject, which follows a rail and a travel plan</summary>
-		public class TrackFollowingObject : TrainBase
+	public class TrackFollowingObject : TrainBase
+	{
+		/// <summary>The time the train appears in-game</summary>
+		public double AppearanceTime;
+		/// <summary>The track position at which the train appears</summary>
+		public double AppearanceStartPosition;
+		/// <summary>The track position at which the train disappears</summary>
+		public double AppearanceEndPosition;
+		/// <summary>The time at which the train is removed from the game</summary>
+		public double LeaveTime;
+		private double InternalTimerTimeElapsed;
+
+		public TrackFollowingObject(TrainState state) : base(state)
 		{
-			/// <summary>The time the train appears in-game</summary>
-			public double AppearanceTime;
-			/// <summary>The track position at which the train appears</summary>
-			public double AppearanceStartPosition;
-			/// <summary>The track position at which the train disappears</summary>
-			public double AppearanceEndPosition;
-			/// <summary>The time at which the train is removed from the game</summary>
-			public double LeaveTime;
-			private double InternalTimerTimeElapsed;
+		}
 
-			public TrackFollowingObject(TrainState state) : base(state)
+		/// <summary>Disposes of the train</summary>
+		public override void Dispose()
+		{
+			State = TrainState.Disposed;
+			for (int i = 0; i < Cars.Length; i++)
 			{
+				Cars[i].ChangeCarSection(CarSectionType.NotVisible);
+				Cars[i].FrontBogie.ChangeSection(-1);
+				Cars[i].RearBogie.ChangeSection(-1);
+				Cars[i].Coupler.ChangeSection(-1);
 			}
-			
-			/// <summary>Disposes of the train</summary>
-			public override void Dispose()
-			{
-				State = TrainState.Disposed;
-				for (int i = 0; i < Cars.Length; i++)
-				{
-					Cars[i].ChangeCarSection(CarSectionType.NotVisible);
-					Cars[i].FrontBogie.ChangeSection(-1);
-					Cars[i].RearBogie.ChangeSection(-1);
-					Cars[i].Coupler.ChangeSection(-1);
-				}
-				TrainManagerBase.currentHost.StopAllSounds(this);
-			}
+			TrainManagerBase.currentHost.StopAllSounds(this);
+		}
 
-			/// <summary>Call this method to update the train</summary>
-			/// <param name="TimeElapsed">The elapsed time this frame</param>
-			public override void Update(double TimeElapsed)
+		/// <summary>Call this method to update the train</summary>
+		/// <param name="TimeElapsed">The elapsed time this frame</param>
+		public override void Update(double TimeElapsed)
+		{
+			if (State == TrainState.Pending)
 			{
-				if (State == TrainState.Pending)
+				// pending train
+				if (TrainManagerBase.currentHost.InGameTime >= AppearanceTime)
 				{
-					// pending train
-					if (TrainManagerBase.currentHost.InGameTime >= AppearanceTime)
+					double PlayerTrainTrackPosition = TrainManagerBase.PlayerTrain.Cars[0].FrontAxle.Follower.TrackPosition + 0.5 * TrainManagerBase.PlayerTrain.Cars[0].Length - TrainManagerBase.PlayerTrain.Cars[0].FrontAxle.Position;
+					if (PlayerTrainTrackPosition < AppearanceStartPosition || (PlayerTrainTrackPosition > AppearanceEndPosition && AppearanceEndPosition > AppearanceStartPosition))
 					{
-						double PlayerTrainTrackPosition = TrainManagerBase.PlayerTrain.Cars[0].FrontAxle.Follower.TrackPosition + 0.5 * TrainManagerBase.PlayerTrain.Cars[0].Length - TrainManagerBase.PlayerTrain.Cars[0].FrontAxle.Position;
-						if (PlayerTrainTrackPosition < AppearanceStartPosition || (PlayerTrainTrackPosition > AppearanceEndPosition && AppearanceEndPosition > AppearanceStartPosition))
+						return;
+					}
+
+					// train is introduced
+					State = TrainState.Available;
+					for (int i = 0; i < Cars.Length; i++)
+					{
+						if (Cars[i].CarSections.Length != 0)
 						{
-							return;
+							Cars[i].ChangeCarSection(CarSectionType.Exterior);
 						}
+						Cars[i].FrontBogie.ChangeSection(0);
+						Cars[i].RearBogie.ChangeSection(0);
+						Cars[i].Coupler.ChangeSection(0);
 
-						// train is introduced
-						State = TrainState.Available;
-						for (int i = 0; i < Cars.Length; i++)
+						if (Cars[i].Specs.IsMotorCar && Cars[i].Sounds.Loop != null)
 						{
-							if (Cars[i].CarSections.Length != 0)
-							{
-								Cars[i].ChangeCarSection(CarSectionType.Exterior);
-							}
-							Cars[i].FrontBogie.ChangeSection(0);
-							Cars[i].RearBogie.ChangeSection(0);
-							Cars[i].Coupler.ChangeSection(0);
-
-							if (Cars[i].Specs.IsMotorCar && Cars[i].Sounds.Loop != null)
-							{
-								Cars[i].Sounds.Loop.Play(Cars[i], true);
-							}
+							Cars[i].Sounds.Loop.Play(Cars[i], true);
 						}
 					}
 				}
-				else if (State == TrainState.Available)
+			}
+			else if (State == TrainState.Available)
+			{
+				// available train
+				UpdatePhysicsAndControls(TimeElapsed);
+				for (int i = 0; i < Cars.Length; i++)
 				{
-					// available train
-					UpdatePhysicsAndControls(TimeElapsed);
-					for (int i = 0; i < Cars.Length; i++)
+					byte dnb;
 					{
-						byte dnb;
+						float b = (float)(Cars[i].Brightness.NextTrackPosition - Cars[i].Brightness.PreviousTrackPosition);
+
+						//1.0f represents a route brightness value of 255
+						//0.0f represents a route brightness value of 0
+
+						if (b != 0.0f)
 						{
-							float b = (float) (Cars[i].Brightness.NextTrackPosition - Cars[i].Brightness.PreviousTrackPosition);
-
-							//1.0f represents a route brightness value of 255
-							//0.0f represents a route brightness value of 0
-
-							if (b != 0.0f)
-							{
-								b = (float) (Cars[i].FrontAxle.Follower.TrackPosition - Cars[i].Brightness.PreviousTrackPosition) / b;
-								if (b < 0.0f) b = 0.0f;
-								if (b > 1.0f) b = 1.0f;
-								b = Cars[i].Brightness.PreviousBrightness * (1.0f - b) + Cars[i].Brightness.NextBrightness * b;
-							}
-							else
-							{
-								b = Cars[i].Brightness.PreviousBrightness;
-							}
-
-							//Calculate the cab brightness
-							double ccb = Math.Round(255.0 * (1.0 - b));
-							//DNB then must equal the smaller of the cab brightness value & the dynamic brightness value
-							dnb = (byte) Math.Min(TrainManagerBase.Renderer.Lighting.DynamicCabBrightness, ccb);
+							b = (float)(Cars[i].FrontAxle.Follower.TrackPosition - Cars[i].Brightness.PreviousTrackPosition) / b;
+							if (b < 0.0f) b = 0.0f;
+							if (b > 1.0f) b = 1.0f;
+							b = Cars[i].Brightness.PreviousBrightness * (1.0f - b) + Cars[i].Brightness.NextBrightness * b;
 						}
-						int cs = Cars[i].CurrentCarSection;
-						if (cs >= 0 && cs < Cars[i].CarSections.Length)
+						else
 						{
-							if (Cars[i].CarSections[cs].Groups.Length > 0)
+							b = Cars[i].Brightness.PreviousBrightness;
+						}
+
+						//Calculate the cab brightness
+						double ccb = Math.Round(255.0 * (1.0 - b));
+						//DNB then must equal the smaller of the cab brightness value & the dynamic brightness value
+						dnb = (byte)Math.Min(TrainManagerBase.Renderer.Lighting.DynamicCabBrightness, ccb);
+					}
+					int cs = Cars[i].CurrentCarSection;
+					if (cs >= 0 && cs < Cars[i].CarSections.Length)
+					{
+						if (Cars[i].CarSections[cs].Groups.Length > 0)
+						{
+							for (int k = 0; k < Cars[i].CarSections[cs].Groups[0].Elements.Length; k++)
 							{
-								for (int k = 0; k < Cars[i].CarSections[cs].Groups[0].Elements.Length; k++)
+								if (Cars[i].CarSections[cs].Groups[0].Elements[k].internalObject != null)
 								{
-									if (Cars[i].CarSections[cs].Groups[0].Elements[k].internalObject != null)
-									{
-										Cars[i].CarSections[cs].Groups[0].Elements[k].internalObject.DaytimeNighttimeBlend = dnb;
-									}
+									Cars[i].CarSections[cs].Groups[0].Elements[k].internalObject.DaytimeNighttimeBlend = dnb;
 								}
 							}
 						}
-
-						if (AI != null)
-						{
-							AI.Trigger(TimeElapsed);
-						}
 					}
-				}
-				else if (State == TrainState.Bogus)
-				{
-					// bogus train
+
 					if (AI != null)
 					{
 						AI.Trigger(TimeElapsed);
 					}
 				}
 			}
-
-			/// <summary>Updates the physics and controls for this train</summary>
-			/// <param name="TimeElapsed">The time elapsed</param>
-			private void UpdatePhysicsAndControls(double TimeElapsed)
+			else if (State == TrainState.Bogus)
 			{
-				if (TimeElapsed == 0.0 || TimeElapsed > 1000)
+				// bogus train
+				if (AI != null)
 				{
-					//HACK: The physics engine really does not like update times above 1000ms
-					//This works around a bug experienced when jumping to a station on a steep hill
-					//causing exessive acceleration
-					return;
+					AI.Trigger(TimeElapsed);
 				}
-
-				// update station and doors
-				UpdateDoors(TimeElapsed);
-
-				// Update Run and Motor sounds
-				foreach (var Car in Cars)
-				{
-					Car.UpdateRunSounds(TimeElapsed);
-					Car.UpdateMotorSounds(TimeElapsed);
-				}
-
-				// infrequent updates
-				InternalTimerTimeElapsed += TimeElapsed;
-				if (InternalTimerTimeElapsed > 10.0)
-				{
-					InternalTimerTimeElapsed -= 10.0;
-					Synchronize();
-				}
-			}
-
-			public override void Jump(int stationIndex)
-			{
-				Dispose();
-				State = TrainState.Pending;
-				TrackFollowingObjectAI myAI = this.AI as TrackFollowingObjectAI;
-				myAI?.SetupTravelData(AppearanceTime);
-				TrainManagerBase.currentHost.ProcessJump(this, stationIndex);
 			}
 		}
+
+		/// <summary>Updates the physics and controls for this train</summary>
+		/// <param name="TimeElapsed">The time elapsed</param>
+		private void UpdatePhysicsAndControls(double TimeElapsed)
+		{
+			if (TimeElapsed == 0.0 || TimeElapsed > 1000)
+			{
+				//HACK: The physics engine really does not like update times above 1000ms
+				//This works around a bug experienced when jumping to a station on a steep hill
+				//causing exessive acceleration
+				return;
+			}
+
+			// update station and doors
+			UpdateDoors(TimeElapsed);
+
+			// Update Run and Motor sounds
+			foreach (var Car in Cars)
+			{
+				Car.UpdateRunSounds(TimeElapsed);
+				Car.UpdateMotorSounds(TimeElapsed);
+			}
+
+			// infrequent updates
+			InternalTimerTimeElapsed += TimeElapsed;
+			if (InternalTimerTimeElapsed > 10.0)
+			{
+				InternalTimerTimeElapsed -= 10.0;
+				Synchronize();
+			}
+		}
+
+		public override void Jump(int stationIndex)
+		{
+			Dispose();
+			State = TrainState.Pending;
+			TrainManagerBase.currentHost.ProcessJump(this, stationIndex);
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes multiple issues with TFO.
- Change: the TFO operation plan to be calculated only when reading the route
  - Previously, if the player jumped between stations, it would be calculated again.
- Fix: the method of calculating the acceleration of TFO
  - Calculation formula of acceleration was incorrect. (Fix: #608)

I'm currently working on fixing #598.

**UPDATE: 2021/04/21**
- Fix: TrackFollower did not consider the Invalid TrackElement when moving backwards
  - Changed to take this into consideration when moving backward as well as when moving forward. (Fix: #598)