### PR TITLE
Change: Move cab handles storage to the car

### DIFF
--- a/source/ObjectViewer/Trains/NearestTrain.cs
+++ b/source/ObjectViewer/Trains/NearestTrain.cs
@@ -46,17 +46,7 @@ namespace ObjectViewer.Trains
 		private static TrainBase CreateDummyTrain()
 		{
 			TrainBase train = new TrainBase(TrainState.Available, TrainType.LocalPlayerTrain);
-			train.Handles.Power = new PowerHandle(Specs.PowerNotches, train);
-			if (Specs.IsAirBrake)
-			{
-				train.Handles.Brake = new AirBrakeHandle(train);
-			}
-			else
-			{
-				train.Handles.Brake = new BrakeHandle(Specs.BrakeNotches, null, train);
-				train.Handles.HasHoldBrake = Specs.HasHoldBrake;
-			}
-			train.Handles.HoldBrake = new HoldBrakeHandle(train);
+			
 			train.Specs.HasConstSpeed = Specs.HasConstSpeed;
 
 			Array.Resize(ref train.Cars, Specs.NumberOfCars);
@@ -88,6 +78,16 @@ namespace ObjectViewer.Trains
 				train.Cars[i].Doors[1] = new Door(1, 1000.0, 0.0);
 			}
 
+			train.Handles.Power = new PowerHandle(Specs.PowerNotches, train);
+			if (Specs.IsAirBrake)
+			{
+				train.Handles.Brake = new AirBrakeHandle(train);
+			}
+			else
+			{
+				train.Handles.Brake = new BrakeHandle(Specs.BrakeNotches, null, train);
+				train.Handles.HasHoldBrake = Specs.HasHoldBrake;
+			}
 			if (Specs.HasLocoBrake)
 			{
 				train.Handles.HasLocoBrake = true;

--- a/source/Plugins/Route.Bve5/Components/ScriptedTrain.cs
+++ b/source/Plugins/Route.Bve5/Components/ScriptedTrain.cs
@@ -186,7 +186,6 @@ namespace Route.Bve5
 
 				TrainManager.Trains.ScriptedTrain Train = new TrainManager.Trains.ScriptedTrain(TrainState.Pending);
 				Train.Cars = new CarBase[OtherTrain.CarObjects.Count];
-				Train.Handles.Reverser = new ReverserHandle(Train);
 
 				for (int i = 0; i < Train.Cars.Length; i++)
 				{

--- a/source/Plugins/Train.MsTs/Train/ConsistParser.cs
+++ b/source/Plugins/Train.MsTs/Train/ConsistParser.cs
@@ -61,14 +61,6 @@ namespace Train.MsTs
 			{
 				throw new Exception();
 			}
-			train.Handles.Reverser = new ReverserHandle(train);
-			train.Handles.EmergencyBrake = new EmergencyHandle(train);
-			train.Handles.Power = new PowerHandle(8, train);
-			train.Handles.Brake = new BrakeHandle(8, train.Handles.EmergencyBrake, train);
-			train.Handles.LocoBrake = new LocoBrakeHandle(0, train.Handles.EmergencyBrake, train);
-			train.Handles.LocoBrakeType = LocoBrakeType.Independant;
-			train.Handles.HasLocoBrake = false;
-			train.Handles.HoldBrake = new HoldBrakeHandle(train);
 			train.Specs.AveragesPressureDistribution = true;
 			train.SafetySystems.Headlights = new LightSource(train, 2);
 			if(Directory.Exists(Plugin.FileSystem.MSTSDirectory))

--- a/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
@@ -1023,9 +1023,28 @@ namespace Train.OpenBve
 					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "TrailerCarMass is expected to be positive in " + FileName);
 					TrailerCarMass = 1.0;	
 				}
-				
 			}
-			
+
+			// apply data (need to set driver car first to ensure handles are assigned to the correct place)
+			if (MotorCars < 1) MotorCars = 1;
+			if (TrailerCars < 0) TrailerCars = 0;
+			int Cars = MotorCars + TrailerCars;
+			Train.Cars = new CarBase[Cars];
+			for (int i = 0; i < Train.Cars.Length; i++)
+			{
+				Train.Cars[i] = new CarBase(Train, i, CoefficientOfStaticFriction, CoefficientOfRollingResistance, AerodynamicDragCoefficient);
+			}
+			double DistanceBetweenTheCars = 0.3;
+
+			if (DriverCar < 0 || DriverCar >= Cars)
+			{
+				Plugin.CurrentHost.AddMessage(MessageType.Error, false, "DriverCar must point to an existing car in " + FileName);
+			}
+			else
+			{
+				Train.DriverCar = DriverCar;
+			}
+
 			if (powerNotches == 0)
 			{
 				Plugin.CurrentHost.AddMessage(MessageType.Error, false, "NumberOfPowerNotches was not set in " + FileName);
@@ -1078,24 +1097,7 @@ namespace Train.OpenBve
 				Train.Handles.LocoBrake = new LocoBrakeHandle(locoBrakeNotches, Train.Handles.EmergencyBrake, locoBrakeDelayUp, locoBrakeDelayDown, Train);
 			}
 			Train.Handles.LocoBrakeType = (LocoBrakeType)locoBrakeType;
