### PR TITLE
New: Implement sprung handle types

### DIFF
--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -449,6 +449,8 @@ namespace CarXmlConvertor
 						newLines.Add("<ReadhesionDevice>NotFitted</ReadhesionDevice>");
 						break;
 				}
+				newLines.Add("<Power>");
+				newLines.Add("<Notches>" + ConvertTrainDat.PowerNotches + "</Notches>");
 				newLines.Add("<AccelerationCurves>");
 				foreach (ConvertTrainDat.AccelerationCurve curve in ConvertTrainDat.AccelerationCurves)
 				{
@@ -461,6 +463,7 @@ namespace CarXmlConvertor
 					newLines.Add("</OpenBVE>");
 				}
 				newLines.Add("</AccelerationCurves>");
+				newLines.Add("</Power>");
 			}
 			else
 			{

--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -604,6 +604,7 @@ namespace CarXmlConvertor
 				newLines.Add("<RearAxle>" + -(0.4 * ConvertTrainDat.CarLength) + "</RearAxle>");
 				newLines.Add("</Car>");
 			}
+			newLines.Add("<DriverCar>" + ConvertTrainDat.DriverCar + "</DriverCar>");
 			string pluginFile = ConvertAts.DllPath(System.IO.Path.GetDirectoryName(FileName));
 			if (!string.IsNullOrEmpty(pluginFile))
 			{

--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -518,6 +518,12 @@ namespace CarXmlConvertor
 				}
 			}
 			newLines.Add("<Brake>");
+			if (i == ConvertTrainDat.DriverCar)
+			{
+				newLines.Add("<Handle>");
+				newLines.Add("<Notches>" + ConvertTrainDat.BrakeNotches + "</Notches>");
+				newLines.Add("</Handle>");
+			}
 			if (ConvertTrainDat.MotorCars[i])
 			{
 

--- a/source/CarXMLConvertor/Convert.TrainDat.cs
+++ b/source/CarXMLConvertor/Convert.TrainDat.cs
@@ -31,6 +31,8 @@ namespace CarXmlConvertor
 		internal static int ReadhesionDeviceType = 0;
 		internal static double DoorWidth = 1000.0;
 		internal static double DoorTolerance = 0.0;
+		internal static int PowerNotches = 0;
+		internal static int BrakeNotches = 0;
 		private static MainForm mainForm;
 		internal static List<AccelerationCurve> AccelerationCurves = new List<AccelerationCurve>();
 
@@ -281,6 +283,32 @@ namespace CarXmlConvertor
 							} i++; n++;
 							AccelerationCurves.Add(curve);
 						} i--; break;
+					case "#handle":
+						i++;
+						while (i < Lines.Length && !Lines[i].StartsWith("#", StringComparison.Ordinal))
+						{
+							double a; if (NumberFormats.TryParseDoubleVb6(Lines[i], out a))
+							{
+								switch (n)
+								{
+									case 1:
+										if (a > 0)
+										{
+											PowerNotches = (int)a;
+										}
+										break;
+									case 2:
+										if (a > 0)
+										{
+											BrakeNotches = (int)a;
+										}
+										break;
+								}
+							}
+							i++; n++;
+						}
+						i--; 
+						break;
 					default:
 					{
 						i++;

--- a/source/OpenBVE/System/Input/Keyboard.cs
+++ b/source/OpenBVE/System/Input/Keyboard.cs
@@ -2,6 +2,7 @@
 using LibRender2.Screens;
 using OpenTK.Input;
 using OpenBveApi.Interface;
+using TrainManager.Handles;
 
 namespace OpenBve
 {
@@ -62,6 +63,10 @@ namespace OpenBve
 					}
 				}
 			}
+			// Attempt to reset handle spring
+			TrainManager.PlayerTrain.Handles.Power.ResetSpring();
+			TrainManager.PlayerTrain.Handles.Brake.ResetSpring();
+			
 			BlockKeyRepeat = false;
 			//Remember to reset the keyboard modifier after we're done, else it repeats.....
 			CurrentKeyboardModifier = KeyboardModifier.None;
@@ -102,6 +107,10 @@ namespace OpenBve
 					}
 				}
 			}
+
+			// Attempt to reset handle spring
+			TrainManager.PlayerTrain.Handles.Power.ResetSpring();
+			TrainManager.PlayerTrain.Handles.Brake.ResetSpring();
 			BlockKeyRepeat = false;
 		}
 	}

