### PR TITLE
Fix: Sander toggle behavior

### DIFF
--- a/source/OpenBVE/System/Input/ProcessControls.Digital.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Digital.cs
@@ -986,7 +986,11 @@ namespace OpenBve
 						{
 							if (TrainManager.PlayerTrain.Cars[c].ReAdhesionDevice is Sanders sanders)
 							{
-								sanders.Toggle();
+								if(sanders.Type == SandersType.PressAndHold) {
+									sanders.SetActive(true);
+								} else {
+									sanders.Toggle();
+								}
 							}
 						}
 
@@ -1479,6 +1483,8 @@ namespace OpenBve
 							{
 								if (sanders.Type == SandersType.PressAndHold)
 								{
+									sanders.SetActive(false);
+								} else {
 									sanders.Toggle();
 								}
 							}

--- a/source/TrainManager/Car/Systems/Sanders.cs
+++ b/source/TrainManager/Car/Systems/Sanders.cs
@@ -94,7 +94,7 @@ namespace TrainManager.Car.Systems
 						timer += timeElapsed;
 						if (timer > ActivationTime && !Active)
 						{
-							Toggle();
+							SetActive(true);
 						}
 					}
 					else
@@ -102,7 +102,7 @@ namespace TrainManager.Car.Systems
 						timer = 0;
 						if (Active)
 						{
-							Toggle();
+							SetActive(false);
 						}
 					}
 					break;
@@ -120,7 +120,7 @@ namespace TrainManager.Car.Systems
 			}
 		}
 
-		public void Toggle()
+		public void SetActive(bool willBeActive)
 		{
 			if (Type == SandersType.NotFitted)
 			{
@@ -137,21 +137,20 @@ namespace TrainManager.Car.Systems
 				}
 				return;
 			}
-			if (Active)
-			{
+
+			// Deactivate
+			if(Active && !willBeActive) {
 				if (Type == SandersType.NumberOfShots && timer > 0)
 				{
 					// Can't cancel shot based
 					return;
 				}
-				Active = false;
+
 				if (DeActivationSound != null)
 				{
-					DeActivationSound.Play(Car, false);	
+					DeActivationSound.Play(Car, false);
 				}
-			}
-			else
-			{
+			} else if(!Active && willBeActive) {
 				if (Type == SandersType.NumberOfShots)
 				{
 					if (NumberOfShots <= 0)
@@ -161,11 +160,22 @@ namespace TrainManager.Car.Systems
 					NumberOfShots--;
 					timer = ApplicationTime;
 				}
-				Active = true;
+
 				if (ActivationSound != null)
 				{
-					ActivationSound.Play(Car, false);	
+					ActivationSound.Play(Car, false);
 				}
+			}
+
+			Active = willBeActive;
+		}
+
+		public void Toggle()
+		{
+			if(Active) {
+				SetActive(false);
+			} else {
+				SetActive(true);
 			}
 		}
 	}


### PR DESCRIPTION
#931

Keyboard repeating input would make the sander toggle on and off repeatedly with `PressAndHold`, this PR fixes that.

Sanders will still only update when power is applied which may lead to oddities when toggled manually, although I am afraid that's not something I am qualified to tweak with...