### PR TITLE
Fix: some issues with the path of texture file in DirectX file

### DIFF
--- a/source/AssimpParser/X/XFileParser.cs
+++ b/source/AssimpParser/X/XFileParser.cs
@@ -84,6 +84,7 @@ using System.Text;
 using System.IO;
 using System.Diagnostics;
 using System.Globalization;
+using OpenBveApi;
 using OpenBveApi.Colors;
 using OpenBveApi.Math;
 using ZlibWithDictionary;
@@ -109,6 +110,9 @@ namespace AssimpNET.X
 		protected readonly uint BinaryFloatSize; // float size in bytes, either 4 or 8
 		// counter for number arrays in binary format
 		protected uint BinaryNumCount;
+
+		// text encoding of text format
+		private readonly Encoding textEncoding;
 
 		protected int currentPosition;
 		protected int End;
@@ -297,6 +301,11 @@ namespace AssimpNET.X
 			{
 				// start reading here
 				ReadUntilEndOfLine();
+			}
+
+			if (!IsBinaryFormat)
+			{
+				textEncoding = TextEncoding.GetSystemEncodingFromBytes(Buffer);
 			}
 
 			Scene = new Scene();
@@ -1426,8 +1435,6 @@ namespace AssimpNET.X
 
 		protected void GetNextTokenAsString(out string token)
 		{
-			token = string.Empty;
-
 			if (IsBinaryFormat)
 			{
 				token = GetNextToken();
@@ -1446,10 +1453,12 @@ namespace AssimpNET.X
 			}
 			++currentPosition;
 
+			List<byte> textBuffer = new List<byte>();
 			while (currentPosition < End && Buffer[currentPosition] != '"')
 			{
-				token += (char)Buffer[currentPosition++];
+				textBuffer.Add(Buffer[currentPosition++]);
 			}
+			token = textEncoding.GetString(textBuffer.ToArray());
 
 			if (currentPosition >= End - 1)
 			{

--- a/source/OpenBveApi/System/Path.cs
+++ b/source/OpenBveApi/System/Path.cs
@@ -229,6 +229,42 @@ namespace OpenBveApi {
 			return false;
 		}
 
+		/// <summary>
+		/// Checks whether the specified path is an absolute path.
+		/// </summary>
+		/// <param name="path">The path to test</param>
+		/// <returns>True if this path is an absolute path, false otherwise</returns>
+		public static bool IsAbsolutePath(string path)
+		{
+			if (path.Length < 1)
+			{
+				return false;
+			}
+
+			if (path[0] == PathSeparationChars[0] || path[0] == PathSeparationChars[1])
+			{
+				// e.g.
+				// \Test\Foo.txt (Windows)
+				// /Test/Foo.txt (Windows, Unix)
+				return true;
+			}
+
+			if (path.Length < 3)
+			{
+				return false;
+			}
+
+			if (path[1] == ':' && (path[2] == PathSeparationChars[0] || path[2] == PathSeparationChars[1]))
+			{
+				// e.g.
+				// C:\Test\Foo.txt (Windows)
+				// C:/Test/Foo.txt (Windows)
+				return true;
+			}
+
+			return false;
+		}
+
 
 		// --- private functions ---
 		

--- a/source/OpenBveApi/System/TextEncoding.cs
+++ b/source/OpenBveApi/System/TextEncoding.cs
@@ -300,7 +300,7 @@ namespace OpenBveApi
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "people6.b3d" && fInfo.Length == 377)
 						{
 							//Polish Warsaw metro object file uses diacritics in filenames
-							return Encoding.GB18030;
+							return Encoding.WIN1252;
 						}
 
 						return Encoding.GB18030;

--- a/source/OpenBveApi/System/TextEncoding.cs
+++ b/source/OpenBveApi/System/TextEncoding.cs
@@ -107,6 +107,18 @@ namespace OpenBveApi
 			UTF8 = 65001
 		}
 
+		/// <summary>
+		/// Gets the character system encoding of the bytes array
+		/// </summary>
+		/// <param name="Data">The bytes array</param>
+		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
+		/// <returns>The character system encoding, or default encoding if unknown</returns>
+		public static System.Text.Encoding GetSystemEncodingFromBytes(byte[] Data, System.Text.Encoding DefaultEncoding = null)
+		{
+			Encoding encoding = GetEncodingFromBytes(Data);
+			return ConvertToSystemEncoding(encoding, DefaultEncoding);
+		}
+
 		/// <summary>Gets the character system encoding of a file</summary>
 		/// <param name="File">The absolute path to a file</param>
 		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
