### PR TITLE
Fix: System language is not used by default

### DIFF
--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
@@ -736,7 +736,7 @@ namespace OpenBve
 				// file not found
 				string Code = CultureInfo.CurrentUICulture.Name;
 				if (string.IsNullOrEmpty(Code)) Code = "en-US";
-				File = Path.CombineFile(Program.FileSystem.GetDataFolder("Languages"), Code + ".cfg");
+				File = Path.CombineFile(Program.FileSystem.GetDataFolder("Languages"), Code + ".xlf");
 				if (System.IO.File.Exists(File))
 				{
 					CurrentOptions.LanguageCode = Code;
@@ -749,7 +749,7 @@ namespace OpenBve
 						if (i > 0)
 						{
 							Code = Code.Substring(0, i);
-							File = Path.CombineFile(Program.FileSystem.GetDataFolder("Languages"), Code + ".cfg");
+							File = Path.CombineFile(Program.FileSystem.GetDataFolder("Languages"), Code + ".xlf");
 							if (System.IO.File.Exists(File))
 							{
 								CurrentOptions.LanguageCode = Code;


### PR DESCRIPTION
The default language being English instead of the system language at first startup has been a long-time issue that confuses many new players. It seems the code for language detection still uses CFG when the format of the language files has been changed to XLF, which makes it inoperative.