### PR TITLE
New: Add a package type for custom plugins

### DIFF
--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -606,6 +606,9 @@
 					<trans-unit id="type_other">
 						<source>Other</source>
 					</trans-unit>
+					<trans-unit id="type_plugin">
+						<source>Plugin</source>
+					</trans-unit>
 					<trans-unit id="type_select">
 						<source>Please select the package type:</source>
 					</trans-unit>

--- a/source/OpenBVE/Game/Menu/Menu.cs
+++ b/source/OpenBVE/Game/Menu/Menu.cs
@@ -475,6 +475,10 @@ namespace OpenBve
 									installedFiles = string.Empty;
 									Manipulation.ExtractPackage(currentPackage, Program.FileSystem.OtherInstallationDirectory, Program.FileSystem.PackageDatabaseFolder, ref installedFiles);
 									break;
+								case PackageType.ContentPlugin:
+									installedFiles = string.Empty;
+									Manipulation.ExtractPackage(currentPackage, Program.FileSystem.PluginInstallationDirectory, Program.FileSystem.PackageDatabaseFolder, ref installedFiles);
+									break;
 							}
 						}
 						break;

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -423,6 +423,7 @@ namespace OpenBve {
 			this.labelDependanciesNextStep = new System.Windows.Forms.Label();
 			this.buttonCreateProceed = new System.Windows.Forms.Button();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.radioButtonQ2Plugin = new System.Windows.Forms.RadioButton();
 			this.radioButtonQ2Other = new System.Windows.Forms.RadioButton();
 			this.radioButtonQ2Train = new System.Windows.Forms.RadioButton();
 			this.radioButtonQ2Route = new System.Windows.Forms.RadioButton();
@@ -4015,6 +4016,7 @@ namespace OpenBve {
 			this.panelPackages.Controls.Add(this.labelPackagesTitleSeparator);
 			this.panelPackages.Controls.Add(this.labelPackagesTitle);
 			this.panelPackages.Controls.Add(this.labelPackagesTitleBackground);
+			this.panelPackages.Controls.Add(this.panelCreatePackage);
 			this.panelPackages.Controls.Add(this.panelUninstallResult);
 			this.panelPackages.Controls.Add(this.panelSuccess);
 			this.panelPackages.Controls.Add(this.panelDependancyError);
@@ -4023,7 +4025,6 @@ namespace OpenBve {
 			this.panelPackages.Controls.Add(this.panelPackageList);
 			this.panelPackages.Controls.Add(this.panelPackageInstall);
 			this.panelPackages.Controls.Add(this.panelVersionError);
-			this.panelPackages.Controls.Add(this.panelCreatePackage);
 			this.panelPackages.Location = new System.Drawing.Point(160, 0);
 			this.panelPackages.Name = "panelPackages";
 			this.panelPackages.Size = new System.Drawing.Size(659, 606);
@@ -5375,6 +5376,7 @@ namespace OpenBve {
 			// groupBox1
 			// 
 			this.groupBox1.Controls.Add(this.radioButtonQ2Other);
+			this.groupBox1.Controls.Add(this.radioButtonQ2Plugin);
 			this.groupBox1.Controls.Add(this.radioButtonQ2Train);
 			this.groupBox1.Controls.Add(this.radioButtonQ2Route);
 			this.groupBox1.Location = new System.Drawing.Point(8, 69);
@@ -5383,17 +5385,17 @@ namespace OpenBve {
 			this.groupBox1.TabIndex = 19;
 			this.groupBox1.TabStop = false;
 			// 
-			// radioButtonQ2Other
+			// radioButtonQ2Plugin
 			// 
-			this.radioButtonQ2Other.AutoSize = true;
-			this.radioButtonQ2Other.Location = new System.Drawing.Point(119, 1);
-			this.radioButtonQ2Other.Name = "radioButtonQ2Other";
-			this.radioButtonQ2Other.Size = new System.Drawing.Size(51, 17);
-			this.radioButtonQ2Other.TabIndex = 19;
-			this.radioButtonQ2Other.TabStop = true;
-			this.radioButtonQ2Other.Text = "Other";
-			this.radioButtonQ2Other.UseVisualStyleBackColor = true;
-			this.radioButtonQ2Other.CheckedChanged += new System.EventHandler(this.Q2_CheckedChanged);
+			this.radioButtonQ2Plugin.AutoSize = true;
+			this.radioButtonQ2Plugin.Location = new System.Drawing.Point(119, 1);
+			this.radioButtonQ2Plugin.Name = "radioButtonQ2Plugin";
+			this.radioButtonQ2Plugin.Size = new System.Drawing.Size(54, 17);
+			this.radioButtonQ2Plugin.TabIndex = 19;
+			this.radioButtonQ2Plugin.TabStop = true;
+			this.radioButtonQ2Plugin.Text = "Plugin";
+			this.radioButtonQ2Plugin.UseVisualStyleBackColor = true;
+			this.radioButtonQ2Plugin.CheckedChanged += new System.EventHandler(this.Q2_CheckedChanged);
 			// 
 			// radioButtonQ2Train
 			// 
@@ -5664,6 +5666,18 @@ namespace OpenBve {
 			this.labelNewGUID.TabIndex = 24;
 			this.labelNewGUID.Text = "The new package has been assigned the following GUID:";
 			// 
+			// radioButtonQ2Other
+			// 
+			this.radioButtonQ2Other.AutoSize = true;
+			this.radioButtonQ2Other.Location = new System.Drawing.Point(176, 1);
+			this.radioButtonQ2Other.Name = "radioButtonQ2Other";
+			this.radioButtonQ2Other.Size = new System.Drawing.Size(51, 17);
+			this.radioButtonQ2Other.TabIndex = 20;
+			this.radioButtonQ2Other.TabStop = true;
+			this.radioButtonQ2Other.Text = "Other";
+			this.radioButtonQ2Other.UseVisualStyleBackColor = true;
+			this.radioButtonQ2Other.CheckedChanged += new System.EventHandler(this.Q2_CheckedChanged);
+			// 
 			// formMain
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -5678,10 +5692,10 @@ namespace OpenBve {
 			this.Controls.Add(this.labelFillerOne);
 			this.Controls.Add(this.labelFillerTwo);
 			this.Controls.Add(this.labelFillerThree);
+			this.Controls.Add(this.panelPackages);
 			this.Controls.Add(this.panelOptions);
 			this.Controls.Add(this.panelStart);
 			this.Controls.Add(this.panelControls);
-			this.Controls.Add(this.panelPackages);
 			this.Controls.Add(this.panelReview);
 			this.KeyPreview = true;
 			this.Name = "formMain";
@@ -6130,7 +6144,7 @@ namespace OpenBve {
 		private System.Windows.Forms.RadioButton radioButtonQ2Train;
 		private System.Windows.Forms.RadioButton radioButtonQ2Route;
 		private System.Windows.Forms.Label labelPackageType;
-		private System.Windows.Forms.RadioButton radioButtonQ2Other;
+		private System.Windows.Forms.RadioButton radioButtonQ2Plugin;
 		private System.Windows.Forms.Panel panelReplacePackage;
 		private System.Windows.Forms.Label packageToReplaceLabel;
 		private System.Windows.Forms.DataGridView dataGridViewReplacePackage;
@@ -6266,5 +6280,6 @@ namespace OpenBve {
 		private System.Windows.Forms.Label labelCompatibilitySignalSet;
 		private System.Windows.Forms.ComboBox comboBoxCompatibilitySignals;
 		private System.Windows.Forms.CheckBox checkBoxAccessibility;
+		private System.Windows.Forms.RadioButton radioButtonQ2Other;
 	}
 }

--- a/source/OpenBVE/UserInterface/formMain.Packages.cs
+++ b/source/OpenBVE/UserInterface/formMain.Packages.cs
@@ -276,6 +276,9 @@ namespace OpenBve
 					case PackageType.Loksim3D:
 						ExtractionDirectory = Program.FileSystem.LoksimPackageInstallationDirectory;
 						break;
+					case PackageType.ContentPlugin:
+						ExtractionDirectory = Program.FileSystem.PluginInstallationDirectory;
+						break;
 					default:
 						ExtractionDirectory = Program.FileSystem.OtherInstallationDirectory;
 						break;
@@ -507,6 +510,7 @@ namespace OpenBve
 				case PackageType.Train:
 					Packages = Database.currentDatabase.InstalledTrains;
 					break;
+				case PackageType.ContentPlugin:
 				case PackageType.Other:
 					Packages = Database.currentDatabase.InstalledOther;
 					break;
@@ -642,6 +646,7 @@ namespace OpenBve
 					case PackageType.Train:
 						UninstallPackage(currentPackage);
 						break;
+					case PackageType.ContentPlugin:
 					case PackageType.Other:
 					case PackageType.Loksim3D:
 						UninstallPackage(currentPackage);
@@ -671,6 +676,7 @@ namespace OpenBve
 				{
 					switch (currentPackage.PackageType)
 					{
+						case PackageType.ContentPlugin:
 						case PackageType.Other:
 							Database.currentDatabase.InstalledOther.Remove(currentPackage);
 							break;
@@ -1092,9 +1098,14 @@ namespace OpenBve
 			{
 				newPackageType = PackageType.Train;
 			}
+			else if (radioButtonQ2Plugin.Checked)
+			{
+				newPackageType = PackageType.ContentPlugin;
+			}
 			else
 			{
 				newPackageType = PackageType.Other;
+				groupBoxQ1.Enabled = true;
 			}
 			if (radioButtonQ1Yes.Checked)
 			{
@@ -1585,7 +1596,7 @@ namespace OpenBve
 			radioButtonQ1No.Checked = false;
 			radioButtonQ2Route.Checked = false;
 			radioButtonQ2Train.Checked = false;
-			radioButtonQ2Other.Checked = false;
+			radioButtonQ2Plugin.Checked = false;
 			//Reset picturebox
 			TryLoadImage(pictureBoxPackageImage, "route_unknown.png");
 			TryLoadImage(pictureBoxProcessing, "logo.png");

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -878,6 +878,7 @@ namespace OpenBve {
 			replacePackageButton.Text = Translations.GetInterfaceString("packages_replace_select");
 			packageToReplaceLabel.Text = Translations.GetInterfaceString("packages_replace_choose");
 			//New package panel
+			radioButtonQ2Plugin.Text = Translations.GetInterfaceString("packages_type_plugin");
 			radioButtonQ2Other.Text = Translations.GetInterfaceString("packages_type_other");
 			radioButtonQ2Route.Text = Translations.GetInterfaceString("packages_type_route");
 			radioButtonQ2Train.Text = Translations.GetInterfaceString("packages_type_train");

--- a/source/OpenBVE/UserInterface/formMain.resx
+++ b/source/OpenBVE/UserInterface/formMain.resx
@@ -126,6 +126,18 @@
   <metadata name="timerEvents.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="dataGridViewTextBoxColumn21.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn22.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn23.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="dataGridViewTextBoxColumn24.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="dataGridViewTextBoxColumn5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -190,18 +202,6 @@
     <value>True</value>
   </metadata>
   <metadata name="dataGridViewTextBoxColumn12.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn21.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn22.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn23.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataGridViewTextBoxColumn24.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="openPackageFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/source/OpenBveApi/Interface/Input/InputDevice.cs
+++ b/source/OpenBveApi/Interface/Input/InputDevice.cs
@@ -227,6 +227,14 @@ namespace OpenBveApi.Interface
 				return;
 			}
 			string[] PluginFiles = System.IO.Directory.GetFiles(PluginsFolder, "*.dll");
+			string[] UserPluginFiles =  System.IO.Directory.GetFiles(FileSystem.PluginInstallationDirectory, "*.dll");
+			if (UserPluginFiles.Length != 0)
+			{
+				int startIdx = PluginFiles.Length;
+				Array.Resize(ref PluginFiles, startIdx + UserPluginFiles.Length);
+				Array.Copy(UserPluginFiles, 0, PluginFiles, startIdx, UserPluginFiles.Length);
+			}
+			
 			foreach (var File in PluginFiles)
 			{
 				Assembly Plugin;

--- a/source/OpenBveApi/Packages/Packages.cs
+++ b/source/OpenBveApi/Packages/Packages.cs
@@ -173,6 +173,8 @@ namespace OpenBveApi.Packages
 		Other = 3,
 		/// <summary>The package contains imported Loksim3D content.</summary>
 		Loksim3D = 4,
+		/// <summary>The package contains a content loading plugin</summary>
+		ContentPlugin = 5
 	}
 
 	/// <summary>Holds the properties of a file, used during creation of a package.</summary>

--- a/source/OpenBveApi/System/FileSystem.cs
+++ b/source/OpenBveApi/System/FileSystem.cs
@@ -51,6 +51,9 @@ namespace OpenBveApi.FileSystem {
 
 		/// <summary>The location to which packaged other items will be installed</summary>
 		public string OtherInstallationDirectory;
+
+		/// <summary>The location to which user plugins will be installed</summary>
+		public string PluginInstallationDirectory;
 		
 		/// <summary>The location to which Loksim3D packages will be installed</summary>
 		public string LoksimPackageInstallationDirectory;
@@ -99,6 +102,7 @@ namespace OpenBveApi.FileSystem {
 			this.DataFolder = OpenBveApi.Path.CombineDirectory(assemblyFolder, "Data");
 			this.ManagedContentFolders = new string[] { OpenBveApi.Path.CombineDirectory(userDataFolder, "ManagedContent") };
 			this.SettingsFolder = OpenBveApi.Path.CombineDirectory(userDataFolder, "Settings");
+			this.PluginInstallationDirectory = OpenBveApi.Path.CombineDirectory(userDataFolder, "Plugins");
 			this.InitialRouteFolder = OpenBveApi.Path.CombineDirectory(OpenBveApi.Path.CombineDirectory(OpenBveApi.Path.CombineDirectory(userDataFolder, "LegacyContent"), "Railway"), "Route");
 			this.RouteInstallationDirectory = OpenBveApi.Path.CombineDirectory(OpenBveApi.Path.CombineDirectory(userDataFolder, "LegacyContent"), "Railway");
 			this.InitialTrainFolder = OpenBveApi.Path.CombineDirectory(OpenBveApi.Path.CombineDirectory(userDataFolder, "LegacyContent"), "Train");


### PR DESCRIPTION
This PR adds a package type and associated plumbing to install and load custom user plugins via the Package Install menu.

Some (minor) flaws if custom plugins are installed, which probably should be addressed at some stage:
* No mediation between two plugins which can load the same type of file.
* No way to enable / disable specific plugins. (Possibly wants something for all plugins as per input device plugins??)
* No current way for a plugin to modify the icon for content it supports.

cc @zbx1425 