### PR TITLE
New: Add basic headlights animation properties

### DIFF
--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -387,7 +387,7 @@ namespace CarXmlConvertor
 			{
 				newLines.Add("<Plugin>" + pluginFile + "</Plugin>");
 			}
-
+			newLines.Add("<HeadlightStates>1</HeadlightStates>");
 			string trainTxt = Path.CombineFile(System.IO.Path.GetDirectoryName(FileName), "train.txt");
 			if (File.Exists(trainTxt))
 			{
@@ -619,7 +619,7 @@ namespace CarXmlConvertor
 			{
 				newLines.Add("<Plugin>" + pluginFile + "</Plugin>");
 			}
-
+			newLines.Add("<HeadlightStates>1</HeadlightStates>");
 			string trainTxt = Path.CombineFile(System.IO.Path.GetDirectoryName(FileName), "train.txt");
 			if (File.Exists(trainTxt))
 			{

--- a/source/ObjectViewer/FunctionScripts.cs
+++ b/source/ObjectViewer/FunctionScripts.cs
@@ -746,6 +746,14 @@ namespace ObjectViewer {
 						//Not currently supported in viewers
 						Function.Stack[s] = 0.0;
 						s++; break;
+					case Instructions.Headlights:
+						if (Train != null)
+						{
+							Function.Stack[s] = Train.SafetySystems.Headlights.CurrentState;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
 					// handles
 					case Instructions.ReverserNotch:
 						if (Train != null) {

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
@@ -847,6 +847,14 @@ namespace OpenBve {
 							Function.Stack[s] = 0.0;
 						}
 						s++; break;
+					case Instructions.Headlights:
+						if (Train != null)
+						{
+							Function.Stack[s] = Train.SafetySystems.Headlights.CurrentState;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
 						// handles
 					case Instructions.ReverserNotch:
 						if (Train != null) {

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1560,6 +1560,21 @@ namespace OpenBve
 									case Translations.Command.GearDown:
 									case Translations.Command.RaisePantograph:
 									case Translations.Command.LowerPantograph:
+										if (TrainManager.PlayerTrain.Plugin != null)
+										{
+											TrainManager.PlayerTrain.Plugin.KeyDown(
+												Translations.SecurityToVirtualKey(Interface.CurrentControls[i].Command));
+										}
+
+										break;
+									case Translations.Command.Headlights:
+										if (TrainManager.PlayerTrain.Plugin != null)
+										{
+											TrainManager.PlayerTrain.Plugin.KeyDown(
+												Translations.SecurityToVirtualKey(Interface.CurrentControls[i].Command));
+										}
+										TrainManager.PlayerTrain.SafetySystems.Headlights.ChangeState();
+										break;
 									case Translations.Command.MainBreaker:
 										if (TrainManager.PlayerTrain.Plugin != null)
 										{

--- a/source/OpenBveApi/FunctionScripts/FunctionScript.cs
+++ b/source/OpenBveApi/FunctionScripts/FunctionScript.cs
@@ -595,6 +595,10 @@ namespace OpenBveApi.FunctionScripting
 							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
 							InstructionSet[n] = Instructions.StationAdjustAlarm;
 							n++; s++; if (s >= m) m = s; break;
+						case "headlights":
+							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
+							InstructionSet[n] = Instructions.Headlights;
+							n++; s++; if (s >= m) m = s; break;
 						// train: handles
 						case "reversernotch":
 							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);

--- a/source/OpenBveApi/FunctionScripts/Instructions.cs
+++ b/source/OpenBveApi/FunctionScripts/Instructions.cs
@@ -24,7 +24,7 @@
 		Doors, DoorsIndex,
 		LeftDoors, LeftDoorsIndex, RightDoors, RightDoorsIndex,
 		LeftDoorsTarget, LeftDoorsTargetIndex, RightDoorsTarget, RightDoorsTargetIndex,
-		LeftDoorButton, RightDoorButton, PilotLamp,
+		LeftDoorButton, RightDoorButton, PilotLamp, Headlights,
 		ReverserNotch, PowerNotch, PowerNotches, LocoBrakeNotch, LocoBrakeNotches, BrakeNotch, BrakeNotches, BrakeNotchLinear, BrakeNotchesLinear, EmergencyBrake, Klaxon, PrimaryKlaxon, SecondaryKlaxon, MusicKlaxon,
 		HasAirBrake, HoldBrake, HasHoldBrake, ConstSpeed, HasConstSpeed,
 		BrakeMainReservoir, BrakeEqualizingReservoir, BrakeBrakePipe, BrakeBrakeCylinder, BrakeStraightAirPipe,

--- a/source/OpenBveApi/Runtime/Train/ElapseData.cs
+++ b/source/OpenBveApi/Runtime/Train/ElapseData.cs
@@ -55,18 +55,23 @@ namespace OpenBveApi.Runtime
 		[DataMember]
 		private readonly int CurrentDestination;
 
+		/// <summary>The current headlights state</summary>
+		[DataMember] 
+		private int MyHeadlightState;
+
 		/// <summary>Creates a new instance of this class.</summary>
 		/// <param name="vehicle">The state of the train.</param>
 		/// <param name="precedingVehicle">The state of the preceding train, or a null reference if there is no preceding train.</param>
 		/// <param name="handles">The virtual handles.</param>
 		/// <param name="doorinterlock">Whether the door interlock is currently enabled</param>
+		/// <param name="headlightState">The headlight state</param>
 		/// <param name="totalTime">The current absolute time.</param>
 		/// <param name="elapsedTime">The elapsed time since the last call to Elapse.</param>
 		/// <param name="stations">The current route's list of stations.</param>
 		/// <param name="cameraView">The current camera view mode</param>
 		/// <param name="languageCode">The current language code</param>
 		/// <param name="destination">The current destination</param>
-		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, DoorInterlockStates doorinterlock, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode, int destination)
+		public ElapseData(VehicleState vehicle, PrecedingVehicleState precedingVehicle, Handles handles, DoorInterlockStates doorinterlock, int headlightState, Time totalTime, Time elapsedTime, List<Station> stations, CameraViewMode cameraView, string languageCode, int destination)
 		{
 			this.MyVehicle = vehicle;
 			this.MyPrecedingVehicle = precedingVehicle;
@@ -79,6 +84,7 @@ namespace OpenBveApi.Runtime
 			this.MyCameraViewMode = cameraView;
 			this.MyLanguageCode = languageCode;
 			this.CurrentDestination = destination;
+			this.MyHeadlightState = headlightState;
 		}
 
 
@@ -203,6 +209,19 @@ namespace OpenBveApi.Runtime
 			get
 			{
 				return this.CurrentDestination;
+			}
+		}
+
+		/// <summary>Gets the destination variable as set by the plugin</summary>
+		public int HeadlightState
+		{
+			get
+			{
+				return this.MyHeadlightState;
+			}
+			set
+			{
+				this.MyHeadlightState = value;
 			}
 		}
 	}

--- a/source/OpenBveApi/Runtime/Train/VehicleSpecs.cs
+++ b/source/OpenBveApi/Runtime/Train/VehicleSpecs.cs
@@ -30,6 +30,10 @@ namespace OpenBveApi.Runtime
 		[DataMember]
 		private readonly int MyCars;
 
+		/// <summary>The number of headlight states the train has.</summary>
+		[DataMember]
+		private readonly int MyHeadlightStates;
+
 		/// <summary>Gets the number of power notches the train has.</summary>
 		public int PowerNotches
 		{
@@ -108,6 +112,15 @@ namespace OpenBveApi.Runtime
 			}
 		}
 
+		/// <summary>Gets the number of headlight states the train has.</summary>
+		public int HeadlightStates
+		{
+			get
+			{
+				return this.MyHeadlightStates;
+			}
+		}
+
 		/// <summary>Creates a new instance of this class.</summary>
 		/// <param name="powerNotches">The number of power notches the train has.</param>
 		/// <param name="brakeType">The type of brake the train uses.</param>
@@ -139,6 +152,25 @@ namespace OpenBveApi.Runtime
 			this.MyHasHoldBrake = hasHoldBrake;
 			this.MyHasLocoBrake = hasLocoBrake;
 			this.MyCars = cars;
+		}
+
+		/// <summary>Creates a new instance of this class.</summary>
+		/// <param name="powerNotches">The number of power notches the train has.</param>
+		/// <param name="brakeType">The type of brake the train uses.</param>
+		/// <param name="brakeNotches">The number of brake notches the train has, including the hold brake, but excluding the emergency brake.</param>
+		/// <param name="hasHoldBrake">Whether the train has a hold brake.</param>
+		/// <param name="hasLocoBrake">Whether the train has a loco brake.</param>
+		/// <param name="cars">The number of cars the train has.</param>
+		/// <param name="headlightStates">The number of headlight states the train has</param>
+		public VehicleSpecs(int powerNotches, BrakeTypes brakeType, int brakeNotches, bool hasHoldBrake, bool hasLocoBrake, int cars, int headlightStates)
+		{
+			this.MyPowerNotches = powerNotches;
+			this.MyBrakeType = brakeType;
+			this.MyBrakeNotches = brakeNotches;
+			this.MyHasHoldBrake = hasHoldBrake;
+			this.MyHasLocoBrake = hasLocoBrake;
+			this.MyCars = cars;
+			this.MyHeadlightStates = headlightStates;
 		}
 	}
 }

