### PR TITLE
New: Add option to allow routes to be driven in the reverse direction

### DIFF
--- a/assets/Shaders/default.frag
+++ b/assets/Shaders/default.frag
@@ -19,7 +19,7 @@ out vec4 fragColor;
 
 void main(void)
 {
-	vec4 finalColor = oColor * texture(uTexture, oUv);
+	vec4 finalColor = vec4(oColor.rgb, 1.0) * texture(uTexture, oUv); // NOTE: only want the RGB of the color, A is passed in as part of opacity
 
 	if((uMaterialFlags & 1) == 0 && (uMaterialFlags & 4) == 0)
 	{

--- a/source/LibRender2/Camera/Camera.cs
+++ b/source/LibRender2/Camera/Camera.cs
@@ -334,9 +334,9 @@ namespace LibRender2.Cameras
 		}
 
 		/// <summary>Unconditionally resets the camera</summary>
-		public void Reset()
+		public void Reset(bool ReverseDirection)
 		{
-			Alignment.Yaw = 0.0;
+			Alignment.Yaw = ReverseDirection ? 180 / 57.2957795130824 : 0;
 			Alignment.Pitch = 0.0;
 			Alignment.Roll = 0.0;
 			Alignment.Position = new Vector3(0.0, 2.5, 0.0);

--- a/source/LibRender2/Camera/CameraRestriction.cs
+++ b/source/LibRender2/Camera/CameraRestriction.cs
@@ -12,5 +12,12 @@ namespace LibRender2.Camera
 		public Vector3 BottomLeft;
 		/// <summary>The relative top right vector</summary>
 		public Vector3 TopRight;
+
+		/// <summary>Reverses the camera restriction</summary>
+		public void Reverse()
+		{
+			AbsoluteBottomLeft.Rotate(Vector3.Forward, 3.14159);
+			AbsoluteTopRight.Rotate(Vector3.Forward, 3.14159);
+		}
 	}
 }

--- a/source/LibRender2/Trains/ElementsGroup.cs
+++ b/source/LibRender2/Trains/ElementsGroup.cs
@@ -1,4 +1,5 @@
-﻿using OpenBveApi.Objects;
+﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 
 namespace LibRender2.Trains
 {
@@ -26,6 +27,23 @@ namespace LibRender2.Trains
 				for (int j = 0; j < Elements[i].States.Length; j++)
 				{
 					Elements[i].Initialize(j, Type, CurrentlyVisible);
+				}
+			}
+		}
+
+		/// <summary>Reverses the elements group</summary>
+		/// <param name="pos">The drivers eye position</param>
+		public void Reverse(Vector3 pos)
+		{
+			for (int i = 0; i < Elements.Length; i++)
+			{
+				for (int j = 0; j < Elements[i].States.Length; j++)
+				{
+					Vector3 translation = Elements[i].States[j].Translation.ExtractTranslation();
+					translation.X -= pos.X * 2;
+					translation.Z += pos.Z * 2;
+					Elements[i].States[j].Translation = Matrix4D.CreateTranslation(translation);
+
 				}
 			}
 		}

