### PR TITLE
New: Add overload to play multi-car sounds

### DIFF
--- a/source/OpenBveApi/Runtime/Runtime.cs
+++ b/source/OpenBveApi/Runtime/Runtime.cs
@@ -25,6 +25,16 @@ namespace OpenBveApi.Runtime {
     /// <returns>The handle to the sound, or a null reference if the sound could not be played.</returns>
     /// <exception cref="System.InvalidOperationException">Raised when the host application does not allow the function to be called.</exception>
     public delegate SoundHandle PlayCarSoundDelegate(int index, double volume, double pitch, bool looped, int carIndex);
+
+    /// <summary>Plays a sound.</summary>
+    /// <param name="index">The index to the sound to be played.</param>
+    /// <param name="volume">The initial volume of the sound. A value of 1.0 represents nominal volume.</param>
+    /// <param name="pitch">The initial pitch of the sound. A value of 1.0 represents nominal pitch.</param>
+    /// <param name="looped">Whether the sound should be played in an indefinate loop.</param>
+    /// <param name="carIndicies">An array of car indicies to start playback on</param>
+    /// <returns>The handle to the sound, or a null reference if the sound could not be played.</returns>
+    /// <exception cref="System.InvalidOperationException">Raised when the host application does not allow the function to be called.</exception>
+    public delegate SoundHandle[] PlayMultipleCarSoundDelegate(int index, double volume, double pitch, bool looped, int[] carIndicies);
 	
 	/// <summary>Adds a message to the in-game display</summary>
 	/// <param name="Message">The message to display</param>

--- a/source/OpenBveApi/Runtime/System/LoadProperties.cs
+++ b/source/OpenBveApi/Runtime/System/LoadProperties.cs
@@ -20,6 +20,10 @@
 		/// <exception cref="System.InvalidOperationException">Raised when the host application does not allow the function to be called.</exception>
 		private readonly PlayCarSoundDelegate MyPlayCarSound;
 
+		/// <summary>The callback function for playing car-based  sounds.</summary>
+		/// <exception cref="System.InvalidOperationException">Raised when the host application does not allow the function to be called.</exception>
+		private readonly PlayMultipleCarSoundDelegate MyPlayMultipleCarSound;
+
 		/// <summary>The callback function for adding interface messages.</summary>
 		/// <exception cref="System.InvalidOperationException">Raised when the host application does not allow the function to be called.</exception>
 		private readonly AddInterfaceMessageDelegate MyAddInterfaceMessage;
@@ -86,6 +90,15 @@
 			get
 			{
 				return this.MyPlayCarSound;
+			}
+		}
+
+		/// <summary>Gets the callback function for playing sounds.</summary>
+		public PlayMultipleCarSoundDelegate PlayMultipleCarSound
+		{
+			get
+			{
+				return this.MyPlayMultipleCarSound;
 			}
 		}
 
@@ -191,6 +204,30 @@
 			this.MyTrainFolder = trainFolder;
 			this.MyPlaySound = playSound;
 			this.MyPlayCarSound = playCarSound;
