### PR TITLE
New: Implement proper sanders

### DIFF
--- a/assets/Controls/Default.controls
+++ b/assets/Controls/Default.controls
@@ -1,7 +1,7 @@
 ﻿; Current control configuration
 ; =============================
 ; This file was automatically generated. Please modify only if you know what you're doing.
-; Default keyconfig version 3- 08.06.2017
+; Default keyconfig version 4- 10.10.2022
 
 POWER_INCREASE, keyboard, Z, 0
 POWER_DECREASE, keyboard, A, 0
@@ -35,6 +35,7 @@ ENGINE_START, keyboard, E, 0
 ENGINE_STOP, keyboard, E, 2
 DEVICE_CONSTSPEED, keyboard, BackSpace, 0
 PLAY_MIC_SOUNDS, keyboard, W, 0
+SANDERS, keyboard, S, 0
 SECURITY_S, keyboard, Space, 0
 SECURITY_A1, keyboard, Insert, 0
 SECURITY_A2, keyboard, Delete, 0

--- a/assets/Languages/ca-ES.xlf
+++ b/assets/Languages/ca-ES.xlf
@@ -2388,6 +2388,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activa o desactiva el dispositiu de velocitat constant.</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activa o desactiva el sistema de seguretat en alguns trens.</target>

--- a/assets/Languages/cs-CZ.xlf
+++ b/assets/Languages/cs-CZ.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activace/deaktivace udržování rychlosti</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activace/deaktivace zabezpečovacího systému u některých vlaků</target>

--- a/assets/Languages/de-CH.xlf
+++ b/assets/Languages/de-CH.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Aktiviert/Deaktiviert die Vorrichtung zum Halten der Geschwindigkeit</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Aktiviert/Deaktiviert auf manchen Zügen das Zugsicherungssystem</target>

--- a/assets/Languages/de-DE.xlf
+++ b/assets/Languages/de-DE.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Aktiviert/Deaktiviert die Vorrichtung zum Halten der Geschwindigkeit</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Aktiviert/Deaktiviert auf manchen Zügen das Zugsicherungssystem</target>

--- a/assets/Languages/en-GB.xlf
+++ b/assets/Languages/en-GB.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activates or deactivates the constant speed device</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activates or deactivates the security system on some trains</target>

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -1837,6 +1837,12 @@
 					<trans-unit id="device_constspeed">
 						<source>Activates or deactivates the constant speed device</source>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 					</trans-unit>

--- a/assets/Languages/es-ES.xlf
+++ b/assets/Languages/es-ES.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activa/desactiva el dispositivo de velocidad constante</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activa/desactiva el sistema de seguridad en algunos trenes</target>

--- a/assets/Languages/fi-FI.xlf
+++ b/assets/Languages/fi-FI.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Aktivoi tai poistaa vakionopeuslaitteen toiminnan</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Aktivoi tai poistaa turvajärjestelmän joissakin junissa</target>

--- a/assets/Languages/fr-FR.xlf
+++ b/assets/Languages/fr-FR.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Active/désactive le dispositif de régulation de vitesse</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Active/désactive le système de sécurité sur certains trains</target>

--- a/assets/Languages/hu-HU.xlf
+++ b/assets/Languages/hu-HU.xlf
@@ -2373,6 +2373,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Tempomat be/ki kapcsolása</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Biztonsági rendszer be/ki kapcsolása egyes vonatokon</target>

--- a/assets/Languages/id-ID.xlf
+++ b/assets/Languages/id-ID.xlf
@@ -2411,6 +2411,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Kecepatan konstan</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Sistem keamanan kereta</target>

--- a/assets/Languages/it-IT.xlf
+++ b/assets/Languages/it-IT.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Attiva o disattiva il dispositivo di velocità costante</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Attiva o disattiva il dispositivo di sicurezza su alcuni treni</target>

--- a/assets/Languages/ja-JP.xlf
+++ b/assets/Languages/ja-JP.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>定速運転装置切替</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>運転保安装置切替</target>

--- a/assets/Languages/ko-KR.xlf
+++ b/assets/Languages/ko-KR.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>정속 운행 장치 전환</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>운전 보안 장치 전환</target>

--- a/assets/Languages/ms_MY.xlf
+++ b/assets/Languages/ms_MY.xlf
@@ -2411,6 +2411,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Mengaktifkan atau menyahaktifkan peranti kelajuan malar</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Mengaktifkan atau menyahaktifkan sistem keselamatan pada beberapa kereta api</target>

--- a/assets/Languages/nb_NO.xlf
+++ b/assets/Languages/nb_NO.xlf
@@ -2323,6 +2323,14 @@
 				    <source>Activates or deactivates the constant speed device</source>
 				    <target>Aktiverer eller deaktiverer kruskontroll</target>
 				  </trans-unit>
+				  <trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 				  <trans-unit id="security_power">
 				    <source>Activates or deactivates the security system on some trains</source>
 				    <target>Aktiverer eller deaktiverer sikkerhetssystemet på noen tog</target>

--- a/assets/Languages/nl-NL.xlf
+++ b/assets/Languages/nl-NL.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activeert of deaciveert het constante-snelheidssysteem</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activeert of deaciveert het veiligheidssysteem op sommige treinen</target>

--- a/assets/Languages/pl-PL.xlf
+++ b/assets/Languages/pl-PL.xlf
@@ -2411,6 +2411,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Aktywuje albo dezaktywuje stałą prędkość</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Aktywacja lub dezaktywacja systemu bezpieczeństwa</target>

--- a/assets/Languages/pt-BR.xlf
+++ b/assets/Languages/pt-BR.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Ativa ou desativa o dispositivo de velocidade constante</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Ativa ou desativa o sistema de segurança em alguns trens</target>

--- a/assets/Languages/pt-PT.xlf
+++ b/assets/Languages/pt-PT.xlf
@@ -2381,6 +2381,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activa ou desactiva o dispositivo de velocidade constante</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activa ou desactiva o sistema de segurança em alguns comboios</target>

--- a/assets/Languages/ro-RO.xlf
+++ b/assets/Languages/ro-RO.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Activează sau dezactivează sistemul de Viteză Constantă.</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Activează sau dezactivează sistemul de siguranţă pentru unele trenuri.</target>

