### PR TITLE
Remove memory debug message when running in 32-bit

### DIFF
--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -1054,7 +1054,6 @@ namespace OpenBve
 				using (Process proc = Process.GetCurrentProcess())
 				{
 					long memoryUsed = proc.PrivateMemorySize64;
-					MessageBox.Show(memoryUsed.ToString());
 					if ((memoryUsed > 900000000 && !Interface.CurrentOptions.LoadInAdvance) || memoryUsed > 1600000000)
 					{
 						// Either using ~900mb at the first station or 1.5gb + with all textures loaded is likely to cause critical OOM errors with the 32-bit process memory limit


### PR DESCRIPTION
Introduced in https://github.com/leezer3/OpenBVE/commit/17ffa6246575a5dbf10eca25a19eb4036848ceb6