### PR TITLE
Change: Pause rather than stop flange / run loops

### DIFF
--- a/source/OpenBVE/Audio/Sounds.Update.cs
+++ b/source/OpenBVE/Audio/Sounds.Update.cs
@@ -59,122 +59,141 @@ namespace OpenBve
 			 * and ensure that all others are stopped.
 			 * */
 			List<SoundSourceAttenuation> toBePlayed = new List<SoundSourceAttenuation>();
-			for (int i = 0; i < SourceCount; i++) {
-				if (Sources[i].State == SoundSourceState.StopPending) {
-					/*
-					 * The sound is still playing but is to be stopped.
-					 * Stop the sound, then remove it from the list of
-					 * sound sources.
-					 * */
-					AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
-					Sources[i].State = SoundSourceState.Stopped;
-					Sources[i].OpenAlSourceName = 0;
-					Sources[i] = Sources[SourceCount - 1];
-					SourceCount--;
-					i--;
-				} else if (Sources[i].State == SoundSourceState.Stopped) {
-					/*
-					 * The sound was already stopped. Remove it from
-					 * the list of sound sources.
-					 * */
-					Sources[i] = Sources[SourceCount - 1];
-					SourceCount--;
-					i--;
-				} else if (GlobalMute) {
-					/*
-					 * The sound is playing or about to be played, but
-					 * the global mute option is enabled. Stop the sound
-					 * sound if necessary, then remove it from the list
-					 * of sound sources if the sound is not looping.
-					 * */
-					if (Sources[i].State == SoundSourceState.Playing) {
+			for (int i = 0; i < SourceCount; i++)
+			{
+				switch (Sources[i].State)
+				{
+					case SoundSourceState.StopPending:
+						/*
+						 * The sound is still playing but is to be stopped.
+						 * Stop the sound, then remove it from the list of
+						 * sound sources.
+						 * */
 						AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
-						Sources[i].State = SoundSourceState.PlayPending;
-						Sources[i].OpenAlSourceName = 0;
-					}
-					if (!Sources[i].Looped) {
 						Sources[i].State = SoundSourceState.Stopped;
 						Sources[i].OpenAlSourceName = 0;
 						Sources[i] = Sources[SourceCount - 1];
 						SourceCount--;
 						i--;
-					}
-				} else {
-					/*
-					 * The sound is to be played or is already playing.
-					 * */
-					if (Sources[i].State == SoundSourceState.Playing) {
-						AL.GetSource(Sources[i].OpenAlSourceName, ALGetSourcei.SourceState, out int state);
-						if (state != (int)ALSourceState.Initial & state != (int)ALSourceState.Playing) {
-							/*
-							 * The sound is not playing any longer.
-							 * Remove it from the list of sound sources.
-							 * */
-							AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
-							Sources[i].State = SoundSourceState.Stopped;
-							Sources[i].OpenAlSourceName = 0;
-							Sources[i] = Sources[SourceCount - 1];
-							SourceCount--;
-							i--;
-							continue;
-						}
-					}
-					/*
-					 * Calculate the gain, then add the sound
-					 * to the list of sounds to be played.
-					 * */
-					Vector3 position;
-					switch (Sources[i].Type)
+						break;
+					case SoundSourceState.PausePending:
+						AL.SourcePause(Sources[i].OpenAlSourceName);
+						Sources[i].State = SoundSourceState.Paused;
+						break;
+					case SoundSourceState.ResumePending:
+						AL.SourcePlay(Sources[i].OpenAlSourceName);
+						Sources[i].State = SoundSourceState.Playing;
+						break;
+					case SoundSourceState.Stopped:
+						/*
+						 * The sound was already stopped. Remove it from
+						 * the list of sound sources.
+						 * */
+						Sources[i] = Sources[SourceCount - 1];
+						SourceCount--;
+						i--;
+						break;
+					default:
 					{
-						case SoundType.TrainCar:
-							var Car = (AbstractCar)Sources[i].Parent;
-							Car.CreateWorldCoordinates(Sources[i].Position, out position, out _);
-							break;
-						case SoundType.AnimatedObject:
-							var WorldSound = (WorldSound)Sources[i].Parent;
-							position = WorldSound.Follower.WorldPosition + WorldSound.Position;
-							break;
-						default:
-							position = Sources[i].Position;
-							break;
-					}
-					Vector3 positionDifference = position - listenerPosition;
-					double distance = positionDifference.Norm();
-					double radius = Sources[i].Radius;
-					if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior | Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead) {
-						if (Sources[i].Parent != TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar]) {
-							radius *= 0.5;
+						if (GlobalMute) {
+							/*
+							 * The sound is playing or about to be played, but
+							 * the global mute option is enabled. Stop the sound
+							 * sound if necessary, then remove it from the list
+							 * of sound sources if the sound is not looping.
+							 * */
+							if (Sources[i].State == SoundSourceState.Playing) {
+								AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
+								Sources[i].State = SoundSourceState.PlayPending;
+								Sources[i].OpenAlSourceName = 0;
+							}
+							if (!Sources[i].Looped) {
+								Sources[i].State = SoundSourceState.Stopped;
+								Sources[i].OpenAlSourceName = 0;
+								Sources[i] = Sources[SourceCount - 1];
+								SourceCount--;
+								i--;
+							}
+						} else {
+							/*
+							 * The sound is to be played or is already playing.
+							 * */
+							if (Sources[i].State == SoundSourceState.Playing) {
+								AL.GetSource(Sources[i].OpenAlSourceName, ALGetSourcei.SourceState, out int state);
+								if (state != (int)ALSourceState.Initial & state != (int)ALSourceState.Playing) {
+									/*
+									 * The sound is not playing any longer.
+									 * Remove it from the list of sound sources.
+									 * */
+									AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
+									Sources[i].State = SoundSourceState.Stopped;
+									Sources[i].OpenAlSourceName = 0;
+									Sources[i] = Sources[SourceCount - 1];
+									SourceCount--;
+									i--;
+									continue;
+								}
+							}
+							/*
+							 * Calculate the gain, then add the sound
+							 * to the list of sounds to be played.
+							 * */
+							Vector3 position;
+							switch (Sources[i].Type)
+							{
+								case SoundType.TrainCar:
+									var Car = (AbstractCar)Sources[i].Parent;
+									Car.CreateWorldCoordinates(Sources[i].Position, out position, out _);
+									break;
+								case SoundType.AnimatedObject:
+									var WorldSound = (WorldSound)Sources[i].Parent;
+									position = WorldSound.Follower.WorldPosition + WorldSound.Position;
+									break;
+								default:
+									position = Sources[i].Position;
+									break;
+							}
+							Vector3 positionDifference = position - listenerPosition;
+							double distance = positionDifference.Norm();
+							double radius = Sources[i].Radius;
+							if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior | Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead) {
+								if (Sources[i].Parent != TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar]) {
+									radius *= 0.5;
+								}
+							}
+							double gain;
+							if (distance < 2.0 * radius) {
+								gain = 1.0 - distance * distance * (4.0 * radius - distance) / (16.0 * radius * radius * radius);
+							} else {
+								gain = radius / distance;
+							}
+							gain *= Sources[i].Volume;
+							if (gain <= 0.0) {
+								/*
+								 * The gain is too low. Stop the sound if playing,
+								 * but keep looping sounds pending.
+								 * */
+								if (Sources[i].State == SoundSourceState.Playing) {
+									AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
+									Sources[i].State = SoundSourceState.PlayPending;
+									Sources[i].OpenAlSourceName = 0;
+								}
+								if (!Sources[i].Looped) {
+									Sources[i].State = SoundSourceState.Stopped;
+									Sources[i].OpenAlSourceName = 0;
+									Sources[i] = Sources[SourceCount - 1];
+									SourceCount--;
+									i--;
+								}
+							} else {
+								/*
+								 * Add the source.
+								 * */
+								toBePlayed.Add(new SoundSourceAttenuation(Sources[i], gain, distance));
+							}
 						}
-					}
-					double gain;
-					if (distance < 2.0 * radius) {
-						gain = 1.0 - distance * distance * (4.0 * radius - distance) / (16.0 * radius * radius * radius);
-					} else {
-						gain = radius / distance;
-					}
-					gain *= Sources[i].Volume;
-					if (gain <= 0.0) {
-						/*
-						 * The gain is too low. Stop the sound if playing,
-						 * but keep looping sounds pending.
-						 * */
-						if (Sources[i].State == SoundSourceState.Playing) {
-							AL.DeleteSources(1, ref Sources[i].OpenAlSourceName);
-							Sources[i].State = SoundSourceState.PlayPending;
-							Sources[i].OpenAlSourceName = 0;
-						}
-						if (!Sources[i].Looped) {
-							Sources[i].State = SoundSourceState.Stopped;
-							Sources[i].OpenAlSourceName = 0;
-							Sources[i] = Sources[SourceCount - 1];
-							SourceCount--;
-							i--;
-						}
-					} else {
-						/*
-						 * Add the source.
-						 * */
-						toBePlayed.Add(new SoundSourceAttenuation(Sources[i], gain, distance));
+
+						break;
 					}
 				}
 			}
