### PR TITLE
Fix: UI Thread Exception not written to log

### DIFF
--- a/source/OpenBVE/System/Functions/CrashHandler.cs
+++ b/source/OpenBVE/System/Functions/CrashHandler.cs
@@ -68,8 +68,8 @@ namespace OpenBve
 	        }
             try
             {
-                MessageBox.Show("Unhandled Windows Forms Exception");
-                LogCrash(t + Environment.StackTrace);
+                MessageBox.Show("Unhandled Windows Forms Exception.");
+                LogCrash(t.Exception.ToString() + Environment.NewLine + Environment.StackTrace);
             }
             catch (Exception exc)
             {

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -218,11 +218,11 @@ namespace OpenBve {
 			if (MechanikRouteIcon != null) listviewRouteRecently.SmallImageList.Images.Add("mechanik", MechanikRouteIcon);
 			for (int i = 0; i < Interface.CurrentOptions.RecentlyUsedRoutes.Length; i++)
 			{
-				if (Interface.CurrentOptions.RecentlyUsedRoutes[i] == null)
-				{
-					continue;
-				}
-				ListViewItem Item = listviewRouteRecently.Items.Add(System.IO.Path.GetFileName(Interface.CurrentOptions.RecentlyUsedRoutes[i]));
+				if (string.IsNullOrEmpty(Interface.CurrentOptions.RecentlyUsedRoutes[i])) continue;
+				string RouteFileName = System.IO.Path.GetFileName(Interface.CurrentOptions.RecentlyUsedRoutes[i]);
+				string RoutePath = System.IO.Path.GetDirectoryName(Interface.CurrentOptions.RecentlyUsedRoutes[i]);
+				if (string.IsNullOrEmpty(RouteFileName) || string.IsNullOrEmpty(RoutePath)) continue;
+				ListViewItem Item = listviewRouteRecently.Items.Add(RouteFileName);
 				string extension = System.IO.Path.GetExtension(Interface.CurrentOptions.RecentlyUsedRoutes[i]).ToLowerInvariant();
 				switch (extension)
 				{
@@ -239,7 +239,6 @@ namespace OpenBve {
 				}
 
 				Item.Tag = Interface.CurrentOptions.RecentlyUsedRoutes[i];
-				string RoutePath = System.IO.Path.GetDirectoryName(Interface.CurrentOptions.RecentlyUsedRoutes[i]);
 				if (textboxRouteFolder.Items.Count == 0 || !textboxRouteFolder.Items.Contains(RoutePath))
 				{
 					textboxRouteFolder.Items.Add(RoutePath);
@@ -261,10 +260,13 @@ namespace OpenBve {
 			if (TrainIcon != null) listviewTrainRecently.SmallImageList.Images.Add("train", TrainIcon);
 			for (int i = 0; i < Interface.CurrentOptions.RecentlyUsedTrains.Length; i++)
 			{
-				ListViewItem Item = listviewTrainRecently.Items.Add(System.IO.Path.GetFileName(Interface.CurrentOptions.RecentlyUsedTrains[i]));
+				if (string.IsNullOrEmpty(Interface.CurrentOptions.RecentlyUsedTrains[i])) continue;
+				string TrainFileName = System.IO.Path.GetFileName(Interface.CurrentOptions.RecentlyUsedTrains[i]);
+				string TrainPath = System.IO.Path.GetDirectoryName(Interface.CurrentOptions.RecentlyUsedTrains[i]);
+				if (string.IsNullOrEmpty(TrainFileName) || string.IsNullOrEmpty(TrainPath)) continue;
+				ListViewItem Item = listviewTrainRecently.Items.Add(TrainFileName);
 				Item.ImageKey = @"train";
 				Item.Tag = Interface.CurrentOptions.RecentlyUsedTrains[i];
-				string TrainPath = System.IO.Path.GetDirectoryName(Interface.CurrentOptions.RecentlyUsedTrains[i]);
 				if (textboxTrainFolder.Items.Count == 0 || !textboxTrainFolder.Items.Contains(TrainPath))
 				{
 					textboxTrainFolder.Items.Add(TrainPath);


### PR DESCRIPTION
This PR addresses these two issues:
1. `t + Environment.StackTrace` calls `ThreadExceptionEventArgs.ToString()`, which simply returns the string `ThreadExceptionEventArgs` instead of the full message and stack trace, and prevented the actual exception message from being written to log. By the way, according to player reports, "Unhandled Windows Forms Exception" is incredibly common. Their causes are partially unknown due to this issue.
2. In rare circumstances `null` can be present in `Interface.CurrentOptions.RecentlyUsedTrains`, and raises exception in formMain_Load resulting in OpenBVE being unable to start.