+			this.MyAddInterfaceMessage = addMessage;
+			this.MyAddScore = addScore;
+			this.MyOpenDoors = openDoors;
+			this.MyCloseDoors = closeDoors;
+			this.MyFailureReason = null;
+		}
+
+		/// <summary>Creates a new instance of this class.</summary>
+		/// <param name="pluginFolder">The absolute path to the plugin folder.</param>
+		/// <param name="trainFolder">The absolute path to the train folder.</param>
+		/// <param name="playSound">The callback function for playing sounds.</param>
+		/// <param name="playCarSound">The callback function for playing car-based sounds.</param>
+		/// <param name="playMultiCarSound">The callback function for playing a sound on multiple cars</param>
+		/// <param name="addMessage">The callback function for adding interface messages.</param>
+		/// <param name="addScore">The callback function for adding scores.</param>
+		/// <param name="openDoors">The callback function for opening the train doors</param>
+		/// <param name="closeDoors">The callback function for closing the train doors</param>
+		public LoadProperties(string pluginFolder, string trainFolder, PlaySoundDelegate playSound, PlayCarSoundDelegate playCarSound, PlayMultipleCarSoundDelegate playMultiCarSound, AddInterfaceMessageDelegate addMessage, AddScoreDelegate addScore, OpenDoorsDelegate openDoors, CloseDoorsDelegate closeDoors)
+		{
+			this.MyPluginFolder = pluginFolder;
+			this.MyTrainFolder = trainFolder;
+			this.MyPlaySound = playSound;
+			this.MyPlayCarSound = playCarSound;
+			this.MyPlayMultipleCarSound = playMultiCarSound;
 			this.MyAddInterfaceMessage = addMessage;
 			this.MyAddScore = addScore;
 			this.MyOpenDoors = openDoors;

--- a/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
@@ -82,7 +82,7 @@ namespace TrainManager.SafetySystems
 		// --- functions ---
 		public override bool Load(VehicleSpecs specs, InitializationModes mode)
 		{
-			LoadProperties properties = new LoadProperties(PluginFolder, TrainFolder, PlaySound, PlaySound, AddInterfaceMessage, AddScore, OpenDoors, CloseDoors);
+			LoadProperties properties = new LoadProperties(PluginFolder, TrainFolder, PlayMultiCarSound, PlayCarSound, PlayMultiCarSound, AddInterfaceMessage, AddScore, OpenDoors, CloseDoors);
 			bool success;
 			try
 			{
@@ -371,7 +371,7 @@ namespace TrainManager.SafetySystems
 		/// <param name="pitch">The pitch of the sound- A pitch of 1.0 represents nominal pitch</param>
 		/// <param name="looped">Whether the sound is looped</param>
 		/// <returns>The sound handle, or null if not successful</returns>
-		internal SoundHandleEx PlaySound(int index, double volume, double pitch, bool looped)
+		internal SoundHandleEx PlayMultiCarSound(int index, double volume, double pitch, bool looped)
 		{
 			if (Train.Cars[Train.DriverCar].Sounds.Plugin.ContainsKey(index) && Train.Cars[Train.DriverCar].Sounds.Plugin[index].Buffer != null)
 			{
@@ -396,7 +396,7 @@ namespace TrainManager.SafetySystems
 		/// <param name="looped">Whether the sound is looped</param>
 		/// <param name="CarIndex">The index of the car which is to emit the sound</param>
 		/// <returns>The sound handle, or null if not successful</returns>
-		internal SoundHandleEx PlaySound(int index, double volume, double pitch, bool looped, int CarIndex)
+		internal SoundHandleEx PlayCarSound(int index, double volume, double pitch, bool looped, int CarIndex)
 		{
 			if (CarIndex < 0 || CarIndex >= Train.Cars.Length)
 			{
@@ -435,6 +435,23 @@ namespace TrainManager.SafetySystems
 			SoundHandles[SoundHandlesCount] = new SoundHandleEx(volume, pitch, Train.Cars[CarIndex].Sounds.Plugin[index].Source);
 			SoundHandlesCount++;
 			return SoundHandles[SoundHandlesCount - 1];
+		}
+
+		/// <summary>May be called from a .Net plugin, in order to play a sound from multiple cars of a train</summary>
+		/// <param name="index">The plugin-based of the sound to play</param>
+		/// <param name="volume">The volume of the sound- A volume of 1.0 represents nominal volume</param>
+		/// <param name="pitch">The pitch of the sound- A pitch of 1.0 represents nominal pitch</param>
+		/// <param name="looped">Whether the sound is looped</param>
+		/// <param name="CarIndicies">The index of the cars which are to emit the sound</param>
+		/// <returns>The sound handle, or null if not successful</returns>
+		internal SoundHandleEx[] PlayMultiCarSound(int index, double volume, double pitch, bool looped, int[] CarIndicies)
+		{
+			SoundHandleEx[] soundHandles = new SoundHandleEx[CarIndicies.Length];
+			for (int i = 0; i < CarIndicies.Length; i++)
+			{
+				soundHandles[i] = PlayCarSound(index, volume, pitch, looped, CarIndicies[i]);
+			}
+			return soundHandles;
 		}
 	}
 }


### PR DESCRIPTION
This adds a further function to the runtime API- PlayMultiCarSound
Allows an array of car indices to be passed allowing for multiple of the same sound to be created in one go.

Needs testing, and will require modifications to the sample plugin.