--- a/assets/Languages/ru-RU.xlf
+++ b/assets/Languages/ru-RU.xlf
@@ -2370,6 +2370,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Включить/выключить устройство поддержания постоянной скорости</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Включить/выключить систему безопасности (на некоторых поездах)</target>

--- a/assets/Languages/uk-UA.xlf
+++ b/assets/Languages/uk-UA.xlf
@@ -2372,6 +2372,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>Активувати або деактивувати сталу швидкість</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>Активація чи деактивація системи безпеки</target>

--- a/assets/Languages/zh-CN.xlf
+++ b/assets/Languages/zh-CN.xlf
@@ -2400,6 +2400,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>开关定速设备</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>启动或关闭信号系统</target>

--- a/assets/Languages/zh-HK.xlf
+++ b/assets/Languages/zh-HK.xlf
@@ -2411,6 +2411,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>啟動或關閉定速設備</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>於部分列車啟動或關閉保安系統</target>

--- a/assets/Languages/zh-TW.xlf
+++ b/assets/Languages/zh-TW.xlf
@@ -2371,6 +2371,14 @@
 						<source>Activates or deactivates the constant speed device</source>
 						<target>啟動或關閉定速設備</target>
 					</trans-unit>
+					<trans-unit id="play_micsounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+						<target>Activates or deactivates the system microphone soundsource</target>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+						<target>Activates or deactivates the sanders</target>
+					</trans-unit>
 					<trans-unit id="security_power">
 						<source>Activates or deactivates the security system on some trains</source>
 						<target>於部分列車啟動或關閉保安系統</target>

--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -488,7 +488,7 @@ namespace CarXmlConvertor
 				newLines.Add("<Object>" + CarInfos[i].Object + "</Object>");
 			}
 			newLines.Add("<Reversed>" + CarInfos[i].Reversed + "</Reversed>");
-			newLines.Add("<LoadingSway>" + CarInfos[i].Reversed + "</LoadingSway>");
+			newLines.Add("<LoadingSway>" + CarInfos[i].LoadingSway + "</LoadingSway>");
 			if (CarInfos[i].FrontBogie.AxlesDefined || !string.IsNullOrEmpty(CarInfos[i].FrontBogie.Object))
 			{
 				newLines.Add("<FrontBogie>");
@@ -570,7 +570,6 @@ namespace CarXmlConvertor
 			newLines.Add("<Width>" + ConvertTrainDat.DoorWidth / 1000.0 + "</Width>");
 			newLines.Add("<Tolerance>" + ConvertTrainDat.DoorTolerance / 1000.0 + "</Tolerance>");
 			newLines.Add("</Doors>");
-			newLines.Add("<LoadingSway>" + CarInfos[i].LoadingSway + "</LoadingSway>");
 			newLines.Add("</Car>");
 			if (i < Couplers.Length)
 			{

--- a/source/ObjectViewer/FunctionScripts.cs
+++ b/source/ObjectViewer/FunctionScripts.cs
@@ -7,6 +7,7 @@ using OpenBveApi.Math;
 using OpenBveApi.Runtime;
 using TrainManager.Handles;
 using TrainManager.Trains;
+using TrainManager.Car.Systems;
 
 namespace ObjectViewer {
 	internal static class FunctionScripts {
@@ -1103,6 +1104,39 @@ namespace ObjectViewer {
 							}
 						}
 						break;
+					case Instructions.Sanders:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders)
+							{
+								Function.Stack[s] = sanders.Active ? 1 : 0;
+							}
+							else
+							{
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandLevel:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders)
+							{
+								Function.Stack[s] = sanders.SandLevel;
+							}
+							else
+							{
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandShots:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.NumberOfShots;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						} 
+						s++; break;
 					default:
 						throw new InvalidOperationException("The unknown instruction " + Function.InstructionSet[i].ToString() + " was encountered in ExecuteFunctionScript.");
 				}

--- a/source/ObjectViewer/ObjectViewer.csproj
+++ b/source/ObjectViewer/ObjectViewer.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,7 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -41,7 +41,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>false</DebugSymbols>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -33,6 +33,8 @@ namespace OpenBve
 			private readonly double SpeedLimit;
 			/// <summary>Holds a reference to the train the AI is driving</summary>
 			private readonly TrainBase Train;
+			/// <summary>The index to the first motor car, if the driver car is not a motor car</summary>
+			private readonly int MotorCar;
 			// functions
 			internal SimpleHumanDriverAI(TrainBase train, double Limit)
 			{
@@ -52,6 +54,18 @@ namespace OpenBve
 					this.LastStation = -1;
 				}
 				this.SpeedLimit = Limit;
+				MotorCar = train.DriverCar;
+				if (!train.Cars[train.DriverCar].Specs.IsMotorCar)
+				{
+					for (int i = 0; i < train.Cars.Length; i++)
+					{
+						if (train.Cars[i].Specs.IsMotorCar)
+						{
+							MotorCar = i;
+							break;
+						}
+					}
+				}
 			}
 
 			/// <summary>Sets the response time for actions triggered by a runtime plugin</summary>
@@ -314,7 +328,12 @@ namespace OpenBve
 				{
 					// drive
 					Train.Handles.Reverser.ApplyState(ReverserPosition.Forwards);
-					if (Train.Cars[Train.DriverCar].FrontAxle.CurrentWheelSlip | Train.Cars[Train.DriverCar].RearAxle.CurrentWheelSlip)
+
+					/*
+					 * BVETS motor cars detect wheelslip, others do not at present
+					 * FIXME: When new traction modelling is merged, this changes
+					 */
+					if (Train.Cars[MotorCar].FrontAxle.CurrentWheelSlip | Train.Cars[MotorCar].RearAxle.CurrentWheelSlip)
 					{
 						// react to wheel slip
 						if (Train.Handles.Power.Driver > 1)

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
@@ -4,6 +4,7 @@ using OpenBveApi.FunctionScripting;
 using OpenBveApi.Math;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
+using TrainManager.Car.Systems;
 using TrainManager.Handles;
 using TrainManager.Trains;
 
@@ -1505,6 +1506,33 @@ namespace OpenBve {
 							}
 						}
 						break;
+					case Instructions.Sanders:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.Active ? 1 : 0;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandLevel:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.SandLevel;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandShots:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.NumberOfShots;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						} 
+						s++; break;
 						// default
 					default:
 						throw new System.InvalidOperationException("The unknown instruction " + Function.InstructionSet[i].ToString() + " was encountered in ExecuteFunctionScript.");

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1995,6 +1995,22 @@ namespace OpenBve
 									case Translations.Command.RailDriverSpeedUnits:
 										Interface.CurrentOptions.RailDriverMPH = !Interface.CurrentOptions.RailDriverMPH;
 										break;