--- a/source/OpenBVE/System/MainLoop.cs
+++ b/source/OpenBVE/System/MainLoop.cs
@@ -359,6 +359,9 @@ namespace OpenBve
 				switch (Interface.CurrentControls[i].Component)
 				{
 					case JoystickComponent.Axis:
+						// Assume that a joystick axis fulfills the criteria for the handle to be 'held' in place
+						TrainManager.PlayerTrain.Handles.Power.ResetSpring();
+						TrainManager.PlayerTrain.Handles.Brake.ResetSpring();
 						var axisState = Program.Joysticks.GetAxis(currentDevice, Interface.CurrentControls[i].Element);
 						if (axisState.ToString(CultureInfo.InvariantCulture) != Interface.CurrentControls[i].LastState)
 						{
@@ -444,6 +447,9 @@ namespace OpenBve
 						//Test whether the state is the same as the last frame
 						if (buttonState.ToString() != Interface.CurrentControls[i].LastState)
 						{
+							// Attempt to reset handle spring
+							TrainManager.PlayerTrain.Handles.Power.ResetSpring();
+							TrainManager.PlayerTrain.Handles.Brake.ResetSpring();
 							if (buttonState == ButtonState.Pressed)
 							{
 								Interface.CurrentControls[i].AnalogState = 1.0;
@@ -466,6 +472,9 @@ namespace OpenBve
 						//Test if the state is the same as last frame
 						if (hatState.ToString() != Interface.CurrentControls[i].LastState)
 						{
+							// Attempt to reset handle spring
+							TrainManager.PlayerTrain.Handles.Power.ResetSpring();
+							TrainManager.PlayerTrain.Handles.Brake.ResetSpring();
 							if ((int)hatState == Interface.CurrentControls[i].Direction)
 							{
 								Interface.CurrentControls[i].AnalogState = 1.0;

--- a/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
+++ b/source/Plugins/Train.OpenBve/Train.OpenBve.csproj
@@ -57,9 +57,11 @@
     <Compile Include="Train\BVE\ExtensionsCfgParser.cs" />
     <Compile Include="Train\BVE\TrainDatParser.cs" />
     <Compile Include="Train\BVE\TrainDatparser.Formats.cs" />
+    <Compile Include="Train\XML\TrainXmlParser.AccelerationNode.cs" />
     <Compile Include="Train\XML\TrainXmlParser.BrakeNode.cs" />
     <Compile Include="Train\XML\TrainXmlParser.CarNode.cs" />
     <Compile Include="Train\XML\TrainXmlParser.cs" />
+    <Compile Include="Train\XML\TrainXmlParser.HandleNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\LibRender2\LibRender2.csproj">

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.AccelerationNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.AccelerationNode.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using TrainManager.Power;
+
+namespace Train.OpenBve
+{
+	partial class TrainXmlParser
+	{
+		private AccelerationCurve[] ParseAccelerationNode(XmlNode c, string fileName)
+		{
+			if (c.ChildNodes.OfType<XmlElement>().Any())
+			{
+				List<AccelerationCurve> accelerationCurves = new List<AccelerationCurve>();
+				foreach (XmlNode cc in c.ChildNodes)
+				{
+					switch (cc.Name.ToLowerInvariant())
+					{
+						case "openbve": // don't support legacy BVE2 curves in XML, but at the same time specify that this is deliberately BVE4 / OpenBVE format
+							BveAccelerationCurve curve = new BveAccelerationCurve();
+							foreach (XmlNode sc in cc.ChildNodes)
+							{
+								switch (sc.Name.ToLowerInvariant())
+								{
+									case "stagezeroacceleration":
+										if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageZeroAcceleration))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage zero acceleration was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
+										}
+
+										curve.StageZeroAcceleration *= 0.277777777777778;
+										break;
+									case "stageoneacceleration":
+										if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageOneAcceleration))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage one acceleration was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
+										}
+
+										curve.StageOneAcceleration *= 0.277777777777778;
+										break;
+									case "stageonespeed":
+										if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageOneSpeed))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage one speed was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
+										}
+
+										curve.StageOneSpeed *= 0.277777777777778;
+										break;
+									case "stagetwospeed":
+										if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageTwoSpeed))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage two speed was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
+										}
+
+										curve.StageTwoSpeed *= 0.277777777777778;
+										break;
+									case "stagetwoexponent":
+										if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageTwoExponent))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage two exponent was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
+										}
+
+										break;
+								}
+							}
+							accelerationCurves.Add(curve);
+							break;
+					}
+				}
+				return accelerationCurves.ToArray();
+			}
+			Plugin.currentHost.AddMessage(MessageType.Warning, false, "An empty list of acceleration curves was provided in XML file " + fileName);
+			return new AccelerationCurve[] { };
+		}
+	}
+}

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
@@ -227,40 +227,64 @@ namespace Train.OpenBve
 							}
 						}
 						break;
