### PR TITLE
Refactor handling of AnimatedObjects

### DIFF
--- a/source/LibRender2/Trains/CarSection.cs
+++ b/source/LibRender2/Trains/CarSection.cs
@@ -39,7 +39,7 @@ namespace LibRender2.Trains
 				Groups[0].Elements = new AnimatedObject[a.Objects.Length];
 				for (int h = 0; h < a.Objects.Length; h++)
 				{
-					Groups[0].Elements[h] = a.Objects[h].Clone();
+					Groups[0].Elements[h] = a.Objects[h].Clone() as AnimatedObject;
 					Groups[0].Elements[h].IsPartOfTrain = true;
 					currentHost.CreateDynamicObject(ref Groups[0].Elements[h].internalObject);
 				}

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
@@ -1,10 +1,7 @@
-using System.IO;
 using System.Linq;
-using CSScriptLibrary;
 using OpenBveApi.FunctionScripting;
 using OpenBveApi.Graphics;
 using OpenBveApi.Hosts;
-using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Trains;
 using OpenBveApi.World;
@@ -12,7 +9,7 @@ using OpenBveApi.World;
 namespace OpenBveApi.Objects
 {
 	/// <summary>The base type for an animated object</summary>
-	public class AnimatedObject
+	public class AnimatedObject : UnifiedObject
 	{
 		/// <summary>The array of states</summary>
 		public ObjectState[] States;
@@ -109,9 +106,19 @@ namespace OpenBveApi.Objects
 			States = new ObjectState[] { };
 		}
 
+		public override void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, int SectionIndex, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness, bool DuplicateMaterials = false)
+		{
+			throw new System.NotImplementedException();
+		}
+
+		public override void OptimizeObject(bool PreserveVerticies, int Threshold, bool VertexCulling)
+		{
+			throw new System.NotImplementedException();
+		}
+
 		/// <summary>Clones this object</summary>
 		/// <returns>The new object</returns>
-		public AnimatedObject Clone()
+		public override UnifiedObject Clone()
 		{
 			AnimatedObject Result = new AnimatedObject(currentHost) { States = States.Select(x => (ObjectState)x.Clone()).ToArray() };
 
@@ -167,6 +174,16 @@ namespace OpenBveApi.Objects
 
 			}
 			return Result;
+		}
+
+		public override UnifiedObject Mirror()
+		{
+			throw new System.NotImplementedException();
+		}
+
+		public override UnifiedObject Transform(double NearDistance, double FarDistance)
+		{
+			throw new System.NotImplementedException();
 		}
 
 		/// <summary>Checks whether this object contains any functions</summary>
@@ -563,7 +580,7 @@ namespace OpenBveApi.Objects
 									t = 1.0;
 								}
 
-								t = t - System.Math.Floor(t);
+								t -= System.Math.Floor(t);
 								t = 0.5 * (1.0 - System.Math.Tan(0.25 * (System.Math.PI - 2.0 * System.Math.PI * t)));
 								double cx = (1.0 - t) * LEDVectors[(currentEdge + 3) % 4].X + t * LEDVectors[currentEdge].X;
 								double cy = (1.0 - t) * LEDVectors[(currentEdge + 3) % 4].Y + t * LEDVectors[currentEdge].Y;
@@ -704,10 +721,9 @@ namespace OpenBveApi.Objects
 		/// <param name="Position">The absolute position</param>
 		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
 		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="SectionIndex">The index of the section if placed using a SigF command</param>
 		/// <param name="TrackPosition">The absolute track position</param>
 		/// <param name="Brightness">The brightness value at the track position</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, int SectionIndex, double TrackPosition, double Brightness)
+		public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double TrackPosition, double Brightness)
 		{
 
 			int a = currentHost.AnimatedWorldObjectsUsed;
@@ -716,7 +732,7 @@ namespace OpenBveApi.Objects
 			//Place track followers if required
 			if (TrackFollowerFunction != null)
 			{
-				var o = this.Clone();
+				var o = this.Clone() as AnimatedObject;
 				currentHost.CreateDynamicObject(ref o.internalObject);
 				TrackFollowingObject currentObject = new TrackFollowingObject(currentHost)
 				{
@@ -761,7 +777,7 @@ namespace OpenBveApi.Objects
 			}
 			else
 			{
-				var o = this.Clone();
+				var o = this.Clone() as AnimatedObject;
 				currentHost.CreateDynamicObject(ref o.internalObject);
 				AnimatedWorldObject currentObject = new AnimatedWorldObject(currentHost)
 				{

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
@@ -71,7 +71,8 @@ namespace OpenBveApi.Objects
 							}
 							else
 							{
-								Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition, Brightness);
+								Objects[i].SectionIndex = SectionIndex;
+								Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, TrackPosition, Brightness);
 							}
 						}
 					}
