### PR TITLE
Fix: No translation/text in the Bug Report Dialog

### DIFF
--- a/source/OpenBVE/UserInterface/formBugReport.cs
+++ b/source/OpenBVE/UserInterface/formBugReport.cs
@@ -31,14 +31,14 @@ namespace OpenBve
 		}
 
 		private void ApplyLanguage() {
-			this.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"});
-			textBoxReportLabel.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_description"});
-			labelViewLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_view_log"});
-			labelViewCrash.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_view_crash_log"});
-			label1.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_enter_description"});
-			buttonReportProblem.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_save"});
-			buttonViewLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_view_log_button"});
-			buttonViewCrashLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_view_log_button"});
+			this.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"});
+			textBoxReportLabel.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "description"});
+			labelViewLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "view_log"});
+			labelViewCrash.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "view_crash_log"});
+			label1.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "enter_description"});
+			buttonReportProblem.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "save"});
+			buttonViewLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "view_log_button"});
+			buttonViewCrashLog.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "view_log_button"});
 		}
 
 		private void buttonViewLog_Click(object sender, EventArgs e)

--- a/source/OpenBVE/UserInterface/formBugReport.cs
+++ b/source/OpenBVE/UserInterface/formBugReport.cs
@@ -59,13 +59,13 @@ namespace OpenBve
 						log.ShowDialog();
 					}
 				} else {
-					MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_no_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
+					MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","no_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
 				}
 			}
 			catch
 			{
 				// Actually failed to load, but same difference
-				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_no_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
+				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "bug_report", "no_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
 			}
 		}
 
@@ -87,7 +87,7 @@ namespace OpenBve
 			}
 			catch
 			{
-				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_no_crash_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
+				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","no_crash_log"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
 			}
 		}
 
@@ -138,13 +138,13 @@ namespace OpenBve
 						}
 
 						// Successful, would've thrown into the catch block otherwise.
-						MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_saved"}).Replace("[filename]", fileName), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
+						MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","saved"}).Replace("[filename]", fileName), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"}), MessageBoxButtons.OK, MessageBoxIcon.Information);
 					}
 				}
 			}
 			catch
 			{
-				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_save_failed"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug","report_title"}), MessageBoxButtons.OK, MessageBoxIcon.Error);
+				MessageBox.Show(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","save_failed"}), Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"bug_report","title"}), MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 
 			this.Close();


### PR DESCRIPTION
Fixes a regression from #972, where the translation path from the bug report dialog are mistakenly converted, resulting in no text in the bug report section.
![image](https://github.com/leezer3/OpenBVE/assets/28094366/cb2a230e-8b9f-41ad-b4c2-b74a2e9753eb)