+									case Translations.Command.Sanders:
+										for (int c = 0; c < TrainManager.PlayerTrain.Cars.Length; c++)
+										{
+											if (TrainManager.PlayerTrain.Cars[c].ReAdhesionDevice is Sanders sanders)
+											{
+												if (sanders.Type == SandersType.PressAndHold)
+												{
+													sanders.Toggle();
+												}
+											}
+										}
+										if (TrainManager.PlayerTrain.Plugin != null)
+										{
+											TrainManager.PlayerTrain.Plugin.KeyUp(VirtualKeys.Sanders);
+										}
+										break;
 								}
 							}
 						}

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -19,6 +19,7 @@ using RouteManager2.Stations;
 using TrainManager;
 using TrainManager.Handles;
 using TrainManager.Car;
+using TrainManager.Car.Systems;
 
 namespace OpenBve
 {
@@ -1593,6 +1594,21 @@ namespace OpenBve
 											//Also inform the plugin that these keys have been pressed
 											TrainManager.PlayerTrain.Plugin.KeyDown(
 												Translations.SecurityToVirtualKey(Interface.CurrentControls[i].Command));
+										}
+										break;
+									case Translations.Command.Sanders:
+										if (TrainManager.PlayerTrain.Plugin != null)
+										{
+											TrainManager.PlayerTrain.Plugin.KeyDown(
+												Translations.SecurityToVirtualKey(Interface.CurrentControls[i].Command));
+										}
+
+										for (int c = 0; c < TrainManager.PlayerTrain.Cars.Length; c++)
+										{
+											if (TrainManager.PlayerTrain.Cars[c].ReAdhesionDevice is Sanders sanders)
+											{
+												sanders.Toggle();
+											}
 										}
 										break;
 									case Translations.Command.TimetableToggle:

--- a/source/OpenBVE/UserInterface/formMain.Controls.cs
+++ b/source/OpenBVE/UserInterface/formMain.Controls.cs
@@ -485,7 +485,7 @@ namespace OpenBve {
 		{
 			try
 			{
-				Interface.LoadControls(OpenBveApi.Path.CombineFile(Program.FileSystem.GetDataFolder("Controls"), "Default keyboard assignment.controls"), out Interface.CurrentControls);
+				Interface.LoadControls(OpenBveApi.Path.CombineFile(Program.FileSystem.GetDataFolder("Controls"), "Default.controls"), out Interface.CurrentControls);
 				for (int i = 0; i < listviewControls.SelectedItems.Count; i++)
 				{
 					listviewControls.SelectedItems[i].Selected = false;

--- a/source/OpenBveApi/FunctionScripts/FunctionScript.cs
+++ b/source/OpenBveApi/FunctionScripts/FunctionScript.cs
@@ -833,6 +833,18 @@ namespace OpenBveApi.FunctionScripting
 							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
 							InstructionSet[n] = Instructions.WheelSlipCar;
 							n++; break;
+						case "sanders":
+							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
+							InstructionSet[n] = Instructions.Sanders;
+							n++; s++; if (s >= m) m = s; break;
+						case "sandlevel":
+							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
+							InstructionSet[n] = Instructions.SandLevel;
+							n++; s++; if (s >= m) m = s; break;
+						case "sandshots":
+							if (n >= InstructionSet.Length) Array.Resize(ref InstructionSet, InstructionSet.Length << 1);
+							InstructionSet[n] = Instructions.SandShots;
+							n++; s++; if (s >= m) m = s; break;
 						// default
 						default:
 							throw new System.IO.InvalidDataException("Unknown command " + Arguments[i] + " encountered in function script " + Expression);

--- a/source/OpenBveApi/FunctionScripts/Instructions.cs
+++ b/source/OpenBveApi/FunctionScripts/Instructions.cs
@@ -35,7 +35,8 @@
 		SectionAspectNumber, CurrentObjectState,
 		RainDrop, SnowFlake, WiperPosition,
 		WheelRadius, WheelRadiusOfCar,
-		WheelSlip, WheelSlipCar
+		WheelSlip, WheelSlipCar,
+		Sanders, SandLevel, SandShots
 #pragma warning restore CS1591
 			
 		}

--- a/source/OpenBveApi/Interface/Input/Commands.CommandInfo.cs
+++ b/source/OpenBveApi/Interface/Input/Commands.CommandInfo.cs
@@ -155,6 +155,7 @@
 			new CommandInfo(Command.HornMusic, CommandType.Digital, "HORN_MUSIC"),
 			new CommandInfo(Command.DeviceConstSpeed, CommandType.Digital, "DEVICE_CONSTSPEED"),
 			new CommandInfo(Command.PlayMicSounds, CommandType.Digital, "PLAY_MIC_SOUNDS"),
+			new CommandInfo(Command.Sanders, CommandType.Digital, "SANDERS"),
 
 //We only want to mark these as obsolete for new users of the API
 #pragma warning disable 618

--- a/source/OpenBveApi/Interface/Input/Commands.cs
+++ b/source/OpenBveApi/Interface/Input/Commands.cs
@@ -302,7 +302,12 @@ namespace OpenBveApi.Interface {
 			/// <summary>Triggers a screen reader message with the distance and aspect to the next signal</summary>
 			AccessibilityNextSignal,
 			/// <summary>Triggers a screen reader message with the distance and aspect to the next station</summary>
-			AccessibilityNextStation
+			AccessibilityNextStation,
+			/*
+			 * Added in 1.8.4.3
+			 */
+			/// <summary>Toggles the sanders if fitted</summary>
+			Sanders
 		}
 
 		/// <summary>Defines the possible command types</summary>

--- a/source/OpenBveApi/Runtime/System/VirtualKeys.cs
+++ b/source/OpenBveApi/Runtime/System/VirtualKeys.cs
@@ -83,6 +83,8 @@
 		/// <summary>Called when the driver presses the left door button [NOTE: This is called whether or not opening succeeds/ is blocked]</summary>
 		LeftDoors = 35,
 		/// <summary>Called when the driver presses the right door button [NOTE: This is called whether or not opening succeeds/ is blocked]</summary>
-		RightDoors = 36
+		RightDoors = 36,
+		/// <summary>Called when the sanders are activated</summary>
+		Sanders = 37
 	}
 }

--- a/source/OpenBveApi/Runtime/System/VirtualKeys.cs
+++ b/source/OpenBveApi/Runtime/System/VirtualKeys.cs
@@ -80,11 +80,13 @@
 		LowerPantograph = 33,
 		/// <summary>Toggles the main breaker. The default assignment is [N/A]. The numerical value of this constant is 34.</summary>
 		MainBreaker = 34,
-		/// <summary>Called when the driver presses the left door button [NOTE: This is called whether or not opening succeeds/ is blocked]</summary>
+		/// <summary>Called when the driver presses the left door button [NOTE: This is called whether or not opening succeeds/ is blocked]. The numerical value of this constant is 35.</summary>
 		LeftDoors = 35,
-		/// <summary>Called when the driver presses the right door button [NOTE: This is called whether or not opening succeeds/ is blocked]</summary>
+		/// <summary>Called when the driver presses the right door button [NOTE: This is called whether or not opening succeeds/ is blocked]. The numerical value of this constant is 36.</summary>
 		RightDoors = 36,
-		/// <summary>Called when the sanders are activated</summary>
-		Sanders = 37
+		/// <summary>Called when the sanders are activated. The default assignment is [S]. The numerical value of this constant is 37.</summary>
+		Sanders = 37,
+		/// <summary>Called when the headlights state changes. The default assignment is [H]. The numerical value of this constant is 38.</summary>
+		Headlights = 38
 	}
 }

