### PR TITLE
Remove: unnecessary pre-loading of textures

### DIFF
--- a/source/Plugins/Train.OpenBve/Panel/Panel2CfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/Panel2CfgParser.cs
@@ -290,7 +290,7 @@ namespace Train.OpenBve
 						if (!File.Exists(PanelNighttimeImage)) {
 							Plugin.currentHost.AddMessage(MessageType.Error, true, "The nighttime panel bitmap could not be found in " + FileName);
 						} else {
-							Plugin.currentHost.RegisterTexture(PanelNighttimeImage, new TextureParameters(null, PanelTransparentColor), out tnight, true);
+							Plugin.currentHost.RegisterTexture(PanelNighttimeImage, new TextureParameters(null, PanelTransparentColor), out tnight);
 						}
 					}
 					CreateElement(ref Car.CarSections[0].Groups[0], 0.0, 0.0, new Vector2(0.5, 0.5), 0.0, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight);
@@ -394,7 +394,7 @@ namespace Train.OpenBve
 										Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(null, TransparentColor), out var tday, true);
 										Texture tnight = null;
 										if (NighttimeImage != null) {
-											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight, true);
+											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight);
 										}
 										int w = tday.Width;
 										int h = tday.Height;
@@ -569,7 +569,7 @@ namespace Train.OpenBve
 										Texture tnight = null;
 										if (NighttimeImage != null)
 										{
-											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight, true);
+											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight);
 										}
 										if (!OriginDefined) {
 											OriginX = 0.5 * tday.Width;
@@ -737,7 +737,7 @@ namespace Train.OpenBve
 										Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(null, TransparentColor), out var tday, true);
 										Texture tnight = null;
 										if (NighttimeImage != null) {
-											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight, true);
+											Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, TransparentColor), out tnight);
 										}
 										int j = CreateElement(ref Car.CarSections[0].Groups[GroupIndex], LocationX, LocationY, tday.Width, tday.Height, new Vector2(0.5, 0.5), Layer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Car.Driver, tday, tnight, Color32.White);
 										if (Maximum < Minimum)
@@ -880,7 +880,7 @@ namespace Train.OpenBve
 											{
 												if ((k + 1) * Interval <= hday)
 												{
-													Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, Interval), TransparentColor), out tday[k], true);
+													Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, Interval), TransparentColor), out tday[k]);
 												}
 												else if (k * Interval >= hday)
 												{
@@ -889,7 +889,7 @@ namespace Train.OpenBve
 												}
 												else
 												{
-													Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, hday - (k * Interval)), TransparentColor), out tday[k], true);
+													Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, hday - (k * Interval)), TransparentColor), out tday[k]);
 												}
 											}
 											if (NighttimeImage != null) {
@@ -898,7 +898,7 @@ namespace Train.OpenBve
 												for (int k = 0; k < numFrames; k++) {
 													if ((k + 1) * Interval <= hnight)
 													{
-														Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, Interval), TransparentColor), out tnight[k], true);
+														Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, Interval), TransparentColor), out tnight[k]);
 													}
 													else if (k * Interval > hnight)
 													{
@@ -906,7 +906,7 @@ namespace Train.OpenBve
 													}
 													else
 													{
-														Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, hnight - (k * Interval)), TransparentColor), out tnight[k], true);
+														Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, hnight - (k * Interval)), TransparentColor), out tnight[k]);
 													}
 												}
 												

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -1079,7 +1079,7 @@ namespace Train.OpenBve
 										Texture[] t = new Texture[n];
 										for (int j = 0; j < n; j++)
 										{
-											Plugin.currentHost.RegisterTexture(Number, new TextureParameters(new TextureClipRegion(w - Width, j * Height, Width, Height), Color24.Blue), out t[j], true);
+											Plugin.currentHost.RegisterTexture(Number, new TextureParameters(new TextureClipRegion(w - Width, j * Height, Width, Height), Color24.Blue), out t[j]);
 										}
 
 										{
@@ -1461,7 +1461,7 @@ namespace Train.OpenBve
 										for (int j = 0; j < n; j++)
 										{
 											TextureClipRegion clip = new TextureClipRegion(j * Width, 0, Width, h);
-											Plugin.currentHost.RegisterTexture(Image, new TextureParameters(clip, Color24.Blue), out var t, true);
+											Plugin.currentHost.RegisterTexture(Image, new TextureParameters(clip, Color24.Blue), out var t);
 											if (j == 0)
 											{
 												k = CreateElement(Car, CornerX, CornerY + SemiHeight, Width, h, WorldZ + EyeDistance - StackDistance, t, Color32.White);

--- a/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelXmlParser.cs
@@ -352,7 +352,7 @@ namespace Train.OpenBve
 							}
 							else
 							{
-								Plugin.currentHost.RegisterTexture(PanelNighttimeImage, new TextureParameters(null, new Color24(PanelTransparentColor.R, PanelTransparentColor.G, PanelTransparentColor.B)), out tnight, true);
+								Plugin.currentHost.RegisterTexture(PanelNighttimeImage, new TextureParameters(null, new Color24(PanelTransparentColor.R, PanelTransparentColor.G, PanelTransparentColor.B)), out tnight);
 							}
 						}
 						Plugin.Panel2CfgParser.CreateElement(ref CarSection.Groups[GroupIndex], 0.0, 0.0, new Vector2(0.5, 0.5), OffsetLayer * StackDistance, PanelResolution, PanelBottom, PanelCenter, Train.Cars[Car].Driver, tday, tnight);
@@ -659,7 +659,7 @@ namespace Train.OpenBve
 								Texture tnight = null;
 								if (NighttimeImage != null)
 								{
-									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight, true);
+									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight);
 								}
 								int w = tday.Width;
 								int h = tday.Height;
