### PR TITLE
Fix: Crash when checking for update without an internet connection

### DIFF
--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -1704,6 +1704,12 @@ namespace OpenBve {
 				}
 
 			}
+			catch (WebException)
+			{
+				//The internet connection is broken.....
+				MessageBox.Show(Translations.GetInterfaceString("panel_updates_invalid"));
+				return;
+			}
 			finally
 			{
 				if (reader != null) reader.Close();
@@ -1711,12 +1717,6 @@ namespace OpenBve {
 			}
 			Version curVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
 			bool newerVersion = curVersion.CompareTo(newVersion) < 0;
-			if (url == null)
-			{
-				//The internet connection is broken.....
-				MessageBox.Show(Translations.GetInterfaceString("panel_updates_invalid"));
-				return;
-			}
 			if (newerVersion)
 			{
 				string question = Translations.GetInterfaceString("panel_updates_new");


### PR DESCRIPTION
Currently the program will crash with an Unhandled Windows Form Exception if a connection to the server cannot be established.
This PR should fixes it, though I still have a few questions:

![image](https://user-images.githubusercontent.com/28094366/129439321-48153581-2c3d-4ed8-9fcc-021a68cde605.png)
Is that suppose to be a typo?
The original code comment has mentioned that "The internet connection is broken...", so I assume we can't establish a connection to the server.

Also on the [contributing guidelines](https://github.com/leezer3/OpenBVE/blob/aa9f170147fea0f707e21307f9d7469d036d1aff/Contributing.md), it is mentioned to use "Unix (CR LF) line terminators"  
but as far as I am aware Unix only uses LF, and Windows uses CR LF?