--- a/source/Plugins/Train.OpenBve/Sound/SoundCfg.Bve4.cs
+++ b/source/Plugins/Train.OpenBve/Sound/SoundCfg.Bve4.cs
@@ -27,21 +27,34 @@ namespace Train.OpenBve
 		/// <param name="trainFolder">The absolute on-disk path to the train's folder</param>
 		internal void Parse(string FileName, string trainFolder, TrainBase train)
 		{
-			//Default sound positions and radii
+			/*
+			 * NOTES:
+			 * ------
+			 *
+			 * BVE2 and BVE4 content shares common (hardcoded) sound radii & positions
+			 * Radius is used to define a sphere, in which the sound is audible at full
+			 * volume, attenuated outside
+			 *
+			 * These are terrible for realism (generally much too small, and may well
+			 * be in the 'wrong' position) but need to be retained for legacy purposes
+			 * 
+			 * The sound.xml format should be used if these are to be changed
+			 *
+			 */
 
-			//3D center of the car
+			// 3D center of the car
 			Vector3 center = Vector3.Zero;
-			//Positioned to the left of the car, but centered Y & Z
+			// Positioned to the left of the car, but centered Y & Z
 			Vector3 left = new Vector3(-1.3, 0.0, 0.0);
-			//Positioned to the right of the car, but centered Y & Z
+			// Positioned to the right of the car, but centered Y & Z
 			Vector3 right = new Vector3(1.3, 0.0, 0.0);
-			//Positioned at the front of the car, centered X and Y
+			// Positioned at the front of the car, centered X and Y
 			Vector3 front = new Vector3(0.0, 0.0, 0.5 * train.Cars[train.DriverCar].Length);
-			//Positioned at the position of the panel / 3D cab (Remember that the panel is just an object in the world...)
+			// Positioned at the position of the panel / 3D cab (Remember that the panel is just an object in the world...)
 			Vector3 panel = new Vector3(train.Cars[train.DriverCar].Driver.X, train.Cars[train.DriverCar].Driver.Y, train.Cars[train.DriverCar].Driver.Z + 1.0);
 
-			//Radius at which the sound is audible at full volume, presumably in m
-			//TODO: All radii are much too small in external mode, but we can't change them by default.....
+			
+			
 
 			Encoding Encoding = TextEncoding.GetSystemEncodingFromFile(FileName);
 
@@ -80,7 +93,7 @@ namespace Train.OpenBve
 			{
 				Plugin.currentHost.AddMessage(MessageType.Error, false, "Invalid file format encountered in " + FileName + ". The first line is expected to be \"Version 1.0\".");
 			}
-			string[] MotorFiles = new string[] { };
+			List<string> MotorFiles = new List<string>();
 			double invfac = Lines.Count == 0 ? 0.1 : 0.1 / Lines.Count;
 			for (int i = 0; i < Lines.Count; i++)
 			{
@@ -191,15 +204,11 @@ namespace Train.OpenBve
 								{
 									if (k >= 0)
 									{
-										if (k >= MotorFiles.Length)
-										{
-											Array.Resize(ref MotorFiles, k + 1);
-										}
-										MotorFiles[k] = Path.CombineFile(trainFolder, b);
+										MotorFiles.Add(Path.CombineFile(trainFolder, b));
 										if (!System.IO.File.Exists(MotorFiles[k]))
 										{
 											Plugin.currentHost.AddMessage(MessageType.Error, true, "File " + MotorFiles[k] + " does not exist at line " + (i + 1).ToString(Culture) + " in file " + FileName);
-											MotorFiles[k] = null;
+											MotorFiles[k] = string.Empty;
 										}
 									}
 									else
@@ -385,7 +394,7 @@ namespace Train.OpenBve
 								{
 									switch (a.ToLowerInvariant())
 									{
-										//PRIMARY HORN (Enter)
+										// PRIMARY HORN (Enter)
 										case "primarystart":
 											Plugin.currentHost.RegisterSound(Path.CombineFile(trainFolder, b), SoundCfgParser.largeRadius, out var primaryStart);
 											train.Cars[train.DriverCar].Horns[0].StartSound = primaryStart as SoundBuffer;
@@ -406,7 +415,7 @@ namespace Train.OpenBve
 											train.Cars[train.DriverCar].Horns[0].SoundPosition = front;
 											train.Cars[train.DriverCar].Horns[0].Loop = false;
 											break;
-										//SECONDARY HORN (Numpad Enter)
+										// SECONDARY HORN (Numpad Enter)
 										case "secondarystart":
 											Plugin.currentHost.RegisterSound(Path.CombineFile(trainFolder, b), SoundCfgParser.largeRadius, out var secondaryStart);
 											train.Cars[train.DriverCar].Horns[1].StartSound = secondaryStart as SoundBuffer;
@@ -427,7 +436,7 @@ namespace Train.OpenBve
 											train.Cars[train.DriverCar].Horns[1].SoundPosition = front;
 											train.Cars[train.DriverCar].Horns[1].Loop = false;
 											break;
-										//MUSIC HORN
+										// MUSIC HORN
 										case "musicstart":
 											Plugin.currentHost.RegisterSound(Path.CombineFile(trainFolder, b), SoundCfgParser.mediumRadius, out var musicStart);
 											train.Cars[train.DriverCar].Horns[2].StartSound = musicStart as SoundBuffer;
@@ -787,7 +796,7 @@ namespace Train.OpenBve
 						i--; break;
 				}
 			}
-			// motor sound
+			// Assign motor sounds to appropriate cars
 			for (int c = 0; c < train.Cars.Length; c++)
 			{
 				if (train.Cars[c].Specs.IsMotorCar)
@@ -802,7 +811,7 @@ namespace Train.OpenBve
 							for (int j = 0; j < motorSound.Tables[i].Entries.Length; j++)
 							{
 								int index = motorSound.Tables[i].Entries[j].SoundIndex;
-								if (index >= 0 && index < MotorFiles.Length && MotorFiles[index] != null)
+								if (index >= 0 && index < MotorFiles.Count && !string.IsNullOrEmpty(MotorFiles[index]))
 								{
 									Plugin.currentHost.RegisterSound(MotorFiles[index], SoundCfgParser.mediumRadius, out var mS);
 									motorSound.Tables[i].Entries[j].Buffer = mS as SoundBuffer;

--- a/source/Plugins/Train.OpenBve/Sound/SoundCfg.Xml.cs
+++ b/source/Plugins/Train.OpenBve/Sound/SoundCfg.Xml.cs
@@ -7,6 +7,7 @@ using OpenBveApi.Math;
 using SoundManager;
 using TrainManager.BrakeSystems;
 using TrainManager.Car;
+using TrainManager.Car.Systems;
 using TrainManager.Motor;
 using TrainManager.Power;
 using TrainManager.Trains;
@@ -537,6 +538,42 @@ namespace Train.OpenBve
 										break;
 									}
 									ParseArrayNode(c, out car.Sounds.Touch, center, SoundCfgParser.mediumRadius);
+									break;
+								case "sanders":
+									if (!c.ChildNodes.OfType<XmlElement>().Any())
+									{
+										Plugin.currentHost.AddMessage(MessageType.Error, false, "An empty list of sanders sounds was defined in in XML file " + fileName);
+										break;
+									}
+									Sanders sanders = car.ReAdhesionDevice as Sanders;
+									if (sanders == null)
+									{
+										break;
+									}
+									foreach (XmlNode cc in c.ChildNodes)
+									{
+										switch (cc.Name.ToLowerInvariant())
+										{
+											case "activate":
+												ParseNode(cc, out sanders.ActivationSound, center, SoundCfgParser.smallRadius);
+												break;
+											case "emptyactivate":
+												ParseNode(cc, out sanders.EmptyActivationSound, center, SoundCfgParser.smallRadius);
+												break;
+											case "deactivate":
+												ParseNode(cc, out sanders.DeActivationSound, center, SoundCfgParser.smallRadius);
+												break;
+											case "loop":
+												ParseNode(cc, out sanders.LoopSound, center, SoundCfgParser.smallRadius);
+												break;
+											case "empty":
+												ParseNode(cc, out sanders.EmptySound, center, SoundCfgParser.smallRadius);
+												break;
+											default:
+												Plugin.currentHost.AddMessage(MessageType.Error, false, "Declaration " + cc.Name + " is unsupported in a " + c.Name + " node.");
+												break;
+										}
+									}
 									break;
 							}
 						}

--- a/source/Plugins/Train.OpenBve/Sound/SoundCfg.Xml.cs
+++ b/source/Plugins/Train.OpenBve/Sound/SoundCfg.Xml.cs
@@ -796,17 +796,17 @@ namespace Train.OpenBve
 						double x = 0.0, y = 0.0, z = 0.0;
 						if (Arguments.Length >= 1 && Arguments[0].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[0], out x))
 						{
-							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound radius X " + Arguments[0] + " in XML node " + node.Name + " is invalid.");
+							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound position X " + Arguments[0] + " in XML node " + node.Name + " is invalid.");
 							x = 0.0;
 						}
 						if (Arguments.Length >= 2 && Arguments[1].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[1], out y))
 						{
-							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound radius Y " + Arguments[1] + " in XML node " + node.Name + " is invalid.");
+							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound position Y " + Arguments[1] + " in XML node " + node.Name + " is invalid.");
 							y = 0.0;
 						}
 						if (Arguments.Length >= 3 && Arguments[2].Length > 0 && !NumberFormats.TryParseDoubleVb6(Arguments[2], out z))
 						{
-							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound radius Z " + Arguments[2] + " in XML node " + node.Name + " is invalid.");
+							Plugin.currentHost.AddMessage(MessageType.Error, false, "Sound position Z " + Arguments[2] + " in XML node " + node.Name + " is invalid.");
 							z = 0.0;
 						}
 						Position = new Vector3(x,y,z);

--- a/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
@@ -1392,7 +1392,7 @@ namespace Train.OpenBve
 			for (int i = 0; i < Cars; i++) {
 				Train.Cars[i].ConstSpeed = new CarConstSpeed(Train.Cars[i]);
 				Train.Cars[i].HoldBrake = new CarHoldBrake(Train.Cars[i]);
-				Train.Cars[i].ReAdhesionDevice = new CarReAdhesionDevice(Train.Cars[i], ReAdhesionDevice);
+				Train.Cars[i].ReAdhesionDevice = new BveReAdhesionDevice(Train.Cars[i], ReAdhesionDevice);
 				if (Train.Cars[i].Specs.IsMotorCar) {
 					// motor car
 					Train.Cars[i].EmptyMass = MotorCarMass;

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -363,8 +363,8 @@ namespace Train.OpenBve
 						SandersType type = SandersType.NotFitted;
 						double rate = double.MaxValue;
 						double level = 0;
-						double applicationTime = 0;
-						double activationTime = 0;
+						double applicationTime = 10.0;
+						double activationTime = 5.0;
 						int shots = int.MaxValue;
 						foreach (XmlNode cc in c.ChildNodes)
 						{

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.CarNode.cs
@@ -11,6 +11,7 @@ using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using TrainManager.BrakeSystems;
 using TrainManager.Car;
+using TrainManager.Car.Systems;
 using TrainManager.Cargo;
 using TrainManager.Handles;
 using TrainManager.Power;
@@ -23,7 +24,11 @@ namespace Train.OpenBve
 		private void ParseCarNode(XmlNode Node, string fileName, int Car, ref TrainBase Train, ref UnifiedObject[] CarObjects, ref UnifiedObject[] BogieObjects, ref bool visibleFromInterior)
 		{
 			string interiorFile = string.Empty;
-			ReadhesionDeviceType readhesionDevice = Train.Cars[0].ReAdhesionDevice.DeviceType;
+			ReadhesionDeviceType readhesionDevice = ReadhesionDeviceType.NotFitted;
+			if (Train.Cars[0].ReAdhesionDevice is BveReAdhesionDevice device)
+			{
+				readhesionDevice = device.DeviceType;
+			}
 			bool CopyAccelerationCurves = true;
 			foreach (XmlNode c in Node.ChildNodes)
 			{
@@ -354,6 +359,66 @@ namespace Train.OpenBve
 								break;
 						}
 						break;
+					case "sanders":
+						SandersType type = SandersType.NotFitted;
+						double rate = double.MaxValue;
+						double level = 0;
+						double applicationTime = 0;
+						double activationTime = 0;
+						int shots = int.MaxValue;
+						foreach (XmlNode cc in c.ChildNodes)
+						{
+							switch (cc.Name.ToLowerInvariant())
+							{
+								case "type":
+									if (!Enum.TryParse(cc.InnerText, true, out type))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sanders type was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+								case "rate":
+									if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out rate))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sanders application rate was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+								case "sandlevel":
+									if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out level))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sand level was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+								case "numberofshots":
+									if (!NumberFormats.TryParseIntVb6(cc.InnerText, out shots))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sand level was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+								case "applicationtime":
+									if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out applicationTime))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sanders application time was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+								case "activationtime":
+									if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out activationTime))
+									{
+										Plugin.currentHost.AddMessage(MessageType.Warning, false, "Sanders activation time was invalid for Car " + Car + " in XML file " + fileName);
+									}
+									break;
+							}
+
+							Train.Cars[Car].ReAdhesionDevice = new Sanders(Train.Cars[Car], type)
+							{
+								ApplicationTime = applicationTime,
+								ActivationTime = activationTime,
+								SandLevel = level,
+								SandingRate = rate,
+								NumberOfShots = shots
+							};
+						}
+
+						break;
 					case "visiblefrominterior":
 						if (c.InnerText.ToLowerInvariant() == "1" || c.InnerText.ToLowerInvariant() == "true")
 						{
@@ -558,7 +623,7 @@ namespace Train.OpenBve
 					Plugin.currentHost.AddMessage(MessageType.Warning, false, "Interior view file is not supported for Car " + Car + " in XML file " + fileName);
 				}
 			}