-					case "handlenotches":
-						if (Car != Train.DriverCar)
+					case "handle":
+						if (c.ChildNodes.OfType<XmlElement>().Any())
 						{
-							// only valid on driver car
-							break;
-						}
-						if (Train.Handles.Brake is AirBrakeHandle)
-						{
-							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Unable to define a number of notches for an AirBrake handle for Car " + Car + " in XML file " + fileName);
-							break;
-						}
+							foreach (XmlNode cc in c.ChildNodes)
+							{
+								switch (cc.Name.ToLowerInvariant())
+								{
+									case "notches":
+										if (Car != Train.DriverCar)
+										{
+											// only valid on driver car
+											break;
+										}
+										if (Train.Handles.Brake is AirBrakeHandle)
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Unable to define a number of notches for an AirBrake handle for Car " + Car + " in XML file " + fileName);
+											break;
+										}
 
-						int numberOfNotches;
-						if (!NumberFormats.TryParseIntVb6(c.InnerText, out numberOfNotches) | numberOfNotches < 0)
-						{
-							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid number of brake notches defined for Car " + Car + " in XML file " + fileName);
+										int numberOfNotches;
+										if (!NumberFormats.TryParseIntVb6(cc.InnerText, out numberOfNotches) | numberOfNotches < 0)
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid number of brake notches defined for Car " + Car + " in XML file " + fileName);
+										}
+										// remember to increase the max driver notch too
+										Train.Handles.Brake.MaximumDriverNotch += numberOfNotches - Train.Handles.Brake.MaximumNotch;
+										Train.Handles.Brake.MaximumNotch = numberOfNotches;
+										break;
+									case "springtime":
+										if (Car != Train.DriverCar)
+										{
+											// only valid on driver car
+											break;
+										}
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out Train.Handles.Brake.SpringTime))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring time defined for Car " + Car + " in XML file " + fileName);
+											Train.Handles.Brake.SpringTime = -1;
+										}
+										break;
+									case "maxsprungnotch":
+										if (Car != Train.DriverCar)
+										{
+											// only valid on driver car
+											break;
+										}
+										int maxSpring;
+										if (!NumberFormats.TryParseIntVb6(cc.InnerText, out maxSpring) | maxSpring > Train.Handles.Brake.MaximumNotch)
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid maximum handle spring value defined for Car " + Car + " in XML file " + fileName);
+										}
+										Train.Handles.Brake.MaxSpring = maxSpring;
+										break;
+								}
+							}
 						}
-						// remember to increase the max driver notch too
-						Train.Handles.Brake.MaximumDriverNotch += numberOfNotches - Train.Handles.Brake.MaximumNotch;
-						Train.Handles.Brake.MaximumNotch = numberOfNotches;
 						break;
-					case "handlespringtime":
-						if (Car != Train.DriverCar)
-						{
-							// only valid on driver car
-							break;
-						}
-						double springTime;
-						if (!NumberFormats.TryParseDoubleVb6(c.InnerText, out springTime))
-						{
-							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring time defined for Car " + Car + " in XML file " + fileName);
-						}
-						Train.Handles.Brake.SpringTime = springTime;
-						break;
+					
 				}
 			}
 			

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Xml;
 using OpenBveApi.Interface;
@@ -261,10 +262,19 @@ namespace Train.OpenBve
 											// only valid on driver car
 											break;
 										}
-										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out Train.Handles.Brake.SpringTime))
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out Train.Handles.Brake.SpringTime) | Train.Handles.Brake.SpringTime <= 0)
 										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring time defined for Car " + Car + " in XML file " + fileName);