@@ -114,7 +126,27 @@ namespace OpenBveApi
 		public static System.Text.Encoding GetSystemEncodingFromFile(string File, System.Text.Encoding DefaultEncoding = null)
 		{
 			Encoding encoding = GetEncodingFromFile(File);
+			return ConvertToSystemEncoding(encoding, DefaultEncoding);
+		}
 
+		/// <summary>Gets the character system encoding of a file within a folder</summary>
+		/// <param name="Folder">The absolute path to the folder containing the file</param>
+		/// <param name="File">The filename</param>
+		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
+		/// <returns>The character system encoding, or default encoding if unknown</returns>
+		public static System.Text.Encoding GetSystemEncodingFromFile(string Folder, string File, System.Text.Encoding DefaultEncoding = null)
+		{
+			return GetSystemEncodingFromFile(Path.CombineFile(Folder, File), DefaultEncoding);
+		}
+
+		/// <summary>
+		/// Converts to the character system encoding
+		/// </summary>
+		/// <param name="encoding">The character encoding, or unknown</param>
+		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
+		/// <returns>The character system encoding, or default encoding if unknown</returns>
+		public static System.Text.Encoding ConvertToSystemEncoding(Encoding encoding, System.Text.Encoding DefaultEncoding = null)
+		{
 			if (encoding == Encoding.Unknown)
 			{
 				return DefaultEncoding ?? System.Text.Encoding.Default;
@@ -135,14 +167,121 @@ namespace OpenBveApi
 			return systemEncoding;
 		}
 
-		/// <summary>Gets the character system encoding of a file within a folder</summary>
-		/// <param name="Folder">The absolute path to the folder containing the file</param>
-		/// <param name="File">The filename</param>
-		/// <param name="DefaultEncoding">The encoding to use if the encoding could not be determined. If not specified, the system default encoding is used.</param>
-		/// <returns>The character system encoding, or default encoding if unknown</returns>
-		public static System.Text.Encoding GetSystemEncodingFromFile(string Folder, string File, System.Text.Encoding DefaultEncoding = null)
+		/// <summary>
+		/// Gets the character encoding of the bytes array
+		/// </summary>
+		/// <param name="Data">The bytes array</param>
+		/// <returns>The character encoding, or unknown</returns>
+		public static Encoding GetEncodingFromBytes(byte[] Data)
 		{
-			return GetSystemEncodingFromFile(Path.CombineFile(Folder, File), DefaultEncoding);
+			if (Data.Length >= 3)
+			{
+				if (Data[0] == 0xEF & Data[1] == 0xBB & Data[2] == 0xBF)
+				{
+					return Encoding.UTF8;
+				}
+
+				if (Data[0] == 0x2b & Data[1] == 0x2f & Data[2] == 0x76)
+				{
+					return Encoding.UTF7;
+				}
+			}
+
+			if (Data.Length >= 2)
+			{
+				if (Data[0] == 0xFE & Data[1] == 0xFF)
+				{
+					return Encoding.UTF16_BE;
+				}
+
+				if (Data[0] == 0xFF & Data[1] == 0xFE)
+				{
+					return Encoding.UTF16_LE;
+				}
+			}
+
+			if (Data.Length >= 4)
+			{
+				if (Data[0] == 0x00 & Data[1] == 0x00 & Data[2] == 0xFE & Data[3] == 0xFF)
+				{
+					return Encoding.UTF32_BE;
+				}
+
+				if (Data[0] == 0xFF & Data[1] == 0xFE & Data[2] == 0x00 & Data[3] == 0x00)
+				{
+					return Encoding.UTF32_LE;
+				}
+			}
+
+			CharsetDetector Det = new CharsetDetector();
+			Det.Feed(Data, 0, Data.Length);
+			Det.DataEnd();
+
+			if (Det.Charset == null)
+			{
+				return Encoding.Unknown;
+			}
+
+			switch (Det.Charset)
+			{
+				case Charsets.IBM855:
+					return Encoding.IBM855;
+				case Charsets.IBM866:
+					return Encoding.IBM866;
+				case Charsets.SHIFT_JIS:
+					return Encoding.SHIFT_JIS;
+				case Charsets.EUCKR:
+					return Encoding.EUC_KR;
+				case Charsets.BIG5:
+					return Encoding.BIG5;
+				case Charsets.UTF16_LE:
+					return Encoding.UTF16_LE;
+				case Charsets.UTF16_BE:
+					return Encoding.UTF16_BE;
+				case Charsets.WIN1251:
+					return Encoding.WIN1251;
+				case Charsets.WIN1252:
+					return Encoding.WIN1252;
+				case Charsets.WIN1253:
+					return Encoding.WIN1253;
+				case Charsets.WIN1255:
+					return Encoding.WIN1255;
+				case Charsets.MAC_CYRILLIC:
+					return Encoding.MAC_CYRILLIC;
+				case Charsets.UTF32_LE:
+					return Encoding.UTF32_LE;
+				case Charsets.UTF32_BE:
+					return Encoding.UTF32_BE;
+				case Charsets.ASCII:
+					return Encoding.ASCII;
+				case Charsets.KOI8R:
+					return Encoding.KOI8_R;
+				case Charsets.EUCJP:
+					return Encoding.EUC_JP;
+				case Charsets.ISO8859_2:
+					return Encoding.ISO8859_2;
+				case Charsets.ISO8859_5:
+					return Encoding.ISO8859_5;
+				case Charsets.ISO_8859_7:
+					return Encoding.ISO8859_7;
+				case Charsets.ISO8859_8:
+					return Encoding.ISO8859_8;
+				case Charsets.ISO2022_JP:
+					return Encoding.ISO2022_JP;
+				case Charsets.ISO2022_KR:
+					return Encoding.ISO2022_KR;
+				case Charsets.ISO2022_CN:
+					return Encoding.ISO2022_CN;
+				case Charsets.HZ_GB_2312:
+					return Encoding.HZ_GB_2312;
+				case Charsets.GB18030:
+					return Encoding.GB18030;
+				case Charsets.UTF8:
+					return Encoding.UTF8;
+			}
+
+			Det.Reset();
+			return Encoding.Unknown;
 		}
 
 		/// <summary>Gets the character encoding of a file</summary>
@@ -158,158 +297,62 @@ namespace OpenBveApi
 			try
 			{
 				System.IO.FileInfo fInfo = new System.IO.FileInfo(File);
-				byte[] Data = System.IO.File.ReadAllBytes(File);
+				Encoding encoding = GetEncodingFromBytes(System.IO.File.ReadAllBytes(File));
 
-				if (Data.Length >= 3)
+				switch (encoding)
 				{
-					if (Data[0] == 0xEF & Data[1] == 0xBB & Data[2] == 0xBF)
-					{
-						return Encoding.UTF8;
-					}
-
-					if (Data[0] == 0x2b & Data[1] == 0x2f & Data[2] == 0x76)
-					{
-						return Encoding.UTF7;
-					}
-				}
-
-				if (Data.Length >= 2)
-				{
-					if (Data[0] == 0xFE & Data[1] == 0xFF)
-					{
-						return Encoding.UTF16_BE;
-					}
-
-					if (Data[0] == 0xFF & Data[1] == 0xFE)
-					{
-						return Encoding.UTF16_LE;
-					}
-				}
-
-				if (Data.Length >= 4)
-				{
-					if (Data[0] == 0x00 & Data[1] == 0x00 & Data[2] == 0xFE & Data[3] == 0xFF)
-					{
-						return Encoding.UTF32_BE;
-					}
-
-					if (Data[0] == 0xFF & Data[1] == 0xFE & Data[2] == 0x00 & Data[3] == 0x00)
-					{
-						return Encoding.UTF32_LE;
-					}
-				}
-
-				CharsetDetector Det = new CharsetDetector();
-				Det.Feed(Data, 0, Data.Length);
-				Det.DataEnd();
-
-				if (Det.Charset == null)
-				{
-					return Encoding.Unknown;
-				}
-
-				switch (Det.Charset)
-				{
-					case Charsets.IBM855:
-						return Encoding.IBM855;
-					case Charsets.IBM866:
-						return Encoding.IBM866;
-					case Charsets.SHIFT_JIS:
-						return Encoding.SHIFT_JIS;
-					case Charsets.EUCKR:
-						return Encoding.EUC_KR;
-					case Charsets.BIG5:
+					case Encoding.BIG5:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "stoklosy.b3d" && fInfo.Length == 18256)
 						{
 							//Polish Warsaw metro object file uses diacritics in filenames
 							return Encoding.WIN1252;
 						}
-
-						return Encoding.BIG5;
-					case Charsets.UTF16_LE:
-						return Encoding.UTF16_LE;
-					case Charsets.UTF16_BE:
-						return Encoding.UTF16_BE;
-					case Charsets.WIN1251:
+						break;
+					case Encoding.WIN1251:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "585tc1.csv" && fInfo.Length == 37302)
 						{
 							return Encoding.SHIFT_JIS;
 						}
-
-						return Encoding.WIN1251;
-					case Charsets.WIN1252:
+						break;
+					case Encoding.WIN1252:
 						if (fInfo.Length == 62861)
 						{
 							//HK tram route. Comes in a non-unicode zip, so filename may be subject to mangling
 							return Encoding.BIG5;
 						}
-
-						return Encoding.WIN1252;
-					case Charsets.WIN1253:
-						return Encoding.WIN1253;
-					case Charsets.WIN1255:
+						break;
+					case Encoding.WIN1255:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "xdbetulasmall.csv" && fInfo.Length == 406)
 						{
 							//Hungarian birch tree; Actually loads OK with 1255, but use the correct one
 							return Encoding.WIN1252;
 						}
