### PR TITLE
Fix: Colored Rail Path Form crash

### DIFF
--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -695,7 +695,7 @@ namespace RouteViewer
 				case Key.P:
 					if (CurrentRouteFile != null && CurrentlyLoading == false)
 					{
-						if (pathForm == null)
+						if (pathForm == null || pathForm.IsDisposed)
 						{
 							pathForm = new formRailPaths();
 						}


### PR DESCRIPTION
Colored Rail Path Form would get disposed if closed without pressing the "close" button (Rather than setting the form to null)
This will result in a crash when pressing P after closing (Cannot access a disposed object)