### PR TITLE
Experimental: Improve forced updates when large numbers of Animated Objects are present

### DIFF
--- a/assets/Compatibility/RoutePatches/Indonesia.xml
+++ b/assets/Compatibility/RoutePatches/Indonesia.xml
@@ -1,0 +1,11 @@
+<openBVE xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <RoutePatches>
+  <!-- Yogyakarta-Madiun -->
+	<Patch>
+		<Hash>FE894F07B945AB4FE30D1805BAC32B44307D2E08D68492C0C47B9F57506DE2DB</Hash>
+		<FileName>Yogyakarta-Madiun.csv</FileName>
+		<DelayedAnimatedUpdates>true</DelayedAnimatedUpdates>
+		<ReducedColorTransparency>true</ReducedColorTransparency>
+	</Patch>
+  </RoutePatches>
+</openBVE>

--- a/assets/Compatibility/RoutePatches/database.xml
+++ b/assets/Compatibility/RoutePatches/database.xml
@@ -10,6 +10,7 @@
 	<PatchList>Hungary.xml</PatchList>
 	<PatchList>Poland.xml</PatchList>
 	<PatchList>Italy.xml</PatchList>
+	<PatchList>Indonesia.xml</PatchList>
 	<PatchList>Japan.xml</PatchList>
 	<PatchList>Misc.xml</PatchList>
 	<PatchList>Spain.xml</PatchList>

--- a/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
+++ b/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
@@ -33,7 +33,7 @@ namespace OpenBve
 
 				if (ForceUpdate)
 				{
-					if (AnimatedWorldObjects[i].TrackPosition - Math.Abs(Program.Renderer.CameraTrackFollower.TrackPosition) <= 5000 || AnimatedWorldObjects[i].Object.TrackFollowerFunction != null)
+					if (Interface.CurrentOptions.DelayedAnimatedUpdates == false || AnimatedWorldObjects[i].TrackPosition - Math.Abs(Program.Renderer.CameraTrackFollower.TrackPosition) <= 5000 || AnimatedWorldObjects[i].Object.TrackFollowerFunction != null)
 					{
 						AnimatedWorldObjects[i].Update(train, TimeElapsed, true, visible);
 					}

--- a/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
+++ b/source/OpenBVE/Game/ObjectManager/ObjectManager.cs
@@ -1,3 +1,4 @@
+using System;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Trains;
@@ -29,7 +30,18 @@ namespace OpenBve
 					//Find the closest train
 					train = Program.CurrentHost.ClosestTrain(AnimatedWorldObjects[i].RelativeTrackPosition);
 				}
-				AnimatedWorldObjects[i].Update(train, TimeElapsed, ForceUpdate, visible);
+
+				if (ForceUpdate)
+				{
+					if (AnimatedWorldObjects[i].TrackPosition - Math.Abs(Program.Renderer.CameraTrackFollower.TrackPosition) <= 5000 || AnimatedWorldObjects[i].Object.TrackFollowerFunction != null)
+					{
+						AnimatedWorldObjects[i].Update(train, TimeElapsed, true, visible);
+					}
+				}
+				else
+				{
+					AnimatedWorldObjects[i].Update(train, TimeElapsed, false, visible);
+				}
 			}
 		}
 

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using OpenBveApi.FunctionScripting;
 using OpenBveApi.Graphics;
