### PR TITLE
Fix: the error when parsing Train.dat that doesn't contain version string

### DIFF
--- a/source/Plugins/Train.OpenBve/Train/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/TrainDatParser.cs
@@ -111,16 +111,13 @@ namespace Train.OpenBve
 					case "bve2060000":
 						return TrainDatFormats.BVE2060000;
 					case "openbve":
+						version = 0;
 						return TrainDatFormats.openBVE;
 					default:
 						if (t.ToLowerInvariant().StartsWith("openbve"))
 						{
 							string tt = t.Substring(7, t.Length - 7).Trim();
-							if (string.IsNullOrEmpty(tt))
-							{
-								version = 0;
-							}
-							else if (!NumberFormats.TryParseIntVb6(tt, out version))
+							if (!NumberFormats.TryParseIntVb6(tt, out version))
 							{
 								version = -1;
 							}


### PR DESCRIPTION
[This commit](https://github.com/leezer3/OpenBVE/commit/963dff02aedd24a911431c38ec956e8a69a823aa) hasn't fixed the error yet.
See also: https://bveworldwide.forumotion.com/t2102-render-bugs-with-non-existing-parts-of-railjet-coaches-object-viewer-complaining-of-train-dat-format#20662