-			Train.Cars[Car].ReAdhesionDevice = new CarReAdhesionDevice(Train.Cars[Car], readhesionDevice);
+			Train.Cars[Car].ReAdhesionDevice = new BveReAdhesionDevice(Train.Cars[Car], readhesionDevice);
 		}
 	}
 }

--- a/source/RouteViewer/FunctionScripts.cs
+++ b/source/RouteViewer/FunctionScripts.cs
@@ -5,6 +5,7 @@ using OpenBveApi.Runtime;
 using LibRender2.Overlays;
 using TrainManager.BrakeSystems;
 using TrainManager.Handles;
+using TrainManager.Car.Systems;
 
 namespace RouteViewer {
 	internal static class FunctionScripts {
@@ -1081,6 +1082,33 @@ namespace RouteViewer {
 							}
 						}
 						break;
+					case Instructions.Sanders:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.Active ? 1 : 0;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandLevel:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.SandLevel;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						}
+						s++; break;
+					case Instructions.SandShots:
+						{
+							if (Train != null && Train.Cars[CarIndex].ReAdhesionDevice is Sanders sanders) {
+								Function.Stack[s] = sanders.NumberOfShots;
+							} else {
+								Function.Stack[s] = 0.0;
+							}
+						} 
+						s++; break;
 					default:
 						throw new InvalidOperationException("The unknown instruction " + Function.InstructionSet[i].ToString() + " was encountered in ExecuteFunctionScript.");
 				}