@@ -6,11 +7,14 @@ using OpenBveApi.Math;
 using OpenBveApi.Trains;
 using OpenBveApi.World;
 
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
 namespace OpenBveApi.Objects
 {
 	/// <summary>The base type for an animated object</summary>
 	public class AnimatedObject
 	{
+		/// <summary>The filename</summary>
+		private readonly string FileName;
 		/// <summary>The array of states</summary>
 		public ObjectState[] States;
 		/// <summary>The function script controlling state changes</summary>
@@ -106,17 +110,18 @@ namespace OpenBveApi.Objects
 		public int SectionIndex;
 
 		/// <summary>Creates a new animated object</summary>
-		public AnimatedObject(HostInterface host)
+		public AnimatedObject(HostInterface host, string fileName = "")
 		{
 			currentHost = host;
 			States = new ObjectState[] { };
+			FileName = fileName;
 		}
 
 		/// <summary>Clones this object</summary>
 		/// <returns>The new object</returns>
 		public AnimatedObject Clone()
 		{
-			AnimatedObject Result = new AnimatedObject(currentHost)
+			AnimatedObject Result = new AnimatedObject(currentHost, FileName)
 			{
 				States = States.Select(x => (ObjectState)x.Clone()).ToArray(),
 				TrackFollowerFunction = TrackFollowerFunction?.Clone(),
@@ -868,5 +873,87 @@ namespace OpenBveApi.Objects
 			TranslateZDirection.Z *= -1.0;
 			//As we are using a rotation matrix, we only need to reverse the translation and not the rotation
 		}
+
+		/// <summary>Checks whether the two specified animated objects are equal</summary>
+		public static bool operator ==(AnimatedObject a, AnimatedObject b)
+		{
+			if (a is null)
+			{
+				return !(b is null);
+			}
+			return a.Equals(b);
+		}
+
+		/// <summary>Checks whether the two specified animated objects are unequal</summary>
+		public static bool operator !=(AnimatedObject a, AnimatedObject b)
+		{
+			if (a is null)
+			{
+				return b is null;
+			}
+			return !a.Equals(b);
+		}
+
+		/// <summary>Indicates whether this instance and a specified instance are equal.</summary>
+		/// <param name="animatedObject">The instance to compare to.</param>
+		/// <returns>True if the instances are equal; false otherwise.</returns>
+		public bool Equals(AnimatedObject animatedObject)
+		{
+			if (animatedObject is null)
+			{
+				return false;
+			}
+			if (animatedObject.FileName != FileName) return false; // fast return hopefully
+			if (animatedObject.States != States) return false;
+			if (animatedObject.StateFunction != StateFunction) return false;
+			if (animatedObject.TranslateXDirection != TranslateXDirection) return false;
+			if (animatedObject.TranslateYDirection != TranslateYDirection) return false;
+			if (animatedObject.TranslateZDirection != TranslateZDirection) return false;
+			if (animatedObject.TranslateXFunction != TranslateXFunction) return false;
+			if (animatedObject.TranslateYFunction != TranslateYFunction) return false;
+			if (animatedObject.TranslateZFunction != TranslateZFunction) return false;
+			if (animatedObject.RotateXDirection != RotateXDirection) return false;
+			if (animatedObject.RotateXDamping != RotateXDamping) return false;
+			if (animatedObject.RotateYDamping != RotateYDamping) return false;
+			if (animatedObject.RotateZDamping != RotateZDamping) return false;
+			if (animatedObject.RotateYDirection != RotateYDirection) return false;
+			if (animatedObject.RotateZDirection != RotateZDirection) return false;
+			if (animatedObject.RotateXFunction != RotateXFunction) return false;
+			if (animatedObject.RotateYFunction != RotateYFunction) return false;
+			if (animatedObject.RotateZFunction != RotateZFunction) return false;
+			if (animatedObject.TextureShiftXDirection != TextureShiftXDirection) return false;
+			if (animatedObject.TextureShiftYDirection != TextureShiftYDirection) return false;
+			if (animatedObject.TextureShiftXFunction != TextureShiftXFunction) return false;
+			if (animatedObject.TextureShiftYFunction != TextureShiftYFunction) return false;
+			if (animatedObject.ScaleXFunction != ScaleXFunction) return false;
+			if (animatedObject.ScaleYFunction != ScaleYFunction) return false;
+			if (animatedObject.ScaleZFunction != ScaleZFunction) return false;
+			if (animatedObject.LEDClockwiseWinding != LEDClockwiseWinding) return false;
+			if (animatedObject.LEDInitialAngle != LEDInitialAngle) return false;
+			if (animatedObject.LEDLastAngle != LEDLastAngle) return false;
+			if (animatedObject.LEDVectors != LEDVectors) return false;
+			if (animatedObject.LEDFunction != LEDFunction) return false;
+			if (animatedObject.RefreshRate != RefreshRate) return false;
+			if (animatedObject.TrackFollowerFunction != TrackFollowerFunction) return false;
+			if (animatedObject.FrontAxlePosition != FrontAxlePosition) return false;
+			if (animatedObject.RearAxlePosition != RearAxlePosition) return false;
+			if (animatedObject.isTimeTableObject != isTimeTableObject) return false;
+			// other fields should be instance related only
+			return true;
+		}
+
+		/// <summary>Indicates whether this instance and a specified object are equal.</summary>
+		/// <param name="obj">The object to compare to.</param>
+		/// <returns>True if the instances are equal; false otherwise.</returns>
+		public override bool Equals(object obj)
+		{
+			if (!(obj is AnimatedObject animatedObject))
+			{
+				return false;
+			}
+
+			return Equals(animatedObject);
+		}
 	}
 }
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()

--- a/source/OpenBveApi/System/BaseOptions.cs
+++ b/source/OpenBveApi/System/BaseOptions.cs
@@ -101,5 +101,8 @@ namespace OpenBveApi
 		public bool UseGDIDecoders;
 		/// <summary>The filename of the current cursor</summary>
 		public string CursorFileName;
+		/// <summary>Whether delayed animated updates based upon track position are used</summary>
+		/// <remarks>Not saved</remarks>
+		public bool DelayedAnimatedUpdates;
 	}
 }