-											Train.Handles.Brake.SpringTime = -1;
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid brake handle spring time defined for Car " + Car + " in XML file " + fileName);
+											Train.Handles.Brake.SpringTime = 0;
+											Train.Handles.Brake.SpringType = SpringType.Unsprung;
+										}
+										break;
+									case "springtype":
+										if (!Enum.TryParse(cc.InnerText, true, out Train.Handles.Brake.SpringType))
+										{
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid brake handle spring type defined for Car " + Car + " in XML file " + fileName);
+											Train.Handles.Brake.SpringTime = 0;
+											Train.Handles.Brake.SpringType = SpringType.Unsprung;
 										}
 										break;
 									case "maxsprungnotch":
@@ -276,7 +286,7 @@ namespace Train.OpenBve
 										int maxSpring;
 										if (!NumberFormats.TryParseIntVb6(cc.InnerText, out maxSpring) | maxSpring > Train.Handles.Brake.MaximumNotch)
 										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid maximum handle spring value defined for Car " + Car + " in XML file " + fileName);
+											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid maximum brake handle spring value defined for Car " + Car + " in XML file " + fileName);
 										}
 										Train.Handles.Brake.MaxSpring = maxSpring;
 										break;

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
@@ -229,70 +229,7 @@ namespace Train.OpenBve
 						}
 						break;
 					case "handle":
-						if (c.ChildNodes.OfType<XmlElement>().Any())
-						{
-							foreach (XmlNode cc in c.ChildNodes)
-							{
-								switch (cc.Name.ToLowerInvariant())
-								{
-									case "notches":
-										if (Car != Train.DriverCar)
-										{
-											// only valid on driver car
-											break;
-										}
-										if (Train.Handles.Brake is AirBrakeHandle)
-										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Unable to define a number of notches for an AirBrake handle for Car " + Car + " in XML file " + fileName);
-											break;
-										}
-
-										int numberOfNotches;
-										if (!NumberFormats.TryParseIntVb6(cc.InnerText, out numberOfNotches) | numberOfNotches < 0)
-										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid number of brake notches defined for Car " + Car + " in XML file " + fileName);
-										}
-										// remember to increase the max driver notch too
-										Train.Handles.Brake.MaximumDriverNotch += numberOfNotches - Train.Handles.Brake.MaximumNotch;
-										Train.Handles.Brake.MaximumNotch = numberOfNotches;
-										break;
-									case "springtime":
-										if (Car != Train.DriverCar)
-										{
-											// only valid on driver car
-											break;
-										}
-										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out Train.Handles.Brake.SpringTime) | Train.Handles.Brake.SpringTime <= 0)
-										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid brake handle spring time defined for Car " + Car + " in XML file " + fileName);
-											Train.Handles.Brake.SpringTime = 0;
-											Train.Handles.Brake.SpringType = SpringType.Unsprung;
-										}
-										break;
-									case "springtype":
-										if (!Enum.TryParse(cc.InnerText, true, out Train.Handles.Brake.SpringType))
-										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid brake handle spring type defined for Car " + Car + " in XML file " + fileName);
-											Train.Handles.Brake.SpringTime = 0;
-											Train.Handles.Brake.SpringType = SpringType.Unsprung;
-										}
-										break;
-									case "maxsprungnotch":
-										if (Car != Train.DriverCar)
-										{
-											// only valid on driver car
-											break;
-										}
-										int maxSpring;
-										if (!NumberFormats.TryParseIntVb6(cc.InnerText, out maxSpring) | maxSpring > Train.Handles.Brake.MaximumNotch)
-										{
-											Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid maximum brake handle spring value defined for Car " + Car + " in XML file " + fileName);
-										}
-										Train.Handles.Brake.MaxSpring = maxSpring;
-										break;
-								}
-							}
-						}
+						ParseHandleNode(c, ref Train.Handles.Brake, Car, Train, fileName);
 						break;
 					
 				}

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Xml;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
@@ -227,8 +227,43 @@ namespace Train.OpenBve
 							}
 						}
 						break;
