### PR TITLE
Change: Improve Car XML Converter

### DIFF
--- a/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
+++ b/source/CarXMLConvertor/Convert.ExtensionsCfg.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Security;
 using System.Threading;
 using System.Windows.Forms;
 using Path = OpenBveApi.Path;
@@ -392,8 +393,8 @@ namespace CarXmlConvertor
 			string trainTxt = Path.CombineFile(System.IO.Path.GetDirectoryName(FileName), "train.txt");
 			if (File.Exists(trainTxt))
 			{
-				string desc = File.ReadAllText(trainTxt);
-				newLines.Add("<Description>" + desc + "</Description>");
+				string desc = File.ReadAllText(trainTxt, OpenBveApi.TextEncoding.GetSystemEncodingFromFile(trainTxt));
+				newLines.Add("<Description>" + SecurityElement.Escape(desc) + "</Description>");
 			}
 			newLines.Add("</Train>");
 			newLines.Add("</openBVE>");

--- a/source/CarXMLConvertor/mainForm.Designer.cs
+++ b/source/CarXMLConvertor/mainForm.Designer.cs
@@ -28,145 +28,164 @@
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-			this.textBox1 = new System.Windows.Forms.TextBox();
-			this.labelSelectTrain = new System.Windows.Forms.Label();
-			this.buttonSelectFolder = new System.Windows.Forms.Button();
-			this.labelInfo = new System.Windows.Forms.Label();
-			this.button1 = new System.Windows.Forms.Button();
-			this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
-			this.radioButtonSingleFile = new System.Windows.Forms.RadioButton();
-			this.radioButtonChildFiles = new System.Windows.Forms.RadioButton();
-			this.panelCarXMLTypes = new System.Windows.Forms.Panel();
-			this.label1 = new System.Windows.Forms.Label();
-			this.textBoxOutput = new System.Windows.Forms.TextBox();
-			this.panelCarXMLTypes.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// textBox1
-			// 
-			this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.labelSelectTrain = new System.Windows.Forms.Label();
+            this.buttonSelectFolder = new System.Windows.Forms.Button();
+            this.labelInfo = new System.Windows.Forms.Label();
+            this.button1 = new System.Windows.Forms.Button();
+            this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
+            this.radioButtonSingleFile = new System.Windows.Forms.RadioButton();
+            this.radioButtonChildFiles = new System.Windows.Forms.RadioButton();
+            this.panelCarXMLTypes = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBoxOutput = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.panelCarXMLTypes.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // textBox1
+            // 
+            this.textBox1.AllowDrop = true;
+            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.textBox1.Location = new System.Drawing.Point(7, 73);
-			this.textBox1.Name = "textBox1";
-			this.textBox1.Size = new System.Drawing.Size(293, 20);
-			this.textBox1.TabIndex = 0;
-			// 
-			// labelSelectTrain
-			// 
-			this.labelSelectTrain.AutoSize = true;
-			this.labelSelectTrain.Location = new System.Drawing.Point(12, 54);
-			this.labelSelectTrain.Name = "labelSelectTrain";
-			this.labelSelectTrain.Size = new System.Drawing.Size(221, 13);
-			this.labelSelectTrain.TabIndex = 1;
-			this.labelSelectTrain.Text = "Please select the train folder to be converted:";
-			// 
-			// buttonSelectFolder
-			// 
-			this.buttonSelectFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonSelectFolder.Location = new System.Drawing.Point(306, 70);
-			this.buttonSelectFolder.Name = "buttonSelectFolder";
-			this.buttonSelectFolder.Size = new System.Drawing.Size(75, 23);
-			this.buttonSelectFolder.TabIndex = 2;
-			this.buttonSelectFolder.Text = "Select...";
-			this.buttonSelectFolder.UseVisualStyleBackColor = true;
-			this.buttonSelectFolder.Click += new System.EventHandler(this.buttonSelectFolder_Click);
-			// 
-			// labelInfo
-			// 
-			this.labelInfo.AutoSize = true;
-			this.labelInfo.Location = new System.Drawing.Point(7, 19);
-			this.labelInfo.Name = "labelInfo";
-			this.labelInfo.Size = new System.Drawing.Size(265, 13);
-			this.labelInfo.TabIndex = 3;
-			this.labelInfo.Text = "This tool may be used to convert a train to XML format.";
-			// 
-			// button1
-			// 
-			this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.button1.Location = new System.Drawing.Point(292, 417);
-			this.button1.Name = "button1";
-			this.button1.Size = new System.Drawing.Size(104, 35);
-			this.button1.TabIndex = 4;
-			this.button1.Text = "Convert!";
-			this.button1.UseVisualStyleBackColor = true;
-			this.button1.Click += new System.EventHandler(this.process_Click);
-			// 
-			// radioButtonSingleFile
-			// 
-			this.radioButtonSingleFile.AutoSize = true;
-			this.radioButtonSingleFile.Checked = true;
-			this.radioButtonSingleFile.Location = new System.Drawing.Point(27, 8);
-			this.radioButtonSingleFile.Name = "radioButtonSingleFile";
-			this.radioButtonSingleFile.Size = new System.Drawing.Size(73, 17);
-			this.radioButtonSingleFile.TabIndex = 0;
-			this.radioButtonSingleFile.TabStop = true;
-			this.radioButtonSingleFile.Text = "Single File";
-			this.radioButtonSingleFile.UseVisualStyleBackColor = true;
-			// 
-			// radioButtonChildFiles
-			// 
-			this.radioButtonChildFiles.AutoSize = true;
-			this.radioButtonChildFiles.Location = new System.Drawing.Point(106, 8);
-			this.radioButtonChildFiles.Name = "radioButtonChildFiles";
-			this.radioButtonChildFiles.Size = new System.Drawing.Size(91, 17);
-			this.radioButtonChildFiles.TabIndex = 1;
-			this.radioButtonChildFiles.Text = "Child Car Files";
-			this.radioButtonChildFiles.UseVisualStyleBackColor = true;
-			// 
-			// panelCarXMLTypes
-			// 
-			this.panelCarXMLTypes.Controls.Add(this.radioButtonSingleFile);
-			this.panelCarXMLTypes.Controls.Add(this.radioButtonChildFiles);
-			this.panelCarXMLTypes.Location = new System.Drawing.Point(48, 125);
-			this.panelCarXMLTypes.Name = "panelCarXMLTypes";
-			this.panelCarXMLTypes.Size = new System.Drawing.Size(200, 27);
-			this.panelCarXMLTypes.TabIndex = 7;
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(7, 96);
-			this.label1.MaximumSize = new System.Drawing.Size(300, 0);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(270, 26);
-			this.label1.TabIndex = 8;
-			this.label1.Text = "Please select whether to use a single Train.xml file, or a Train.xml file with ch" +
+            this.textBox1.Location = new System.Drawing.Point(13, 57);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(293, 20);
+            this.textBox1.TabIndex = 0;
+            this.textBox1.DragDrop += new System.Windows.Forms.DragEventHandler(this.textBox1_DragDrop);
+            this.textBox1.DragEnter += new System.Windows.Forms.DragEventHandler(this.textBox1_DragEnter);
+            // 
+            // labelSelectTrain
+            // 
+            this.labelSelectTrain.AutoSize = true;
+            this.labelSelectTrain.Location = new System.Drawing.Point(12, 37);
+            this.labelSelectTrain.Name = "labelSelectTrain";
+            this.labelSelectTrain.Size = new System.Drawing.Size(221, 13);
+            this.labelSelectTrain.TabIndex = 1;
+            this.labelSelectTrain.Text = "Please select the train folder to be converted:";
+            // 
+            // buttonSelectFolder
+            // 
+            this.buttonSelectFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonSelectFolder.Location = new System.Drawing.Point(312, 56);
+            this.buttonSelectFolder.Name = "buttonSelectFolder";
+            this.buttonSelectFolder.Size = new System.Drawing.Size(75, 23);
+            this.buttonSelectFolder.TabIndex = 2;
+            this.buttonSelectFolder.Text = "Select...";
+            this.buttonSelectFolder.UseVisualStyleBackColor = true;
+            this.buttonSelectFolder.Click += new System.EventHandler(this.buttonSelectFolder_Click);
+            // 
+            // labelInfo
+            // 
+            this.labelInfo.AutoSize = true;
+            this.labelInfo.Location = new System.Drawing.Point(10, 9);
+            this.labelInfo.Name = "labelInfo";
+            this.labelInfo.Size = new System.Drawing.Size(265, 13);
+            this.labelInfo.TabIndex = 3;
+            this.labelInfo.Text = "This tool may be used to convert a train to XML format.";
+            // 
+            // button1
+            // 
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button1.Location = new System.Drawing.Point(292, 417);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(104, 35);
+            this.button1.TabIndex = 4;
+            this.button1.Text = "Convert!";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.process_Click);
+            // 
+            // radioButtonSingleFile
+            // 
+            this.radioButtonSingleFile.AutoSize = true;
+            this.radioButtonSingleFile.Checked = true;
+            this.radioButtonSingleFile.Location = new System.Drawing.Point(3, 7);
+            this.radioButtonSingleFile.Name = "radioButtonSingleFile";
+            this.radioButtonSingleFile.Size = new System.Drawing.Size(73, 17);
+            this.radioButtonSingleFile.TabIndex = 0;
+            this.radioButtonSingleFile.TabStop = true;
+            this.radioButtonSingleFile.Text = "Single File";
+            this.radioButtonSingleFile.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonChildFiles
+            // 
+            this.radioButtonChildFiles.AutoSize = true;
+            this.radioButtonChildFiles.Location = new System.Drawing.Point(106, 8);
+            this.radioButtonChildFiles.Name = "radioButtonChildFiles";
+            this.radioButtonChildFiles.Size = new System.Drawing.Size(91, 17);
+            this.radioButtonChildFiles.TabIndex = 1;
+            this.radioButtonChildFiles.Text = "Child Car Files";
+            this.radioButtonChildFiles.UseVisualStyleBackColor = true;
+            // 
+            // panelCarXMLTypes
+            // 
+            this.panelCarXMLTypes.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.panelCarXMLTypes.Controls.Add(this.radioButtonSingleFile);
+            this.panelCarXMLTypes.Controls.Add(this.radioButtonChildFiles);
+            this.panelCarXMLTypes.Location = new System.Drawing.Point(93, 125);
+            this.panelCarXMLTypes.Name = "panelCarXMLTypes";
+            this.panelCarXMLTypes.Size = new System.Drawing.Size(200, 27);
+            this.panelCarXMLTypes.TabIndex = 7;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(64, 96);
+            this.label1.MaximumSize = new System.Drawing.Size(300, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(270, 26);
+            this.label1.TabIndex = 8;
+            this.label1.Text = "Please select whether to use a single Train.xml file, or a Train.xml file with ch" +
     "ild Car.xml files:";
-			// 
-			// textBoxOutput
-			// 
-			this.textBoxOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // textBoxOutput
+            // 
+            this.textBoxOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.textBoxOutput.Enabled = false;
-			this.textBoxOutput.Location = new System.Drawing.Point(15, 158);
-			this.textBoxOutput.Multiline = true;
-			this.textBoxOutput.Name = "textBoxOutput";
-			this.textBoxOutput.Size = new System.Drawing.Size(381, 253);
-			this.textBoxOutput.TabIndex = 9;
-			// 
-			// MainForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(408, 464);
-			this.Controls.Add(this.textBoxOutput);
-			this.Controls.Add(this.label1);
-			this.Controls.Add(this.panelCarXMLTypes);
-			this.Controls.Add(this.button1);
-			this.Controls.Add(this.labelInfo);
-			this.Controls.Add(this.buttonSelectFolder);
-			this.Controls.Add(this.labelSelectTrain);
-			this.Controls.Add(this.textBox1);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.Name = "MainForm";
-			this.Text = "Car XML Convertor";
-			this.panelCarXMLTypes.ResumeLayout(false);
-			this.panelCarXMLTypes.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.textBoxOutput.Location = new System.Drawing.Point(15, 171);
+            this.textBoxOutput.Multiline = true;
+            this.textBoxOutput.Name = "textBoxOutput";
+            this.textBoxOutput.ReadOnly = true;
+            this.textBoxOutput.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.textBoxOutput.Size = new System.Drawing.Size(381, 240);
+            this.textBoxOutput.TabIndex = 9;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 155);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(33, 13);
+            this.label2.TabIndex = 10;
+            this.label2.Text = "Logs:";
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(408, 464);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.textBoxOutput);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.panelCarXMLTypes);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.labelInfo);
+            this.Controls.Add(this.buttonSelectFolder);
+            this.Controls.Add(this.labelSelectTrain);
+            this.Controls.Add(this.textBox1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MinimumSize = new System.Drawing.Size(300, 400);
+            this.Name = "MainForm";
+            this.Text = "Car XML Convertor";
+            this.panelCarXMLTypes.ResumeLayout(false);
+            this.panelCarXMLTypes.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -183,6 +202,7 @@
 		private System.Windows.Forms.Panel panelCarXMLTypes;
 		private System.Windows.Forms.Label label1;
 	    internal System.Windows.Forms.TextBox textBoxOutput;
+		private System.Windows.Forms.Label label2;
 	}
 }
 