-
-						return Encoding.WIN1255;
-					case Charsets.MAC_CYRILLIC:
+						break;
+					case Encoding.MAC_CYRILLIC:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "exit01.csv" && fInfo.Length == 752)
 						{
 							//hira2
 							return Encoding.SHIFT_JIS;
 						}
-
-						return Encoding.MAC_CYRILLIC;
-					case Charsets.UTF32_LE:
-						return Encoding.UTF32_LE;
-					case Charsets.UTF32_BE:
-						return Encoding.UTF32_BE;
-					case Charsets.ASCII:
-						return Encoding.ASCII;
-					case Charsets.KOI8R:
-						return Encoding.KOI8_R;
-					case Charsets.EUCJP:
+						break;
+					case Encoding.EUC_JP:
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "xsara.b3d" && fInfo.Length == 3429)
 						{
 							//Uses an odd character in the comments, ASCII works just fine
 							return Encoding.ASCII;
 						}
-
-						return Encoding.EUC_JP;
-					case Charsets.ISO8859_2:
-						return Encoding.ISO8859_2;
-					case Charsets.ISO8859_5:
-						return Encoding.ISO8859_5;
-					case Charsets.ISO_8859_7:
-						return Encoding.ISO8859_7;
-					case Charsets.ISO8859_8:
-						return Encoding.ISO8859_8;
-					case Charsets.ISO2022_JP:
-						return Encoding.ISO2022_JP;
-					case Charsets.ISO2022_KR:
-						return Encoding.ISO2022_KR;
-					case Charsets.ISO2022_CN:
-						return Encoding.ISO2022_CN;
-					case Charsets.HZ_GB_2312:
-						return Encoding.HZ_GB_2312;
-					case Charsets.GB18030:
+						break;
+					case Encoding.GB18030:
 						//Extended new Chinese charset
 						if (System.IO.Path.GetFileName(File).ToLowerInvariant() == "people6.b3d" && fInfo.Length == 377)
 						{
 							//Polish Warsaw metro object file uses diacritics in filenames
 							return Encoding.WIN1252;
 						}