+					case "handlenotches":
+						if (Car != Train.DriverCar)
+						{
+							// only valid on driver car
+							break;
+						}
+						if (Train.Handles.Brake is AirBrakeHandle)
+						{
+							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Unable to define a number of notches for an AirBrake handle for Car " + Car + " in XML file " + fileName);
+							break;
+						}
+
+						int numberOfNotches;
+						if (!NumberFormats.TryParseIntVb6(c.InnerText, out numberOfNotches) | numberOfNotches < 0)
+						{
+							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid number of brake notches defined for Car " + Car + " in XML file " + fileName);
+						}
+						// remember to increase the max driver notch too
+						Train.Handles.Brake.MaximumDriverNotch += numberOfNotches - Train.Handles.Brake.MaximumNotch;
+						Train.Handles.Brake.MaximumNotch = numberOfNotches;
+						break;
+					case "handlespringtime":
+						if (Car != Train.DriverCar)
+						{
+							// only valid on driver car
+							break;
+						}
+						double springTime;
+						if (!NumberFormats.TryParseDoubleVb6(c.InnerText, out springTime))
+						{
+							Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring time defined for Car " + Car + " in XML file " + fileName);
+						}
+						Train.Handles.Brake.SpringTime = springTime;
+						break;
 				}
 			}
+			
 			Train.Cars[Car].CarBrake.mainReservoir = new MainReservoir(compressorMinimumPressure, compressorMaximumPressure, 0.01, (Train.Handles.Brake is AirBrakeHandle ? 0.25 : 0.075) / Train.Cars.Length);
 			Train.Cars[Car].CarBrake.airCompressor = new Compressor(compressorRate, Train.Cars[Car].CarBrake.mainReservoir, Train.Cars[Car]);
 			Train.Cars[Car].CarBrake.equalizingReservoir = new EqualizingReservoir(equalizingReservoirServiceRate, equalizingReservoirEmergencyRate, equalizingReservoirChargeRate);

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -12,6 +12,7 @@ using OpenBveApi.Objects;
 using TrainManager.BrakeSystems;
 using TrainManager.Car;
 using TrainManager.Cargo;
+using TrainManager.Handles;
 using TrainManager.Power;
 using TrainManager.Trains;
 
@@ -394,61 +395,32 @@ namespace Train.OpenBve
 						}
 						break;
 					case "accelerationcurves":
+						/*
+						 * NOTE: This was initially implemented here.
+						 * It has moved to being a child-node of the power node
+						 * Retain this for the minute in case someone has actually used the thing (although the format is an ongoing WIP)....
+						 */
 						CopyAccelerationCurves = false;
+						Train.Cars[Car].Specs.AccelerationCurves = ParseAccelerationNode(c, fileName);
+						break;
+					case "power":
 						if (c.ChildNodes.OfType<XmlElement>().Any())
 						{
-							List<AccelerationCurve> accelerationCurves = new List<AccelerationCurve>();
 							foreach (XmlNode cc in c.ChildNodes)
 							{
 								switch (cc.Name.ToLowerInvariant())
 								{
-									case "openbve": // don't support legacy BVE2 curves in XML, but at the same time specify that this is deliberately BVE4 / OpenBVE format
-										BveAccelerationCurve curve = new BveAccelerationCurve();
-										foreach (XmlNode sc in cc.ChildNodes)
-										{
-											switch (sc.Name.ToLowerInvariant())
-											{
-												case "stagezeroacceleration":
-													if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageZeroAcceleration))
-													{
-														Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage zero acceleration was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
-													}
-													curve.StageZeroAcceleration *= 0.277777777777778;
-													break;
-												case "stageoneacceleration":
-													if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageOneAcceleration))
-													{
-														Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage one acceleration was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
-													}
-													curve.StageOneAcceleration *= 0.277777777777778;
-													break;
-												case "stageonespeed":
-													if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageOneSpeed))
-													{
-														Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage one speed was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
-													}
-													curve.StageOneSpeed *= 0.277777777777778;
-													break;
-												case "stagetwospeed":
-													if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageTwoSpeed))
-													{
-														Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage two speed was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
-													}
-													curve.StageTwoSpeed *= 0.277777777777778;
-													break;
-												case "stagetwoexponent":
-													if (!NumberFormats.TryParseDoubleVb6(sc.InnerText, out curve.StageTwoExponent))
-													{
-														Plugin.currentHost.AddMessage(MessageType.Warning, false, "Stage two exponent was invalid for curve " + accelerationCurves.Count + " in XML file " + fileName);
-													}
-													break;
-											}
-										}
-										accelerationCurves.Add(curve);
+									case "handle":
+										AbstractHandle p = Train.Handles.Power; // yuck, but we can't store this as the base type due to constraints elsewhere
+										ParseHandleNode(cc, ref p, Car, Train, fileName);
+										break;
+									case "accelerationcurves":
+										CopyAccelerationCurves = false;
+										Train.Cars[Car].Specs.AccelerationCurves = ParseAccelerationNode(c, fileName);
 										break;
 								}
 							}
