### PR TITLE
Additions to the CSScript animation C# script interface

### DIFF
--- a/source/OpenBveApi/FunctionScripts/AnimationScripts.cs
+++ b/source/OpenBveApi/FunctionScripts/AnimationScripts.cs
@@ -1,4 +1,4 @@
-﻿using OpenBveApi.Math;
+using OpenBveApi.Math;
 
 namespace OpenBveApi.FunctionScripting
 {
@@ -7,11 +7,30 @@ namespace OpenBveApi.FunctionScripting
 	{
 		/// <summary> Call to execute this script </summary>
 		/// <param name="Train">A reference to the nearest train</param>
+		/// <param name="CarIndex">The object's car index in a train, if is a car object</param>
 		/// <param name="Position">The object's absolute in world position</param>
 		/// <param name="TrackPosition">The object's track position</param>
 		/// <param name="SectionIndex"></param>
 		/// <param name="IsPartOfTrain">Whether this object forms part of a train</param>
 		/// <param name="TimeElapsed">The time elapsed since the previous call to this function</param>
-		double ExecuteScript(Trains.AbstractTrain Train, Vector3 Position, double TrackPosition, int SectionIndex, bool IsPartOfTrain, double TimeElapsed);
+		/// <param name="CurrentState">The value at the last invocation</param>
+		double ExecuteScript(Trains.AbstractTrain Train, int CarIndex, Vector3 Position, double TrackPosition, int SectionIndex, bool IsPartOfTrain, double TimeElapsed, int CurrentState);
+
+		/// <summary> Clone this script object </summary>
+		/// <returns> An shallow copy </returns>
+		AnimationScript Clone();
+
+		/// <summary> The result on the last invocation. 0 if not yet invoked. </summary>
+		double LastResult {
+			get; set;
+		}
+		/// <summary>The maximum pinned result or NaN to set no maximum</summary>
+		double Maximum {
+			get; set;
+		}
+		/// <summary>The minimum pinned result or NaN to set no minimum</summary>
+		double Minimum {
+			get; set;
+		}
 	}
 }