--- a/source/RouteViewer/RouteViewer.csproj
+++ b/source/RouteViewer/RouteViewer.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -39,7 +39,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>false</DebugSymbols>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -13,6 +13,7 @@ using OpenBveApi.Trains;
 using OpenBveApi.World;
 using SoundManager;
 using TrainManager.BrakeSystems;
+using TrainManager.Car.Systems;
 using TrainManager.Cargo;
 using TrainManager.Motor;
 using TrainManager.Power;
@@ -66,7 +67,7 @@ namespace TrainManager.Car
 		/// <summary>The constant speed device for this car</summary>
 		public CarConstSpeed ConstSpeed;
 		/// <summary>The readhesion device for this car</summary>
-		public CarReAdhesionDevice ReAdhesionDevice;
+		public AbstractReAdhesionDevice ReAdhesionDevice;
 		/// <summary>The position of the beacon reciever within the car</summary>
 		public double BeaconReceiverPosition;
 		/// <summary>The beacon reciever</summary>
@@ -1163,10 +1164,21 @@ namespace TrainManager.Car
 							}
 
 							// readhesion device
-							if (a > ReAdhesionDevice.MaximumAccelerationOutput)
+							if (ReAdhesionDevice is BveReAdhesionDevice device)
 							{
-								a = ReAdhesionDevice.MaximumAccelerationOutput;
+								if (a > device.MaximumAccelerationOutput)
+								{
+									a = device.MaximumAccelerationOutput;
+								}
 							}
