### PR TITLE
Implement DoorState, SetSignal and SetBeacon for input device plugins

### DIFF
--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -283,6 +283,25 @@ namespace DenshaDeGoInput
 			ConfigureMappings();
 		}
 
+		/// <summary>Is called when the state of the doors changes.</summary>
+		/// <param name="oldState">The old state of the doors.</param>
+		/// <param name="newState">The new state of the doors.</param>
+		public void DoorChange(DoorStates oldState, DoorStates newState)
+		{
+		}
+
+		/// <summary>Is called when the aspect in the current or in any of the upcoming sections changes, or when passing section boundaries.</summary>
+		/// <remarks>The signal array is guaranteed to have at least one element. When accessing elements other than index 0, you must check the bounds of the array first.</remarks>
+		public void SetSignal(SignalData[] signal)
+		{
+		}
+
+		/// <summary>Is called when the train passes a beacon.</summary>
+		/// <param name="data">The beacon data.</param>
+		public void SetBeacon(BeaconData data)
+		{
+		}
+
 		/// <summary>
 		/// Configures the correct mappings for the buttons and notches according to the user settings.
 		/// </summary>

--- a/source/OpenBveApi/Interface/Input/InputDevice.cs
+++ b/source/OpenBveApi/Interface/Input/InputDevice.cs
@@ -108,6 +108,20 @@ namespace OpenBveApi.Interface
 		/// </summary>
 		/// <param name="mySpecs"></param>
 		void SetVehicleSpecs(VehicleSpecs mySpecs);
+
+		/// <summary>Is called when the state of the doors changes.</summary>
+		/// <param name="oldState">The old state of the doors.</param>
+		/// <param name="newState">The new state of the doors.</param>
+		void DoorChange(DoorStates oldState, DoorStates newState);
+
+		/// <summary>Is called when the aspect in the current or in any of the upcoming sections changes, or when passing section boundaries.</summary>
+		/// <param name="data">Signal information per section. In the array, index 0 is the current section, index 1 the upcoming section, and so on.</param>
+		/// <remarks>The signal array is guaranteed to have at least one element. When accessing elements other than index 0, you must check the bounds of the array first.</remarks>
+		void SetSignal(SignalData[] data);
+
+		/// <summary>Is called when the train passes a beacon.</summary>
+		/// <param name="data">The beacon data.</param>
+		void SetBeacon(BeaconData data);
 	}
 
 	/// <summary>

--- a/source/TrainManager/Train/Doors.cs
+++ b/source/TrainManager/Train/Doors.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Runtime;
+﻿using OpenBveApi.Interface;
+using OpenBveApi.Runtime;
 using TrainManager.Car;
 
 namespace TrainManager.Trains
@@ -260,6 +261,14 @@ namespace TrainManager.Trains
 				if (Plugin != null)
 				{
 					Plugin.DoorChange(oldState, newState);
+				}
+				for (int j = 0; j < InputDevicePlugin.AvailablePluginInfos.Count; j++)
+				{
+					if (InputDevicePlugin.AvailablePluginInfos[j].Status == InputDevicePlugin.PluginInfo.PluginStatus.Enable && InputDevicePlugin.AvailablePlugins[j] is ITrainInputDevice)
+					{
+						ITrainInputDevice trainInputDevice = (ITrainInputDevice)InputDevicePlugin.AvailablePlugins[j];
+						trainInputDevice.DoorChange(oldState, newState);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR implements DoorState, SetSignal and SetBeacon for input device plugins, making the data available to them on-par with train plugins.