### PR TITLE
Fix mapping for Densha de GO! controllers

### DIFF
--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -381,14 +381,14 @@ namespace DenshaDeGoInput
 				{
 					brakeCommands[0] = 0;
 					brakeCommands[1] = 100 + (int)Translations.Command.HoldBrake;
-					for (int i = 2; i < controllerBrakeNotches + 2; i++)
+					for (int i = 2; i <= controllerBrakeNotches + 1; i++)
 					{
 						brakeCommands[i] = i - 1;
 					}
 				}
 				else
 				{
-					for (int i = 0; i < controllerBrakeNotches + 2; i++)
+					for (int i = 0; i <= controllerBrakeNotches + 1; i++)
 					{
 						brakeCommands[i] = i;
 					}
@@ -399,7 +399,7 @@ namespace DenshaDeGoInput
 					brakeCommands[(int)InputTranslator.BrakeNotches.Emergency] = 100 + (int)Translations.Command.BrakeEmergency;
 				}
 				// Power notches
-				for (int i = 0; i < controllerPowerNotches; i++)
+				for (int i = 0; i <= controllerPowerNotches; i++)
 				{
 					powerCommands[i] = i;
 				}

--- a/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2021-2023, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -88,6 +88,11 @@ namespace DenshaDeGoInput
 						if (ControllerDevice != null)
 						{
 							controllerName = ControllerDevice.Info.ProductString;
+							if (string.IsNullOrEmpty(controllerName))
+							{
+								// The name may be blank, use VID+PID
+								controllerName = VendorID.ToString("X4") + ":" + ProductID.ToString("X4");
+							}
 						}
 					}
 					catch


### PR DESCRIPTION
This PR fixes a mapping issue caused by an off-by-one error. Also improves detection of PS2 controllers, which previously had a fixed endpoint.

Fixes #952