--- a/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
@@ -1264,6 +1264,7 @@ namespace Train.OpenBve
 			Train.SafetySystems.PassAlarm = new PassAlarm(passAlarm, Train.Cars[DriverCar]);
 			Train.SafetySystems.PilotLamp = new PilotLamp(Train.Cars[DriverCar]);
 			Train.SafetySystems.StationAdjust = new StationAdjustAlarm(Train);
+			Train.SafetySystems.Headlights = new LightSource(1);
 			switch (Plugin.CurrentOptions.TrainStart)
 			{
 				// starting mode

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
@@ -237,7 +237,7 @@ namespace Train.OpenBve
 
 					}
 				}
-				DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/Plugin");
+				DocumentNodes = currentXML.DocumentElement.SelectNodes("/openBVE/Train/*[self::Plugin or self::HeadlightStates]");
 				if (DocumentNodes != null && DocumentNodes.Count > 0)
 				{
 					// More optional, but needs to be loaded after the car list
@@ -256,6 +256,16 @@ namespace Train.OpenBve
 										Train.Plugin = null;
 									}
 								}
+								break;
+							case "HeadlightStates":
+								int numStates;
+								if (!NumberFormats.TryParseIntVb6(DocumentNodes[i].InnerText, out numStates))
+								{
+									Plugin.currentHost.AddMessage(MessageType.Error, false, "NumStates is invalid for HeadlightStates in XML file " + fileName);
+									break;
+								}
+
+								Train.SafetySystems.Headlights = new LightSource(numStates);
 								break;
 						}
 					}