--- a/source/Plugins/Object.Animated/Plugin.Parser.cs
+++ b/source/Plugins/Object.Animated/Plugin.Parser.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Globalization;
-using OpenBveApi;
+using System.IO;
 using OpenBveApi.FunctionScripting;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Sounds;
 using OpenBveApi.Textures;
+using Path = OpenBveApi.Path;
 
 namespace Plugin
 {
@@ -144,7 +145,7 @@ namespace Plugin
 											{
 												Array.Resize(ref Result.Objects, Result.Objects.Length << 1);
 											}
-											AnimatedObject a = new AnimatedObject(currentHost);
+											AnimatedObject a = new AnimatedObject(currentHost, FileName);
 											ObjectState aos = new ObjectState
 											{
 												Prototype = s,
@@ -191,7 +192,7 @@ namespace Plugin
 								{
 									Array.Resize(ref Result.Objects, Result.Objects.Length << 1);
 								}
-								Result.Objects[ObjectCount] = new AnimatedObject(currentHost)
+								Result.Objects[ObjectCount] = new AnimatedObject(currentHost, FileName)
 								{
 									CurrentState = -1,
 									TranslateXDirection = Vector3.Right,

--- a/source/Plugins/Object.LokSim/GroupParser.cs
+++ b/source/Plugins/Object.LokSim/GroupParser.cs
@@ -274,7 +274,7 @@ namespace Plugin
 								obj[obj.Length - 1] = Object;
 								int aL = Result.Objects.Length;
 								Array.Resize(ref Result.Objects, aL + 1);
-								AnimatedObject a = new AnimatedObject(Plugin.currentHost);
+								AnimatedObject a = new AnimatedObject(Plugin.currentHost, FileName);
 								ObjectState aos = new ObjectState
 								{
 									Prototype = Object,
@@ -311,7 +311,7 @@ namespace Plugin
 								}
 								else
 								{
-									Result.Objects[o] = new AnimatedObject(Plugin.currentHost);
+									Result.Objects[o] = new AnimatedObject(Plugin.currentHost, FileName);
 								}
 							}
 						}
@@ -319,7 +319,7 @@ namespace Plugin
 					if (staticObject != null)
 					{
 						Array.Resize(ref Result.Objects, Result.Objects.Length + 1);
-						AnimatedObject a = new AnimatedObject(Plugin.currentHost);
+						AnimatedObject a = new AnimatedObject(Plugin.currentHost, FileName);
 						ObjectState aos = new ObjectState(staticObject);
 						a.States = new [] { aos };
 						Result.Objects[Result.Objects.Length - 1] = a;

--- a/source/Plugins/Object.Msts/ShapeParser.cs
+++ b/source/Plugins/Object.Msts/ShapeParser.cs
@@ -421,7 +421,7 @@ namespace Plugin
 			{
 				for (int j = 0; j < shape.LODs[i].subObjects.Count; j++)
 				{
-					Result.Objects[idx] = new AnimatedObject(Plugin.currentHost);
+					Result.Objects[idx] = new AnimatedObject(Plugin.currentHost, fileName);
 					Result.Objects[idx].States = new ObjectState[1];
 					ObjectState aos = new ObjectState();
 					shape.LODs[i].subObjects[j].Apply(out aos.Prototype);

--- a/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
+++ b/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
@@ -52,6 +52,7 @@ namespace CsvRwRouteParser
 
 				Plugin.CurrentOptions.Derailments = patch.Derailments;
 				Plugin.CurrentOptions.Toppling = patch.Toppling;
+				Plugin.CurrentOptions.DelayedAnimatedUpdates = patch.DelayedAnimatedUpdates;
 				SplitLineHack = patch.SplitLineHack;
 				AllowTrackPositionArguments = patch.AllowTrackPositionArguments;
 				foreach (int i in patch.DummyRailTypes)
@@ -155,5 +156,7 @@ namespace CsvRwRouteParser
 		internal bool Incompatible = false;
 		/// <summary>Whether aggressive RW bracket fixing is applied</summary>
 		internal bool AggressiveRwBrackets = false;
+		/// <summary>Whether animated object updates are delayed based upon distance</summary>
+		internal bool DelayedAnimatedUpdates = false;
 	}
 }

--- a/source/Plugins/Route.CsvRw/XML/RoutePatchDatabase.cs
+++ b/source/Plugins/Route.CsvRw/XML/RoutePatchDatabase.cs
@@ -280,6 +280,17 @@ namespace CsvRwRouteParser
 							currentPatch.Incompatible = false;
 						}
 						break;
+					case "DelayedAnimatedUpdates":
+						t = childNode.InnerText.Trim().ToLowerInvariant();
+						if (t == "1" || t == "true")
+						{
+							currentPatch.DelayedAnimatedUpdates = true;
+						}
+						else
+						{
+							currentPatch.DelayedAnimatedUpdates = false;
+						}
+						break;
 				}
 			}
 


### PR DESCRIPTION
https://github.com/leezer3/OpenBVE/issues/955

The (essential) cause of the above issue is that it uses large numbers of animated objects, all of which contain functions which are costly to execute. 

The game executes a forced update on all world animated objects in the two following circumstances:
* At game start
* After a jump (manual / change ends)

If our world contains thousands of animated objects, each of which contains one or more heavy functions, this can bog down significantly, and cause the slow loading above.

This PR does the following:
* Implements a custom equality operator for animated objects. (This speeds up some aspects of the update)
* On a forced update, only objects placed within 5km of the camera position or having a **TrackFollowerFunction** will be evaluated. 

This brings the loading time of the linked route above to a sensible level, and as a bonus improves loading times for anything using lots of animated objects.

### RISKS:
Actually, I'm not sure, and this is what concerns me a little.
There was obviously a reason for updating all animated objects. but I can't immediately think of one. Any objects present after a jump should be culled before the start of the frame with the standard visibility update routine. 

https://bveworldwide.forumotion.com/t2168-building-a-route-based-on-the-staten-island-railway-integrated-into-the-nyc-subway-system-download-update-10-24-2023#21704

Should be properly tested with the above, as another instance of massive animated function use.....