--- a/source/CarXMLConvertor/mainForm.cs
+++ b/source/CarXMLConvertor/mainForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Windows.Forms;
 using Path = OpenBveApi.Path;
@@ -30,22 +31,24 @@ namespace CarXmlConvertor
 
         private void process_Click(object sender, EventArgs e)
         {
+			terminateEarly = false;
 	        if (string.IsNullOrEmpty(ConvertTrainDat.FileName) && !string.IsNullOrEmpty(textBox1.Text) && System.IO.Directory.Exists(textBox1.Text))
 	        {
 		        ConvertTrainDat.FileName = Path.CombineFile(textBox1.Text, "train.dat");
 		        ConvertSoundCfg.FileName = Path.CombineFile(textBox1.Text, "sound.cfg");
 		        ConvertPanel2.FileName = Path.CombineFile(textBox1.Text, "panel2.cfg");
 		        ConvertPanelAnimated.FileName = Path.CombineFile(textBox1.Text, "panel.animated");
-		        animatedPanel = System.IO.File.Exists(ConvertPanelAnimated.FileName);
+		        animatedPanel = File.Exists(ConvertPanelAnimated.FileName);
 		        ConvertExtensionsCfg.FileName = Path.CombineFile(textBox1.Text, "extensions.cfg");
 	        }
 	        updateLogBoxText = "Loading parameters from train.dat file " + ConvertTrainDat.FileName + Environment.NewLine;
 	        ConvertTrainDat.Process(this);
-	        if (terminateEarly)
-		        return;
+			if (terminateEarly)
+				return;
+		    
 	        if (!animatedPanel)
 	        {
-		        if (!System.IO.File.Exists(ConvertPanel2.FileName))
+				if (!File.Exists(ConvertPanel2.FileName))
 		        {
 			        updateLogBoxText += "INFO: No panel2.cfg file detected." + Environment.NewLine;
 			        if (MessageBox.Show("The selected folder does not contain a valid panel2.cfg", "CarXML Convertor", MessageBoxButtons.OKCancel, MessageBoxIcon.Information) == DialogResult.Cancel)
@@ -56,7 +59,7 @@ namespace CarXmlConvertor
 		        }
 	        }
 
-	        if (System.IO.File.Exists(Path.CombineFile(System.IO.Path.GetDirectoryName(ConvertPanelAnimated.FileName), "panel.xml")))
+			if (File.Exists(Path.CombineFile(System.IO.Path.GetDirectoryName(ConvertPanelAnimated.FileName), "panel.xml")))
 	        {
 		        updateLogBoxText += "INFO: An existing panel.xml file was detected." + Environment.NewLine;
 		        if (MessageBox.Show("The selected folder already contains a panel.xml file. \r\n Do you wish to continue?", "CarXML Convertor", MessageBoxButtons.OKCancel, MessageBoxIcon.Information) == DialogResult.Cancel)
@@ -102,7 +105,7 @@ namespace CarXmlConvertor
 			}
 	        updateLogBoxText += "Loading existing sound.cfg file " + ConvertSoundCfg.FileName + Environment.NewLine;
 			ConvertSoundCfg.Process(this);
-	        if (System.IO.File.Exists(Path.CombineFile(System.IO.Path.GetDirectoryName(ConvertExtensionsCfg.FileName), "train.xml")))
+	        if (File.Exists(Path.CombineFile(System.IO.Path.GetDirectoryName(ConvertExtensionsCfg.FileName), "train.xml")))
 	        {
 		        updateLogBoxText += "INFO: An existing train.xml file was detected." + Environment.NewLine;
 				if (MessageBox.Show("The selected folder already contains a train.xml file. \r\n Do you wish to continue?", "CarXML Convertor", MessageBoxButtons.OKCancel, MessageBoxIcon.Information) == DialogResult.Cancel)
@@ -132,14 +135,40 @@ namespace CarXmlConvertor
             folderBrowserDialog = new FolderBrowserDialog();
             if (folderBrowserDialog.ShowDialog() == DialogResult.OK)
             {
-	            ConvertTrainDat.FileName = Path.CombineFile(folderBrowserDialog.SelectedPath, "train.dat");
-				ConvertSoundCfg.FileName = Path.CombineFile(folderBrowserDialog.SelectedPath, "sound.cfg");
-				ConvertPanel2.FileName = Path.CombineFile(folderBrowserDialog.SelectedPath, "panel2.cfg");
-				ConvertPanelAnimated.FileName = Path.CombineFile(folderBrowserDialog.SelectedPath, "panel.animated");
-				animatedPanel = System.IO.File.Exists(ConvertPanelAnimated.FileName);
-	            ConvertExtensionsCfg.FileName = Path.CombineFile(folderBrowserDialog.SelectedPath, "extensions.cfg");
+				UpdatePath(folderBrowserDialog.SelectedPath);
 	            textBox1.Text = folderBrowserDialog.SelectedPath;
             }
         }
-    }
+
+		private void UpdatePath(string path) {
+			ConvertTrainDat.FileName = Path.CombineFile(path, "train.dat");
+			ConvertSoundCfg.FileName = Path.CombineFile(path, "sound.cfg");
+			ConvertPanel2.FileName = Path.CombineFile(path, "panel2.cfg");
+			ConvertPanelAnimated.FileName = Path.CombineFile(path, "panel.animated");
+			animatedPanel = File.Exists(ConvertPanelAnimated.FileName);
+			ConvertExtensionsCfg.FileName = Path.CombineFile(path, "extensions.cfg");
+		}
+
+		private void textBox1_DragEnter(object sender, DragEventArgs e) {
+			if (e.Data.GetDataPresent(DataFormats.FileDrop)) {
+				e.Effect = DragDropEffects.Copy;
+			} else {
+				e.Effect = DragDropEffects.None;
+			}
+		}
+
+		private void textBox1_DragDrop(object sender, DragEventArgs e) {
+			if (e.Data.GetDataPresent(DataFormats.FileDrop)) {
+				string path = ((string[]) e.Data.GetData(DataFormats.FileDrop))[0];
+				if (File.Exists(path)) {
+					path = Directory.GetParent(path).FullName;
+				}
+
+				if (Directory.Exists(path)) {
+					UpdatePath(path);
+					textBox1.Text = path;
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes some of the bugs and improve the Car XML Converter.  
Nothing major, just found several annoyances when needing to use the program.
## Fixes
- Special characters from **train.txt** not escaped in **train.xml**, leading to in-game crash due to an invalid train xml.
- Encoding is now detected, non-UTF8 encoded **train.txt** should be converted properly.
- `terminatedEarly` not reset between runs, resulting in conversion not working if the first attempt failed.

## Improvements
- Minor changes on the UI, should look slightly nicer now
![image](https://user-images.githubusercontent.com/28094366/202245864-5b9ba392-f22f-419b-ad1c-c9aee958709c.png)
- Support drag and drop files/folders to the textbox. (Will grab parent directory if it's a file, the folder browser dialog is quite tedious to navigate)
- The log box is now read only rather than disabled, should result in easier readability. (Also allows scrolling)