+							else if (ReAdhesionDevice is Sanders sanders)
+							{
+								wheelSlipAccelerationMotorFront *= 2.0;
+								wheelSlipAccelerationMotorRear *= 2.0;
+								wheelSlipAccelerationBrakeFront *= 2.0;
+								wheelSlipAccelerationBrakeRear *= 2.0;
+							}
+							
 
 							// wheel slip
 							if (a < wheelSlipAccelerationMotorFront)

--- a/source/TrainManager/Car/Systems/AbstractReAdhesionDevice.cs
+++ b/source/TrainManager/Car/Systems/AbstractReAdhesionDevice.cs
@@ -1,0 +1,27 @@
+﻿namespace TrainManager.Car.Systems
+{
+	/// <summary>An abstract readhesion device</summary>
+	public abstract class AbstractReAdhesionDevice
+	{
+		/// <summary>Holds a reference to the base car</summary>
+		internal readonly CarBase Car;
+
+		internal AbstractReAdhesionDevice(CarBase car)
+		{
+			Car = car;
+		}
+
+		/// <summary>Called once a frame to update the re-adhesion device when powering</summary>
+		/// <param name="CurrentAcceleration">The current acceleration output</param>
+		public virtual void Update(double CurrentAcceleration)
+		{
+
+		}
+
+		/// <summary>Called to reset the readhesion device after a jump</summary>
+		public virtual void Jump()
+		{
+
+		}
+	}
+}