--- a/source/OpenBveApi/FunctionScripts/CSAnimationScript.cs
+++ b/source/OpenBveApi/FunctionScripts/CSAnimationScript.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using CSScriptLibrary;
+using OpenBveApi.Hosts;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using OpenBveApi.Trains;
+
+namespace OpenBveApi.FunctionScripting {
+
+	/// <summary>Animation script implemented in external C# code.</summary>
+	public class CSAnimationScript : AnimationScript {
+
+		/// <summary>The last result returned</summary>
+		public double LastResult { get; set; }
+		/// <summary>The minimum pinned result or NaN to set no minimum</summary>
+		public double Maximum { get; set; } = Double.NaN;
+		/// <summary>The maximum pinned result or NaN to set no maximum</summary>
+		public double Minimum { get; set; } = Double.NaN;
+
+		private readonly HostInterface currentHost;
+		private readonly object scriptObject;
+		private readonly MethodInfo executeMethod;
+		private readonly int invokeType;
+
+		/// <summary>Load a script with or without arguments.</summary>
+		/// <param name="host">A reference to the base application host interface.</param>
+		/// <param name="path">The path to the CS file. Suffix similar to URL query string will be parsed as arguments.</param>
+		public CSAnimationScript(HostInterface host, string path) : this(host, GetFileNameFromPath(path), GetArgsFromPath(path)) { }
+
+		private static string GetFileNameFromPath(string path) {
+			if (path.Contains('?')) {
+				return path.Split('?').First();
+			} else {
+				return path;
+			}
+		}
+
+		private static Dictionary<string, string> GetArgsFromPath(string path) {
+			if (path.Contains('?')) {
+				var queryStr = path.Split('?').Last();
+				var result = new Dictionary<string, string>();
+				foreach (string t in queryStr.Split('&')) {
+					if (t.Contains('=')) {
+						result.Add(t.Split('=').First(), t.Split('=').Last());
+					} else {
+						result.Add(t, null);
+					}
+				}
+				return result;
+			} else {
+				return null;
+			}
+		}
+
+		/// <summary>Load a script with or without arguments.</summary>
+		/// <param name="host">A reference to the base application host interface.</param>
+		/// <param name="path">The path to the CS file.</param>
+		/// <param name="args">The arguments to pass to the script, or null.</param>
+		public CSAnimationScript(HostInterface host, string path, Dictionary<string, string> args) {
+			currentHost = host;
+			try {
+				CSScript.GlobalSettings.TargetFramework = "v4.0";
+				Assembly assembly = CSScript.LoadCode(File.ReadAllText(path));
+				Type scriptType = assembly.GetTypes().FirstOrDefault(t => t.Name == "OpenBVEScript");
+				if (scriptType == null)
+					throw new EntryPointNotFoundException("Script file does not contain the type 'OpenBVEScript'");
+
+				foreach (var ctor in scriptType.GetConstructors()) {
+					if (ctor.GetParameters().Length == 0) {
+						scriptObject = Activator.CreateInstance(scriptType);
+						break;
+					} else if (ctor.GetParameters().Length == 1 
+						&& ctor.GetParameters()[0].ParameterType == typeof(Dictionary<string, string>)) {
+						scriptObject = Activator.CreateInstance(scriptType, new object[] { args });
+						break;
+					}
+				}
+				if (scriptObject == null)
+					throw new EntryPointNotFoundException("Public constructor must take no parameter or a 'Dictionary<string, string>'");
+
+				foreach (var method in scriptType.GetMethods().Where(m => m.Name == "ExecuteScript" && m.ReturnType == typeof(double))) {
+					Type[][] invokeTypes = {
+						// The original interface
+						new Type[] {typeof(AbstractTrain), typeof(Vector3), typeof(double), typeof(int), typeof(bool), typeof(double) },
+						// The full interface
+						new Type[] {typeof(AbstractTrain), typeof(int), typeof(Vector3), typeof(double), typeof(int), typeof(bool), typeof(double), typeof(int) }
+					};
+					for (int i = 0; i < invokeTypes.Length; i++) {
+						if (method.GetParameters().Select(p => p.ParameterType).SequenceEqual(invokeTypes[i])) {
+							executeMethod = method;
+							invokeType = i;
+							break;
+						}
+					}
+					if (executeMethod != null) break;
+				}
+
+				if (executeMethod == null)
+					throw new EntryPointNotFoundException("Not containing method with correct signature and name 'ExecuteScript'");
+
+			} catch (Exception ex) {
+				currentHost.AddMessage(MessageType.Error, false,
+					"An error occcured whilst parsing script " + path + ": " + ex.Message);
+				throw;
+			}
+		}
+
+		/// <summary>Clone this object.</summary>
+		/// <returns>A shallow copy.</returns>
+		public AnimationScript Clone() {
+			return (AnimationScript) MemberwiseClone();
+		}
+
+		/// <summary>Performs the function script, and returns the current result</summary>
+		public double ExecuteScript(AbstractTrain Train, int CarIndex, Vector3 Position, double TrackPosition, int SectionIndex, bool IsPartOfTrain, double TimeElapsed, int CurrentState) {
+			switch (invokeType) {
+				case 0:
+					LastResult = (double)executeMethod.Invoke(scriptObject, new object[] { Train, Position, TrackPosition,
+					SectionIndex, IsPartOfTrain, TimeElapsed });
+					break;
+				case 1:
+					LastResult = (double)executeMethod.Invoke(scriptObject, new object[] { Train, CarIndex, Position, TrackPosition,
+					SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState });
+					break;
+			}
+			if (this.Minimum != Double.NaN & this.LastResult < Minimum) {
+				return Minimum;
+			}
+			if (this.Maximum != Double.NaN & this.LastResult > Maximum) {
+				return Maximum;
+			}
+			return LastResult;
+		}
+	}
+}