-			Train.Handles.HoldBrake = new HoldBrakeHandle(Train);
-			// apply data
-			if (MotorCars < 1) MotorCars = 1;
-			if (TrailerCars < 0) TrailerCars = 0;
-			int Cars = MotorCars + TrailerCars;
-			Train.Cars = new CarBase[Cars];
-			for (int i = 0; i < Train.Cars.Length; i++)
-			{
-				Train.Cars[i] = new CarBase(Train, i, CoefficientOfStaticFriction, CoefficientOfRollingResistance, AerodynamicDragCoefficient);
-			}
-			double DistanceBetweenTheCars = 0.3;
 			
-			if (DriverCar < 0 | DriverCar >= Cars) {
-				Plugin.CurrentHost.AddMessage(MessageType.Error, false, "DriverCar must point to an existing car in " + FileName);
-				DriverCar = 0;
-
-			}
-			Train.DriverCar = DriverCar;
 			// brake system
 			double OperatingPressure;
 			if (BrakePipePressure <= 0.0) {

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -42,6 +42,9 @@ namespace TrainManager.Car
 		public Door[] Doors;
 		/// <summary>The horns attached to this car</summary>
 		public Horn[] Horns;
+		/// <summary>The cab handles</summary>
+		/// <remarks>This property will be null if the vehicle does not posses a cab</remarks>
+		public CabHandles Handles;
 		/// <summary>Contains the physics properties for the car</summary>
 		public readonly CarPhysics Specs;
 		/// <summary>The car brake for this car</summary>
@@ -443,9 +446,8 @@ namespace TrainManager.Car
 				// Create new train
 				TrainBase newTrain = new TrainBase(TrainState.Available, TrainType.StaticCars);
 				UncouplingBehaviour uncouplingBehaviour = UncouplingBehaviour.Emergency;
-				newTrain.Handles.Power = new PowerHandle(0, newTrain);
-				newTrain.Handles.Brake = new BrakeHandle(0, newTrain.Handles.EmergencyBrake, newTrain);
-				newTrain.Handles.HoldBrake = new HoldBrakeHandle(newTrain);
+				newTrain.Cars[0].Handles = new CabHandles(newTrain);
+				
 				if (Front)
 				{
 					int totalPreceedingCars = trainCarIndex;

--- a/source/TrainManager/Handles/CabHandles.cs
+++ b/source/TrainManager/Handles/CabHandles.cs
@@ -1,12 +1,13 @@
 ﻿using OpenBveApi.Interface;
+using TrainManager.Trains;
 
 namespace TrainManager.Handles
 {
 	/// <summary>The cab handles (controls) of a train</summary>
-	public struct CabHandles
+	public class CabHandles
 	{
 		/// <summary>The Reverser</summary>
-		public ReverserHandle Reverser;
+		public readonly ReverserHandle Reverser;
 		/// <summary>The Power</summary>
 		public AbstractHandle Power;
 		/// <summary>The Brake</summary>
@@ -14,9 +15,9 @@ namespace TrainManager.Handles
 		/// <summary>The Loco brake handle</summary>
 		public AbstractHandle LocoBrake;
 		/// <summary>The Emergency Brake</summary>
-		public EmergencyHandle EmergencyBrake;
+		public readonly EmergencyHandle EmergencyBrake;
 		/// <summary>The Hold Brake</summary>
-		public HoldBrakeHandle HoldBrake;
+		public readonly HoldBrakeHandle HoldBrake;
 		/// <summary>Whether the train has a combined power and brake handle</summary>
 		public HandleType HandleType;
 		/// <summary>Whether the train has the Hold Brake fitted</summary>
@@ -25,6 +26,16 @@ namespace TrainManager.Handles
 		public bool HasLocoBrake;
 		/// <summary>The loco brake type</summary>
 		public LocoBrakeType LocoBrakeType;
+
+		public CabHandles(TrainBase train)
+		{
+			Reverser = new ReverserHandle(train);
+			EmergencyBrake = new EmergencyHandle(train);
+			HoldBrake = new HoldBrakeHandle(train);
+
+			Power = new PowerHandle(0, train);
+			Brake = new BrakeHandle(0, EmergencyBrake, train);
+		}
 
 		public void ControlDown(Control Control)
 		{

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -33,7 +33,7 @@ namespace TrainManager.Trains
 		/// <summary>Contains information on the specifications of the train</summary>
 		public TrainSpecs Specs;
 		/// <summary>The cab handles</summary>
-		public CabHandles Handles;
+		public CabHandles Handles => Cars[DriverCar].Handles;
 		/// <summary>Holds the safety systems for the train</summary>
 		public TrainSafetySystems SafetySystems;
 		/// <summary>Holds the cars</summary>
@@ -152,11 +152,9 @@ namespace TrainManager.Trains
 			Specs.DoorCloseMode = DoorMode.AutomaticManualOverride;
 			Specs.PantographState = PantographState.Lowered;
 			DriverBody = new DriverBody(this);
-			Handles.Reverser = new ReverserHandle(this);
-			Handles.EmergencyBrake = new EmergencyHandle(this);
 		}
 
-		/// <summary>Called once when the simulation loads to initalize the train</summary>
+		/// <summary>Called once when the simulation loads to initialize the train</summary>
 		public virtual void Initialize()
 		{
 			for (int i = 0; i < Cars.Length; i++)


### PR DESCRIPTION
https://github.com/leezer3/OpenBVE/pull/930

This actually appears to be a relatively minor change.
CabHandles are moved to the driver car, and the train handle struct is changed to an accessor.

Can't see any immediate crashes or issues, but not going to merge this at the minute- Needs a way to specifiy different handles on a per-car basis, and then see what happens after that, and what becomes unhappy there when it changes....