-							Train.Cars[Car].Specs.AccelerationCurves = accelerationCurves.ToArray();
+
 						}
 						break;
 					case "doors":

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.HandleNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.HandleNode.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Xml;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using TrainManager.Handles;
+using TrainManager.Trains;
+
+namespace Train.OpenBve
+{
+	partial class TrainXmlParser
+	{
+		private void ParseHandleNode(XmlNode c, ref AbstractHandle Handle, int Car, TrainBase Train, string fileName)
+		{
+			if (c.ChildNodes.OfType<XmlElement>().Any())
+			{
+				foreach (XmlNode cc in c.ChildNodes)
+				{
+					switch (cc.Name.ToLowerInvariant())
+					{
+						case "notches":
+							if (Car != Train.DriverCar)
+							{
+								// only valid on driver car
+								break;
+							}
+
+							if (Handle is AirBrakeHandle)
+							{
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "Unable to define a number of notches for an AirBrake handle for Car " + Car + " in XML file " + fileName);
+								break;
+							}
+
+							int numberOfNotches;
+							if (!NumberFormats.TryParseIntVb6(cc.InnerText, out numberOfNotches) | numberOfNotches < 0)
+							{
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid number of handle notches defined for Car " + Car + " in XML file " + fileName);
+							}
+
+							// remember to increase the max driver notch too
+							Handle.MaximumDriverNotch += numberOfNotches - Handle.MaximumNotch;
+							Handle.MaximumNotch = numberOfNotches;
+							break;
+						case "springtime":
+							if (Car != Train.DriverCar)
+							{
+								// only valid on driver car
+								break;
+							}
+
+							if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out Handle.SpringTime) | Handle.SpringTime <= 0)
+							{
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring time defined for Car " + Car + " in XML file " + fileName);
+								Handle.SpringTime = 0;
+								Handle.SpringType = SpringType.Unsprung;
+							}
+
+							break;
+						case "springtype":
+							if (!Enum.TryParse(cc.InnerText, true, out Handle.SpringType))
+							{
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid handle spring type defined for Car " + Car + " in XML file " + fileName);
+								Handle.SpringTime = 0;
+								Handle.SpringType = SpringType.Unsprung;
+							}
+
+							break;
+						case "maxsprungnotch":
+							if (Car != Train.DriverCar)
+							{
+								// only valid on driver car
+								break;
+							}
+
+							int maxSpring;
+							if (!NumberFormats.TryParseIntVb6(cc.InnerText, out maxSpring) | maxSpring > Handle.MaximumNotch)
+							{
+								Plugin.currentHost.AddMessage(MessageType.Warning, false, "Invalid maximum handle spring value defined for Car " + Car + " in XML file " + fileName);
+							}
+
+							Handle.MaxSpring = maxSpring;
+							break;
+					}
+				}
+			}
+		}
+	}
+}

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
@@ -54,7 +54,25 @@ namespace Train.OpenBve
 			interiorVisible = new bool[Train.Cars.Length];
 			if (currentXML.DocumentElement != null)
 			{
-				XmlNodeList DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/*[self::Car or self::Coupler]");
+				XmlNodeList DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/DriverCar");
+				if (DocumentNodes != null && DocumentNodes.Count > 0)
+				{
+					// Optional stuff, needs to be loaded before the car list
+					for (int i = 0; i < DocumentNodes.Count; i++)
+					{
+						switch (DocumentNodes[i].Name)
+						{
+							case "DriverCar":
+								if (!NumberFormats.TryParseIntVb6(DocumentNodes[i].InnerText, out Train.DriverCar))
+								{
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "DriverCar is invalid in XML file " + fileName);
+								}
+								break;
+						}
+					}
+				}
+
+				DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/*[self::Car or self::Coupler]");
 				if (DocumentNodes == null || DocumentNodes.Count == 0)
 				{
 					Plugin.currentHost.AddMessage(MessageType.Error, false, "No car nodes defined in XML file " + fileName);
@@ -221,7 +239,7 @@ namespace Train.OpenBve
 				DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/Plugin");
 				if (DocumentNodes != null && DocumentNodes.Count > 0)
 				{
-					// More optional
+					// More optional, but needs to be loaded after the car list
 					for (int i = 0; i < DocumentNodes.Count; i++)
 					{
 						switch (DocumentNodes[i].Name)

--- a/source/TrainManager/Handles/AbstractHandle.cs
+++ b/source/TrainManager/Handles/AbstractHandle.cs
@@ -54,6 +54,9 @@ namespace TrainManager.Handles
 		/// <summary>The time with no action in seconds before the sprung step increases or decreases</summary>
 		public double SpringTime = -1;
 
+		/// <summary>The maximum notch a handle may spring to</summary>
+		public int MaxSpring;
+
 		internal double SpringTimer;
 
 		internal readonly TrainBase baseTrain;

--- a/source/TrainManager/Handles/AbstractHandle.cs
+++ b/source/TrainManager/Handles/AbstractHandle.cs
@@ -51,6 +51,11 @@ namespace TrainManager.Handles
 		/// <summary>The max width used in px for the description string</summary>
 		public double MaxWidth = 48;
 
+		/// <summary>The time with no action in seconds before the sprung step increases or decreases</summary>
+		public double SpringTime = -1;
+
+		internal double SpringTimer;
+
 		internal readonly TrainBase baseTrain;
 
 		public abstract void Update();

--- a/source/TrainManager/Handles/AbstractHandle.cs
+++ b/source/TrainManager/Handles/AbstractHandle.cs
@@ -76,6 +76,14 @@ namespace TrainManager.Handles
 
 		}
 
+		public virtual void ResetSpring()
+		{
+			if (SpringType > SpringType.AnyHandle)
+			{
+				SpringTime = TrainManagerBase.currentHost.InGameTime;
+			}
+		}
+
 		protected AbstractHandle(TrainBase Train)
 		{
 			baseTrain = Train;

--- a/source/TrainManager/Handles/AbstractHandle.cs
+++ b/source/TrainManager/Handles/AbstractHandle.cs
@@ -51,8 +51,11 @@ namespace TrainManager.Handles
 		/// <summary>The max width used in px for the description string</summary>
 		public double MaxWidth = 48;
 
+		/// <summary>The type of spring for this handle</summary>
+		public SpringType SpringType = SpringType.Unsprung;
+		
 		/// <summary>The time with no action in seconds before the sprung step increases or decreases</summary>
-		public double SpringTime = -1;
+		public double SpringTime = 0;
 
 		/// <summary>The maximum notch a handle may spring to</summary>
 		public int MaxSpring;

--- a/source/TrainManager/Handles/Handles.Brake.cs
+++ b/source/TrainManager/Handles/Handles.Brake.cs
@@ -54,7 +54,7 @@ namespace TrainManager.Handles
 			}
 
 			// Spring increase
-			if (SpringTime != -1)
+			if (SpringType != SpringType.Unsprung)
 			{
 				if (TrainManagerBase.currentHost.InGameTime > SpringTimer)
 				{
@@ -65,6 +65,10 @@ namespace TrainManager.Handles
 
 		public override void ApplyState(int BrakeValue, bool BrakeRelative, bool IsOverMaxDriverNotch = false)
 		{
+			if (baseTrain.Handles.Power.SpringType > SpringType.Single)
+			{
+				baseTrain.Handles.Power.SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
+			}
 			SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
 			int b = BrakeRelative ? BrakeValue + Driver : BrakeValue;
 			if (b < 0)

--- a/source/TrainManager/Handles/Handles.Brake.cs
+++ b/source/TrainManager/Handles/Handles.Brake.cs
@@ -52,10 +52,20 @@ namespace TrainManager.Handles
 					RemoveChanges(1);
 				}
 			}
+
+			// Spring increase
+			if (SpringTime != -1)
+			{
+				if (TrainManagerBase.currentHost.InGameTime > SpringTimer)
+				{
+					ApplyState(1, true);
+				}
+			}
 		}
 
 		public override void ApplyState(int BrakeValue, bool BrakeRelative, bool IsOverMaxDriverNotch = false)
 		{
+			SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
 			int b = BrakeRelative ? BrakeValue + Driver : BrakeValue;
 			if (b < 0)
 			{

--- a/source/TrainManager/Handles/Handles.Power.cs
+++ b/source/TrainManager/Handles/Handles.Power.cs
@@ -53,10 +53,20 @@ namespace TrainManager.Handles
 					RemoveChanges(1);
 				}
 			}
+
+			// Spring return
+			if (SpringTime != -1)
+			{
+				if (TrainManagerBase.currentHost.InGameTime > SpringTimer)
+				{
+					ApplyState(-1, true);
+				}
+			}
 		}
 
 		public override void ApplyState(int newState, bool relativeChange, bool isOverMaxDriverNotch = false)
 		{
+			SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
 			// determine notch
 			int p = relativeChange ? newState + Driver : newState;
 			if (p < 0)

--- a/source/TrainManager/Handles/Handles.Power.cs
+++ b/source/TrainManager/Handles/Handles.Power.cs
@@ -66,6 +66,10 @@ namespace TrainManager.Handles
 
 		public override void ApplyState(int newState, bool relativeChange, bool isOverMaxDriverNotch = false)
 		{
+			if (baseTrain.Handles.Brake.SpringType > SpringType.Single)
+			{
+				baseTrain.Handles.Brake.SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
+			}
 			SpringTimer = TrainManagerBase.currentHost.InGameTime + SpringTime;
 			// determine notch
 			int p = relativeChange ? newState + Driver : newState;

--- a/source/TrainManager/Handles/Handles.SpringTypes.cs
+++ b/source/TrainManager/Handles/Handles.SpringTypes.cs
@@ -1,0 +1,15 @@
+﻿namespace TrainManager.Handles
+{
+	/// <summary>Describes the available handle spring types</summary>
+	public enum SpringType
+	{
+		/// <summary>The handle is unsprung</summary>
+		Unsprung,
+		/// <summary>The handle spring is reset by this handle only</summary>
+		Single,
+		/// <summary>The handle spring is reset by any handle</summary>
+		AnyHandle,
+		/// <summary>The handle spring is reset by any keypress</summary>
+		AnyKey
+	}
+}

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Handles\Handles.Power.cs" />
     <Compile Include="Handles\Handles.Reverser.cs" />
     <Compile Include="Handles\Handles.Reverser.Positions.cs" />
+    <Compile Include="Handles\Handles.SpringTypes.cs" />
     <Compile Include="Motor\AbstractMotorSound.cs" />
     <Compile Include="Motor\BVE4\MotorSound.cs" />
     <Compile Include="Motor\BVE4\MotorSoundTable.cs" />


### PR DESCRIPTION
A relatively common feature of prototype power / brake handles is a spring feature.
This gradually returns the handle to a 'default' position after a set period of time. 

This PR implements this, along with some missing XML plumbing for setting the number of power / brake notches.

### Significant Changes:
- Allows the driver car to be set via the train.xml
- Allows the number of brake notches to be set via XML using the _Train --> Car --> Brake --> Handle --> Notches_ **NOTE:** The number of brake notches is only set via the driver car (values set on other cars will be ignored)
- A brake handle spring delay in seconds may be set in XML via _Train --> Car --> Brake --> Handle --> SpringTime_ - Each time the timer elapses, the brake will be increased by one notch. Interacting with the handle resets the timer.
- The maximum notch a sprung brake handle returns to may be set in XML via _Train --> Car --> Brake --> Handle --> MaxSprungNotch_
- Spring type may be set via XML _Train --> Car --> Brake --> Handle --> SpringType_ with available values as follows:
   1. _Unsprung_ - No spring return
   2. _Single_ - Spring return timer is only reset when this handle is operated
   3. _AnyHandle_ - Spring return timer is reset when any power / brake / reverser handle is operated
   4. _AnyKey_ - Spring return timer is reset when any key is pressed. (think about whether to limit this to security keys etc, or whether it should be global??)

### TODO:
- Sprung reverser handles???


### Future Design Issues to Consider:
Really, we ought to have a per-car handle. If in the future, decoupling or changing the physical driving cab is implemented, this would allow the 'new' driving cab to have correct handle types etc.
This could *possibly* be done relatively easily via changing the current handle location to be a reference to the actual handle within the current driver car.
However, this could equally create a total and utter mess with existing content, and anything not specifically designed for this.

_Possibly_ could do something like aliasing **DriverCar** to the inital driver car, and using **CurrentDriverCar** as the reccomended variable going forward, but that's just got a different set of messes to contend with.



Still a WIP, and not added to the documentation yet.

Loosely related to https://github.com/leezer3/OpenBVE/pull/684 as MSTS allows this handle type.