--- a/source/RouteViewer/FunctionScripts.cs
+++ b/source/RouteViewer/FunctionScripts.cs
@@ -744,6 +744,14 @@ namespace RouteViewer {
 						//Not currently supported in viewers
 						Function.Stack[s] = 0.0;
 						s++; break;
+					case Instructions.Headlights:
+						if (Train != null)
+						{
+							Function.Stack[s] = Train.SafetySystems.Headlights.CurrentState;
+						} else {
+							Function.Stack[s] = 0.0;
+						}
+						s++; break;
 					// handles
 					case Instructions.ReverserNotch:
 						if (Train != null) {

--- a/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using OpenBveApi;
 using OpenBveApi.Colors;

--- a/source/TrainManager/SafetySystems/Plugin/Plugin.Functions.cs
+++ b/source/TrainManager/SafetySystems/Plugin/Plugin.Functions.cs
@@ -142,7 +142,7 @@ namespace TrainManager.Trains
 
 			bool hasLocoBrake = Handles.HasLocoBrake;
 			int cars = Cars.Length;
-			return new VehicleSpecs(powerNotches, brakeType, brakeNotches, hasHoldBrake, hasLocoBrake, cars);
+			return new VehicleSpecs(powerNotches, brakeType, brakeNotches, hasHoldBrake, hasLocoBrake, SafetySystems.Headlights.NumberOfStates, cars);
 		}
 
 		/// <summary>Loads the specified plugin for the specified train.</summary>

--- a/source/TrainManager/SafetySystems/Plugin/Plugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/Plugin.cs
@@ -154,12 +154,13 @@ namespace TrainManager.SafetySystems
 			double totalTime = TrainManagerBase.currentHost.InGameTime;
 			double elapsedTime = TrainManagerBase.currentHost.InGameTime - LastTime;
 
-			ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, this.Train.SafetySystems.DoorInterlockState, new Time(totalTime), new Time(elapsedTime), currentRouteStations, TrainManagerBase.Renderer.Camera.CurrentMode, Translations.CurrentLanguageCode, this.Train.Destination);
+			ElapseData data = new ElapseData(vehicle, precedingVehicle, handles, this.Train.SafetySystems.DoorInterlockState, this.Train.SafetySystems.Headlights.CurrentState, new Time(totalTime), new Time(elapsedTime), currentRouteStations, TrainManagerBase.Renderer.Camera.CurrentMode, Translations.CurrentLanguageCode, this.Train.Destination);
 			ElapseData inputDevicePluginData = data;
 			LastTime = TrainManagerBase.currentHost.InGameTime;
 			Elapse(ref data);
 			this.PluginMessage = data.DebugMessage;
 			this.Train.SafetySystems.DoorInterlockState = data.DoorInterlockState;