--- a/source/OpenBveApi/FunctionScripts/FunctionScript.cs
+++ b/source/OpenBveApi/FunctionScripts/FunctionScript.cs
@@ -7,7 +7,7 @@ using OpenBveApi.Trains;
 namespace OpenBveApi.FunctionScripting
 {
 	/// <summary>The base abstract function script which consumers must implement</summary>
-	public class FunctionScript
+	public class FunctionScript : AnimationScript
 	{
 		private readonly HostInterface currentHost;
 		/// <summary>The instructions to perform</summary>
@@ -17,16 +17,16 @@ namespace OpenBveApi.FunctionScripting
 		/// <summary>All constants used for the script</summary>
 		public readonly double[] Constants;
 		/// <summary>The last result returned</summary>
-		public double LastResult;
+		public double LastResult { get; set; }
 		/// <summary>The minimum pinned result or NaN to set no minimum</summary>
-		public double Maximum = Double.NaN;
+		public double Maximum { get; set; } = Double.NaN;
 		/// <summary>The maximum pinned result or NaN to set no maximum</summary>
-		public double Minimum = Double.NaN;
+		public double Minimum { get; set; } = Double.NaN;
 		/// <summary>We caught an exception on the last execution of the script, so further execution has been stopped</summary> 
 		private bool exceptionCaught;
 
 		/// <summary>Performs the function script, and returns the current result</summary>
-		public double Perform(AbstractTrain Train, int CarIndex, Vector3 Position, double TrackPosition, int SectionIndex, bool IsPartOfTrain, double TimeElapsed, int CurrentState)
+		public double ExecuteScript(AbstractTrain Train, int CarIndex, Vector3 Position, double TrackPosition, int SectionIndex, bool IsPartOfTrain, double TimeElapsed, int CurrentState)
 		{
 			if (exceptionCaught)
 			{
@@ -819,7 +819,7 @@ namespace OpenBveApi.FunctionScripting
 		
 
 		/// <summary>Clones the function script</summary>
-		public FunctionScript Clone()
+		public AnimationScript Clone()
 		{
 			return (FunctionScript) this.MemberwiseClone();
 		}

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
@@ -17,7 +17,7 @@ namespace OpenBveApi.Objects
 		/// <summary>The array of states</summary>
 		public ObjectState[] States;
 		/// <summary>The function script controlling state changes</summary>
-		public FunctionScript StateFunction;
+		public AnimationScript StateFunction;
 		/// <summary>The index of the current state</summary>
 		public int CurrentState;
 		/// <summary>A 3D vector describing the direction taken when TranslateXFunction is called</summary>
@@ -28,13 +28,13 @@ namespace OpenBveApi.Objects
 		public Vector3 TranslateZDirection;
 		/// <summary>The function script controlling translation in the X direction</summary>
 		/// <remarks>X is an arbitrary 3D direction, nominally 1,0,0</remarks>
-		public FunctionScript TranslateXFunction;
+		public AnimationScript TranslateXFunction;
 		/// <summary>The function script controlling translation in the Y direction</summary>
 		/// <remarks>Y is an arbitrary 3D direction, nominally 0,1,0</remarks>
-		public FunctionScript TranslateYFunction;
+		public AnimationScript TranslateYFunction;
 		/// <summary>The function script controlling translation in the Z direction</summary>
 		/// <remarks>Z is an arbitrary 3D direction, nominally 0,0,1</remarks>
-		public FunctionScript TranslateZFunction;
+		public AnimationScript TranslateZFunction;
 		/// <summary>A 3D vector describing the rotation performed when RotateXFunction is called</summary>
 		public Vector3 RotateXDirection;
 		/// <summary>A 3D vector describing the rotation performed when RotateYFunction is called</summary>
@@ -43,13 +43,13 @@ namespace OpenBveApi.Objects
 		public Vector3 RotateZDirection;
 		/// <summary>The function script controlling translation in the X direction</summary>
 		/// <remarks>X is an arbitrary 3D direction, nominally 1,0,0</remarks>
-		public FunctionScript RotateXFunction;
+		public AnimationScript RotateXFunction;
 		/// <summary>The function script controlling translation in the Y direction</summary>
 		/// <remarks>Y is an arbitrary 3D direction, nominally 0,1,0</remarks>
-		public FunctionScript RotateYFunction;
+		public AnimationScript RotateYFunction;
 		/// <summary>The function script controlling translation in the Z direction</summary>
 		/// <remarks>Z is an arbitrary 3D direction, nominally 0,0,1</remarks>
-		public FunctionScript RotateZFunction;
+		public AnimationScript RotateZFunction;
 		/// <summary>The damping (if any) to perform when RotateXFunction is called</summary>
 		public Damping RotateXDamping;
 		/// <summary>The damping (if any) to perform when RotateYFunction is called</summary>
@@ -62,10 +62,10 @@ namespace OpenBveApi.Objects
 		public Vector2 TextureShiftYDirection;
 		/// <summary>The function script controlling texture shifting in the X direction</summary>
 		/// <remarks>X is an arbitrary 2D direction, nominally 1,0</remarks>
-		public FunctionScript TextureShiftXFunction;
+		public AnimationScript TextureShiftXFunction;
 		/// <summary>The function script controlling texture shifting in the Y direction</summary>
 		/// <remarks>X is an arbitrary 2D direction, nominally 0,1</remarks>
-		public FunctionScript TextureShiftYFunction;
+		public AnimationScript TextureShiftYFunction;
 		/// <summary>If the LED function is used, this controls whether the winding is clockwise or anti-clockwise</summary>
 		public bool LEDClockwiseWinding;
 		/// <summary>The initial angle of the LED function</summary>
@@ -75,27 +75,14 @@ namespace OpenBveApi.Objects
 		/// <summary>If LEDFunction is used, an array of five vectors representing the bottom-left, up-left, up-right, bottom-right and center coordinates of the LED square, or a null reference otherwise.</summary>
 		public Vector3[] LEDVectors;
 		/// <summary>The function script controlling the LED square</summary>
-		public FunctionScript LEDFunction;
+		public AnimationScript LEDFunction;
 		/// <summary>The refresh rate in seconds</summary>
 		public double RefreshRate;
 		/// <summary>The time since the last update of this object</summary>
 		public double SecondsSinceLastUpdate;
-
-		//This section holds script files executed by CS-Script
-		/// <summary>The absolute path to the script file to be evaluated when TranslateXScript is called</summary>
-		public string TranslateXScriptFile;
-		/// <summary>The actual script interface</summary>
-		public AnimationScript TranslateXAnimationScript;
-		/// <summary>The absolute path to the script file to be evaluated when TranslateYScript is called</summary>
-		public AnimationScript TranslateYAnimationScript;
-		/// <summary>The actual script interface</summary>
-		public string TranslateYScriptFile;
-		/// <summary>The absolute path to the script file to be evaluated when TranslateZScript is called</summary>
-		public AnimationScript TranslateZAnimationScript;
-		/// <summary>The actual script interface</summary>
-		public string TranslateZScriptFile;
+		
 		/// <summary>The function script controlling movement along the track</summary>
-		public FunctionScript TrackFollowerFunction;
+		public AnimationScript TrackFollowerFunction;
 		/// <summary>The front axle position if TrackFollowerFunction is used</summary>
 		public double FrontAxlePosition = 1;
 		/// <summary>The rear axle position if TrackFollowerFunction is used</summary>
@@ -126,7 +113,6 @@ namespace OpenBveApi.Objects
 			Result.TrackFollowerFunction = TrackFollowerFunction?.Clone();
 			Result.FrontAxlePosition = this.FrontAxlePosition;
 			Result.RearAxlePosition = this.RearAxlePosition;
-			Result.TranslateXScriptFile = this.TranslateXScriptFile;
 			Result.StateFunction = StateFunction?.Clone();
 			Result.CurrentState = this.CurrentState;
 			Result.TranslateZDirection = this.TranslateZDirection;
@@ -185,7 +171,6 @@ namespace OpenBveApi.Objects
 			if (this.RotateXFunction != null | this.RotateYFunction != null | this.RotateZFunction != null) return false;
 			if (this.TextureShiftXFunction != null | this.TextureShiftYFunction != null) return false;
 			if (this.LEDFunction != null) return false;
-			if (this.TranslateXScriptFile != null | this.TranslateYScriptFile != null | this.TranslateZScriptFile != null) return false;
 			if (this.TrackFollowerFunction != null) return false;
 			return true;
 		}
@@ -239,7 +224,7 @@ namespace OpenBveApi.Objects
 			// state change
 			if (StateFunction != null & UpdateFunctions)
 			{
-				double sd = StateFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+				double sd = StateFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				int si = (int) System.Math.Round(sd);
 				if (si < 0 | si >= States.Length) si = -1;
 				if (CurrentState != si)
@@ -261,38 +246,9 @@ namespace OpenBveApi.Objects
 				double x = TranslateXFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					x = TranslateXFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					x = TranslateXFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 
-				Vector3 translationVector = new Vector3(TranslateXDirection); //Must clone
-				translationVector.Rotate(Direction, Up, Side);
-				translationVector *= x;
-				Position += translationVector;
-			}
-			else if (TranslateXScriptFile != null)
-			{
-				//Translate X Script
-				if (TranslateXAnimationScript == null)
-				{
-					//Load the script if required
-					try
-					{
-						CSScript.GlobalSettings.TargetFramework = "v4.0";
-						TranslateXAnimationScript = CSScript.LoadCode(File.ReadAllText(TranslateXScriptFile))
-							.CreateObject("OpenBVEScript")
-							.AlignToInterface<AnimationScript>(true);
-					}
-					catch
-					{
-						currentHost.AddMessage(MessageType.Error, false,
-							"An error occcured whilst parsing script " + TranslateXScriptFile);
-						TranslateXScriptFile = null;
-						return;
-					}
-				}
-
-				double x = TranslateXAnimationScript.ExecuteScript(Train, Position, TrackPosition, SectionIndex,
-					IsPartOfTrain, TimeElapsed);
 				Vector3 translationVector = new Vector3(TranslateXDirection); //Must clone
 				translationVector.Rotate(Direction, Up, Side);
 				translationVector *= x;
@@ -305,38 +261,9 @@ namespace OpenBveApi.Objects
 				double y = TranslateYFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					y = TranslateYFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					y = TranslateYFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 
-				Vector3 translationVector = new Vector3(TranslateYDirection); //Must clone
-				translationVector.Rotate(Direction, Up, Side);
-				translationVector *= y;
-				Position += translationVector;
-			}
-			else if (TranslateYScriptFile != null)
-			{
-				//Translate X Script
-				if (TranslateYAnimationScript == null)
-				{
-					//Load the script if required
-					try
-					{
-						CSScript.GlobalSettings.TargetFramework = "v4.0";
-						TranslateYAnimationScript = CSScript.LoadCode(File.ReadAllText(TranslateYScriptFile))
-							.CreateObject("OpenBVEScript")
-							.AlignToInterface<AnimationScript>(true);
-					}
-					catch
-					{
-						currentHost.AddMessage(MessageType.Error, false,
-							"An error occcured whilst parsing script " + TranslateYScriptFile);
-						TranslateYScriptFile = null;
-						return;
-					}
-				}
-
-				double y = TranslateYAnimationScript.ExecuteScript(Train, Position, TrackPosition, SectionIndex,
-					IsPartOfTrain, TimeElapsed);
 				Vector3 translationVector = new Vector3(TranslateYDirection); //Must clone
 				translationVector.Rotate(Direction, Up, Side);
 				translationVector *= y;
@@ -348,38 +275,9 @@ namespace OpenBveApi.Objects
 				double z = TranslateZFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					z = TranslateZFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					z = TranslateZFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 				
-				Vector3 translationVector = new Vector3(TranslateZDirection); //Must clone
-				translationVector.Rotate(Direction, Up, Side);
-				translationVector *= z;
-				Position += translationVector;
-			}
-			else if (TranslateZScriptFile != null)
-			{
-				//Translate X Script
-				if (TranslateZAnimationScript == null)
-				{
-					//Load the script if required
-					try
-					{
-						CSScript.GlobalSettings.TargetFramework = "v4.0";
-						TranslateZAnimationScript = CSScript.LoadCode(File.ReadAllText(TranslateZScriptFile))
-							.CreateObject("OpenBVEScript")
-							.AlignToInterface<AnimationScript>(true);
-					}
-					catch
-					{
-						currentHost.AddMessage(MessageType.Error, false,
-							"An error occcured whilst parsing script " + TranslateZScriptFile);
-						TranslateZScriptFile = null;
-						return;
-					}
-				}
-
-				double z = TranslateZAnimationScript.ExecuteScript(Train, Position, TrackPosition, SectionIndex,
-					IsPartOfTrain, TimeElapsed);
 				Vector3 translationVector = new Vector3(TranslateZDirection); //Must clone
 				translationVector.Rotate(Direction, Up, Side);
 				translationVector *= z;
@@ -396,7 +294,7 @@ namespace OpenBveApi.Objects
 				radianX = RotateXFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					radianX = RotateXFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					radianX = RotateXFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 				
 				if (RotateXDamping != null)
@@ -411,7 +309,7 @@ namespace OpenBveApi.Objects
 				radianY = RotateYFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					radianY = RotateYFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					radianY = RotateYFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 				
 				if (RotateYDamping != null)
@@ -426,7 +324,7 @@ namespace OpenBveApi.Objects
 				radianZ = RotateZFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					radianZ = RotateZFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					radianZ = RotateZFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 				
 				if (RotateZDamping != null)
@@ -447,7 +345,7 @@ namespace OpenBveApi.Objects
 					double x = TextureShiftXFunction.LastResult;
 					if (UpdateFunctions)
 					{
-						x = TextureShiftXFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+						x = TextureShiftXFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 					}
 					
 					x -= System.Math.Floor(x);
@@ -459,7 +357,7 @@ namespace OpenBveApi.Objects
 					double y = TextureShiftYFunction.LastResult;
 					if (UpdateFunctions)
 					{
-						y = TextureShiftYFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+						y = TextureShiftYFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 					}
 					
 					y -= System.Math.Floor(y);
@@ -475,7 +373,7 @@ namespace OpenBveApi.Objects
 				ledangle = LEDFunction.LastResult;
 				if (UpdateFunctions)
 				{
-					ledangle = LEDFunction.Perform(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
+					ledangle = LEDFunction.ExecuteScript(Train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 				}
 			}
 

--- a/source/OpenBveApi/Objects/ObjectTypes/TrackFollowingObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/TrackFollowingObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using OpenBveApi.Math;
 using OpenBveApi.Routes;
 using OpenBveApi.Trains;
@@ -149,7 +149,7 @@ namespace OpenBveApi.Objects
 			double x = 0.0;
 			if (Object.TrackFollowerFunction != null)
 			{
-				x = UpdateFunctions ? Object.TrackFollowerFunction.Perform(Train, CarIndex, WorldPosition, currentTrackPosition, currentSectionIndex, IsPartOfTrain, TimeElapsed, Object.CurrentState) : Object.TrackFollowerFunction.LastResult;
+				x = UpdateFunctions ? Object.TrackFollowerFunction.ExecuteScript(Train, CarIndex, WorldPosition, currentTrackPosition, currentSectionIndex, IsPartOfTrain, TimeElapsed, Object.CurrentState) : Object.TrackFollowerFunction.LastResult;
 			}
 
 			return x;

--- a/source/OpenBveApi/Objects/ObjectTypes/WorldSound.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/WorldSound.cs
@@ -1,4 +1,4 @@
-﻿using OpenBveApi.FunctionScripting;
+using OpenBveApi.FunctionScripting;
 using OpenBveApi.Math;
 using OpenBveApi.Routes;
 using OpenBveApi.Sounds;
@@ -23,11 +23,11 @@ namespace OpenBveApi.Objects
 		/// <summary>The track follower used to hold/ move the sound</summary>
 		public TrackFollower Follower;
 		/// <summary>The function script controlling the sound's movement along the track, or a null reference</summary>
-		public FunctionScript TrackFollowerFunction;
+		public AnimationScript TrackFollowerFunction;
 		/// <summary>The function script controlling the sound's volume, or a null reference</summary>
-		public FunctionScript VolumeFunction;
+		public AnimationScript VolumeFunction;
 		/// <summary>The function script controlling the sound's pitch, or a null reference</summary>
-		public FunctionScript PitchFunction;
+		public AnimationScript PitchFunction;
 
 		/// <inheritdoc/>
 		/// <remarks>In this case, the position of the track follower is returned.</remarks>
@@ -85,19 +85,19 @@ namespace OpenBveApi.Objects
 				if (this.TrackFollowerFunction != null)
 				{
 
-					double delta = this.TrackFollowerFunction.Perform(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+					double delta = this.TrackFollowerFunction.ExecuteScript(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
 					this.Follower.UpdateRelative(this.currentTrackPosition + delta, true, true);
 					this.Follower.UpdateWorldCoordinates(false);
 				}
 
 				if (this.VolumeFunction != null)
 				{
-					this.currentVolume = this.VolumeFunction.Perform(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+					this.currentVolume = this.VolumeFunction.ExecuteScript(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
 				}
 
 				if (this.PitchFunction != null)
 				{
-					this.currentPitch = this.PitchFunction.Perform(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
+					this.currentPitch = this.PitchFunction.ExecuteScript(NearestTrain, NearestTrain?.DriverCar ?? 0, this.Position, this.Follower.TrackPosition, 0, false, TimeElapsed, 0);
 				}
 
 				if (this.Source != null)

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -91,6 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FunctionScripts\AnimationScripts.cs" />
+    <Compile Include="FunctionScripts\CSAnimationScript.cs" />
     <Compile Include="FunctionScripts\FunctionScript.cs" />
     <Compile Include="FunctionScripts\FunctionScript.Notation.cs" />
     <Compile Include="FunctionScripts\Instructions.cs" />

--- a/source/OpenBveApi/System/Path.cs
+++ b/source/OpenBveApi/System/Path.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable 0659, 0661
+#pragma warning disable 0659, 0661
 
 using System;
 using System.IO;
@@ -25,9 +25,10 @@ namespace OpenBveApi {
 		/// <summary>Combines a platform-specific absolute path with a platform-independent relative path that points to a directory.</summary>
 		/// <param name="absolute">The platform-specific absolute path.</param>
 		/// <param name="relative">The platform-independent relative path.</param>
+		/// <param name="allowQueryStr">If a part similar to a URL query string at the end of the path should be preserved.</param>
 		/// <returns>A platform-specific absolute path to the specified directory.</returns>
 		/// <exception cref="System.Exception">Raised when combining the paths failed, for example due to malformed paths or due to unauthorized access.</exception>
-		public static string CombineDirectory(string absolute, string relative) {
+		public static string CombineDirectory(string absolute, string relative, bool allowQueryStr = false) {
             int index = relative.IndexOf("??", StringComparison.Ordinal);
 			if (index >= 0) {
 				string directory = CombineDirectory(absolute, relative.Substring(0, index).TrimEnd());
@@ -35,6 +36,12 @@ namespace OpenBveApi {
 					return directory;
 				}
 				return CombineDirectory(absolute, relative.Substring(index + 2).TrimStart());
+			}
+			string queryString = "";
+			int questionMarkIndex = relative.IndexOf("?", StringComparison.Ordinal);
+			if (allowQueryStr && questionMarkIndex >= 0) {
+				queryString = relative.Substring(questionMarkIndex);
+				relative = relative.Substring(0, questionMarkIndex);
 			}
 			if (relative.IndexOfAny(InvalidPathChars) >= 0) {
 				throw new ArgumentException("The relative path contains invalid characters.");
@@ -101,7 +108,7 @@ namespace OpenBveApi {
 					}
 				}
 			}
-			return absolute;
+			return absolute + queryString;
 		}
 		
 		/// <summary>Combines a platform-specific absolute path with a platform-independent relative path that points to a file.</summary>

--- a/source/Plugins/Object.Animated/Plugin.Parser.cs
+++ b/source/Plugins/Object.Animated/Plugin.Parser.cs
@@ -356,7 +356,8 @@ namespace Plugin
 												case "translatexscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateXScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateXFunction = new CSAnimationScript(currentHost, 
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{
@@ -382,7 +383,8 @@ namespace Plugin
 												case "translateyscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateYScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateYFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{
@@ -408,7 +410,8 @@ namespace Plugin
 												case "translatezscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateZScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateZFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{
@@ -549,6 +552,14 @@ namespace Plugin
 													{
 														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 													} break;
+												case "rotatexscript":
+													try {
+														Result.Objects[ObjectCount].RotateXFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
+													} catch (Exception ex) {
+														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+													}
+													break;
 												case "rotateyfunction":
 													try
 													{
@@ -562,6 +573,14 @@ namespace Plugin
 													{
 														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 													} break;
+												case "rotateyscript":
+													try {
+														Result.Objects[ObjectCount].RotateYFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
+													} catch (Exception ex) {
+														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+													}
+													break;
 												case "rotatezfunction":
 													try
 													{
@@ -575,6 +594,14 @@ namespace Plugin
 													{
 														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 													} break;
+												case "rotatezscript":
+													try {
+														Result.Objects[ObjectCount].RotateZFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
+													} catch (Exception ex) {
+														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+													}
+													break;
 												case "rotatexfunctionrpn":
 													try
 													{
@@ -689,6 +716,14 @@ namespace Plugin
 													{
 														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 													} break;
+												case "textureshiftxscript":
+													try {
+														Result.Objects[ObjectCount].TextureShiftXFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
+													} catch (Exception ex) {
+														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+													}
+													break;
 												case "textureshiftyfunction":
 													try
 													{
@@ -698,6 +733,14 @@ namespace Plugin
 													{
 														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 													} break;
+												case "textureshiftyscript":
+													try {
+														Result.Objects[ObjectCount].TextureShiftYFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
+													} catch (Exception ex) {
+														currentHost.AddMessage(MessageType.Error, false, ex.Message + " in " + a + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
+													}
+													break;
 												case "textureshiftxfunctionrpn":
 													try
 													{
@@ -1082,7 +1125,8 @@ namespace Plugin
 												case "translatexscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateXScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateXFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{
@@ -1110,7 +1154,8 @@ namespace Plugin
 												case "translateyscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateYScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateYFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{
@@ -1138,7 +1183,8 @@ namespace Plugin
 												case "translatezscript":
 													try
 													{
-														Result.Objects[ObjectCount].TranslateZScriptFile = OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b);
+														Result.Objects[ObjectCount].TranslateZFunction = new CSAnimationScript(currentHost,
+															OpenBveApi.Path.CombineDirectory(System.IO.Path.GetDirectoryName(FileName), b, true));
 													}
 													catch (Exception ex)
 													{


### PR DESCRIPTION
## Changes
- An argument list can be passed to the constructor of the script class, in a format similar to URL query string. This enables reusing the same script file for multiple purposes, such as doors on both sides, which requires 4 individual script files before.
Example: 

```ini
[Object]
Position = 0, 0, 0
States = test.csv
TranslateZScript = test.cs?value=1
```

```csharp
using System;
using System.Collections.Generic;
using OpenBveApi.Hosts;
using OpenBveApi.Interface;
using OpenBveApi.Math;
using OpenBveApi.Trains;

public class OpenBVEScript {

	private int val;

	public OpenBVEScript(Dictionary<string, string> args) {
		val = int.Parse(args["value"]);
	}

	public double ExecuteScript(AbstractTrain Train, int CarIndex, Vector3 Position, double TrackPosition, 
		int SectionIndex, bool IsPartOfTrain, double TimeElapsed, int CurrentState) {
		return val;
	}
}
```
- CSScript and FunctionScript now all implement the AnimationScript interface, eliminating the need of special-case handling
- Usage of scripts expanded to Rotate and TextureShift