-
-						return Encoding.GB18030;
-					case Charsets.UTF8:
-						return Encoding.UTF8;
+						break;
 				}
 
-				Det.Reset();
-				return Encoding.Unknown;
+				return encoding;
 			}
 			catch
 			{

--- a/source/Plugins/Object.DirectX/Plugin.cs
+++ b/source/Plugins/Object.DirectX/Plugin.cs
@@ -10,7 +10,7 @@ namespace Plugin
     {
 	    internal static HostInterface currentHost;
 	    private static XParsers currentXParser = XParsers.Original;
-	    internal static bool BlackTransparency = true;
+	    internal static CompatabilityHacks EnabledHacks;
 
 	    public override string[] SupportedStaticObjectExtensions => new[] { ".x" };
 
@@ -19,9 +19,9 @@ namespace Plugin
 		    currentHost = host;
 	    }
 
-	    public override void SetCompatibilityHacks(CompatabilityHacks EnabledHacks)
+	    public override void SetCompatibilityHacks(CompatabilityHacks enabledHacks)
 	    {
-		    BlackTransparency = EnabledHacks.BlackTransparency;
+		    EnabledHacks = enabledHacks;
 	    }
 		
 	    public override void SetObjectParser(object parserType)


### PR DESCRIPTION
- Fix: a text encoding issue in Assimp X file parser
  - Assimp X file parser didn't consider the character encoding of the text format.
- Fix: the issue where some object files specify absolute paths
  - For example, the texture is specified as an absolute path on the 1490, 1499, and 1532 lines of `railway\object\marumado\5250.x` on the route published [here](http://marumado.umic.jp/marumado_go_download.php).