--- a/source/TrainManager/Car/Systems/ReadhesionDevice.cs
+++ b/source/TrainManager/Car/Systems/ReadhesionDevice.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using TrainManager.Car.Systems;
 
 namespace TrainManager.Car
 {
-	public class CarReAdhesionDevice
+	/// <summary>Implements a BVE2 / BVE4 readhesion device</summary>
+	/// <remarks>Designed to simulate an electric motor control system reacting to wheelslip</remarks>
+	public class BveReAdhesionDevice : AbstractReAdhesionDevice
 	{
 		/// <summary>The time between updates in seconds</summary>
 		public double UpdateInterval;
@@ -18,14 +21,11 @@ namespace TrainManager.Car
 		private double NextUpdateTime;
 		/// <summary>The amount of time with NO wheelslip occuring</summary>
 		private double TimeStable;
-		/// <summary>Holds a reference to the base car</summary>
-		private readonly CarBase Car;
 		/// <summary>The type of device</summary>
 		public readonly ReadhesionDeviceType DeviceType;
 
-		public CarReAdhesionDevice(CarBase car, ReadhesionDeviceType type)
+		public BveReAdhesionDevice(CarBase car, ReadhesionDeviceType type) : base(car)
 		{
-			this.Car = car;
 			this.DeviceType = type;
 			this.MaximumAccelerationOutput = Double.PositiveInfinity;
 			this.ApplicationFactor = 0.0;
@@ -69,7 +69,7 @@ namespace TrainManager.Car
 
 		/// <summary>Called once a frame to update the re-adhesion device when powering</summary>
 		/// <param name="CurrentAcceleration">The current acceleration output</param>
-		public void Update(double CurrentAcceleration)
+		public override void Update(double CurrentAcceleration)
 		{
 			if (TrainManagerBase.currentHost.InGameTime < NextUpdateTime)
 			{
@@ -108,7 +108,7 @@ namespace TrainManager.Car
 		}
 
 		/// <summary>Called to reset the readhesion device after a jump</summary>
-		public void Jump()
+		public override void Jump()
 		{
 			NextUpdateTime = 0;
 			MaximumAccelerationOutput = double.PositiveInfinity;

--- a/source/TrainManager/Car/Systems/Sanders.Types.cs
+++ b/source/TrainManager/Car/Systems/Sanders.Types.cs
@@ -1,0 +1,16 @@
+﻿namespace TrainManager.Car.Systems
+{
+	public enum SandersType
+	{
+		/// <summary>The sanders are active whilst the key is held</summary>
+		PressAndHold,
+		/// <summary>The sanders toggle on and off</summary>
+		Toggle,
+		/// <summary>There are N timed shots available when the sanders key is pressed</summary>
+		NumberOfShots,
+		/// <summary>The sanders activate automatically</summary>
+		Automatic,
+		/// <summary>No sanders are fitted</summary>
+		NotFitted
+	}
+}

--- a/source/TrainManager/Car/Systems/Sanders.cs
+++ b/source/TrainManager/Car/Systems/Sanders.cs
@@ -1,0 +1,165 @@
+﻿using SoundManager;
+
+namespace TrainManager.Car.Systems
+{
+	public class Sanders : AbstractReAdhesionDevice
+	{
+		/// <summary>The sanding rate</summary>
+		public double SandingRate;
+		/// <summary>The level of sand in the sandbox</summary>
+		public double SandLevel;
+		/// <summary>The application time available before the sander cuts off</summary>
+		public double ApplicationTime;
+		/// <summary>The time required before activation if using automatic mode</summary>
+		public double ActivationTime;
+		/// <summary>If a number of shots is available, the number remaining</summary>
+		public int NumberOfShots;
+		/// <summary>Whether the sanders are currently active</summary>
+		public bool Active;
+		/// <summary>The type of sanders</summary>
+		public readonly SandersType Type;
+		/// <summary>The sound played when the sanders are activated</summary>
+		public CarSound ActivationSound;
+		/// <summary>The sound played when the sanders are deactivated</summary>
+		public CarSound DeActivationSound;
+		/// <summary>The sound loop played when the sanders are active</summary>
+		public CarSound LoopSound;
+		/// <summary>The sound played when the sand is emptied</summary>
+		public CarSound EmptySound;
+		/// <summary>The sound played when activation is attempted whilst empty</summary>
+		public CarSound EmptyActivationSound;
+
+		private bool emptied = false;
+		private double timer;
+		public Sanders(CarBase car, SandersType type) : base(car)
+		{
+			Type = type;
+		}
+
+		public override void Update(double timeElapsed)
+		{
+			if (Type == SandersType.NotFitted)
+			{
+				return;
+			}
+
+			if (Active)
+			{
+				if ((ActivationSound != null && !ActivationSound.IsPlaying) || ActivationSound == null)
+				{
+					if (LoopSound != null)
+					{
+						LoopSound.Play(Car, true);
+					}
+				}
+			}
+
+			if (SandLevel <= 0)
+			{
+				SandLevel = 0;
+				if (SandingRate != 0)
+				{
+					Active = false;
+					if (!emptied)
+					{
+						if (EmptySound != null)
+						{
+							EmptySound.Play(Car, false);
+						}
+
+						emptied = true;
+					}
+				}
+			}
+			else
+			{
+				if (SandingRate > 0 && SandingRate < double.MaxValue)
+				{
+					SandLevel -= SandingRate * timeElapsed;
+				}
+				
+			}
+			switch (Type)
+			{
+				case SandersType.Automatic:
+					if (Car.FrontAxle.CurrentWheelSlip)
+					{
+						timer += timeElapsed;
+						if (timer > ActivationTime && !Active)
+						{
+							Toggle();
+						}
+					}
+					else
+					{
+						timer = 0;
+						if (Active)
+						{
+							Toggle();
+						}
+					}
+					break;
+				case SandersType.NumberOfShots:
+					if (Active)
+					{
+						timer -= timeElapsed;
+						if (timer <= 0)
+						{
+							Toggle();
+						}
+					}
+					
+					break;
+			}
+		}
+
+		public void Toggle()
+		{
+			if (Type == SandersType.NotFitted)
+			{
+				return;
+			}
+
+			if (emptied)
+			{
+				if (Type != SandersType.Automatic && EmptyActivationSound != null)
+				{
+					// Assume that whatever is controlling the automatic activation has the brains not to do so
+					// when the sand is empty
+					EmptyActivationSound.Play(Car, false);
+				}
+				return;
+			}
+			if (Active)
+			{
+				if (Type == SandersType.NumberOfShots && timer > 0)
+				{
+					// Can't cancel shot based
+					return;
+				}
+				Active = false;
+				if (DeActivationSound != null)
+				{
+					DeActivationSound.Play(Car, false);	
+				}
+			}
+			else
+			{
+				if (Type == SandersType.NumberOfShots)
+				{
+					if (NumberOfShots <= 0)
+					{
+						return;
+					}
+					NumberOfShots--;
+					timer = ApplicationTime;
+				}
+				Active = true;
+				if (ActivationSound != null)
+				{
+					ActivationSound.Play(Car, false);	
+				}
+			}
+		}
+	}
+}

--- a/source/TrainManager/TrainManager.csproj
+++ b/source/TrainManager/TrainManager.csproj
@@ -62,10 +62,13 @@
     <Compile Include="Car\Door.DoorModes.cs" />
     <Compile Include="Car\Door.TrainDoorState.cs" />
     <Compile Include="Car\Physics.cs" />
+    <Compile Include="Car\Systems\AbstractReAdhesionDevice.cs" />
     <Compile Include="Car\Systems\ConstantSpeedDevice.cs" />
     <Compile Include="Car\Systems\HoldBrake.cs" />
     <Compile Include="Car\Systems\ReadhesionDevice.cs" />
     <Compile Include="Car\Systems\ReadhesionDevice.Types.cs" />
+    <Compile Include="Car\Systems\Sanders.cs" />
+    <Compile Include="Car\Systems\Sanders.Types.cs" />
     <Compile Include="Car\Windscreen\Raindrop.cs" />
     <Compile Include="Car\Windscreen\Windscreen.cs" />
     <Compile Include="Car\Windscreen\Wiper.cs" />


### PR DESCRIPTION
This PR implements 'proper' sanders as an alternative to the BVE readhesion device (this is intended to simulate a control system for an electric motor)

XML only feature.
At the moment, sanders are assumed to double the base adhesion rate. Probably OK, as this might get a little too complex otherwise....

### Usage:
A Car node may contain a **\<Sanders>** node, with the following child nodes:
* Type- controls the type of sanders fitted, from the following _PressAndHold, Toggle, NumberOfShots, Automatic, NotFitted_
* Rate- The application rate of sand in units /s
* SandLevel- The initial level of sand.
* NumberOfShots- The number of shots available (if type is set to _NumberOfShots_)
* ApplicationTime- The time after which a sand application cuts off automatically.
* ActivationTime- The amount of time for which wheelslip must occur before the sanders are activated in _Automatic_ mode

A Sound node may contain a **\<Sanders>** node with the following child nodes:
* Activate- Played once when the sanders are activated with sand available.
* EmptyActivate- Played once when the sanders are activated with no sand available.
* Deactivate- Played once when the sanders are deactivated.
* Loop- Played looped when the sanders are active.
* Empty- Played once when the sand supply empties.

New animated variables:
* Sanders- Returns 1 if the sanders are active for a car, 0 otherwise
* SandLevel- Returns the sand level for a car
* SandShots- Returns the number of sand shots available

### TODO:
* A little more plumbing in the control activation / deactivation.
* Hook up panel variables.
* ???

Follow-up to https://github.com/leezer3/OpenBVE/issues/815#issuecomment-1272571285
@JunmoreHeavyBox