### PR TITLE
Fix: Wrongly detected broken dependencies

### DIFF
--- a/source/OpenBveApi/Packages/Packages.Database.cs
+++ b/source/OpenBveApi/Packages/Packages.Database.cs
@@ -300,7 +300,7 @@ namespace OpenBveApi.Packages
 					brokenPackages.Add(Train);
 				}
 			}
-			foreach (Package Other in currentDatabase.InstalledRoutes)
+			foreach (Package Other in currentDatabase.InstalledOther)
 			{
 				if (packagesToRemove.Contains(Other.GUID))
 				{


### PR DESCRIPTION
A typo caused broken dependencies (For routes) to be listed twice instead of detecting the "Other" package type.

- Fixes Route being displayed twice when listing broken dependencies (Affect others who are consuming the API as well?)

- Fixes Other not being listed for broken dependencies