@@ -874,7 +874,7 @@ namespace Train.OpenBve
 								Texture tnight = null;
 								if (NighttimeImage != null)
 								{
-									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight, true);
+									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight);
 								}
 								if (!OriginDefined)
 								{
@@ -1061,7 +1061,7 @@ namespace Train.OpenBve
 								Texture tnight = null;
 								if (NighttimeImage != null)
 								{
-									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight, true);
+									Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(null, new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight);
 								}
 								int w = tday.Width;
 								int h = tday.Height;
@@ -1227,7 +1227,7 @@ namespace Train.OpenBve
 									{
 										if ((k + 1) * Interval <= hday)
 										{
-											Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, Interval), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tday[k], true);
+											Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, Interval), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tday[k]);
 										}
 										else if (k * Interval >= hday)
 										{
@@ -1236,7 +1236,7 @@ namespace Train.OpenBve
 										}
 										else
 										{
-											Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, hday - (k * Interval)), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tday[k], true);
+											Plugin.currentHost.RegisterTexture(DaytimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wday, hday - (k * Interval)), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tday[k]);
 										}
 									}
 									if (NighttimeImage != null)
@@ -1247,7 +1247,7 @@ namespace Train.OpenBve
 										{
 											if ((k + 1) * Interval <= hnight)
 											{
-												Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, Interval), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight[k], true);
+												Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, Interval), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight[k]);
 											}
 											else if (k * Interval > hnight)
 											{
@@ -1255,7 +1255,7 @@ namespace Train.OpenBve
 											}
 											else
 											{
-												Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, hnight - (k * Interval)), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight[k], true);
+												Plugin.currentHost.RegisterTexture(NighttimeImage, new TextureParameters(new TextureClipRegion(0, k * Interval, wnight, hnight - (k * Interval)), new Color24(TransparentColor.R, TransparentColor.G, TransparentColor.B)), out tnight[k]);
 											}
 										}
 


### PR DESCRIPTION
From v1.7.3.0, the loading time of some trains will be more than 10 times longer.
Tokyu 5050 series on [here](http://www.nozomi.vc/02_toyoko/index.htm) is that.
The following table shows the results of measuring the loading time on the same route and the same train.

| Version          | Loading time (s) |
| ---------------- | ------------- |
| v1.7.2.4         | 12            |
| **v1.7.3.1**         | **155**       |
| This PR (32 bit) | 12            |

This is because we are pre-loading unnecessary textures.
This train takes a long time to load `[DigitalNumber]` from lines 726 to 751 of Panel2.cfg.
Since the height of `Sub\Target.bmp` is 1024 and `Interval` is 1, we are loading `Sub\Target.bmp` 1024 times [here](https://github.com/leezer3/OpenBVE/blob/7ac627b08c4e771c280ac709a08dbd25475a8d80/source/Plugins/Train.OpenBve/Panel/Panel2CfgParser.cs#L879-L894).
Pre-loading the texture is done to get the size of the texture.
But there we already have the size of the texture.

------
Measurement environment
- OS: Windows 10 64 bit
- CPU: Intel Core i5-10210U
- GPU: Intel UHD Graphics
- Memory: 8 GB