@@ -82,7 +83,8 @@ namespace OpenBveApi.Objects
 					{
 						if (Objects[i].States.Length != 0)
 						{
-							Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition, Brightness);
+							Objects[i].SectionIndex = SectionIndex;
+							Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, TrackPosition, Brightness);
 						}
 					}
 				}
@@ -123,7 +125,7 @@ namespace OpenBveApi.Objects
 				AnimatedObjectCollection aoc = new AnimatedObjectCollection(currentHost);
 				if (Objects != null)
 				{
-					aoc.Objects = Objects.Select(x => x?.Clone()).ToArray();
+					aoc.Objects = Objects.Select(x => x?.Clone() as AnimatedObject).ToArray();
 				}
 				if (Sounds != null)
 				{
@@ -141,7 +143,7 @@ namespace OpenBveApi.Objects
 				};
 				for (int i = 0; i < Objects.Length; i++)
 				{
-					Result.Objects[i] = Objects[i].Clone();
+					Result.Objects[i] = Objects[i].Clone() as AnimatedObject;
 					for (int j = 0; j < Objects[i].States.Length; j++)
 					{
 						Result.Objects[i].States[j].Prototype = (StaticObject)Result.Objects[i].States[j].Prototype.Mirror();

--- a/source/OpenBveApi/Objects/ObjectTypes/WorldObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/WorldObject.cs
@@ -40,7 +40,7 @@ namespace OpenBveApi.Objects
 		public virtual WorldObject Clone()
 		{
 			WorldObject wo = (WorldObject)MemberwiseClone();
-			wo.Object = Object?.Clone();
+			wo.Object = Object?.Clone() as AnimatedObject;
 
 			if (wo.Object != null)
 			{

--- a/source/Plugins/Object.Animated/Plugin.Parser.cs
+++ b/source/Plugins/Object.Animated/Plugin.Parser.cs
@@ -1422,7 +1422,7 @@ namespace Plugin
 								{
 									AnimatedWorldObjectStateSound snd = new AnimatedWorldObjectStateSound(currentHost)
 									{
-										Object = Result.Objects[ObjectCount - 1].Clone(),
+										Object = Result.Objects[ObjectCount - 1].Clone() as AnimatedObject,
 										Buffers = new SoundHandle[fileNames.Length]
 									};
 									for (int j = 0; j < fileNames.Length; j++)

--- a/source/Plugins/Object.LokSim/GroupParser.cs
+++ b/source/Plugins/Object.LokSim/GroupParser.cs
@@ -300,7 +300,7 @@ namespace Plugin
 							{
 								if (AnimatedObject.Objects[o - rl] != null)
 								{
-									Result.Objects[o] = AnimatedObject.Objects[o - rl].Clone();
+									Result.Objects[o] = AnimatedObject.Objects[o - rl].Clone() as AnimatedObject;
 									for (int si = 0; si < Result.Objects[o].States.Length; si++)
 									{
 										Result.Objects[o].States[si].Translation *= Matrix4D.CreateTranslation(CurrentObjects[i].Position.X, CurrentObjects[i].Position.Y, -CurrentObjects[i].Position.Z);

--- a/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
+++ b/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
@@ -817,8 +817,9 @@ namespace MechanikRouteParser
 						{
 							nextHeldAtRed = true;
 						}
-						
-						signal.Object().CreateObject(worldPosition + eyePosition, t, Transformation.NullTransformation, s + 1, StartingDistance, 1.0);
+
+						signal.Object().SectionIndex = s + 1;
+						signal.Object().CreateObject(worldPosition + eyePosition, t, Transformation.NullTransformation, StartingDistance, 1.0);
 					}
 
 					if (currentRouteData.Blocks[i].HornBlow)


### PR DESCRIPTION
This PR refactors AnimatedObjects so that they are a subset of the overarching **UnifiedObject**

Required by https://github.com/leezer3/OpenBVE/pull/684 in order to get the **HierarchyAnimatedObjects** working correctly, as these require a totally different update method.

### TODO:
* Need to slim down and combine the methods.
* Provide a virtual __Update()__ method within the **UnifiedObject**
* Can we get rid of some more of the excess parameters in some of these methods?
* Possibly convert a bunch of the AnimatedObject booleans to a flags enum??