+			this.Train.SafetySystems.Headlights.SetState(data.HeadlightState);
 			DisableTimeAcceleration = data.DisableTimeAcceleration;
 			if (Train.IsPlayerTrain)
 			{

--- a/source/TrainManager/SafetySystems/TrainSafetySystems.cs
+++ b/source/TrainManager/SafetySystems/TrainSafetySystems.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Runtime;
+using TrainManager.Trains;
 
 namespace TrainManager.SafetySystems
 {
@@ -12,5 +13,7 @@ namespace TrainManager.SafetySystems
 		public StationAdjustAlarm StationAdjust;
 		/// <summary>The state of the door interlock</summary>
 		public DoorInterlockStates DoorInterlockState;
+		/// <summary>The train headlights</summary>
+		public LightSource Headlights;
 	}
 }

--- a/source/TrainManager/Train/LightSource.cs
+++ b/source/TrainManager/Train/LightSource.cs
@@ -1,0 +1,29 @@
+﻿namespace TrainManager.Trains
+{
+	/// <summary>Represents an abstract light source on the train</summary>
+	public class LightSource
+	{
+		/// <summary>The number of states</summary>
+		private int numberOfStates;
+		/// <summary>The current state</summary>
+		public int CurrentState;
+
+		/// <summary>Creates a new light source</summary>
+		/// <param name="NumberOfStates">The number of distinct lit light states</param>
+		public LightSource(int NumberOfStates)
+		{
+			numberOfStates = NumberOfStates; // state zero is off
+		}
+
+		/// <summary>Changes the light source state</summary>
+		public void ChangeState()
+		{
+			CurrentState++;
+			if (CurrentState > numberOfStates)
+			{
+				CurrentState = 0;
+			}
+
+		}
+	}
+}

--- a/source/TrainManager/Train/LightSource.cs
+++ b/source/TrainManager/Train/LightSource.cs
@@ -4,26 +4,38 @@
 	public class LightSource
 	{
 		/// <summary>The number of states</summary>
-		private int numberOfStates;
+		public int NumberOfStates;
 		/// <summary>The current state</summary>
 		public int CurrentState;
 
 		/// <summary>Creates a new light source</summary>
-		/// <param name="NumberOfStates">The number of distinct lit light states</param>
-		public LightSource(int NumberOfStates)
+		/// <param name="numberOfStates">The number of distinct lit light states</param>
+		public LightSource(int numberOfStates)
 		{
-			numberOfStates = NumberOfStates; // state zero is off
+			this.NumberOfStates = numberOfStates; // state zero is off
 		}
 
 		/// <summary>Changes the light source state</summary>
 		public void ChangeState()
 		{
 			CurrentState++;
-			if (CurrentState > numberOfStates)
+			if (CurrentState > NumberOfStates)
 			{
 				CurrentState = 0;
 			}
+		}
 
+		/// <summary>Sets a specific light source state</summary>
+		/// <param name="newState">The new state</param>
+		public void SetState(int newState)
+		{
+			if (newState >= NumberOfStates)
+			{
+				CurrentState = 0;
+				return;
+			}
+
+			CurrentState = newState;
 		}
 	}
 }

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Train\CommandEntry.cs" />
     <Compile Include="Train\Doors.cs" />
     <Compile Include="Train\DriverBody.cs" />
+    <Compile Include="Train\LightSource.cs" />
     <Compile Include="Train\Horn.cs" />
     <Compile Include="Train\RequestStop.cs" />
     <Compile Include="Train\Station.cs" />


### PR DESCRIPTION
This PR adds a basic headlights animation property.

Simple state based toggle, with function script instruction.
https://bveworldwide.forumotion.com/t2266-how-to-set-the-keyboard-key-for-turn-on-off-lamp-in-statefunction-formula#21235

### NOTES:
The keybindings for these exist, & were added several years ago (along with many others....) for plugin usage initially, with the idea that they would eventually be implemented into the sim.

**train.dat** based trains are assumed to have a simple single state on / off headlight.

Requires documentation to be added before merging.