--- a/source/ObjectViewer/FunctionScripts.cs
+++ b/source/ObjectViewer/FunctionScripts.cs
@@ -435,8 +435,8 @@ namespace ObjectViewer {
 						break;
 					case Instructions.TrainTrackDistance:
 						if (Train != null) {
-							double t0 = Train.FrontCarTrackPosition();
-							double t1 = Train.RearCarTrackPosition();
+							double t0 = Train.FrontCarTrackPosition;
+							double t1 = Train.RearCarTrackPosition;
 							Function.Stack[s] = TrackPosition > t0 ? TrackPosition - t0 : TrackPosition < t1 ? TrackPosition - t1 : 0.0;
 						} else {
 							Function.Stack[s] = 0.0;

--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -89,6 +89,14 @@ namespace OpenBve
 				return response;
 			}
 
+			// Temp variables
+			private double dec;
+			private double decelerationCruise;   /* power below this deceleration, cruise above */
+			private double decelerationStart;    /* brake above this deceleration, cruise below */
+			private double decelerationStep;     /* the deceleration step per brake notch */
+			private double BrakeDeceleration;
+			private bool reduceDecelerationCruiseAndStart;
+
 			/// <summary>Performs all default actions</summary>
 			private void PerformDefault()
 			{
@@ -101,7 +109,6 @@ namespace OpenBve
 					return;
 				}
 				// personality
-				double spd = Train.CurrentSpeed;
 				if (Train.Station >= 0 & Train.StationState == TrainStopState.Boarding)
 				{
 					if (Train.Station != this.LastStation)
@@ -251,7 +258,7 @@ namespace OpenBve
 						else
 						{
 							int b;
-							if (Math.Abs(spd) < 0.02)
+							if (Math.Abs(Train.CurrentSpeed) < 0.02)
 							{
 								b = (int)Math.Ceiling(0.5 * (double)Train.Handles.Brake.MaximumNotch);
 								CurrentInterval = 0.3;
@@ -384,7 +391,7 @@ namespace OpenBve
 					else
 					{
 						lim *= this.CurrentSpeedFactor;
-						if (spd < 8.0)
+						if (Train.CurrentSpeed < 8.0)
 						{
 							powerstart = 0.75 * lim;
 							powerend = 0.95 * lim;
@@ -403,11 +410,8 @@ namespace OpenBve
 							brakestart = lim + 0.5;
 						}
 					}
-					double dec = 0.0;
-					double decelerationCruise;   /* power below this deceleration, cruise above */
-					double decelerationStart;    /* brake above this deceleration, cruise below */
-					double decelerationStep;     /* the deceleration step per brake notch */
-					double BrakeDeceleration = Train.Cars[Train.DriverCar].CarBrake.DecelerationAtServiceMaximumPressure(Train.Handles.Brake.Actual, Train.Cars[Train.DriverCar].CurrentSpeed);
+					dec = 0.0;
+					BrakeDeceleration = Train.Cars[Train.DriverCar].CarBrake.DecelerationAtServiceMaximumPressure(Train.Handles.Brake.Actual, Train.Cars[Train.DriverCar].CurrentSpeed);
 					for (int i = 0; i < Train.Cars.Length; i++)
 					{
 						if (Train.Cars[i].Specs.IsMotorCar)
@@ -444,319 +448,21 @@ namespace OpenBve
 						decelerationStep *= 1.25;
 					}
 
-					if (spd > 0.0 & spd > brakestart)
+					if (Train.CurrentSpeed > 0.0 & Train.CurrentSpeed > brakestart)
 					{
-						dec = decelerationStep + 0.1 * (spd - brakestart);
+						dec = decelerationStep + 0.1 * (Train.CurrentSpeed - brakestart);
 					}
-					bool reduceDecelerationCruiseAndStart = false;
+					reduceDecelerationCruiseAndStart = false;
 					// look ahead
-					double lookahead = (Train.Station >= 0 ? 150.0 : 50.0) + (spd * spd) / (2.0 * decelerationCruise);
-					double tp = Train.FrontCarTrackPosition();
-					double stopDistance = double.MaxValue;
+					if (Program.CurrentRoute.ReverseDirection)
 					{
-						// next station stop
-						int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
-						int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
-						for (int i = te; i < Program.CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
-						{
-							double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
-							if (tp + lookahead <= stp) break;
-							for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
-							{
-								if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
-								{
-									StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
-									{
-										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
-										if (s >= 0)
-										{
-											double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - tp;
-											if (dist > 0.0 & dist < stopDistance)
-											{
-												stopDistance = dist;
-											}
-										}
-									}
-								}
-							}
-						}
+						LookAheadBackwards();
 					}
+					else
 					{
-						// events
-						int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
-						int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
-						for (int i = te; i < Program.CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
-						{
-							double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
-							if (tp + lookahead <= stp) break;
-							for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
-							{
-								if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is LimitChangeEvent)
-								{
-									// speed limit
-									LimitChangeEvent e = (LimitChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-									if (e.NextSpeedLimit < spd)
-									{
-										double dist = stp + e.TrackPositionDelta - tp;
-										double edec = (spd * spd - e.NextSpeedLimit * e.NextSpeedLimit * this.CurrentSpeedFactor) / (2.0 * dist);
-										if (edec > dec) dec = edec;
-									}
-								}
-								else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is SectionChangeEvent)
-								{
-									// section
-									SectionChangeEvent e = (SectionChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-									if (stp + e.TrackPositionDelta > tp)
-									{
-										if (!Program.CurrentRoute.Sections[e.NextSectionIndex].Invisible & Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect >= 0)
-										{
-											double elim = Program.CurrentRoute.Sections[e.NextSectionIndex].Aspects[Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect].Speed * this.CurrentSpeedFactor;
-											if (elim < spd | spd <= 0.0)
-											{
-												double dist = stp + e.TrackPositionDelta - tp;
-												double edec;
-												if (elim == 0.0)
-												{
-													double redstopdist;
-													if (Train.Station >= 0 & Train.StationState == TrainStopState.Completed & dist < 120.0)
-													{
-														dist = 1.0;
-														redstopdist = 25.0;
-													}
-													else if (Train.Station >= 0 & Train.StationState == TrainStopState.Pending | stopDistance < dist)
-													{
-														redstopdist = 1.0;
-													}
-													else if (spd > 9.72222222222222)
-													{
-														redstopdist = 55.0;
-													}
-													else
-													{
-														redstopdist = 35.0;
-													}
-													if (dist > redstopdist)
-													{
-														edec = (spd * spd) / (2.0 * (dist - redstopdist));
-													}
-													else
-													{
-														edec = BrakeDeceleration;
-													}
-													if (dist < 100.0)
-													{
-														reduceDecelerationCruiseAndStart = true;
-													}
-												}
-												else
-												{
-													if (dist >= 1.0)
-													{
-														edec = (spd * spd - elim * elim) / (2.0 * dist);
-													}
-													else
-													{
-														edec = 0.0;
-													}
-												}
-												if (edec > dec) dec = edec;
-											}
-										}
-									}
-								}
-								else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
-								{
-									// station start
-									if (Train.Station == -1)
-									{
-										StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-										if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
-										{
-											int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
-											if (s >= 0)
-											{
-												double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - tp;
-												if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
-												{
-													if (dist < 25.0)
-													{
-														reduceDecelerationCruiseAndStart = true;
-													}
-													else if (this.CurrentSpeedFactor < 1.0)
-													{
-														dist -= 5.0;
-													}
-													var edec = spd * spd / (2.0 * dist);
-													if (edec > dec) dec = edec;
-												}
-											}
-										}
-									}
-								}
-								else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.Decelerate)
-								{
-									// Brakes the train when passing through a request stop, which is not to be passed at linespeed
-									if (Train.Station == -1)
-									{
-										StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-										if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
-										{
-											int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
-											if (s >= 0)
-											{
-												double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - tp;
-												if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
-												{
-													if (dist < 25.0)
-													{
-														reduceDecelerationCruiseAndStart = true;
-													}
-													else if (this.CurrentSpeedFactor < 1.0)
-													{
-														dist -= 5.0;
-													}
-													if (dist > 25)
-													{
-														var edec = spd * spd / (2.0 * dist);
-														if (edec > dec) dec = edec;
-													}
-
-												}
-											}
-										}
-									}
-								}
-								else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationEndEvent && Train.NextStopSkipped == StopSkipMode.None)
-								{
-									// station end
-									if (Train.Station == -1)
-									{
-										StationEndEvent e = (StationEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-										if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
-										{
-											int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
-											if (s >= 0)
-											{
-												double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - tp;
-												if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
-												{
-													if (dist < 25.0)
-													{
-														reduceDecelerationCruiseAndStart = true;
-													}
-													else if (this.CurrentSpeedFactor < 1.0)
-													{
-														dist -= 5.0;
-													}
-													var edec = spd * spd / (2.0 * dist);
-													if (edec > dec) dec = edec;
-												}
-											}
-										}
-									}
-								}
-								else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackEndEvent)
-								{
-									// track end
-									if (Train.IsPlayerTrain)
-									{
-										TrackEndEvent e = (TrackEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
-										double dist = stp + e.TrackPositionDelta - tp;
-										double edec;
-										if (dist >= 15.0)
-										{
-											edec = spd * spd / (2.0 * dist);
-										}
-										else
-										{
-											edec = BrakeDeceleration;
-										}
-										if (edec > dec) dec = edec;
-									}
-								}
-							}
-						}
+						LookAheadForwards();
 					}
-					// buffers ahead
-					if (Train.IsPlayerTrain)
-					{
-						for (int i = 0; i < Program.CurrentRoute.BufferTrackPositions.Length; i++)
-						{
-							double dist = Program.CurrentRoute.BufferTrackPositions[i] - tp;
-							if (dist > 0.0)
-							{
-								double edec;
-								if (dist >= 10.0)
-								{
-									edec = spd * spd / (2.0 * dist);
-								}
-								else if (dist >= 5.0)
-								{
-									Train.Handles.Brake.ApplyState(1, true);
-									Train.Handles.Power.ApplyState(-1, true);
-									Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
-									this.CurrentInterval = 0.1;
-									return;
-								}
-								else
-								{
-									Train.Handles.Brake.ApplyState(1, true);
-									Train.Handles.Power.ApplyState(-1, true);
-									Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
-									Train.Handles.EmergencyBrake.Apply();
-									this.CurrentInterval = 10.0;
-									return;
-								}
-								if (edec > dec) dec = edec;
-							}
-						}
-					}
-					// trains ahead
-					for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
-					{
-						if (Program.TrainManager.Trains[i] != Train && Program.TrainManager.Trains[i].State == TrainState.Available)
-						{
-							double pos =
-								Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Follower.TrackPosition -
-								Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Position -
-								0.5 * Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].Length;
-							double dist = pos - tp;
-							if (dist > -10.0 & dist < lookahead)
-							{
-								const double minDistance = 10.0;
-								const double maxDistance = 100.0;
-								double edec;
-								if (dist > minDistance)
-								{
-									double shift = 0.75 * minDistance + 1.0 * spd;
-									edec = spd * spd / (2.0 * (dist - shift));
-								}
-								else if (dist > 0.5 * minDistance)
-								{
-									Train.Handles.Brake.ApplyState(1, true);
-									Train.Handles.Power.ApplyState(-1, true);
-									Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
-									this.CurrentInterval = 0.1;
-									return;
-								}
-								else
-								{
-									Train.Handles.Brake.ApplyState(1, true);
-									Train.Handles.Power.ApplyState(-1, true);
-									Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
-									Train.Handles.EmergencyBrake.Apply();
-									this.CurrentInterval = 1.0;
-									return;
-								}
-								if (dist < maxDistance)
-								{
-									reduceDecelerationCruiseAndStart = true;
-								}
-								if (edec > dec) dec = edec;
-							}
-						}
-					}
+					
 					Train.Handles.EmergencyBrake.Release();
 					// current station
 					if (Train.Station >= 0 & Train.StationState == TrainStopState.Pending)
@@ -766,7 +472,7 @@ namespace OpenBve
 							int s = Program.CurrentRoute.Stations[Train.Station].GetStopIndex(Train.NumberOfCars);
 							if (s >= 0)
 							{
-								double dist = Program.CurrentRoute.Stations[Train.Station].Stops[s].TrackPosition - tp;
+								double dist = Program.CurrentRoute.Stations[Train.Station].Stops[s].TrackPosition - Train.FrontCarTrackPosition;
 								if (dist > 0.0)
 								{
 									if (dist < 25.0)
@@ -777,7 +483,7 @@ namespace OpenBve
 									{
 										dist -= 5.0;
 									}
-									var edec = spd * spd / (2.0 * dist);
+									var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
 									if (edec > dec) dec = edec;
 								}
 								else
@@ -876,7 +582,7 @@ namespace OpenBve
 						double acclim;
 						if (!double.IsInfinity(lim))
 						{
-							double d = lim - spd;
+							double d = lim - Train.CurrentSpeed;
 							if (d > 0.0)
 							{
 								acclim = 0.1 / (0.1 * d + 1.0) - 0.12;
@@ -890,7 +596,7 @@ namespace OpenBve
 						{
 							acclim = -1.0;
 						}
-						if (spd < powerstart)
+						if (Train.CurrentSpeed < powerstart)
 						{
 							// power start (under-speed)
 							if (Train.Handles.Brake.Driver == 0)
@@ -912,11 +618,11 @@ namespace OpenBve
 							else
 							{
 								double p = (double)Train.Handles.Power.Driver / (double)Train.Handles.Power.MaximumNotch;
-								CurrentInterval = 0.3 + 15.0 * p / (powerstart - spd + 1.0);
+								CurrentInterval = 0.3 + 15.0 * p / (powerstart - Train.CurrentSpeed + 1.0);
 							}
 							if (CurrentInterval > 1.3) CurrentInterval = 1.3;
 						}
-						else if (spd > powerend)
+						else if (Train.CurrentSpeed > powerend)
 						{
 							// power end (over-speed)
 							if (Train.Handles.Power.Driver > 0)
@@ -1004,6 +710,649 @@ namespace OpenBve
 						wiperTimer = 5.0;
 					}
 
+				}
+			}
+
+
+			private void LookAheadForwards()
+			{
+				double lookahead = (Train.Station >= 0 ? 150.0 : 50.0) + (Train.CurrentSpeed * Train.CurrentSpeed) / (2.0 * decelerationCruise);
+				double stopDistance = double.MaxValue;
+				{
+					// next station stop
+					int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
+					int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
+					for (int i = te; i < Program.CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
+					{
+						double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+						if (Train.FrontCarTrackPosition + lookahead <= stp) break;
+						for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
+						{
+							if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+								{
+									int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+									if (s >= 0)
+									{
+										double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - Train.FrontCarTrackPosition;
+										if (dist > 0.0 & dist < stopDistance)
+										{
+											stopDistance = dist;
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					// events
+					int te = Train.Cars[0].FrontAxle.Follower.LastTrackElement;
+					int currentTrack = Train.Cars[0].FrontAxle.Follower.TrackIndex;
+					for (int i = te; i < Program.CurrentRoute.Tracks[currentTrack].Elements.Length; i++)
+					{
+						double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+						if (Train.FrontCarTrackPosition + lookahead <= stp) break;
+						for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
+						{
+							if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is LimitChangeEvent)
+							{
+								// speed limit
+								LimitChangeEvent e = (LimitChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (e.NextSpeedLimit < Train.CurrentSpeed)
+								{
+									double dist = stp + e.TrackPositionDelta - Train.FrontCarTrackPosition;
+									double edec = (Train.CurrentSpeed * Train.CurrentSpeed - e.NextSpeedLimit * e.NextSpeedLimit * this.CurrentSpeedFactor) / (2.0 * dist);
+									if (edec > dec) dec = edec;
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is SectionChangeEvent)
+							{
+								// section
+								SectionChangeEvent e = (SectionChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (stp + e.TrackPositionDelta > Train.FrontCarTrackPosition)
+								{
+									if (!Program.CurrentRoute.Sections[e.NextSectionIndex].Invisible & Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect >= 0)
+									{
+										double elim = Program.CurrentRoute.Sections[e.NextSectionIndex].Aspects[Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect].Speed * this.CurrentSpeedFactor;
+										if (elim < Train.CurrentSpeed | Train.CurrentSpeed <= 0.0)
+										{
+											double dist = stp + e.TrackPositionDelta - Train.FrontCarTrackPosition;
+											double edec;
+											if (elim == 0.0)
+											{
+												double redstopdist;
+												if (Train.Station >= 0 & Train.StationState == TrainStopState.Completed & dist < 120.0)
+												{
+													dist = 1.0;
+													redstopdist = 25.0;
+												}
+												else if (Train.Station >= 0 & Train.StationState == TrainStopState.Pending | stopDistance < dist)
+												{
+													redstopdist = 1.0;
+												}
+												else if (Train.CurrentSpeed > 9.72222222222222)
+												{
+													redstopdist = 55.0;
+												}
+												else
+												{
+													redstopdist = 35.0;
+												}
+
+												if (dist > redstopdist)
+												{
+													edec = (Train.CurrentSpeed * Train.CurrentSpeed) / (2.0 * (dist - redstopdist));
+												}
+												else
+												{
+													edec = BrakeDeceleration;
+												}
+
+												if (dist < 100.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+											}
+											else
+											{
+												if (dist >= 1.0)
+												{
+													edec = (Train.CurrentSpeed * Train.CurrentSpeed - elim * elim) / (2.0 * dist);
+												}
+												else
+												{
+													edec = 0.0;
+												}
+											}
+
+											if (edec > dec) dec = edec;
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								// station start
+								if (Train.Station == -1)
+								{
+									StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - Train.FrontCarTrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+												if (edec > dec) dec = edec;
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.Decelerate)
+							{
+								// Brakes the train when passing through a request stop, which is not to be passed at linespeed
+								if (Train.Station == -1)
+								{
+									StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - Train.FrontCarTrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												if (dist > 25)
+												{
+													var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+													if (edec > dec) dec = edec;
+												}
+
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationEndEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								// station end
+								if (Train.Station == -1)
+								{
+									StationEndEvent e = (StationEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition - Train.FrontCarTrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+												if (edec > dec) dec = edec;
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackEndEvent)
+							{
+								// track end
+								if (Train.IsPlayerTrain)
+								{
+									TrackEndEvent e = (TrackEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									double dist = stp + e.TrackPositionDelta - Train.FrontCarTrackPosition;
+									double edec;
+									if (dist >= 15.0)
+									{
+										edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+									}
+									else
+									{
+										edec = BrakeDeceleration;
+									}
+
+									if (edec > dec) dec = edec;
+								}
+							}
+						}
+					}
+				}
+				// buffers ahead
+				if (Train.IsPlayerTrain)
+				{
+					for (int i = 0; i < Program.CurrentRoute.BufferTrackPositions.Length; i++)
+					{
+						double dist = Program.CurrentRoute.BufferTrackPositions[i] - Train.FrontCarTrackPosition;
+						if (dist > 0.0)
+						{
+							double edec;
+							if (dist >= 10.0)
+							{
+								edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+							}
+							else if (dist >= 5.0)
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								this.CurrentInterval = 0.1;
+								return;
+							}
+							else
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								Train.Handles.EmergencyBrake.Apply();
+								this.CurrentInterval = 10.0;
+								return;
+							}
+
+							if (edec > dec) dec = edec;
+						}
+					}
+				}
+
+				// trains ahead
+				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				{
+					if (Program.TrainManager.Trains[i] != Train && Program.TrainManager.Trains[i].State == TrainState.Available)
+					{
+						double pos =
+							Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Follower.TrackPosition -
+							Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Position -
+							0.5 * Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].Length;
+						double dist = pos - Train.FrontCarTrackPosition;
+						if (dist > -10.0 & dist < lookahead)
+						{
+							const double minDistance = 10.0;
+							const double maxDistance = 100.0;
+							double edec;
+							if (dist > minDistance)
+							{
+								double shift = 0.75 * minDistance + 1.0 * Train.CurrentSpeed;
+								edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * (dist - shift));
+							}
+							else if (dist > 0.5 * minDistance)
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								this.CurrentInterval = 0.1;
+								return;
+							}
+							else
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								Train.Handles.EmergencyBrake.Apply();
+								this.CurrentInterval = 1.0;
+								return;
+							}
+
+							if (dist < maxDistance)
+							{
+								reduceDecelerationCruiseAndStart = true;
+							}
+
+							if (edec > dec) dec = edec;
+						}
+					}
+				}
+			}
+
+			private void LookAheadBackwards()
+			{
+				double lookahead = (Train.Station >= 0 ? 150.0 : 50.0) + (Train.CurrentSpeed * Train.CurrentSpeed) / (2.0 * decelerationCruise);
+				double stopDistance = double.MaxValue;
+				{
+					// next station stop
+					int te = Train.Cars[Train.Cars.Length - 1].FrontAxle.Follower.LastTrackElement;
+					int currentTrack = Train.Cars[Train.Cars.Length - 1].FrontAxle.Follower.TrackIndex;
+					for (int i = te; i > 0; i--)
+					{
+						double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+						if (Train.FrontCarTrackPosition + lookahead <= stp) break;
+						for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
+						{
+							if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+								{
+									int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+									if (s >= 0)
+									{
+										double dist = Train.FrontCarTrackPosition - Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition;
+										if (dist > 0.0 & dist < stopDistance)
+										{
+											stopDistance = dist;
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				{
+					// events
+					int te = Train.Cars[Train.Cars.Length - 1].FrontAxle.Follower.LastTrackElement;
+					int currentTrack = Train.Cars[Train.Cars.Length - 1].FrontAxle.Follower.TrackIndex;
+					for (int i = te; i > 0; i--)
+					{
+						double stp = Program.CurrentRoute.Tracks[currentTrack].Elements[i].StartingTrackPosition;
+						if (Train.FrontCarTrackPosition + lookahead <= stp) break;
+						for (int j = 0; j < Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events.Length; j++)
+						{
+							if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is LimitChangeEvent)
+							{
+								// speed limit
+								LimitChangeEvent e = (LimitChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (e.NextSpeedLimit < Train.CurrentSpeed)
+								{
+									double dist = stp + Train.FrontCarTrackPosition - e.TrackPositionDelta;
+									double edec = (Train.CurrentSpeed * Train.CurrentSpeed - e.NextSpeedLimit * e.NextSpeedLimit * this.CurrentSpeedFactor) / (2.0 * dist);
+									if (edec > dec) dec = edec;
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is SectionChangeEvent)
+							{
+								// section
+								SectionChangeEvent e = (SectionChangeEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+								if (stp + Train.FrontCarTrackPosition > e.TrackPositionDelta)
+								{
+									if (!Program.CurrentRoute.Sections[e.NextSectionIndex].Invisible & Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect >= 0)
+									{
+										double elim = Program.CurrentRoute.Sections[e.NextSectionIndex].Aspects[Program.CurrentRoute.Sections[e.NextSectionIndex].CurrentAspect].Speed * this.CurrentSpeedFactor;
+										if (elim < Train.CurrentSpeed | Train.CurrentSpeed <= 0.0)
+										{
+											double dist = stp + Train.FrontCarTrackPosition - e.TrackPositionDelta;
+											double edec;
+											if (elim == 0.0)
+											{
+												double redstopdist;
+												if (Train.Station >= 0 & Train.StationState == TrainStopState.Completed & dist < 120.0)
+												{
+													dist = 1.0;
+													redstopdist = 25.0;
+												}
+												else if (Train.Station >= 0 & Train.StationState == TrainStopState.Pending | stopDistance < dist)
+												{
+													redstopdist = 1.0;
+												}
+												else if (Train.CurrentSpeed > 9.72222222222222)
+												{
+													redstopdist = 55.0;
+												}
+												else
+												{
+													redstopdist = 35.0;
+												}
+
+												if (dist > redstopdist)
+												{
+													edec = (Train.CurrentSpeed * Train.CurrentSpeed) / (2.0 * (dist - redstopdist));
+												}
+												else
+												{
+													edec = BrakeDeceleration;
+												}
+
+												if (dist < 100.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+											}
+											else
+											{
+												if (dist >= 1.0)
+												{
+													edec = (Train.CurrentSpeed * Train.CurrentSpeed - elim * elim) / (2.0 * dist);
+												}
+												else
+												{
+													edec = 0.0;
+												}
+											}
+
+											if (edec > dec) dec = edec;
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								// station start
+								if (Train.Station == -1)
+								{
+									StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Train.FrontCarTrackPosition - Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+												if (edec > dec) dec = edec;
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationStartEvent && Train.NextStopSkipped == StopSkipMode.Decelerate)
+							{
+								// Brakes the train when passing through a request stop, which is not to be passed at linespeed
+								if (Train.Station == -1)
+								{
+									StationStartEvent e = (StationStartEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Train.FrontCarTrackPosition - Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												if (dist > 25)
+												{
+													var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+													if (edec > dec) dec = edec;
+												}
+
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is StationEndEvent && Train.NextStopSkipped == StopSkipMode.None)
+							{
+								// station end
+								if (Train.Station == -1)
+								{
+									StationEndEvent e = (StationEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									if (Program.CurrentRoute.Stations[e.StationIndex].StopsHere(Train) & Train.LastStation != e.StationIndex)
+									{
+										int s = Program.CurrentRoute.Stations[e.StationIndex].GetStopIndex(Train.NumberOfCars);
+										if (s >= 0)
+										{
+											double dist = Train.FrontCarTrackPosition - Program.CurrentRoute.Stations[e.StationIndex].Stops[s].TrackPosition;
+											if (dist > -Program.CurrentRoute.Stations[e.StationIndex].Stops[s].ForwardTolerance)
+											{
+												if (dist < 25.0)
+												{
+													reduceDecelerationCruiseAndStart = true;
+												}
+												else if (this.CurrentSpeedFactor < 1.0)
+												{
+													dist -= 5.0;
+												}
+
+												var edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+												if (edec > dec) dec = edec;
+											}
+										}
+									}
+								}
+							}
+							else if (Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j] is TrackEndEvent)
+							{
+								// track end
+								if (Train.IsPlayerTrain)
+								{
+									TrackEndEvent e = (TrackEndEvent)Program.CurrentRoute.Tracks[currentTrack].Elements[i].Events[j];
+									double dist = stp + Train.FrontCarTrackPosition - e.TrackPositionDelta;
+									double edec;
+									if (dist >= 15.0)
+									{
+										edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+									}
+									else
+									{
+										edec = BrakeDeceleration;
+									}
+
+									if (edec > dec) dec = edec;
+								}
+							}
+						}
+					}
+				}
+				// buffers ahead
+				if (Train.IsPlayerTrain)
+				{
+					for (int i = 0; i < Program.CurrentRoute.BufferTrackPositions.Length; i++)
+					{
+						double dist = Train.FrontCarTrackPosition - Program.CurrentRoute.BufferTrackPositions[i];
+						if (dist > 0.0)
+						{
+							double edec;
+							if (dist >= 10.0)
+							{
+								edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * dist);
+							}
+							else if (dist >= 5.0)
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								this.CurrentInterval = 0.1;
+								return;
+							}
+							else
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								Train.Handles.EmergencyBrake.Apply();
+								this.CurrentInterval = 10.0;
+								return;
+							}
+
+							if (edec > dec) dec = edec;
+						}
+					}
+				}
+
+				// trains ahead
+				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				{
+					if (Program.TrainManager.Trains[i] != Train && Program.TrainManager.Trains[i].State == TrainState.Available)
+					{
+						double pos =
+							Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Follower.TrackPosition -
+							Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].RearAxle.Position -
+							0.5 * Program.TrainManager.Trains[i].Cars[Program.TrainManager.Trains[i].Cars.Length - 1].Length;
+						double dist = Train.FrontCarTrackPosition - pos;
+						if (dist > -10.0 & dist < lookahead)
+						{
+							const double minDistance = 10.0;
+							const double maxDistance = 100.0;
+							double edec;
+							if (dist > minDistance)
+							{
+								double shift = 0.75 * minDistance + 1.0 * Train.CurrentSpeed;
+								edec = Train.CurrentSpeed * Train.CurrentSpeed / (2.0 * (dist - shift));
+							}
+							else if (dist > 0.5 * minDistance)
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								this.CurrentInterval = 0.1;
+								return;
+							}
+							else
+							{
+								Train.Handles.Brake.ApplyState(1, true);
+								Train.Handles.Power.ApplyState(-1, true);
+								Train.Handles.Brake.ApplyState(AirBrakeHandleState.Service);
+								Train.Handles.EmergencyBrake.Apply();
+								this.CurrentInterval = 1.0;
+								return;
+							}
+
+							if (dist < maxDistance)
+							{
+								reduceDecelerationCruiseAndStart = true;
+							}
+
+							if (edec > dec) dec = edec;
+						}
+					}
 				}
 			}
 

--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -1,5 +1,6 @@
 using System;
 using OpenBveApi.Interface;
+using OpenBveApi.Routes;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
 using RouteManager2.Events;
@@ -454,7 +455,7 @@ namespace OpenBve
 					}
 					reduceDecelerationCruiseAndStart = false;
 					// look ahead
-					if (Program.CurrentRoute.ReverseDirection)
+					if (Train.CurrentDirection == TrackDirection.Reverse)
 					{
 						LookAheadBackwards();
 					}

--- a/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
+++ b/source/OpenBVE/Game/ObjectManager/AnimatedObjects/FunctionScripts.cs
@@ -433,8 +433,8 @@ namespace OpenBve {
 						break;
 					case Instructions.TrainTrackDistance:
 						if (Train != null) {
-							double t0 = Train.FrontCarTrackPosition();
-							double t1 = Train.RearCarTrackPosition();
+							double t0 = Train.FrontCarTrackPosition;
+							double t1 = Train.RearCarTrackPosition;
 							Function.Stack[s] = TrackPosition > t0 ? TrackPosition - t0 : TrackPosition < t1 ? TrackPosition - t1 : 0.0;
 						} else {
 							Function.Stack[s] = 0.0;
@@ -1219,7 +1219,7 @@ namespace OpenBve {
 								stationIdx = Train.LastStation;
 							}
 							int n = Program.CurrentRoute.Stations[stationIdx].GetStopIndex(Train.NumberOfCars);
-							double p0 = Train.FrontCarTrackPosition();
+							double p0 = Train.FrontCarTrackPosition;
 							double p1;
 							if (Program.CurrentRoute.Stations[stationIdx].Stops.Length > 0)
 							{
@@ -1257,7 +1257,7 @@ namespace OpenBve {
 							}
 							
 							int n = Program.CurrentRoute.Stations[stationIdx].GetStopIndex(Train.NumberOfCars);
-							double p0 = Train.FrontCarTrackPosition();
+							double p0 = Train.FrontCarTrackPosition;
 							double p1;
 							if (Program.CurrentRoute.Stations[stationIdx].Stops.Length > 0)
 							{
@@ -1307,7 +1307,7 @@ namespace OpenBve {
 							else
 							{
 								int n = Program.CurrentRoute.Stations[stationIdx].GetStopIndex(Train.NumberOfCars);
-								double p0 = Train.FrontCarTrackPosition();
+								double p0 = Train.FrontCarTrackPosition;
 								double p1;
 								if (Program.CurrentRoute.Stations[stationIdx].Stops.Length > 0)
 								{

--- a/source/OpenBVE/Game/RouteInfoOverlay.cs
+++ b/source/OpenBVE/Game/RouteInfoOverlay.cs
@@ -101,7 +101,7 @@ namespace OpenBve
 			case state.gradient:
 				Program.Renderer.Rectangle.Draw(gradientImage, origin, gradientSize);
 				// get current train position in track
-				int trackPos	= (int)(TrainManager.PlayerTrain.FrontCarTrackPosition());
+				int trackPos	= (int)(TrainManager.PlayerTrain.FrontCarTrackPosition);
 				// convert to gradient profile offset
 				xPos = gradientSize.Y * (trackPos - Program.CurrentRoute.Information.GradientMinTrack) /
 						(Program.CurrentRoute.Information.GradientMaxTrack - Program.CurrentRoute.Information.GradientMinTrack);

--- a/source/OpenBVE/Game/TrainManager.cs
+++ b/source/OpenBVE/Game/TrainManager.cs
@@ -41,14 +41,14 @@ namespace OpenBve
 					// with other trains
 					if (Trains[i].State == TrainState.Available)
 					{
-						double a = Trains[i].FrontCarTrackPosition();
-						double b = Trains[i].RearCarTrackPosition();
+						double a = Trains[i].FrontCarTrackPosition;
+						double b = Trains[i].RearCarTrackPosition;
 						for (int j = i + 1; j < Trains.Length; j++)
 						{
 							if (Trains[j].State == TrainState.Available)
 							{
-								double c = Trains[j].FrontCarTrackPosition();
-								double d = Trains[j].RearCarTrackPosition();
+								double c = Trains[j].FrontCarTrackPosition;
+								double d = Trains[j].RearCarTrackPosition;
 								if (a > d & b < c)
 								{
 									if (a > c)

--- a/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
@@ -165,7 +165,7 @@ namespace OpenBve.Graphics.Renderers
 				"speed: " + (Math.Abs(TrainManager.PlayerTrain.CurrentSpeed) * 3.6).ToString("0.00", Culture) + " km/h",
 				"power (car " + car.ToString(Culture) +  "): " + (TrainManager.PlayerTrain.Cars[car].Specs.MotorAcceleration < 0.0 ? TrainManager.PlayerTrain.Cars[car].Specs.MotorAcceleration * Math.Sign(TrainManager.PlayerTrain.Cars[car].CurrentSpeed) : TrainManager.PlayerTrain.Cars[car].Specs.MotorAcceleration * (double)TrainManager.PlayerTrain.Handles.Reverser.Actual).ToString("0.0000", Culture) + " m/s²",
 				"acceleration: " + TrainManager.PlayerTrain.Specs.CurrentAverageAcceleration.ToString("0.0000", Culture) + " m/s²",
-				"position: " + TrainManager.PlayerTrain.FrontCarTrackPosition().ToString("0.00", Culture) + " m",
+				"position: " + TrainManager.PlayerTrain.FrontCarTrackPosition.ToString("0.00", Culture) + " m",
 				"rain intensity: " + rainIntensity,
 				"elevation: " + (Program.CurrentRoute.Atmosphere.InitialElevation + TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].FrontAxle.Follower.WorldPosition.Y).ToString("0.00", Culture) + " m",
 				"temperature: " + (airTemperature - 273.15).ToString("0.00", Culture) + " °C",

--- a/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
@@ -50,7 +50,7 @@ namespace OpenBve.Graphics.Renderers
 			// safety handles
 			{
 				string t = "safety: ";
-				if (Program.CurrentRoute.ReverseDirection)
+				if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 				{
 					t += (TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Reverse ? "F" : TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Forwards ? "B" : "N");
 				}
@@ -89,7 +89,7 @@ namespace OpenBve.Graphics.Renderers
 			// driver handles
 			{
 				string t = "driver: ";
-				if (Program.CurrentRoute.ReverseDirection)
+				if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 				{
 					t += (TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Reverse ? "F" : TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Forwards ? "B" : "N");
 				}

--- a/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.Debug.cs
@@ -49,7 +49,15 @@ namespace OpenBve.Graphics.Renderers
 			}
 			// safety handles
 			{
-				string t = "safety: " + (TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Reverse ? "B" : TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Forwards ? "F" : "N");
+				string t = "safety: ";
+				if (Program.CurrentRoute.ReverseDirection)
+				{
+					t += (TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Reverse ? "F" : TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Forwards ? "B" : "N");
+				}
+				else
+				{
+					t += (TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Reverse ? "B" : TrainManager.PlayerTrain.Handles.Reverser.Actual == ReverserPosition.Forwards ? "F" : "N");
+				}
 				if (TrainManager.PlayerTrain.Handles.HandleType == HandleType.SingleHandle)
 				{
 					t += " - " + (TrainManager.PlayerTrain.Handles.EmergencyBrake.Safety ? "EMG" : TrainManager.PlayerTrain.Handles.Brake.Safety != 0 ? "B" + TrainManager.PlayerTrain.Handles.Brake.Safety.ToString(Culture) : TrainManager.PlayerTrain.Handles.HoldBrake.Actual ? "HLD" : TrainManager.PlayerTrain.Handles.Power.Safety != 0 ? "P" + TrainManager.PlayerTrain.Handles.Power.Safety.ToString(Culture) : "N");
@@ -80,7 +88,16 @@ namespace OpenBve.Graphics.Renderers
 			}
 			// driver handles
 			{
-				string t = "driver: " + (TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Reverse ? "B" : TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Forwards ? "F" : "N");
+				string t = "driver: ";
+				if (Program.CurrentRoute.ReverseDirection)
+				{
+					t += (TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Reverse ? "F" : TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Forwards ? "B" : "N");
+				}
+				else
+				{
+					t += (TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Reverse ? "B" : TrainManager.PlayerTrain.Handles.Reverser.Driver == ReverserPosition.Forwards ? "F" : "N");
+				}
+					
 				if (TrainManager.PlayerTrain.Handles.HandleType == HandleType.SingleHandle)
 				{
 					t += " - " + (TrainManager.PlayerTrain.Handles.EmergencyBrake.Driver ? "EMG" : TrainManager.PlayerTrain.Handles.Brake.Driver != 0 ? "B" + TrainManager.PlayerTrain.Handles.Brake.Driver.ToString(Culture) : TrainManager.PlayerTrain.Handles.HoldBrake.Driver ? "HLD" : TrainManager.PlayerTrain.Handles.Power.Driver != 0 ? "P" + TrainManager.PlayerTrain.Handles.Power.Driver.ToString(Culture) : "N");

--- a/source/OpenBVE/Graphics/Renderers/Overlays.HUD.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.HUD.cs
@@ -384,7 +384,7 @@ namespace OpenBve.Graphics.Renderers
 					if (!Program.CurrentRoute.Stations[stationIndex].PlayerStops())
 					{
 						int n = Program.CurrentRoute.Stations[stationIndex].GetStopIndex(PlayerTrain.NumberOfCars);
-						double p0 = PlayerTrain.FrontCarTrackPosition();
+						double p0 = PlayerTrain.FrontCarTrackPosition;
 						double p1 = Program.CurrentRoute.Stations[stationIndex].Stops.Length > 0 ? Program.CurrentRoute.Stations[stationIndex].Stops[n].TrackPosition : Program.CurrentRoute.Stations[stationIndex].DefaultTrackPosition;
 						double m = p1 - p0;
 						if (m < 0)
@@ -422,7 +422,7 @@ namespace OpenBve.Graphics.Renderers
 					if (!Program.CurrentRoute.Stations[stationIndex].PlayerStops())
 					{
 						
-						double p0 = PlayerTrain.FrontCarTrackPosition();
+						double p0 = PlayerTrain.FrontCarTrackPosition;
 						double p1 = 0.0;
 						for (int i = stationIndex; i < Program.CurrentRoute.Stations.Length; i++)
 						{
@@ -460,7 +460,7 @@ namespace OpenBve.Graphics.Renderers
 					else
 					{
 						int n = Program.CurrentRoute.Stations[stationIndex].GetStopIndex(PlayerTrain.NumberOfCars);
-						double p0 = PlayerTrain.FrontCarTrackPosition();
+						double p0 = PlayerTrain.FrontCarTrackPosition;
 						double p1 = Program.CurrentRoute.Stations[stationIndex].Stops.Length > 0 ? Program.CurrentRoute.Stations[stationIndex].Stops[n].TrackPosition : Program.CurrentRoute.Stations[stationIndex].DefaultTrackPosition;
 						double m = p1 - p0;
 						if (renderer.OptionDistanceToNextStation == NewRenderer.DistanceToNextStationDisplayMode.Km)

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -746,7 +746,7 @@ namespace OpenBve
 			{
 				if (Program.CurrentRoute.ReverseDirection)
 				{
-					Program.TrainManager.Trains[i].Reverse();
+					Program.TrainManager.Trains[i].Reverse(true, true);
 				}
 				double p;
 				if (Program.TrainManager.Trains[i].IsPlayerTrain)
@@ -909,6 +909,10 @@ namespace OpenBve
 			RenderTimeElapsed = 0.0;
 			World.InitializeCameraRestriction();
 			Loading.SimulationSetup = true;
+			if (Program.CurrentRoute.ReverseDirection)
+			{
+				Program.Renderer.Camera.Alignment.Yaw = 180 / 57.2957795130824;
+			}
 			switch (Interface.CurrentOptions.InitialViewpoint)
 			{
 				case 0:

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -570,32 +570,9 @@ namespace OpenBve
 			// starting time and track position
 			Program.CurrentRoute.SecondsSinceMidnight = 0.0;
 			Game.StartupTime = 0.0;
-			int PlayerFirstStationIndex = -1;
+			int PlayerFirstStationIndex = Program.CurrentRoute.PlayerFirstStationIndex;
 			double PlayerFirstStationPosition;
-			int os = -1;
-			bool f = false;
-			for (int i = 0; i < Program.CurrentRoute.Stations.Length; i++)
-			{
-				if (!String.IsNullOrEmpty(Program.CurrentRoute.InitialStationName))
-				{
-					if (Program.CurrentRoute.InitialStationName.ToLowerInvariant() == Program.CurrentRoute.Stations[i].Name.ToLowerInvariant())
-					{
-						PlayerFirstStationIndex = i;
-					}
-				}
-				if (Program.CurrentRoute.Stations[i].StopMode == StationStopMode.AllStop | Program.CurrentRoute.Stations[i].StopMode == StationStopMode.PlayerStop & Program.CurrentRoute.Stations[i].Stops.Length != 0)
-				{
-					if (f == false)
-					{
-						os = i;
-						f = true;
-					}
-				}
-			}
-			if (PlayerFirstStationIndex == -1)
-			{
-				PlayerFirstStationIndex = os == -1 ? 0 : os;
-			}
+			
 			{
 				int s = Program.CurrentRoute.Stations[PlayerFirstStationIndex].GetStopIndex(TrainManager.PlayerTrain.NumberOfCars);
 				if (s >= 0)
@@ -767,6 +744,10 @@ namespace OpenBve
 			// move train in position
 			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
 			{
+				if (Program.CurrentRoute.ReverseDirection)
+				{
+					Program.TrainManager.Trains[i].Reverse();
+				}
 				double p;
 				if (Program.TrainManager.Trains[i].IsPlayerTrain)
 				{

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -794,8 +794,18 @@ namespace OpenBve
 			TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].UpdateCamera();
 			Program.Renderer.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
 			Program.Renderer.UpdateVisibility(true);
-			Program.Renderer.Camera.SavedExterior = new CameraAlignment(new OpenBveApi.Math.Vector3(-2.5, 1.5, -15.0), 0.3, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
-			Program.Renderer.Camera.SavedTrack = new CameraAlignment(new OpenBveApi.Math.Vector3(-3.0, 2.5, 0.0), 0.3, 0.0, 0.0, TrainManager.PlayerTrain.Cars[0].TrackPosition - 10.0, 1.0);
+			if (Program.CurrentRoute.ReverseDirection)
+			{
+				double reverse = 180 / 57.2957795130824;
+				Program.Renderer.Camera.SavedExterior = new CameraAlignment(new OpenBveApi.Math.Vector3(2.5, 1.5, 15), 0.3 + reverse, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
+				Program.Renderer.Camera.SavedTrack = new CameraAlignment(new OpenBveApi.Math.Vector3(3.0, 2.5, 0.0), 0.3 + reverse, 0.0, 0.0, TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.Cars.Length - 1].TrackPosition, 1.0);
+			}
+			else
+			{
+				Program.Renderer.Camera.SavedExterior = new CameraAlignment(new OpenBveApi.Math.Vector3(-2.5, 1.5, -15.0), 0.3, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
+				Program.Renderer.Camera.SavedTrack = new CameraAlignment(new OpenBveApi.Math.Vector3(-3.0, 2.5, 0.0), 0.3, 0.0, 0.0, TrainManager.PlayerTrain.Cars[0].TrackPosition - 10.0, 1.0);
+			}
+			
 			// signalling sections
 			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
 			{

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -749,10 +749,6 @@ namespace OpenBve
 			// move train in position
 			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
 			{
-				if (Program.CurrentRoute.ReverseDirection)
-				{
-					Program.TrainManager.Trains[i].Reverse(true, true);
-				}
 				double p;
 				if (Program.TrainManager.Trains[i].IsPlayerTrain)
 				{
@@ -766,6 +762,17 @@ namespace OpenBve
 				else
 				{
 					p = OtherFirstStationPosition;
+				}
+				if (Program.CurrentRoute.ReverseDirection)
+				{
+					/*
+					 * Flip the train if running in reverse direction
+					 * We also need to add the length of the train so that the driver car is actually positioned on the platform
+					 *
+					 * Position on routes not specificially designed for reverse running may well be wrong, but that's life
+					 */
+					Program.TrainManager.Trains[i].Reverse(true, true);
+					p += Program.TrainManager.Trains[i].Length;
 				}
 				for (int j = 0; j < Program.TrainManager.Trains[i].Cars.Length; j++)
 				{

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -763,7 +763,7 @@ namespace OpenBve
 				{
 					p = OtherFirstStationPosition;
 				}
-				if (Program.CurrentRoute.ReverseDirection)
+				if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 				{
 					/*
 					 * Flip the train if running in reverse direction
@@ -794,7 +794,7 @@ namespace OpenBve
 			TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].UpdateCamera();
 			Program.Renderer.CameraTrackFollower.UpdateAbsolute(-1.0, true, false);
 			Program.Renderer.UpdateVisibility(true);
-			if (Program.CurrentRoute.ReverseDirection)
+			if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 			{
 				double reverse = 180 / 57.2957795130824;
 				Program.Renderer.Camera.SavedExterior = new CameraAlignment(new OpenBveApi.Math.Vector3(2.5, 1.5, 15), 0.3 + reverse, -0.2, 0.0, PlayerFirstStationPosition, 1.0);
@@ -931,7 +931,7 @@ namespace OpenBve
 			RenderTimeElapsed = 0.0;
 			World.InitializeCameraRestriction();
 			Loading.SimulationSetup = true;
-			if (Program.CurrentRoute.ReverseDirection)
+			if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 			{
 				Program.Renderer.Camera.Alignment.Yaw = 180 / 57.2957795130824;
 			}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -258,8 +258,13 @@ namespace OpenBve
 				TimeElapsed = RealTimeElapsed * (double)TimeFactor;
 				if (loadComplete && !firstFrame)
 				{
-					//Our current in-game time is equal to or greater than the startup time, but the first frame has not yet been processed
-					//Therefore, reset the timer to zero as time consuming texture loads may cause us to be late at the first station
+					/*
+					 * Our current in-game time is equal to or greater than the startup time, but the first frame has not yet been processed
+					 * Therefore, reset the timer to zero as time consuming texture loads may cause us to be late at the first station
+					 *
+					 * Also update the viewing distances in case of jumps etc.
+					 */
+					Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
 					RealTimeElapsed = 0.0;
 					TimeElapsed = 0.0;
 					firstFrame = true;

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -595,7 +595,7 @@ namespace OpenBve {
 						TrainBase train = Program.TrainManager.Trains[i];
 						int c = train.Cars.Length - 1;
 						double z = train.Cars[c].RearAxle.Follower.TrackPosition - train.Cars[c].RearAxle.Position - 0.5 * train.Cars[c].Length;
-						if (z >= baseTrain.FrontCarTrackPosition() & z < bestLocation)
+						if (z >= baseTrain.FrontCarTrackPosition & z < bestLocation)
 						{
 							bestLocation = z;
 							closestTrain = Program.TrainManager.Trains[i];

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -848,8 +848,17 @@ namespace OpenBve
 										break;
 									case Translations.Command.CameraExterior:
 										// camera: exterior
-										MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+										if (Program.CurrentRoute.ReverseDirection)
+										{
+											MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.Cars.Length - TrainManager.PlayerTrain.CameraCar), MessageDependency.CameraView, GameMode.Expert,
 												MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+										}
+										else
+										{
+											MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+												MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+										}
+										
 										SaveCameraSettings();
 										Program.Renderer.Camera.CurrentMode = CameraViewMode.Exterior;
 										RestoreCameraSettings();
@@ -916,12 +925,7 @@ namespace OpenBve
 										//If we are in the exterior train view, shift down one car until we hit the last car
 										if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior)
 										{
-											if (TrainManager.PlayerTrain.CameraCar < TrainManager.PlayerTrain.Cars.Length - 1)
-											{
-												TrainManager.PlayerTrain.CameraCar++;
-												MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
-												MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
-											}
+											TrainManager.PlayerTrain.ChangeCameraCar(false);
 											return;
 										}
 										//Otherwise, check if we can move down to the previous POI
@@ -962,12 +966,7 @@ namespace OpenBve
 										//If we are in the exterior train view, shift up one car until we hit index 0
 										if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior)
 										{
-											if (TrainManager.PlayerTrain.CameraCar > 0)
-											{
-												TrainManager.PlayerTrain.CameraCar--;
-												MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
-												MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
-											}
+											TrainManagerBase.PlayerTrain.ChangeCameraCar(true);
 											return;
 										}
 										//Otherwise, check if we can move up to the next POI
@@ -1013,7 +1012,7 @@ namespace OpenBve
 											Program.Renderer.Camera.Alignment.Position = new OpenBveApi.Math.Vector3(0.0, 0.0,
 												0.0);
 										}
-										Program.Renderer.Camera.Alignment.Yaw = 0.0;
+										Program.Renderer.Camera.Alignment.Yaw = Program.CurrentRoute.ReverseDirection ? 180 / 57.2957795130824 : 0;
 										Program.Renderer.Camera.Alignment.Pitch = 0.0;
 										Program.Renderer.Camera.Alignment.Roll = 0.0;
 										if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Track)

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -20,6 +20,7 @@ using TrainManager;
 using TrainManager.Handles;
 using TrainManager.Car;
 using TrainManager.Car.Systems;
+using OpenBveApi.Routes;
 
 namespace OpenBve
 {
@@ -848,7 +849,7 @@ namespace OpenBve
 										break;
 									case Translations.Command.CameraExterior:
 										// camera: exterior
-										if (Program.CurrentRoute.ReverseDirection)
+										if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 										{
 											MessageManager.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManager.PlayerTrain.Cars.Length - TrainManager.PlayerTrain.CameraCar), MessageDependency.CameraView, GameMode.Expert,
 												MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
@@ -1012,7 +1013,7 @@ namespace OpenBve
 											Program.Renderer.Camera.Alignment.Position = new OpenBveApi.Math.Vector3(0.0, 0.0,
 												0.0);
 										}
-										Program.Renderer.Camera.Alignment.Yaw = Program.CurrentRoute.ReverseDirection ? 180 / 57.2957795130824 : 0;
+										Program.Renderer.Camera.Alignment.Yaw = TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse ? 180 / 57.2957795130824 : 0;
 										Program.Renderer.Camera.Alignment.Pitch = 0.0;
 										Program.Renderer.Camera.Alignment.Roll = 0.0;
 										if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Track)

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -1864,21 +1864,21 @@ namespace OpenBve
 									Program.CurrentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
 									break;
 								case Translations.Command.AccessibilityNextSignal:
-									Section nextSection = TrainManagerBase.CurrentRoute.NextSection(TrainManagerBase.PlayerTrain.FrontCarTrackPosition());
+									Section nextSection = TrainManagerBase.CurrentRoute.NextSection(TrainManagerBase.PlayerTrain.FrontCarTrackPosition);
 									if (nextSection != null)
 									{
-										double tPos = nextSection.TrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition();
+										double tPos = nextSection.TrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition;
 										string st = Translations.GetInterfaceString("message_route_nextsection_aspect").Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[aspect]", nextSection.CurrentAspect.ToString());
 										Program.CurrentHost.AddMessage(st, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
 									}
 									break; 
 								case Translations.Command.AccessibilityNextStation:
-									RouteStation nextStation = TrainManagerBase.CurrentRoute.NextStation(TrainManagerBase.PlayerTrain.FrontCarTrackPosition());
+									RouteStation nextStation = TrainManagerBase.CurrentRoute.NextStation(TrainManagerBase.PlayerTrain.FrontCarTrackPosition);
 									if (nextStation != null)
 									{
 										//If we find an appropriate signal, and the distance to it is less than 500m, announce if screen reader is present
 										//Aspect announce to be triggered via a separate keybind
-										double tPos = nextStation.DefaultTrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition();
+										double tPos = nextStation.DefaultTrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition;
 										string stt = Translations.GetInterfaceString("message_route_nextstation").Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[name]", nextStation.Name);
 										Program.CurrentHost.AddMessage(stt, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
 										nextStation.AccessibilityAnnounced = true;

--- a/source/OpenBVE/System/Scripting.cs
+++ b/source/OpenBVE/System/Scripting.cs
@@ -215,8 +215,8 @@ namespace OpenBve
             public static double trackDistance(TrainBase Train, double TrackPosition)
             {
                 if (Train == null) return 0.0;
-                double t0 = Train.FrontCarTrackPosition();
-                double t1 = Train.RearCarTrackPosition();
+                double t0 = Train.FrontCarTrackPosition;
+                double t1 = Train.RearCarTrackPosition;
                 return TrackPosition > t0 ? TrackPosition - t0 : TrackPosition < t1 ? TrackPosition - t1 : 0.0;
             }
 

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Routes\RouteInterface.cs" />
     <Compile Include="Routes\StaticBackground.cs" />
     <Compile Include="Routes\Track.cs" />
+    <Compile Include="Routes\Track.Direction.cs" />
     <Compile Include="Routes\Track.TrackElement.cs" />
     <Compile Include="Routes\Track.TrackFollower.cs" />
     <Compile Include="Runtime\ElapseProxy.cs" />

--- a/source/OpenBveApi/Routes/Track.Direction.cs
+++ b/source/OpenBveApi/Routes/Track.Direction.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenBveApi.Routes
+{
+	/// <summary>The default direction of travel on a track</summary>
+	public enum TrackDirection
+	{
+		/// <summary>The track position counts downwards towards zero</summary>
+		Reverse = -1,
+		/// <summary>Unknown</summary>
+		Unknown = 0,
+		/// <summary>The track position counts up from zero</summary>
+		Forwards = 1
+	}
+}

--- a/source/OpenBveApi/Routes/Track.cs
+++ b/source/OpenBveApi/Routes/Track.cs
@@ -13,6 +13,9 @@ namespace OpenBveApi.Routes
 		/// <summary>The rail gauge for this track</summary>
 		public double RailGauge = 1.435;
 
+		/// <summary>The default direction of travel on this track</summary>
+		public TrackDirection Direction;
+
 		/// <summary>Gets the innacuracy (Gauge spread and track bounce) for a given track position and routefile innacuracy value</summary>
 		/// <param name="position">The track position</param>
 		/// <param name="inaccuracy">The openBVE innacuaracy value</param>
@@ -114,7 +117,7 @@ namespace OpenBveApi.Routes
 				{
 					int q = i / subdivisions;
 					
-					double r = (double) m / (double) subdivisions;
+					double r = m / (double) subdivisions;
 					double p = (1.0 - r) * Elements[q].StartingTrackPosition + r * Elements[q + 1].StartingTrackPosition;
 					follower.UpdateAbsolute(-1.0, true, false);
 					follower.UpdateAbsolute(p, true, false);
@@ -254,10 +257,10 @@ namespace OpenBveApi.Routes
 							double bestT = d.NormSquared();
 							int bestJ = 0;
 							int n = 1000;
-							double a = 1.0 / (double) n * (Elements[i + 1].StartingTrackPosition - Elements[i].StartingTrackPosition);
+							double a = 1.0 / n * (Elements[i + 1].StartingTrackPosition - Elements[i].StartingTrackPosition);
 							for (int j = 1; j < n - 1; j++)
 							{
-								follower.UpdateAbsolute(Elements[i + 1].StartingTrackPosition - (double) j * a, true, false);
+								follower.UpdateAbsolute(Elements[i + 1].StartingTrackPosition - j * a, true, false);
 								d = Elements[i + 1].WorldPosition - follower.WorldPosition;
 								double t = d.NormSquared();
 								if (t < bestT)
@@ -271,7 +274,7 @@ namespace OpenBveApi.Routes
 								}
 							}
 
-							double s = (double) bestJ * a;
+							double s = bestJ * a;
 							for (int j = i + 1; j < Elements.Length; j++)
 							{
 								Elements[j].StartingTrackPosition -= s;
@@ -311,7 +314,7 @@ namespace OpenBveApi.Routes
 								bestJ = 0;
 								for (int j = -1; j <= 1; j++)
 								{
-									double g = (double) j * originalAngle;
+									double g = j * originalAngle;
 									Elements[i] = originalTrackElement;
 									Elements[i].WorldDirection.Rotate(Vector3.Down, g);
 									Elements[i].WorldUp.Rotate(Vector3.Down, g);
@@ -329,7 +332,7 @@ namespace OpenBveApi.Routes
 								}
 
 								{
-									double newAngle = (double) bestJ * originalAngle;
+									double newAngle = bestJ * originalAngle;
 									Elements[i] = originalTrackElement;
 									Elements[i].WorldDirection.Rotate(Vector3.Down, newAngle);
 									Elements[i].WorldUp.Rotate(Vector3.Down, newAngle);
@@ -343,10 +346,10 @@ namespace OpenBveApi.Routes
 								bestT = d.NormSquared();
 								bestJ = 0;
 								n = 1000;
-								a = 1.0 / (double) n * (Elements[i + 1].StartingTrackPosition - Elements[i].StartingTrackPosition);
+								a = 1.0 / n * (Elements[i + 1].StartingTrackPosition - Elements[i].StartingTrackPosition);
 								for (int j = 1; j < n - 1; j++)
 								{
-									follower.UpdateAbsolute(Elements[i + 1].StartingTrackPosition - (double) j * a, true, false);
+									follower.UpdateAbsolute(Elements[i + 1].StartingTrackPosition - j * a, true, false);
 									d = Elements[i + 1].WorldPosition - follower.WorldPosition;
 									double t = d.NormSquared();
 									if (t < bestT)
@@ -360,7 +363,7 @@ namespace OpenBveApi.Routes
 									}
 								}
 
-								s = (double) bestJ * a;
+								s = bestJ * a;
 								for (int j = i + 1; j < Elements.Length; j++)
 								{
 									Elements[j].StartingTrackPosition -= s;

--- a/source/OpenBveApi/Train/AbstractCar.cs
+++ b/source/OpenBveApi/Train/AbstractCar.cs
@@ -75,7 +75,7 @@ namespace OpenBveApi.Trains
 		}
 
 		/// <summary>Call this method to reverse (flip) the car</summary>
-		public virtual void Reverse()
+		public virtual void Reverse(bool flipInterior = false)
 		{
 
 		}

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -37,11 +37,12 @@
 		public double TimetableDelta;
 		/// <summary>A string storing the absolute on-disk path to the current train folder</summary>
 		public string TrainFolder;
-		/// <summary>Gets the track position of the front car</summary>
-		public abstract double FrontCarTrackPosition();
 
+		/// <summary>Gets the track position of the front car</summary>
+		public virtual double FrontCarTrackPosition => 0;
+		
 		/// <summary>Gets the track position of the rear car</summary>
-		public abstract double RearCarTrackPosition();
+		public virtual double RearCarTrackPosition => 0;
 
 		/// <summary>Returns true if this is the player driven train</summary>
 		/// <remarks>NOTE: An abstract train in and of itself cannot be the player train</remarks>

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -1,6 +1,4 @@
-﻿using OpenBveApi.Routes;
-
-namespace OpenBveApi.Trains
+﻿namespace OpenBveApi.Trains
 {
 	/// <summary>An abstract train</summary>
 	public abstract class AbstractTrain
@@ -88,7 +86,7 @@ namespace OpenBveApi.Trains
 		}
 
 		/// <summary>Call this method to reverse (flip) the entire train</summary>
-		public virtual void Reverse()
+		public virtual void Reverse(bool FlipInterior = false, bool FlipDriver = false)
 		{
 
 		}

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -417,7 +417,7 @@ namespace CsvRwRouteParser
 					int s = Data.Blocks[i].Station;
 					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
 					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
-					if (CurrentRoute.ReverseDirection)
+					if (CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse)
 					{
 						CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationEndEvent(Plugin.CurrentHost, Plugin.CurrentRoute, 0.0, s);
 					}
@@ -950,7 +950,7 @@ namespace CsvRwRouteParser
 						double d = p - (k + Data.FirstUsedBlock) * Data.BlockInterval;
 						int m = CurrentRoute.Tracks[0].Elements[k].Events.Length;
 						Array.Resize(ref CurrentRoute.Tracks[0].Elements[k].Events, m + 1);
-						if (CurrentRoute.ReverseDirection)
+						if (CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse)
 						{
 							CurrentRoute.Tracks[0].Elements[k].Events[m] = new StationStartEvent(CurrentRoute, d, i);
 						}
@@ -1082,7 +1082,7 @@ namespace CsvRwRouteParser
 			}
 			if (CurrentRoute.Stations.Length != 0)
 			{
-				if (CurrentRoute.ReverseDirection)
+				if (CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse)
 				{
 					CurrentRoute.Stations[0].Type = StationType.Terminal;
 					if (CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type == StationType.Terminal)

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -417,7 +417,15 @@ namespace CsvRwRouteParser
 					int s = Data.Blocks[i].Station;
 					int m = CurrentRoute.Tracks[0].Elements[n].Events.Length;
 					Array.Resize(ref CurrentRoute.Tracks[0].Elements[n].Events, m + 1);
-					CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationStartEvent(0.0, s);
+					if (CurrentRoute.ReverseDirection)
+					{
+						CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationEndEvent(Plugin.CurrentHost, Plugin.CurrentRoute, 0.0, s);
+					}
+					else
+					{
+						CurrentRoute.Tracks[0].Elements[n].Events[m] = new StationStartEvent(CurrentRoute, 0.0, s);
+					}
+					
 					double dx, dy = 3.0;
 					if (CurrentRoute.Stations[s].OpenLeftDoors && !CurrentRoute.Stations[s].OpenRightDoors)
 					{
@@ -942,7 +950,15 @@ namespace CsvRwRouteParser
 						double d = p - (k + Data.FirstUsedBlock) * Data.BlockInterval;
 						int m = CurrentRoute.Tracks[0].Elements[k].Events.Length;
 						Array.Resize(ref CurrentRoute.Tracks[0].Elements[k].Events, m + 1);
-						CurrentRoute.Tracks[0].Elements[k].Events[m] = new StationEndEvent(Plugin.CurrentHost, CurrentRoute, d, i);
+						if (CurrentRoute.ReverseDirection)
+						{
+							CurrentRoute.Tracks[0].Elements[k].Events[m] = new StationStartEvent(CurrentRoute, d, i);
+						}
+						else
+						{
+							CurrentRoute.Tracks[0].Elements[k].Events[m] = new StationEndEvent(Plugin.CurrentHost, CurrentRoute, d, i);
+						}
+						
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -1066,8 +1066,21 @@ namespace CsvRwRouteParser
 			}
 			if (CurrentRoute.Stations.Length != 0)
 			{
-				CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Terminal;
+				if (CurrentRoute.ReverseDirection)
+				{
+					CurrentRoute.Stations[0].Type = StationType.Terminal;
+					if (CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type == StationType.Terminal)
+					{
+						CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Normal;
+					}
+				}
+				else
+				{
+					CurrentRoute.Stations[CurrentRoute.Stations.Length - 1].Type = StationType.Terminal;
+				}
+				
 			}
+			
 			if (CurrentRoute.Tracks[0].Elements.Length != 0)
 			{
 				int n = CurrentRoute.Tracks[0].Elements.Length - 1;

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
@@ -183,6 +183,7 @@ namespace CsvRwRouteParser {
 			
 			string Section = ""; bool SectionAlwaysPrefix = false;
 			int BlockIndex = 0;
+			CurrentRoute.ReverseDirection = false;
 			CurrentRoute.Stations = new RouteStation[] { };
 			Data.RequestStops = new StopRequest[] { };
 			double progressFactor = Expressions.Length == 0 ? 0.3333 : 0.3333 / Expressions.Length;

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
@@ -183,7 +183,7 @@ namespace CsvRwRouteParser {
 			
 			string Section = ""; bool SectionAlwaysPrefix = false;
 			int BlockIndex = 0;
-			CurrentRoute.ReverseDirection = false;
+			CurrentRoute.Tracks[0].Direction = TrackDirection.Forwards;
 			CurrentRoute.Stations = new RouteStation[] { };
 			Data.RequestStops = new StopRequest[] { };
 			double progressFactor = Expressions.Length == 0 ? 0.3333 : 0.3333 / Expressions.Length;

--- a/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.Commands.cs
+++ b/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.Commands.cs
@@ -23,6 +23,7 @@
 		FogBehavior,
 		/// <summary>Controls whether BVETS Hacks are forced on / off for this route</summary>
 		EnableBveTsHacks,
-
+		/// <summary>Controls whether the route is driven in the reverse direction to construction</summary>
+		ReverseDirection,
 	}
 }

--- a/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.cs
+++ b/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.cs
@@ -204,7 +204,7 @@ namespace CsvRwRouteParser
 						}
 						else
 						{
-							CurrentRoute.ReverseDirection = a == 1;
+							CurrentRoute.Tracks[0].Direction = a == 1 ? TrackDirection.Reverse : TrackDirection.Forwards;
 						}
 					}
 					break;

--- a/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.cs
+++ b/source/Plugins/Route.CsvRw/Namespaces/NonTrack/Options.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
@@ -66,7 +65,6 @@ namespace CsvRwRouteParser
 							}
 						}
 					}
-
 					break;
 				case OptionsCommand.UnitOfLength:
 				case OptionsCommand.UnitOfSpeed:
@@ -185,6 +183,28 @@ namespace CsvRwRouteParser
 						else
 						{
 							EnabledHacks.BveTsHacks = a == 1;
+						}
+					}
+					break;
+				case OptionsCommand.ReverseDirection:
+					if (Arguments.Length < 1)
+					{
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, Command + " is expected to have one argument at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
+					}
+					else
+					{
+						int a;
+						if (!NumberFormats.TryParseIntVb6(Arguments[0], out a))
+						{
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "Mode is invalid in " + Command + " at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
+						}
+						else if (a != 0 & a != 1)
+						{
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "Mode is expected to be either 0 or 1 in " + Command + " at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
+						}
+						else
+						{
+							CurrentRoute.ReverseDirection = a == 1;
 						}
 					}
 					break;

--- a/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
+++ b/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
@@ -748,7 +748,7 @@ namespace MechanikRouteParser
 						};
 						int e = Plugin.CurrentRoute.Tracks[0].Elements[n].Events.Length; 
 						Array.Resize(ref Plugin.CurrentRoute.Tracks[0].Elements[n].Events, e + 1);
-						Plugin.CurrentRoute.Tracks[0].Elements[n].Events[e] = new StationStartEvent(0, s);
+						Plugin.CurrentRoute.Tracks[0].Elements[n].Events[e] = new StationStartEvent(Plugin.CurrentRoute, 0, s);
 					}
 					else
 					{

--- a/source/RouteManager2/CurrentRoute.cs
+++ b/source/RouteManager2/CurrentRoute.cs
@@ -246,7 +246,7 @@ namespace RouteManager2
 
 							if (c >= 0)
 							{
-								double p0 = train.FrontCarTrackPosition();
+								double p0 = train.FrontCarTrackPosition;
 								double p1 = Stations[d].Stops[c].TrackPosition - Stations[d].Stops[c].BackwardTolerance;
 
 								if (p0 >= p1)

--- a/source/RouteManager2/CurrentRoute.cs
+++ b/source/RouteManager2/CurrentRoute.cs
@@ -81,19 +81,23 @@ namespace RouteManager2
 
 		public Atmosphere Atmosphere;
 
-		public double[] BufferTrackPositions = new double[] { };
+		public double[] BufferTrackPositions = { };
 
 		/// <summary>The current in game time, expressed as the number of seconds since midnight on the first day</summary>
 		public double SecondsSinceMidnight;
 
 		/// <summary>Holds the length conversion units</summary>
-		public double[] UnitOfLength = new double[] { 1.0 };
+		public double[] UnitOfLength = { 1.0 };
 
 		/// <summary>The length of a block in meters</summary>
 		public double BlockLength = 25.0;
 
 		/// <summary>Controls the object disposal mode</summary>
 		public ObjectDisposalMode AccurateObjectDisposal;
+
+		/// <summary>Whether running in the nominal 'F' direction increases or decreases the TrackPosition</summary>
+		/// <remarks>'F' is the direction that the current cab faces</remarks>
+		public bool ReverseDirection;
 
 		public CurrentRoute(HostInterface host, BaseRenderer renderer)
 		{
@@ -511,6 +515,61 @@ namespace RouteManager2
 			renderer.Lighting.OptionDiffuseColor = Atmosphere.DiffuseLightColor;
 			renderer.Lighting.OptionLightPosition = Atmosphere.LightPosition;
 			renderer.Lighting.ShouldInitialize = true;
+		}
+
+		/// <summary>The index of the first station</summary>
+		public int PlayerFirstStationIndex
+		{
+			get
+			{
+				int idx = ReverseDirection ? Stations.Length - 1 : 0;
+				bool f = false;
+				int os = -1;
+				if (ReverseDirection)
+				{
+					for (int i = Stations.Length -1; i > 0; i--)
+					{
+						if (!string.IsNullOrEmpty(InitialStationName))
+						{
+							if (InitialStationName.ToLowerInvariant() == Stations[i].Name.ToLowerInvariant())
+							{
+								return i;
+							}
+						}
+						if (Stations[i].StopMode == StationStopMode.AllStop | Stations[i].StopMode == StationStopMode.PlayerStop & Stations[i].Stops.Length != 0)
+						{
+							if (f == false)
+							{
+								os = i;
+								f = true;
+							}
+						}
+					}
+				}
+				else
+				{
+					for (int i = 0; i < Stations.Length; i++)
+					{
+						if (!string.IsNullOrEmpty(InitialStationName))
+						{
+							if (InitialStationName.ToLowerInvariant() == Stations[i].Name.ToLowerInvariant())
+							{
+								return i;
+							}
+						}
+						if (Stations[i].StopMode == StationStopMode.AllStop | Stations[i].StopMode == StationStopMode.PlayerStop & Stations[i].Stops.Length != 0)
+						{
+							if (f == false)
+							{
+								os = i;
+								f = true;
+							}
+						}
+					}
+				}
+				
+				return os == -1 ? idx : os;
+			}
 		}
 	}
 }

--- a/source/RouteManager2/CurrentRoute.cs
+++ b/source/RouteManager2/CurrentRoute.cs
@@ -95,17 +95,13 @@ namespace RouteManager2
 		/// <summary>Controls the object disposal mode</summary>
 		public ObjectDisposalMode AccurateObjectDisposal;
 
-		/// <summary>Whether running in the nominal 'F' direction increases or decreases the TrackPosition</summary>
-		/// <remarks>'F' is the direction that the current cab faces</remarks>
-		public bool ReverseDirection;
-
 		public CurrentRoute(HostInterface host, BaseRenderer renderer)
 		{
 			currentHost = host;
 			this.renderer = renderer;
 			
 			Tracks = new Dictionary<int, Track>();
-			Track t = new Track()
+			Track t = new Track
 			{
 				Elements = new TrackElement[0]
 			};
@@ -522,10 +518,10 @@ namespace RouteManager2
 		{
 			get
 			{
-				int idx = ReverseDirection ? Stations.Length - 1 : 0;
+				int idx = Tracks[0].Direction == TrackDirection.Forwards ? Stations.Length - 1 : 0;
 				bool f = false;
 				int os = -1;
-				if (ReverseDirection)
+				if (Tracks[0].Direction == TrackDirection.Forwards)
 				{
 					for (int i = Stations.Length -1; i > 0; i--)
 					{

--- a/source/RouteManager2/Events/Station.cs
+++ b/source/RouteManager2/Events/Station.cs
@@ -1,4 +1,4 @@
-﻿using OpenBveApi.Hosts;
+using OpenBveApi.Hosts;
 using OpenBveApi.Routes;
 
 namespace RouteManager2.Events
@@ -9,14 +9,22 @@ namespace RouteManager2.Events
 		/// <summary>The index of the station this event describes</summary>
 		public readonly int StationIndex;
 
-		public StationStartEvent(double TrackPositionDelta, int StationIndex) : base(TrackPositionDelta)
+		private readonly CurrentRoute currentRoute;
+
+		public StationStartEvent(CurrentRoute CurrentRoute, double TrackPositionDelta, int StationIndex) : base(TrackPositionDelta)
 		{
 			DontTriggerAnymore = false;
 			this.StationIndex = StationIndex;
+			currentRoute = CurrentRoute;
 		}
 
 		public override void Trigger(int direction, TrackFollower trackFollower)
 		{
+			if (currentRoute.ReverseDirection)
+			{
+				direction = -direction;
+			}
+
 			trackFollower.EnterStation(StationIndex, direction);
 
 			if (trackFollower.TriggerType == EventTriggerType.TrainFront)
@@ -46,6 +54,10 @@ namespace RouteManager2.Events
 
 		public override void Trigger(int direction, TrackFollower trackFollower)
 		{
+			if (currentRoute.ReverseDirection)
+			{
+				direction = -direction;
+			}
 			trackFollower.LeaveStation(StationIndex, direction);
 
 			switch (trackFollower.TriggerType)

--- a/source/RouteManager2/Events/Station.cs
+++ b/source/RouteManager2/Events/Station.cs
@@ -20,7 +20,7 @@ namespace RouteManager2.Events
 
 		public override void Trigger(int direction, TrackFollower trackFollower)
 		{
-			if (currentRoute.ReverseDirection)
+			if (currentRoute.Tracks[trackFollower.TrackIndex].Direction == TrackDirection.Reverse)
 			{
 				direction = -direction;
 			}
@@ -54,7 +54,7 @@ namespace RouteManager2.Events
 
 		public override void Trigger(int direction, TrackFollower trackFollower)
 		{
-			if (currentRoute.ReverseDirection)
+			if (currentRoute.Tracks[trackFollower.TrackIndex].Direction == TrackDirection.Reverse)
 			{
 				direction = -direction;
 			}

--- a/source/RouteManager2/SignalManager/Section.cs
+++ b/source/RouteManager2/SignalManager/Section.cs
@@ -212,14 +212,14 @@ namespace RouteManager2.SignalManager
 					aspect = Aspects[CurrentAspect].Number;
 				}
 
-				double position = train.FrontCarTrackPosition();
+				double position = train.FrontCarTrackPosition;
 				double distance = TrackPosition - position;
 				return new SignalData(aspect, distance);
 			}
 			else
 			{
 				int aspect = Aspects[CurrentAspect].Number;
-				double position = train.FrontCarTrackPosition();
+				double position = train.FrontCarTrackPosition;
 				double distance = TrackPosition - position;
 				return new SignalData(aspect, distance);
 			}

--- a/source/RouteViewer/FunctionScripts.cs
+++ b/source/RouteViewer/FunctionScripts.cs
@@ -433,8 +433,8 @@ namespace RouteViewer {
 						break;
 					case Instructions.TrainTrackDistance:
 						if (Train != null) {
-							double t0 = Train.FrontCarTrackPosition();
-							double t1 = Train.RearCarTrackPosition();
+							double t0 = Train.FrontCarTrackPosition;
+							double t1 = Train.RearCarTrackPosition;
 							Function.Stack[s] = TrackPosition > t0 ? TrackPosition - t0 : TrackPosition < t1 ? TrackPosition - t1 : 0.0;
 						} else {
 							Function.Stack[s] = 0.0;

--- a/source/RouteViewer/LoadingR.cs
+++ b/source/RouteViewer/LoadingR.cs
@@ -222,7 +222,7 @@ namespace RouteViewer {
 			// starting track position
 			System.Threading.Thread.Sleep(1); if (Cancel) return;
 			double FirstStationPosition = 0.0;
-			if (Program.CurrentRoute.ReverseDirection)
+			if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 			{
 				for (int i = Program.CurrentRoute.Stations.Length - 1; i > 0; i--) {
 					if (Program.CurrentRoute.Stations[i].Stops.Length != 0) {

--- a/source/RouteViewer/LoadingR.cs
+++ b/source/RouteViewer/LoadingR.cs
@@ -221,22 +221,41 @@ namespace RouteViewer {
 			Program.CurrentRoute.UpdateAllSections();
 			// starting track position
 			System.Threading.Thread.Sleep(1); if (Cancel) return;
-			// int FirstStationIndex = -1;
 			double FirstStationPosition = 0.0;
-			for (int i = 0; i < Program.CurrentRoute.Stations.Length; i++) {
-				if (Program.CurrentRoute.Stations[i].Stops.Length != 0) {
-					// FirstStationIndex = i;
-					FirstStationPosition = Program.CurrentRoute.Stations[i].Stops[Program.CurrentRoute.Stations[i].Stops.Length - 1].TrackPosition;
-					if (Program.CurrentRoute.Stations[i].ArrivalTime < 0.0) {
-						if (Program.CurrentRoute.Stations[i].DepartureTime < 0.0) {
-							Game.SecondsSinceMidnight = 0.0;
+			if (Program.CurrentRoute.ReverseDirection)
+			{
+				for (int i = Program.CurrentRoute.Stations.Length - 1; i > 0; i--) {
+					if (Program.CurrentRoute.Stations[i].Stops.Length != 0) {
+						FirstStationPosition = Program.CurrentRoute.Stations[i].Stops[Program.CurrentRoute.Stations[i].Stops.Length - 1].TrackPosition;
+						if (Program.CurrentRoute.Stations[i].ArrivalTime < 0.0) {
+							if (Program.CurrentRoute.Stations[i].DepartureTime < 0.0) {
+								Game.SecondsSinceMidnight = 0.0;
+							} else {
+								Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].DepartureTime - Program.CurrentRoute.Stations[i].StopTime;
+							}
 						} else {
-							Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].DepartureTime - Program.CurrentRoute.Stations[i].StopTime;
+							Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].ArrivalTime;
 						}
-					} else {
-						Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].ArrivalTime;
+						break;
 					}
-					break;
+				}
+			}
+			else
+			{
+				for (int i = 0; i < Program.CurrentRoute.Stations.Length; i++) {
+					if (Program.CurrentRoute.Stations[i].Stops.Length != 0) {
+						FirstStationPosition = Program.CurrentRoute.Stations[i].Stops[Program.CurrentRoute.Stations[i].Stops.Length - 1].TrackPosition;
+						if (Program.CurrentRoute.Stations[i].ArrivalTime < 0.0) {
+							if (Program.CurrentRoute.Stations[i].DepartureTime < 0.0) {
+								Game.SecondsSinceMidnight = 0.0;
+							} else {
+								Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].DepartureTime - Program.CurrentRoute.Stations[i].StopTime;
+							}
+						} else {
+							Game.SecondsSinceMidnight = Program.CurrentRoute.Stations[i].ArrivalTime;
+						}
+						break;
+					}
 				}
 			}
 			// initialize camera

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -633,7 +633,7 @@ namespace RouteViewer
 					// info
 					double x = 0.5 * Screen.Width - 256.0;
 					double Yaw = Camera.Alignment.Yaw * 57.2957795130824;
-					if (Program.CurrentRoute.ReverseDirection)
+					if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 					{
 						Yaw -= 180;
 					}

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -632,7 +632,12 @@ namespace RouteViewer
 
 					// info
 					double x = 0.5 * Screen.Width - 256.0;
-					OpenGlString.Draw(Fonts.SmallFont, $"Position: {GetLengthString(Camera.Alignment.TrackPosition)} (X={GetLengthString(Camera.Alignment.Position.X)}, Y={GetLengthString(Camera.Alignment.Position.Y)}), Orientation: (Yaw={(Camera.Alignment.Yaw * 57.2957795130824).ToString("0.00", culture)}°, Pitch={(Camera.Alignment.Pitch * 57.2957795130824).ToString("0.00", culture)}°, Roll={(Camera.Alignment.Roll * 57.2957795130824).ToString("0.00", culture)}°)", new Vector2((int)x, 4), TextAlignment.TopLeft, Color128.White, true);
+					double Yaw = Camera.Alignment.Yaw * 57.2957795130824;
+					if (Program.CurrentRoute.ReverseDirection)
+					{
+						Yaw -= 180;
+					}
+					OpenGlString.Draw(Fonts.SmallFont, $"Position: {GetLengthString(Camera.Alignment.TrackPosition)} (X={GetLengthString(Camera.Alignment.Position.X)}, Y={GetLengthString(Camera.Alignment.Position.Y)}), Orientation: (Yaw={Yaw.ToString("0.00", culture)}°, Pitch={(Camera.Alignment.Pitch * 57.2957795130824).ToString("0.00", culture)}°, Roll={(Camera.Alignment.Roll * 57.2957795130824).ToString("0.00", culture)}°)", new Vector2((int)x, 4), TextAlignment.TopLeft, Color128.White, true);
 					OpenGlString.Draw(Fonts.SmallFont, $"Radius: {GetLengthString(CameraTrackFollower.CurveRadius)}, Cant: {(1000.0 * CameraTrackFollower.CurveCant).ToString("0", culture)} mm, Adhesion={(100.0 * CameraTrackFollower.AdhesionMultiplier).ToString("0", culture)}" + " , Rain intensity= " + CameraTrackFollower.RainIntensity +"%", new Vector2((int)x, 20), TextAlignment.TopLeft, Color128.White, true);
 					OpenGlString.Draw(Fonts.SmallFont, ForceLegacyOpenGL ? $"Renderer: Old (GL 1.2)- GL 3.0 not available" : $"Renderer: {(AvailableNewRenderer ? "New (GL 3.0)" : "Old (GL 1.2)")}", new Vector2((int)x, 40), TextAlignment.TopLeft, Color128.White, true);
 

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -237,7 +237,7 @@ namespace RouteViewer
 
 		// jump to station
 		private static void JumpToStation(int Direction) {
-			if (CurrentRoute.ReverseDirection)
+			if (Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse)
 			{
 				Direction = -Direction;
 			}
@@ -248,7 +248,7 @@ namespace RouteViewer
 						if (p < Program.Renderer.CameraTrackFollower.TrackPosition - 0.1) {
 							Program.Renderer.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Renderer.Camera.Alignment.TrackPosition = p;
-							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+							Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 							break;
 						}
 					}
@@ -260,7 +260,7 @@ namespace RouteViewer
 						if (p > Program.Renderer.CameraTrackFollower.TrackPosition + 0.1) {
 							Program.Renderer.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Renderer.Camera.Alignment.TrackPosition = p;
-							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+							Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 							break;
 						}
 					}
@@ -355,7 +355,7 @@ namespace RouteViewer
 			LoadRoute();
 			ObjectManager.UpdateAnimatedWorldObjects(0.0, true);
 			CurrentlyLoading = false;
-			Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+			Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 			UpdateCaption();
 		}
 
@@ -409,7 +409,7 @@ namespace RouteViewer
 						}
 						else
 						{
-							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+							Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -451,7 +451,7 @@ namespace RouteViewer
 						if (canLoad && LoadRoute())
 						{
 							ObjectManager.UpdateAnimatedWorldObjects(0.0, true);
-							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+							Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -482,7 +482,7 @@ namespace RouteViewer
 								MessageBox.Show("No plugins found capable of loading routefile: " +Environment.NewLine + CurrentRouteFile);
 							}
 							
-							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+							Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							CurrentRouteFile = null;
@@ -546,11 +546,11 @@ namespace RouteViewer
 					break;
 				case Key.W:
 				case Key.Keypad9:
-					Renderer.Camera.AlignmentDirection.TrackPosition = CameraProperties.ExteriorTopSpeed * (CurrentRoute.ReverseDirection ? -speedModified : speedModified);
+					Renderer.Camera.AlignmentDirection.TrackPosition = CameraProperties.ExteriorTopSpeed * (Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse ? -speedModified : speedModified);
 					break;
 				case Key.S:
 				case Key.Keypad3:
-					Renderer.Camera.AlignmentDirection.TrackPosition = -CameraProperties.ExteriorTopSpeed * (CurrentRoute.ReverseDirection ? -speedModified : speedModified);
+					Renderer.Camera.AlignmentDirection.TrackPosition = -CameraProperties.ExteriorTopSpeed * (Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse ? -speedModified : speedModified);
 					break;
 				case Key.Left:
 					Renderer.Camera.AlignmentDirection.Yaw = -CameraProperties.ExteriorTopAngularSpeed * speedModified;
@@ -589,7 +589,7 @@ namespace RouteViewer
 					JumpToStation(-1);
 					break;
 				case Key.Keypad5:
-					Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+					Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 					Renderer.UpdateViewport();
 					World.UpdateAbsoluteCamera(0.0);
 					Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -691,7 +691,7 @@ namespace RouteViewer
 
 									Program.Renderer.CameraTrackFollower.UpdateAbsolute(value, true, false);
 									Renderer.Camera.Alignment.TrackPosition = value;
-									Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
+									Renderer.Camera.Reset(Program.CurrentRoute.Tracks[0].Direction == TrackDirection.Reverse);
 									World.UpdateAbsoluteCamera(0.0);
 									Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
 								}
@@ -731,10 +731,6 @@ namespace RouteViewer
 					}
 					
 					//pathForm.ShowDialog();
-					break;
-				case Key.Z:
-					// TEMP
-					CurrentRoute.ReverseDirection = !CurrentRoute.ReverseDirection;
 					break;
 			}
 		}

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -237,6 +237,10 @@ namespace RouteViewer
 
 		// jump to station
 		private static void JumpToStation(int Direction) {
+			if (CurrentRoute.ReverseDirection)
+			{
+				Direction = -Direction;
+			}
 			if (Direction < 0) {
 				for (int i = CurrentRoute.Stations.Length - 1; i >= 0; i--) {
 					if (CurrentRoute.Stations[i].Stops.Length != 0) {
@@ -244,7 +248,7 @@ namespace RouteViewer
 						if (p < Program.Renderer.CameraTrackFollower.TrackPosition - 0.1) {
 							Program.Renderer.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Renderer.Camera.Alignment.TrackPosition = p;
-							Renderer.Camera.Reset();
+							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 							break;
 						}
 					}
@@ -256,7 +260,7 @@ namespace RouteViewer
 						if (p > Program.Renderer.CameraTrackFollower.TrackPosition + 0.1) {
 							Program.Renderer.CameraTrackFollower.UpdateAbsolute(p, true, false);
 							Renderer.Camera.Alignment.TrackPosition = p;
-							Renderer.Camera.Reset();
+							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 							break;
 						}
 					}
@@ -266,7 +270,7 @@ namespace RouteViewer
 
 		internal static void UpdateGraphicsSettings()
 		{
-			Renderer.Camera.ForwardViewingDistance = (double)Interface.CurrentOptions.ViewingDistance;
+			Renderer.Camera.ForwardViewingDistance = Interface.CurrentOptions.ViewingDistance;
 			Program.CurrentRoute.CurrentBackground.BackgroundImageDistance = Interface.CurrentOptions.ViewingDistance;
 			if (CurrentRouteFile != null)
 			{
@@ -330,13 +334,13 @@ namespace RouteViewer
 				Renderer.Camera.AlignmentDirection.Position.Y = 0.0;
 				if (MouseButton == 1)
 				{
-					Renderer.Camera.AlignmentDirection.Yaw = 0.025 * (double) (previousMouseState.X - currentMouseState.X);
-					Renderer.Camera.AlignmentDirection.Pitch = 0.025 * (double)(previousMouseState.Y - currentMouseState.Y);
+					Renderer.Camera.AlignmentDirection.Yaw = 0.025 * (previousMouseState.X - currentMouseState.X);
+					Renderer.Camera.AlignmentDirection.Pitch = 0.025 * (previousMouseState.Y - currentMouseState.Y);
 				}
 				else if (MouseButton == 2)
 				{
-					Renderer.Camera.AlignmentDirection.Position.X = 0.1 * (double)(previousMouseState.X - currentMouseState.X);
-					Renderer.Camera.AlignmentDirection.Position.Y = 0.1 * (double)(previousMouseState.Y - currentMouseState.Y);
+					Renderer.Camera.AlignmentDirection.Position.X = 0.1 * (previousMouseState.X - currentMouseState.X);
+					Renderer.Camera.AlignmentDirection.Position.Y = 0.1 * (previousMouseState.Y - currentMouseState.Y);
 				}
 				
 			}
@@ -351,7 +355,7 @@ namespace RouteViewer
 			LoadRoute();
 			ObjectManager.UpdateAnimatedWorldObjects(0.0, true);
 			CurrentlyLoading = false;
-			Renderer.Camera.Reset();
+			Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 			UpdateCaption();
 		}
 
@@ -405,7 +409,7 @@ namespace RouteViewer
 						}
 						else
 						{
-							Renderer.Camera.Reset();
+							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -447,7 +451,7 @@ namespace RouteViewer
 						if (canLoad && LoadRoute())
 						{
 							ObjectManager.UpdateAnimatedWorldObjects(0.0, true);
-							Renderer.Camera.Reset();
+							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -478,7 +482,7 @@ namespace RouteViewer
 								MessageBox.Show("No plugins found capable of loading routefile: " +Environment.NewLine + CurrentRouteFile);
 							}
 							
-							Renderer.Camera.Reset();
+							Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 							Renderer.UpdateViewport();
 							World.UpdateAbsoluteCamera(0.0);
 							CurrentRouteFile = null;
@@ -542,11 +546,11 @@ namespace RouteViewer
 					break;
 				case Key.W:
 				case Key.Keypad9:
-					Renderer.Camera.AlignmentDirection.TrackPosition = CameraProperties.ExteriorTopSpeed * speedModified;
+					Renderer.Camera.AlignmentDirection.TrackPosition = CameraProperties.ExteriorTopSpeed * (CurrentRoute.ReverseDirection ? -speedModified : speedModified);
 					break;
 				case Key.S:
 				case Key.Keypad3:
-					Renderer.Camera.AlignmentDirection.TrackPosition = -CameraProperties.ExteriorTopSpeed * speedModified;
+					Renderer.Camera.AlignmentDirection.TrackPosition = -CameraProperties.ExteriorTopSpeed * (CurrentRoute.ReverseDirection ? -speedModified : speedModified);
 					break;
 				case Key.Left:
 					Renderer.Camera.AlignmentDirection.Yaw = -CameraProperties.ExteriorTopAngularSpeed * speedModified;
@@ -585,7 +589,7 @@ namespace RouteViewer
 					JumpToStation(-1);
 					break;
 				case Key.Keypad5:
-					Renderer.Camera.Reset();
+					Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 					Renderer.UpdateViewport();
 					World.UpdateAbsoluteCamera(0.0);
 					Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
@@ -682,12 +686,12 @@ namespace RouteViewer
 								{
 									if (direction != 0)
 									{
-										value = Program.Renderer.CameraTrackFollower.TrackPosition + (double)direction * value;
+										value = Program.Renderer.CameraTrackFollower.TrackPosition + direction * value;
 									}
 
 									Program.Renderer.CameraTrackFollower.UpdateAbsolute(value, true, false);
 									Renderer.Camera.Alignment.TrackPosition = value;
-									Renderer.Camera.Reset();
+									Renderer.Camera.Reset(CurrentRoute.ReverseDirection);
 									World.UpdateAbsoluteCamera(0.0);
 									Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
 								}
@@ -727,6 +731,10 @@ namespace RouteViewer
 					}
 					
 					//pathForm.ShowDialog();
+					break;
+				case Key.Z:
+					// TEMP
+					CurrentRoute.ReverseDirection = !CurrentRoute.ReverseDirection;
 					break;
 			}
 		}

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Threading;
 using OpenBveApi;
 using OpenBveApi.Math;
+using OpenBveApi.Routes;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
@@ -38,7 +39,7 @@ namespace RouteViewer
 	        if (Loading.Complete && currentlyLoading)
 	        {
 		        currentlyLoading = false;
-		        if (Program.CurrentRoute.ReverseDirection)
+		        if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 		        {
 			        Program.Renderer.Camera.Alignment.Yaw = 180 / 57.2957795130824;
 					Program.Renderer.UpdateVisibility(true);

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -38,7 +38,13 @@ namespace RouteViewer
 	        if (Loading.Complete && currentlyLoading)
 	        {
 		        currentlyLoading = false;
+		        if (Program.CurrentRoute.ReverseDirection)
+		        {
+			        Program.Renderer.Camera.Alignment.Yaw = 180 / 57.2957795130824;
+					Program.Renderer.UpdateVisibility(true);
+		        }
 	        }
+	        
         }
 
         //This renders the frame

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -497,7 +497,7 @@ namespace RouteViewer
 					{
 						int c = Program.TrainManager.Trains[i].Cars.Length - 1;
 						double z = Program.TrainManager.Trains[i].Cars[c].RearAxle.Follower.TrackPosition - Program.TrainManager.Trains[i].Cars[c].RearAxle.Position - 0.5 * Program.TrainManager.Trains[i].Cars[c].Length;
-						if (z >= baseTrain.FrontCarTrackPosition() & z < bestLocation)
+						if (z >= baseTrain.FrontCarTrackPosition & z < bestLocation)
 						{
 							bestLocation = z;
 							closestTrain = Program.TrainManager.Trains[i];

--- a/source/RouteViewer/TrainManagerR.cs
+++ b/source/RouteViewer/TrainManagerR.cs
@@ -34,15 +34,9 @@ namespace RouteViewer {
 			}
 			public override int NumberOfCars => this.Cars.Length;
 
-			public override double FrontCarTrackPosition()
-			{
-				return Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;
-			}
+			public override double FrontCarTrackPosition => Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;
 
-			public override double RearCarTrackPosition()
-			{
-				return Cars[Cars.Length - 1].RearAxle.Follower.TrackPosition - Cars[Cars.Length - 1].RearAxle.Position - 0.5 * Cars[Cars.Length - 1].Length;
-			}
+			public override double RearCarTrackPosition => Cars[Cars.Length - 1].RearAxle.Follower.TrackPosition - Cars[Cars.Length - 1].RearAxle.Position - 0.5 * Cars[Cars.Length - 1].Length;
 
 			public override bool IsPlayerTrain => true;
 		}

--- a/source/TrainEditor2/Simulation/TrainManager/Train/Train.cs
+++ b/source/TrainEditor2/Simulation/TrainManager/Train/Train.cs
@@ -19,16 +19,6 @@ namespace TrainEditor2.Simulation.TrainManager
 				Program.SoundApi.StopAllSounds(this);
 				Car = null;
 			}
-
-			public override double FrontCarTrackPosition()
-			{
-				throw new NotImplementedException();
-			}
-
-			public override double RearCarTrackPosition()
-			{
-				throw new NotImplementedException();
-			}
 		}
 	}
 }

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -242,20 +242,50 @@ namespace TrainManager.Car
 			get;
 		}
 
-		public override void Reverse()
+		public override void Reverse(bool flipInterior = false)
 		{
 			// reverse axle positions
 			double temp = FrontAxle.Position;
 			FrontAxle.Position = -RearAxle.Position;
 			RearAxle.Position = -temp;
-			int idxToReverse = HasInteriorView ? 1 : 0;
-			if (CarSections != null && CarSections.Length > 0)
+			if (flipInterior)
 			{
-				foreach (AnimatedObject animatedObject in CarSections[idxToReverse].Groups[0].Elements)
+				if (CarSections != null && CarSections.Length > 0)
 				{
-					animatedObject.Reverse();
+					for (int i = 0; i < CarSections.Length; i++)
+					{
+						if (CarSections[i].Type == ObjectType.Overlay)
+						{
+							for (int j = 0; j < CarSections[i].Groups.Length; j++)
+							{
+								CarSections[i].Groups[j].Reverse(Driver);
+							}
+						}
+						else
+						{
+							foreach (AnimatedObject animatedObject in CarSections[i].Groups[0].Elements)
+							{
+								animatedObject.Reverse();
+							}	
+						}
+						
+					}
 				}
+				Driver = new Vector3(-Driver.X, Driver.Y, -Driver.Z);
+				CameraRestriction.Reverse();
 			}
+			else
+			{
+				int idxToReverse = HasInteriorView ? 1 : 0;
+				if (CarSections != null && CarSections.Length > 0)
+				{
+					foreach (AnimatedObject animatedObject in CarSections[idxToReverse].Groups[0].Elements)
+					{
+						animatedObject.Reverse();
+					}
+				}	
+			}
+			
 
 			Bogie b = RearBogie;
 			RearBogie = FrontBogie;
@@ -264,10 +294,8 @@ namespace TrainManager.Car
 			RearBogie.Reverse();
 			FrontBogie.FrontAxle.Follower.UpdateAbsolute(FrontAxle.Position + FrontBogie.FrontAxle.Position, true, false);
 			FrontBogie.RearAxle.Follower.UpdateAbsolute(FrontAxle.Position + FrontBogie.RearAxle.Position, true, false);
-
 			RearBogie.FrontAxle.Follower.UpdateAbsolute(RearAxle.Position + RearBogie.FrontAxle.Position, true, false);
 			RearBogie.RearAxle.Follower.UpdateAbsolute(RearAxle.Position + RearBogie.RearAxle.Position, true, false);
-
 		}
 
 		public override void OpenDoors(bool Left, bool Right)

--- a/source/TrainManager/Handles/Handles.Reverser.cs
+++ b/source/TrainManager/Handles/Handles.Reverser.cs
@@ -47,6 +47,10 @@ namespace TrainManager.Handles
 			int r = Relative ? a + Value : Value;
 			if (r < -1) r = -1;
 			if (r > 1) r = 1;
+			if (TrainManagerBase.CurrentRoute.ReverseDirection)
+			{
+				r = 0 - r;
+			}
 			if (a != r)
 			{
 				Driver = (ReverserPosition)r;
@@ -78,11 +82,21 @@ namespace TrainManager.Handles
 				switch (Driver)
 				{
 					case ReverserPosition.Reverse:
+						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						{
+							color = MessageColor.Blue;
+							return Translations.QuickReferences.HandleForward;
+						}
 						color = MessageColor.Orange;
 						return Translations.QuickReferences.HandleBackward;
 					case ReverserPosition.Neutral:
 						return Translations.QuickReferences.HandleNeutral;
 					case ReverserPosition.Forwards:
+						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						{
+							color = MessageColor.Orange;
+							return Translations.QuickReferences.HandleBackward;
+						}
 						color = MessageColor.Blue;
 						return Translations.QuickReferences.HandleForward;
 				}
@@ -92,11 +106,21 @@ namespace TrainManager.Handles
 				switch (Driver)
 				{
 					case ReverserPosition.Reverse:
+						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						{
+							color = MessageColor.Blue;
+							return NotchDescriptions[1];
+						}
 						color = MessageColor.Orange;
 						return NotchDescriptions[2];
 					case ReverserPosition.Neutral:
 						return NotchDescriptions[0];
 					case ReverserPosition.Forwards:
+						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						{
+							color = MessageColor.Orange;
+							return NotchDescriptions[2];
+						}
 						color = MessageColor.Blue;
 						return NotchDescriptions[1];
 				}

--- a/source/TrainManager/Handles/Handles.Reverser.cs
+++ b/source/TrainManager/Handles/Handles.Reverser.cs
@@ -1,5 +1,6 @@
 ﻿using OpenBveApi.Colors;
 using OpenBveApi.Interface;
+using OpenBveApi.Routes;
 using SoundManager;
 using TrainManager.Trains;
 
@@ -47,7 +48,7 @@ namespace TrainManager.Handles
 			int r = Relative ? a + Value : Value;
 			if (r < -1) r = -1;
 			if (r > 1) r = 1;
-			if (TrainManagerBase.CurrentRoute.ReverseDirection)
+			if (baseTrain.CurrentDirection == TrackDirection.Reverse)
 			{
 				r = 0 - r;
 			}
@@ -82,7 +83,7 @@ namespace TrainManager.Handles
 				switch (Driver)
 				{
 					case ReverserPosition.Reverse:
-						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						if (baseTrain.CurrentDirection == TrackDirection.Reverse)
 						{
 							color = MessageColor.Blue;
 							return Translations.QuickReferences.HandleForward;
@@ -92,7 +93,7 @@ namespace TrainManager.Handles
 					case ReverserPosition.Neutral:
 						return Translations.QuickReferences.HandleNeutral;
 					case ReverserPosition.Forwards:
-						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						if (baseTrain.CurrentDirection == TrackDirection.Reverse)
 						{
 							color = MessageColor.Orange;
 							return Translations.QuickReferences.HandleBackward;
@@ -106,7 +107,7 @@ namespace TrainManager.Handles
 				switch (Driver)
 				{
 					case ReverserPosition.Reverse:
-						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						if (baseTrain.CurrentDirection == TrackDirection.Reverse)
 						{
 							color = MessageColor.Blue;
 							return NotchDescriptions[1];
@@ -116,7 +117,7 @@ namespace TrainManager.Handles
 					case ReverserPosition.Neutral:
 						return NotchDescriptions[0];
 					case ReverserPosition.Forwards:
-						if (TrainManagerBase.CurrentRoute.ReverseDirection)
+						if (baseTrain.CurrentDirection == TrackDirection.Reverse)
 						{
 							color = MessageColor.Orange;
 							return NotchDescriptions[2];

--- a/source/TrainManager/SafetySystems/Plugin/Plugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/Plugin.cs
@@ -151,7 +151,7 @@ namespace TrainManager.SafetySystems
 			try
 			{
 				AbstractTrain closestTrain = TrainManagerBase.currentHost.ClosestTrain(this.Train);
-				precedingVehicle = closestTrain != null ? new PrecedingVehicleState(closestTrain.RearCarTrackPosition(), closestTrain.RearCarTrackPosition() - location, new Speed(closestTrain.CurrentSpeed)) : new PrecedingVehicleState(Double.MaxValue, Double.MaxValue - location, new Speed(0.0));
+				precedingVehicle = closestTrain != null ? new PrecedingVehicleState(closestTrain.RearCarTrackPosition, closestTrain.RearCarTrackPosition - location, new Speed(closestTrain.CurrentSpeed)) : new PrecedingVehicleState(Double.MaxValue, Double.MaxValue - location, new Speed(0.0));
 			}
 			catch
 			{

--- a/source/TrainManager/Train/Station.cs
+++ b/source/TrainManager/Train/Station.cs
@@ -99,7 +99,9 @@ namespace TrainManager.Trains
 				double tf, tb;
 				if (n >= 0)
 				{
-					double p0 = Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;
+					int frontCar = TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length -1 : 0;
+
+					double p0 = Cars[frontCar].FrontAxle.Follower.TrackPosition - Cars[frontCar].FrontAxle.Position + 0.5 * Cars[frontCar].Length;
 					double p1 = TrainManagerBase.CurrentRoute.Stations[i].Stops[n].TrackPosition;
 					tf = TrainManagerBase.CurrentRoute.Stations[i].Stops[n].ForwardTolerance;
 					tb = TrainManagerBase.CurrentRoute.Stations[i].Stops[n].BackwardTolerance;

--- a/source/TrainManager/Train/Station.cs
+++ b/source/TrainManager/Train/Station.cs
@@ -2,6 +2,7 @@
 using OpenBveApi;
 using OpenBveApi.Colors;
 using OpenBveApi.Interface;
+using OpenBveApi.Routes;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
 using RouteManager2.MessageManager;
@@ -99,7 +100,7 @@ namespace TrainManager.Trains
 				double tf, tb;
 				if (n >= 0)
 				{
-					int frontCar = TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length -1 : 0;
+					int frontCar = CurrentDirection == TrackDirection.Reverse ? Cars.Length -1 : 0;
 
 					double p0 = Cars[frontCar].FrontAxle.Follower.TrackPosition - Cars[frontCar].FrontAxle.Position + 0.5 * Cars[frontCar].Length;
 					double p1 = TrainManagerBase.CurrentRoute.Stations[i].Stops[n].TrackPosition;

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -1047,5 +1047,36 @@ namespace TrainManager.Trains
 				TrainManagerBase.currentHost.ProcessJump(this, stationIndex);
 			}
 		}
+
+		/// <summary>Change the camera car</summary>
+		/// <param name="shouldIncrement">Whether to increase or decrease the camera car index</param>
+		public void ChangeCameraCar(bool shouldIncrement)
+		{
+			if (TrainManagerBase.CurrentRoute.ReverseDirection)
+			{
+				// If in the reverse direction, the last car is Car0 and the direction of increase is reversed
+				shouldIncrement = !shouldIncrement;
+			}
+
+			if (shouldIncrement)
+			{
+				if (CameraCar < Cars.Length - 1)
+				{
+					CameraCar++;
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+						MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+				}
+			}
+			else
+			{
+				if (CameraCar > 0)
+				{
+					CameraCar--;
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+						MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+				}
+			}
+
+		}
 	}
 }

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -5,7 +5,6 @@ using LibRender2.Trains;
 using OpenBveApi;
 using OpenBveApi.Colors;
 using OpenBveApi.Interface;
-using OpenBveApi.Routes;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
 using RouteManager2.MessageManager;
@@ -345,12 +344,12 @@ namespace TrainManager.Trains
 						TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("message_route_newlimit"), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
 					}
 
-					Section nextSection = TrainManagerBase.CurrentRoute.NextSection(FrontCarTrackPosition());
+					Section nextSection = TrainManagerBase.CurrentRoute.NextSection(FrontCarTrackPosition);
 					if (nextSection != null)
 					{
 						//If we find an appropriate signal, and the distance to it is less than 500m, announce if screen reader is present
 						//Aspect announce to be triggered via a separate keybind
-						double tPos = nextSection.TrackPosition - FrontCarTrackPosition();
+						double tPos = nextSection.TrackPosition - FrontCarTrackPosition;
 						if (!nextSection.AccessibilityAnnounced && tPos < 500)
 						{
 							string s = Translations.GetInterfaceString("message_route_nextsection").Replace("[distance]", $"{tPos:0.0}") + "m";
@@ -358,12 +357,12 @@ namespace TrainManager.Trains
 							nextSection.AccessibilityAnnounced = true;
 						}
 					}
-					RouteStation nextStation = TrainManagerBase.CurrentRoute.NextStation(FrontCarTrackPosition());
+					RouteStation nextStation = TrainManagerBase.CurrentRoute.NextStation(FrontCarTrackPosition);
 					if (nextStation != null)
 					{
 						//If we find an appropriate signal, and the distance to it is less than 500m, announce if screen reader is present
 						//Aspect announce to be triggered via a separate keybind
-						double tPos = nextStation.DefaultTrackPosition - FrontCarTrackPosition();
+						double tPos = nextStation.DefaultTrackPosition - FrontCarTrackPosition;
 						if (!nextStation.AccessibilityAnnounced && tPos < 500)
 						{
 							string s = Translations.GetInterfaceString("message_route_nextstation").Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[name]", nextStation.Name);
@@ -873,18 +872,32 @@ namespace TrainManager.Trains
 			UpdateCabObjects();
 		}
 
-			
+
 
 		/// <inheritdoc/>
-		public override double FrontCarTrackPosition()
+		public override double FrontCarTrackPosition
 		{
-			return Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;
+			get
+			{
+				if (TrainManagerBase.CurrentRoute.ReverseDirection)
+				{
+					return Cars[Cars.Length - 1].FrontAxle.Follower.TrackPosition - Cars[Cars.Length - 1].FrontAxle.Position + 0.5 * Cars[Cars.Length -  1].Length;
+				}
+				return Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;
+			}
 		}
-
+		
 		/// <inheritdoc/>
-		public override double RearCarTrackPosition()
+		public override double RearCarTrackPosition
 		{
-			return Cars[Cars.Length - 1].RearAxle.Follower.TrackPosition - Cars[Cars.Length - 1].RearAxle.Position - 0.5 * Cars[Cars.Length - 1].Length;
+			get
+			{
+				if (TrainManagerBase.CurrentRoute.ReverseDirection)
+				{
+					return Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;	
+				}
+				return Cars[Cars.Length - 1].RearAxle.Follower.TrackPosition - Cars[Cars.Length - 1].RearAxle.Position - 0.5 * Cars[Cars.Length - 1].Length;
+			}
 		}
 
 		/// <inheritdoc/>

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -836,13 +836,13 @@ namespace TrainManager.Trains
 		}
 
 		/// <inheritdoc/>
-		public override void Reverse()
+		public override void Reverse(bool flipInterior = false, bool flipDriver = false)
 		{
 			double trackPosition = Cars[0].TrackPosition;
 			Cars = Cars.Reverse().ToArray();
 			for (int i = 0; i < Cars.Length; i++)
 			{
-				Cars[i].Reverse();
+				Cars[i].Reverse(flipInterior);
 				// Re-create the coupler with appropriate distances between the cars
 				double minDistance = 0, maxDistance = 0;
 				if (i < Cars.Length - 1)
@@ -854,6 +854,7 @@ namespace TrainManager.Trains
 			}
 			PlaceCars(trackPosition);
 			DriverCar = Cars.Length - 1 - DriverCar;
+			CameraCar = Cars.Length - 1 - CameraCar;
 			UpdateCabObjects();
 		}
 

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -5,6 +5,7 @@ using LibRender2.Trains;
 using OpenBveApi;
 using OpenBveApi.Colors;
 using OpenBveApi.Interface;
+using OpenBveApi.Routes;
 using OpenBveApi.Runtime;
 using OpenBveApi.Trains;
 using RouteManager2.MessageManager;
@@ -92,6 +93,9 @@ namespace TrainManager.Trains
 				return myLength;
 			}
 		}
+
+		/// <summary>The direction of travel on the current track</summary>
+		public TrackDirection CurrentDirection => TrainManagerBase.CurrentRoute.Tracks[Cars[DriverCar].FrontAxle.Follower.TrackIndex].Direction;
 
 		public TrainBase(TrainState state)
 		{
@@ -879,7 +883,7 @@ namespace TrainManager.Trains
 		{
 			get
 			{
-				if (TrainManagerBase.CurrentRoute.ReverseDirection)
+				if (CurrentDirection == TrackDirection.Reverse)
 				{
 					return Cars[Cars.Length - 1].FrontAxle.Follower.TrackPosition - Cars[Cars.Length - 1].FrontAxle.Position + 0.5 * Cars[Cars.Length -  1].Length;
 				}
@@ -892,7 +896,7 @@ namespace TrainManager.Trains
 		{
 			get
 			{
-				if (TrainManagerBase.CurrentRoute.ReverseDirection)
+				if (CurrentDirection == TrackDirection.Reverse)
 				{
 					return Cars[0].FrontAxle.Follower.TrackPosition - Cars[0].FrontAxle.Position + 0.5 * Cars[0].Length;	
 				}
@@ -1052,7 +1056,7 @@ namespace TrainManager.Trains
 		/// <param name="shouldIncrement">Whether to increase or decrease the camera car index</param>
 		public void ChangeCameraCar(bool shouldIncrement)
 		{
-			if (TrainManagerBase.CurrentRoute.ReverseDirection)
+			if (CurrentDirection == TrackDirection.Reverse)
 			{
 				// If in the reverse direction, the last car is Car0 and the direction of increase is reversed
 				shouldIncrement = !shouldIncrement;
@@ -1063,7 +1067,7 @@ namespace TrainManager.Trains
 				if (CameraCar < Cars.Length - 1)
 				{
 					CameraCar++;
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
 						MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
 				}
 			}
@@ -1072,7 +1076,7 @@ namespace TrainManager.Trains
 				if (CameraCar > 0)
 				{
 					CameraCar--;
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (TrainManagerBase.CurrentRoute.ReverseDirection ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString("notification_exterior") + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
 						MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
 				}
 			}


### PR DESCRIPTION
Still somewhat of a WIP, needs various camera related glitches sorting.

### Significant Changes:
* Add **Options.ReverseDirection** - If set in a routefile, it may be driven in the reverse direction.
* In the **AbstractTrain** the FrontCarTrackPosition and RearCarTrackPosition have changed signature from a method to a virtual double. This is technically breaking. but I don't think anything will be using these, and it's much more sensible.

### TODO:
* ~~Direction for F / R needs changing in the main program.~~
* ~~lnitial camera position is in car 0, not last car (Oddly, is OK going in / out of train)~~
* ~~Cabview is not being reversed when calling Reverse() function on train.~~
* Needs tag in train.xml to allow reversal of cab views so dual ends work properly.
* ~~Arrival / departure messages glitched- Probably needs the events reversing?~~
* If train overhangs signal at initial station, this generates a passed red signal message. Signalling is probably somewhat broken at the minute.
* ~~AI overshoots stations. Probably distance to the next station related (??)~~
* ?? Flip signalling objects ?? - Unconvinced, is this a developer only option?