@@ -237,7 +256,7 @@ namespace OpenBve
 					/*
 					 * Stop the sound.
 					 * */
-					if (source.State == SoundSourceState.Playing) {
+					if (source.State == SoundSourceState.Playing && source.State != SoundSourceState.Paused && source.State != SoundSourceState.PausePending) {
 						AL.DeleteSources(1, ref source.OpenAlSourceName);
 						source.State = SoundSourceState.PlayPending;
 						source.OpenAlSourceName = 0;
@@ -250,7 +269,7 @@ namespace OpenBve
 					/*
 					 * Ensure the buffer is loaded, then play the sound.
 					 * */
-					if (source.State != SoundSourceState.Playing) {
+					if (source.State != SoundSourceState.Playing && source.State != SoundSourceState.Paused && source.State != SoundSourceState.PausePending) {
 						LoadBuffer(source.Buffer);
 						if (source.Buffer.Loaded) {
 							AL.GenSources(1, out source.OpenAlSourceName);
@@ -289,7 +308,7 @@ namespace OpenBve
 					AL.Source(source.OpenAlSourceName, ALSource3f.Velocity, (float)velocity.X, (float)velocity.Y, (float)velocity.Z);
 					AL.Source(source.OpenAlSourceName, ALSourcef.Pitch, (float)source.Pitch);
 					AL.Source(source.OpenAlSourceName, ALSourcef.Gain, (float)gain);
-					if (source.State != SoundSourceState.Playing) {
+					if (source.State != SoundSourceState.Playing && source.State != SoundSourceState.Paused && source.State != SoundSourceState.PausePending) {
 						AL.Source(source.OpenAlSourceName, ALSourceb.Looping, source.Looped);
 						AL.SourcePlay(source.OpenAlSourceName);
 						source.State = SoundSourceState.Playing;

--- a/source/OpenBveApi/Sounds/Sounds.SoundSourceState.cs
+++ b/source/OpenBveApi/Sounds/Sounds.SoundSourceState.cs
@@ -10,6 +10,12 @@
 		/// <summary>The sound will stop playing. The OpenAL sound name is still valid.</summary>
 		StopPending,
 		/// <summary>The sound has stopped and will be removed from the list of sound sources. The OpenAL source name is not valid any longer.</summary>
-		Stopped
+		Stopped,
+		/// <summary>The sound is not yet in audible range, but is paused</summary>
+		PausePending,
+		/// <summary>The sound is paused</summary>
+		Paused,
+		/// <summary>The sound is pending resuming</summary>
+		ResumePending
 	}
 }

--- a/source/SoundManager/Sounds.CarSound.cs
+++ b/source/SoundManager/Sounds.CarSound.cs
@@ -109,9 +109,15 @@ namespace SoundManager
 		/// <param name="looped">Whether the sound is to be played looped</param>
 		public void Play(double pitch, double volume, AbstractCar Car, bool looped)
 		{
+			if (looped && IsPaused)
+			{
+				Source.Resume();
+				Source.Volume = volume;
+				Source.Pitch = pitch;
+				return;
+			}
 			if (looped && IsPlaying)
 			{
-				// If looped and already playing, update the pitch / volume values
 				Source.Volume = volume;
 				Source.Pitch = pitch;
 				return;
@@ -139,6 +145,15 @@ namespace SoundManager
 			Source.Stop();
 		}
 
+		public void Pause()
+		{
+			if (Source == null)
+			{
+				return;
+			}
+			Source.Pause();
+		}
+
 		/// <summary>Whether the sound is currently playing</summary>
 		public bool IsPlaying
 		{
@@ -147,6 +162,19 @@ namespace SoundManager
 				if (Source != null)
 				{
 					return Source.IsPlaying();
+				}
+				return false;
+			}
+		}
+
+		/// <summary>Whether the sound is currently paused</summary>
+		public bool IsPaused
+		{
+			get
+			{
+				if (Source != null)
+				{
+					return Source.IsPaused();
 				}
 				return false;
 			}

--- a/source/SoundManager/Sounds.SoundSource.cs
+++ b/source/SoundManager/Sounds.SoundSource.cs
@@ -100,11 +100,21 @@ namespace SoundManager
 			{
 				return true;
 			}
-
 			return false;
 		}
 
-		/// <summary>Stops this sound.</summary>
+		/// <summary>Checks whether this sound is paused or supposed to be paused.</summary>
+		/// <returns>Whether the sound is paused or supposed to be paused.</returns>
+		public bool IsPaused()
+		{
+			if (State == SoundSourceState.PausePending | State == SoundSourceState.Paused)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>Stops this sound</summary>
 		public void Stop()
 		{
 			if (State == SoundSourceState.PlayPending)
@@ -114,6 +124,27 @@ namespace SoundManager
 			else if (State == SoundSourceState.Playing)
 			{
 				State = SoundSourceState.StopPending;
+			}
+		}
+
+		/// <summary>Pauses this sound</summary>
+		public void Pause()
+		{
+			if (State == SoundSourceState.PlayPending)
+			{
+				State = SoundSourceState.Paused;
+			}
+			else if (State == SoundSourceState.Playing)
+			{
+				State = SoundSourceState.PausePending;
+			}
+		}
+
+		public void Resume()
+		{
+			if (State == SoundSourceState.Paused || State == SoundSourceState.PausePending)
+			{
+				State = SoundSourceState.ResumePending;
 			}
 		}
 	}

--- a/source/TrainEditor2/Simulation/TrainManager/Car/Car.cs
+++ b/source/TrainEditor2/Simulation/TrainManager/Car/Car.cs
@@ -75,7 +75,7 @@ namespace TrainEditor2.Simulation.TrainManager
 
 					double gain = baseGain * Sounds.Run[key].TargetVolume;
 
-					if (Sounds.Run[key].IsPlaying)
+					if (Sounds.Run[key].IsPlaying || Sounds.Run[key].IsPaused)
 					{
 						if (pitch > 0.01 & gain > 0.001)
 						{

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -613,7 +613,7 @@ namespace TrainManager.Car
 					}
 					else
 					{
-						TrainManagerBase.currentHost.StopSound(Sounds.Run[key].Source);
+						Sounds.Run[key].Pause();
 					}
 				}
 				else if (pitch > 0.02 & gain > 0.01)
@@ -1245,7 +1245,7 @@ namespace TrainManager.Car
 						}
 						else
 						{
-							Sounds.Flange[key].Stop();
+							Sounds.Flange[key].Pause();
 						}
 					}
 					else if (pitch > 0.02 & gain > 0.01)


### PR DESCRIPTION
This experimental PR pauses rather than stops the **Flange** and **Run** sounds.

May allow over-length sounds to work a little better by stopping repetition glitches.
[PauseResume.zip](https://github.com/leezer3/OpenBVE/files/13451367/PauseResume.zip)

**NOTES:**
* Currently applies to all content. Unlikely to require restricting to BVE stuff, as this seems a logical addition.
* If merged, requires an errata note for changed behaviour.
* When resumed, volume is at the set volume, not the original volume.