### PR TITLE
Densha de GO! Input: fixes and support for MTC

### DIFF
--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -2640,6 +2640,9 @@
 					<trans-unit id="label_power">
 						<source>Power: [notch]</source>
 					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
 					<trans-unit id="calibration_button">
 						<source>Start calibration</source>
 					</trans-unit>
@@ -2699,6 +2702,12 @@
 					</trans-unit>
 					<trans-unit id="label_rdoor">
 						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
 					</trans-unit>
 					<trans-unit id="linkLabel_driver">
 						<source>My controller is not detected or does not work properly</source>

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.Designer.cs
@@ -52,7 +52,6 @@ namespace DenshaDeGoInput
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.components = new System.ComponentModel.Container();
             this.deviceInputBox = new System.Windows.Forms.GroupBox();
             this.label_rdoor = new System.Windows.Forms.Label();
             this.label_ldoor = new System.Windows.Forms.Label();
@@ -106,6 +105,13 @@ namespace DenshaDeGoInput
             this.deviceBox = new System.Windows.Forms.ComboBox();
             this.label_device = new System.Windows.Forms.Label();
             this.linkLabel_driver = new System.Windows.Forms.LinkLabel();
+            this.label_a2 = new System.Windows.Forms.Label();
+            this.label_ats = new System.Windows.Forms.Label();
+            this.buttona2Box = new System.Windows.Forms.ComboBox();
+            this.label_buttona2 = new System.Windows.Forms.Label();
+            this.buttonatsBox = new System.Windows.Forms.ComboBox();
+            this.label_buttonats = new System.Windows.Forms.Label();
+            this.label_reverser = new System.Windows.Forms.Label();
             this.deviceInputBox.SuspendLayout();
             this.buttonMappingBox.SuspendLayout();
             this.handleMappingBox.SuspendLayout();
@@ -113,6 +119,9 @@ namespace DenshaDeGoInput
             // 
             // deviceInputBox
             // 
+            this.deviceInputBox.Controls.Add(this.label_reverser);
+            this.deviceInputBox.Controls.Add(this.label_ats);
+            this.deviceInputBox.Controls.Add(this.label_a2);
             this.deviceInputBox.Controls.Add(this.label_rdoor);
             this.deviceInputBox.Controls.Add(this.label_ldoor);
             this.deviceInputBox.Controls.Add(this.label_power);
@@ -131,7 +140,7 @@ namespace DenshaDeGoInput
             this.deviceInputBox.Controls.Add(this.label_a);
             this.deviceInputBox.Location = new System.Drawing.Point(12, 37);
             this.deviceInputBox.Name = "deviceInputBox";
-            this.deviceInputBox.Size = new System.Drawing.Size(178, 313);
+            this.deviceInputBox.Size = new System.Drawing.Size(178, 358);
             this.deviceInputBox.TabIndex = 1;
             this.deviceInputBox.TabStop = false;
             this.deviceInputBox.Text = "Device input";
@@ -142,7 +151,7 @@ namespace DenshaDeGoInput
             this.label_rdoor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_rdoor.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_rdoor.ForeColor = System.Drawing.Color.Black;
-            this.label_rdoor.Location = new System.Drawing.Point(92, 215);
+            this.label_rdoor.Location = new System.Drawing.Point(92, 238);
             this.label_rdoor.Margin = new System.Windows.Forms.Padding(3);
             this.label_rdoor.Name = "label_rdoor";
             this.label_rdoor.Size = new System.Drawing.Size(80, 24);
@@ -156,7 +165,7 @@ namespace DenshaDeGoInput
             this.label_ldoor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_ldoor.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_ldoor.ForeColor = System.Drawing.Color.Black;
-            this.label_ldoor.Location = new System.Drawing.Point(92, 185);
+            this.label_ldoor.Location = new System.Drawing.Point(92, 208);
             this.label_ldoor.Margin = new System.Windows.Forms.Padding(3);
             this.label_ldoor.Name = "label_ldoor";
             this.label_ldoor.Size = new System.Drawing.Size(80, 24);
@@ -194,7 +203,7 @@ namespace DenshaDeGoInput
             this.label_pedal.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_pedal.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_pedal.ForeColor = System.Drawing.Color.Black;
-            this.label_pedal.Location = new System.Drawing.Point(6, 245);
+            this.label_pedal.Location = new System.Drawing.Point(92, 268);
             this.label_pedal.Margin = new System.Windows.Forms.Padding(3);
             this.label_pedal.Name = "label_pedal";
             this.label_pedal.Size = new System.Drawing.Size(80, 24);
@@ -208,7 +217,7 @@ namespace DenshaDeGoInput
             this.label_right.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_right.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_right.ForeColor = System.Drawing.Color.Black;
-            this.label_right.Location = new System.Drawing.Point(92, 155);
+            this.label_right.Location = new System.Drawing.Point(92, 178);
             this.label_right.Margin = new System.Windows.Forms.Padding(3);
             this.label_right.Name = "label_right";
             this.label_right.Size = new System.Drawing.Size(80, 24);
@@ -222,7 +231,7 @@ namespace DenshaDeGoInput
             this.label_left.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_left.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_left.ForeColor = System.Drawing.Color.Black;
-            this.label_left.Location = new System.Drawing.Point(92, 125);
+            this.label_left.Location = new System.Drawing.Point(92, 148);
             this.label_left.Margin = new System.Windows.Forms.Padding(3);
             this.label_left.Name = "label_left";
             this.label_left.Size = new System.Drawing.Size(80, 24);
@@ -236,7 +245,7 @@ namespace DenshaDeGoInput
             this.label_down.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_down.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_down.ForeColor = System.Drawing.Color.Black;
-            this.label_down.Location = new System.Drawing.Point(92, 95);
+            this.label_down.Location = new System.Drawing.Point(92, 118);
             this.label_down.Margin = new System.Windows.Forms.Padding(3);
             this.label_down.Name = "label_down";
             this.label_down.Size = new System.Drawing.Size(80, 24);
@@ -250,7 +259,7 @@ namespace DenshaDeGoInput
             this.label_up.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_up.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_up.ForeColor = System.Drawing.Color.Black;
-            this.label_up.Location = new System.Drawing.Point(92, 65);
+            this.label_up.Location = new System.Drawing.Point(92, 88);
             this.label_up.Margin = new System.Windows.Forms.Padding(3);
             this.label_up.Name = "label_up";
             this.label_up.Size = new System.Drawing.Size(80, 24);
@@ -260,7 +269,7 @@ namespace DenshaDeGoInput
             // 
             // buttonCalibrate
             // 
-            this.buttonCalibrate.Location = new System.Drawing.Point(6, 275);
+            this.buttonCalibrate.Location = new System.Drawing.Point(6, 328);
             this.buttonCalibrate.Name = "buttonCalibrate";
             this.buttonCalibrate.Size = new System.Drawing.Size(166, 24);
             this.buttonCalibrate.TabIndex = 21;
@@ -274,7 +283,7 @@ namespace DenshaDeGoInput
             this.label_select.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_select.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_select.ForeColor = System.Drawing.Color.Black;
-            this.label_select.Location = new System.Drawing.Point(6, 65);
+            this.label_select.Location = new System.Drawing.Point(6, 88);
             this.label_select.Margin = new System.Windows.Forms.Padding(3);
             this.label_select.Name = "label_select";
             this.label_select.Size = new System.Drawing.Size(80, 24);
@@ -288,7 +297,7 @@ namespace DenshaDeGoInput
             this.label_start.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_start.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_start.ForeColor = System.Drawing.Color.Black;
-            this.label_start.Location = new System.Drawing.Point(6, 95);
+            this.label_start.Location = new System.Drawing.Point(6, 118);
             this.label_start.Margin = new System.Windows.Forms.Padding(3);
             this.label_start.Name = "label_start";
             this.label_start.Size = new System.Drawing.Size(80, 24);
@@ -302,7 +311,7 @@ namespace DenshaDeGoInput
             this.label_d.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_d.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_d.ForeColor = System.Drawing.Color.Black;
-            this.label_d.Location = new System.Drawing.Point(6, 215);
+            this.label_d.Location = new System.Drawing.Point(6, 238);
             this.label_d.Margin = new System.Windows.Forms.Padding(3);
             this.label_d.Name = "label_d";
             this.label_d.Size = new System.Drawing.Size(80, 24);
@@ -316,7 +325,7 @@ namespace DenshaDeGoInput
             this.label_c.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_c.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_c.ForeColor = System.Drawing.Color.Black;
-            this.label_c.Location = new System.Drawing.Point(6, 185);
+            this.label_c.Location = new System.Drawing.Point(6, 208);
             this.label_c.Margin = new System.Windows.Forms.Padding(3);
             this.label_c.Name = "label_c";
             this.label_c.Size = new System.Drawing.Size(80, 24);
@@ -330,7 +339,7 @@ namespace DenshaDeGoInput
             this.label_b.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_b.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_b.ForeColor = System.Drawing.Color.Black;
-            this.label_b.Location = new System.Drawing.Point(6, 155);
+            this.label_b.Location = new System.Drawing.Point(6, 178);
             this.label_b.Margin = new System.Windows.Forms.Padding(3);
             this.label_b.Name = "label_b";
             this.label_b.Size = new System.Drawing.Size(80, 24);
@@ -344,7 +353,7 @@ namespace DenshaDeGoInput
             this.label_a.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label_a.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_a.ForeColor = System.Drawing.Color.Black;
-            this.label_a.Location = new System.Drawing.Point(6, 125);
+            this.label_a.Location = new System.Drawing.Point(6, 148);
             this.label_a.Margin = new System.Windows.Forms.Padding(3);
             this.label_a.Name = "label_a";
             this.label_a.Size = new System.Drawing.Size(80, 24);
@@ -354,6 +363,10 @@ namespace DenshaDeGoInput
             // 
             // buttonMappingBox
             // 
+            this.buttonMappingBox.Controls.Add(this.buttonatsBox);
+            this.buttonMappingBox.Controls.Add(this.label_buttonats);
+            this.buttonMappingBox.Controls.Add(this.buttona2Box);
+            this.buttonMappingBox.Controls.Add(this.label_buttona2);
             this.buttonMappingBox.Controls.Add(this.buttonrdoorBox);
             this.buttonMappingBox.Controls.Add(this.label_buttonrdoor);
             this.buttonMappingBox.Controls.Add(this.buttonldoorBox);
@@ -382,7 +395,7 @@ namespace DenshaDeGoInput
             this.buttonMappingBox.Controls.Add(this.label_buttona);
             this.buttonMappingBox.Location = new System.Drawing.Point(196, 37);
             this.buttonMappingBox.Name = "buttonMappingBox";
-            this.buttonMappingBox.Size = new System.Drawing.Size(499, 212);
+            this.buttonMappingBox.Size = new System.Drawing.Size(500, 257);
             this.buttonMappingBox.TabIndex = 2;
             this.buttonMappingBox.TabStop = false;
             this.buttonMappingBox.Text = "Button mapping";
@@ -391,7 +404,7 @@ namespace DenshaDeGoInput
             // 
             this.buttonrdoorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.buttonrdoorBox.FormattingEnabled = true;
-            this.buttonrdoorBox.Location = new System.Drawing.Point(306, 182);
+            this.buttonrdoorBox.Location = new System.Drawing.Point(306, 155);
             this.buttonrdoorBox.Name = "buttonrdoorBox";
             this.buttonrdoorBox.Size = new System.Drawing.Size(182, 21);
             this.buttonrdoorBox.TabIndex = 24;
@@ -399,7 +412,7 @@ namespace DenshaDeGoInput
             // 
             // label_buttonrdoor
             // 
-            this.label_buttonrdoor.Location = new System.Drawing.Point(250, 185);
+            this.label_buttonrdoor.Location = new System.Drawing.Point(250, 158);
             this.label_buttonrdoor.Margin = new System.Windows.Forms.Padding(3);
             this.label_buttonrdoor.Name = "label_buttonrdoor";
             this.label_buttonrdoor.Size = new System.Drawing.Size(50, 15);
@@ -410,7 +423,7 @@ namespace DenshaDeGoInput
             // 
             this.buttonldoorBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.buttonldoorBox.FormattingEnabled = true;
-            this.buttonldoorBox.Location = new System.Drawing.Point(306, 155);
+            this.buttonldoorBox.Location = new System.Drawing.Point(306, 128);
             this.buttonldoorBox.Name = "buttonldoorBox";
             this.buttonldoorBox.Size = new System.Drawing.Size(182, 21);
             this.buttonldoorBox.TabIndex = 22;
@@ -418,7 +431,7 @@ namespace DenshaDeGoInput
             // 
             // label_buttonldoor
             // 
-            this.label_buttonldoor.Location = new System.Drawing.Point(250, 158);
+            this.label_buttonldoor.Location = new System.Drawing.Point(250, 131);
             this.label_buttonldoor.Margin = new System.Windows.Forms.Padding(3);
             this.label_buttonldoor.Name = "label_buttonldoor";
             this.label_buttonldoor.Size = new System.Drawing.Size(50, 15);
@@ -468,7 +481,7 @@ namespace DenshaDeGoInput
             // 
             this.buttonpedalBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.buttonpedalBox.FormattingEnabled = true;
-            this.buttonpedalBox.Location = new System.Drawing.Point(306, 128);
+            this.buttonpedalBox.Location = new System.Drawing.Point(306, 182);
             this.buttonpedalBox.Name = "buttonpedalBox";
             this.buttonpedalBox.Size = new System.Drawing.Size(182, 21);
             this.buttonpedalBox.TabIndex = 17;
@@ -514,7 +527,7 @@ namespace DenshaDeGoInput
             // 
             // label_buttonpedal
             // 
-            this.label_buttonpedal.Location = new System.Drawing.Point(250, 131);
+            this.label_buttonpedal.Location = new System.Drawing.Point(250, 185);
             this.label_buttonpedal.Margin = new System.Windows.Forms.Padding(3);
             this.label_buttonpedal.Name = "label_buttonpedal";
             this.label_buttonpedal.Size = new System.Drawing.Size(50, 15);
@@ -637,7 +650,7 @@ namespace DenshaDeGoInput
             // buttonSave
             // 
             this.buttonSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonSave.Location = new System.Drawing.Point(502, 356);
+            this.buttonSave.Location = new System.Drawing.Point(503, 402);
             this.buttonSave.Name = "buttonSave";
             this.buttonSave.Size = new System.Drawing.Size(94, 23);
             this.buttonSave.TabIndex = 3;
@@ -648,7 +661,7 @@ namespace DenshaDeGoInput
             // buttonCancel
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonCancel.Location = new System.Drawing.Point(602, 356);
+            this.buttonCancel.Location = new System.Drawing.Point(603, 402);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(93, 23);
             this.buttonCancel.TabIndex = 4;
@@ -661,7 +674,7 @@ namespace DenshaDeGoInput
             this.handleMappingBox.Controls.Add(this.holdbrakeCheck);
             this.handleMappingBox.Controls.Add(this.minmaxCheck);
             this.handleMappingBox.Controls.Add(this.convertnotchesCheck);
-            this.handleMappingBox.Location = new System.Drawing.Point(196, 255);
+            this.handleMappingBox.Location = new System.Drawing.Point(196, 300);
             this.handleMappingBox.Name = "handleMappingBox";
             this.handleMappingBox.Size = new System.Drawing.Size(499, 95);
             this.handleMappingBox.TabIndex = 5;
@@ -722,20 +735,98 @@ namespace DenshaDeGoInput
             // linkLabel_driver
             // 
             this.linkLabel_driver.AutoEllipsis = true;
-            this.linkLabel_driver.Location = new System.Drawing.Point(12, 361);
+            this.linkLabel_driver.Location = new System.Drawing.Point(12, 407);
             this.linkLabel_driver.Name = "linkLabel_driver";
             this.linkLabel_driver.Size = new System.Drawing.Size(484, 21);
             this.linkLabel_driver.TabIndex = 9;
             this.linkLabel_driver.TabStop = true;
             this.linkLabel_driver.Text = "My controller is not detected or does not work properly";
-			this.linkLabel_driver.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.linkLabel_driver.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            // 
+            // label_a2
+            // 
+            this.label_a2.BackColor = System.Drawing.Color.Plum;
+            this.label_a2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_a2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_a2.ForeColor = System.Drawing.Color.Black;
+            this.label_a2.Location = new System.Drawing.Point(6, 268);
+            this.label_a2.Margin = new System.Windows.Forms.Padding(3);
+            this.label_a2.Name = "label_a2";
+            this.label_a2.Size = new System.Drawing.Size(80, 24);
+            this.label_a2.TabIndex = 31;
+            this.label_a2.Text = "A2";
+            this.label_a2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label_ats
+            // 
+            this.label_ats.BackColor = System.Drawing.Color.White;
+            this.label_ats.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.label_ats.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_ats.ForeColor = System.Drawing.Color.Black;
+            this.label_ats.Location = new System.Drawing.Point(6, 298);
+            this.label_ats.Margin = new System.Windows.Forms.Padding(3);
+            this.label_ats.Name = "label_ats";
+            this.label_ats.Size = new System.Drawing.Size(80, 24);
+            this.label_ats.TabIndex = 32;
+            this.label_ats.Text = "ATS";
+            this.label_ats.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // buttona2Box
+            // 
+            this.buttona2Box.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttona2Box.FormattingEnabled = true;
+            this.buttona2Box.Location = new System.Drawing.Point(62, 182);
+            this.buttona2Box.Name = "buttona2Box";
+            this.buttona2Box.Size = new System.Drawing.Size(182, 21);
+            this.buttona2Box.TabIndex = 26;
+			this.buttona2Box.SelectedIndexChanged += new System.EventHandler(this.buttona2Box_SelectedIndexChanged);
 
 			// 
-			// Config
+			// label_buttona2
 			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.label_buttona2.Location = new System.Drawing.Point(6, 185);
+            this.label_buttona2.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttona2.Name = "label_buttona2";
+            this.label_buttona2.Size = new System.Drawing.Size(50, 15);
+            this.label_buttona2.TabIndex = 25;
+            this.label_buttona2.Text = "A2";
+            // 
+            // buttonatsBox
+            // 
+            this.buttonatsBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.buttonatsBox.FormattingEnabled = true;
+            this.buttonatsBox.Location = new System.Drawing.Point(62, 209);
+            this.buttonatsBox.Name = "buttonatsBox";
+            this.buttonatsBox.Size = new System.Drawing.Size(182, 21);
+            this.buttonatsBox.TabIndex = 28;
+            this.buttonatsBox.SelectedIndexChanged += new System.EventHandler(this.buttonatsBox_SelectedIndexChanged);
+            // 
+            // label_buttonats
+            // 
+            this.label_buttonats.Location = new System.Drawing.Point(6, 212);
+            this.label_buttonats.Margin = new System.Windows.Forms.Padding(3);
+            this.label_buttonats.Name = "label_buttonats";
+            this.label_buttonats.Size = new System.Drawing.Size(50, 15);
+            this.label_buttonats.TabIndex = 27;
+            this.label_buttonats.Text = "ATS";
+            // 
+            // label_reverser
+            // 
+            this.label_reverser.AutoSize = true;
+            this.label_reverser.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_reverser.Location = new System.Drawing.Point(6, 65);
+            this.label_reverser.Margin = new System.Windows.Forms.Padding(3);
+            this.label_reverser.MaximumSize = new System.Drawing.Size(200, 17);
+            this.label_reverser.Name = "label_reverser";
+            this.label_reverser.Size = new System.Drawing.Size(134, 17);
+            this.label_reverser.TabIndex = 33;
+            this.label_reverser.Text = "Reverser: [notch]";
+            // 
+            // Config
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(707, 391);
+            this.ClientSize = new System.Drawing.Size(708, 437);
             this.Controls.Add(this.linkLabel_driver);
             this.Controls.Add(this.label_device);
             this.Controls.Add(this.deviceBox);
@@ -811,5 +902,12 @@ namespace DenshaDeGoInput
 		private System.Windows.Forms.ComboBox buttonldoorBox;
 		private System.Windows.Forms.Label label_buttonldoor;
 		private System.Windows.Forms.LinkLabel linkLabel_driver;
+		private System.Windows.Forms.Label label_a2;
+		private System.Windows.Forms.Label label_ats;
+		private System.Windows.Forms.ComboBox buttonatsBox;
+		private System.Windows.Forms.Label label_buttonats;
+		private System.Windows.Forms.ComboBox buttona2Box;
+		private System.Windows.Forms.Label label_buttona2;
+		private System.Windows.Forms.Label label_reverser;
 	}
 }

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -1,6 +1,6 @@
 //Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -40,45 +40,45 @@ namespace DenshaDeGoInput
 		/// </summary>
 		private readonly List<Guid> controllerList = new List<Guid>();
 
+		/// <summary>
+		/// Internal list of commands.
+		/// </summary>
+		private readonly Translations.Command[] commandList;
+
 		private readonly Timer Timer1;
 
 		public Config()
 		{
 			InitializeComponent();
 
+			// Populate the list of commands
+			commandList = new Translations.Command[Translations.CommandInfos.Count + 1];
+			commandList[0] = Translations.Command.None;
+			for (int i = 0; i < Translations.CommandInfos.Count; i++)
+			{
+				commandList[i+1] = Translations.CommandInfos.Keys.ElementAt(i);
+			}
+
 			// Load language files
 			Translations.LoadLanguageFiles(OpenBveApi.Path.CombineDirectory(DenshaDeGoInput.FileSystem.DataFolder, "Languages"));
 
 			// Populate command boxes
-			buttonselectBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonstartBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonaBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonbBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttoncBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttondBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonupBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttondownBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonleftBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonrightBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonpedalBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonldoorBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			buttonrdoorBox.Items.Add(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"}));
-			for (int i = 0; i < Translations.CommandInfos.Count; i++)
+			for (int i = 0; i < commandList.Length; i++)
 			{
-				Translations.Command key = Translations.CommandInfos.ElementAt(i).Key;
-				buttonselectBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonstartBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonaBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonbBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttoncBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttondBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonupBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttondownBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonleftBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonrightBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonpedalBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonldoorBox.Items.Add(Translations.CommandInfos[key].Name);
-				buttonrdoorBox.Items.Add(Translations.CommandInfos[key].Name);
+				string commandName = Translations.CommandInfos.TryGetInfo(commandList[i]).Name;
+				buttonselectBox.Items.Add(commandName);
+				buttonstartBox.Items.Add(commandName);
+				buttonaBox.Items.Add(commandName);
+				buttonbBox.Items.Add(commandName);
+				buttoncBox.Items.Add(commandName);
+				buttondBox.Items.Add(commandName);
+				buttonupBox.Items.Add(commandName);
+				buttondownBox.Items.Add(commandName);
+				buttonleftBox.Items.Add(commandName);
+				buttonrightBox.Items.Add(commandName);
+				buttonpedalBox.Items.Add(commandName);
+				buttonldoorBox.Items.Add(commandName);
+				buttonrdoorBox.Items.Add(commandName);
 			}
 
 			Timer1 = new Timer {Interval = 100};
@@ -193,19 +193,19 @@ namespace DenshaDeGoInput
 			buttonSave.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","save_button"});
 			buttonCancel.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","cancel_button"});
 
-			buttonselectBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonstartBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonaBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonbBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttoncBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttondBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonupBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttondownBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonleftBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonrightBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonpedalBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonldoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
-			buttonldoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","command_none"});
+			buttonselectBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonstartBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonaBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonbBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttoncBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttondBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonupBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttondownBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonleftBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonrightBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonpedalBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonldoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonrdoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 
 			label_up.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_up"});
 			label_down.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_down"});
@@ -221,7 +221,7 @@ namespace DenshaDeGoInput
 			label_buttonpedal.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_pedal"});
 			label_buttonldoor.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_ldoor"});
 			label_buttonrdoor.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_rdoor"});
-
+		
 			linkLabel_driver.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","linkLabel_driver"});
 		}
 
@@ -238,19 +238,19 @@ namespace DenshaDeGoInput
 			}
 
 			// Set command boxes
-			buttonselectBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Select];
-			buttonstartBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Start];
-			buttonaBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A];
-			buttonbBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.B];
-			buttoncBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.C];
-			buttondBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.D];
-			buttonupBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Up];
-			buttondownBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Down];
-			buttonleftBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Left];
-			buttonrightBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right];
-			buttonpedalBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal];
-			buttonldoorBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor];
-			buttonrdoorBox.SelectedIndex = DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor];
+			buttonselectBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Select].Command);
+			buttonstartBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Start].Command);
+			buttonaBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A].Command);
+			buttonbBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.B].Command);
+			buttoncBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.C].Command);
+			buttondBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.D].Command);
+			buttonupBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Up].Command);
+			buttondownBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Down].Command);
+			buttonleftBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Left].Command);
+			buttonrightBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right].Command);
+			buttonpedalBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command);
+			buttonldoorBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].Command);
+			buttonrdoorBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command);
 
 
 			// Set checkboxes
@@ -280,65 +280,67 @@ namespace DenshaDeGoInput
 
 		private void buttonselectBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Select] = buttonselectBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Select].Command = buttonselectBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonselectBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonstartBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Start] = buttonstartBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Start].Command = buttonstartBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonstartBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonaBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A] = buttonaBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A].Command = buttonaBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonaBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonbBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.B] = buttonbBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.B].Command = buttonbBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonbBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttoncBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.C] = buttoncBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.C].Command = buttoncBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttoncBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttondBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.D] = buttondBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.D].Command = buttondBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttondBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonupBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Up] = buttonupBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Up].Command = buttonupBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonupBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttondownBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Down] = buttondownBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Down].Command = buttondownBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttondownBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonleftBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Left] = buttonleftBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Left].Command = buttonleftBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonleftBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonrightBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right] = buttonrightBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right].Command = buttonrightBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonrightBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void buttonpedalBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal] = buttonpedalBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command = buttonpedalBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonpedalBox.SelectedIndex - 1) : Translations.Command.None;
 		}
+
 		private void buttonldoorBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor] = buttonldoorBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].Command = buttonldoorBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonldoorBox.SelectedIndex - 1) : Translations.Command.None;
 		}
+
 		private void buttonrdoorBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor] = buttonrdoorBox.SelectedIndex;
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command = buttonrdoorBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonrdoorBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Config.cs
@@ -76,9 +76,11 @@ namespace DenshaDeGoInput
 				buttondownBox.Items.Add(commandName);
 				buttonleftBox.Items.Add(commandName);
 				buttonrightBox.Items.Add(commandName);
-				buttonpedalBox.Items.Add(commandName);
 				buttonldoorBox.Items.Add(commandName);
 				buttonrdoorBox.Items.Add(commandName);
+				buttonpedalBox.Items.Add(commandName);
+				buttona2Box.Items.Add(commandName);
+				buttonatsBox.Items.Add(commandName);
 			}
 
 			Timer1 = new Timer {Interval = 100};
@@ -120,60 +122,74 @@ namespace DenshaDeGoInput
 		/// </summary>
 		private void UpdateInterface()
 		{
-			if (InputTranslator.IsControllerConnected)
+			switch (InputTranslator.BrakeNotch)
 			{
-				switch (InputTranslator.BrakeNotch)
-				{
-					case InputTranslator.BrakeNotches.Released:
-						label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleBrakeNull);
-						break;
-					case InputTranslator.BrakeNotches.Emergency:
-						label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleEmergency);
-						break;
-					default:
-						label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleBrake + (int)InputTranslator.BrakeNotch);
-						break;
-				}
-
-				switch (InputTranslator.PowerNotch)
-				{
-					case InputTranslator.PowerNotches.N:
-						label_power.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_power"}).Replace("[notch]", Translations.QuickReferences.HandlePowerNull);
-						break;
-					default:
-						label_power.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_power"}).Replace("[notch]", Translations.QuickReferences.HandlePower + (int)InputTranslator.PowerNotch);
-						break;
-				}
-
-				label_select.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_start.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_a.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_b.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_c.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_d.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_up.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_down.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_left.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_right.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_pedal.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Pedal] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_ldoor.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.LDoor] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-				label_rdoor.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.RDoor] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
-
-				buttonCalibrate.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].RequiresCalibration;
-				label_select.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Select);
-				label_start.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Start);
-				label_a.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.A);
-				label_b.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.B);
-				label_c.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.C);
-				label_d.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.D);
-				label_up.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
-				label_down.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
-				label_left.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
-				label_right.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
-				label_pedal.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Pedal);
-				label_ldoor.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.LDoor);
-				label_rdoor.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.RDoor);
+				case InputTranslator.BrakeNotches.Released:
+					label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleBrakeNull);
+					break;
+				case InputTranslator.BrakeNotches.Emergency:
+					label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleEmergency);
+					break;
+				default:
+					label_brake.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_brake"}).Replace("[notch]", Translations.QuickReferences.HandleBrake + (int)InputTranslator.BrakeNotch);
+					break;
 			}
+
+			switch (InputTranslator.PowerNotch)
+			{
+				case InputTranslator.PowerNotches.N:
+					label_power.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_power"}).Replace("[notch]", Translations.QuickReferences.HandlePowerNull);
+					break;
+				default:
+					label_power.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_power"}).Replace("[notch]", Translations.QuickReferences.HandlePower + (int)InputTranslator.PowerNotch);
+					break;
+			}
+
+			switch (InputTranslator.ReverserPosition)
+			{
+				case InputTranslator.ReverserPositions.Forward:
+					label_reverser.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_reverser" }).Replace("[notch]", Translations.QuickReferences.HandleForward);
+					break;
+				case InputTranslator.ReverserPositions.Backward:
+					label_reverser.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_reverser" }).Replace("[notch]", Translations.QuickReferences.HandleBackward);
+					break;
+				default:
+					label_reverser.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_reverser" }).Replace("[notch]", Translations.QuickReferences.HandleNeutral);
+					break;
+			}
+
+			label_select.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_start.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_a.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_b.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_c.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_d.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_up.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_down.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_left.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_right.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_ldoor.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.LDoor] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_rdoor.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.RDoor] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_pedal.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Pedal] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_a2.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A2] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+			label_ats.ForeColor = InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.ATS] == OpenTK.Input.ButtonState.Pressed ? Color.White : Color.Black;
+
+			buttonCalibrate.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].RequiresCalibration;
+			label_select.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Select);
+			label_start.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Start);
+			label_a.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.A);
+			label_b.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.B);
+			label_c.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.C);
+			label_d.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.D);
+			label_up.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
+			label_down.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
+			label_left.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
+			label_right.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.DPad);
+			label_ldoor.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.LDoor);
+			label_rdoor.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.RDoor);
+			label_pedal.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.Pedal);
+			label_a2.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.A2);
+			label_ats.Visible = InputTranslator.Controllers[InputTranslator.ActiveControllerGuid].Buttons.HasFlag(Controller.ControllerButtons.ATS);
 		}
 
 		/// <summary>
@@ -203,9 +219,11 @@ namespace DenshaDeGoInput
 			buttondownBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 			buttonleftBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 			buttonrightBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
-			buttonpedalBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 			buttonldoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 			buttonrdoorBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonpedalBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttona2Box.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
+			buttonatsBox.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "command_none" });
 
 			label_up.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_up"});
 			label_down.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_down"});
@@ -218,10 +236,12 @@ namespace DenshaDeGoInput
 			label_buttondown.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_down"});
 			label_buttonleft.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_left"});
 			label_buttonright.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_right"});
-			label_buttonpedal.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_pedal"});
 			label_buttonldoor.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_ldoor"});
 			label_buttonrdoor.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","label_rdoor"});
-		
+			label_buttonpedal.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_pedal" });
+			label_buttona2.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_a2" });
+			label_buttonats.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "denshadego", "label_ats" });
+
 			linkLabel_driver.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"denshadego","linkLabel_driver"});
 		}
 
@@ -248,9 +268,11 @@ namespace DenshaDeGoInput
 			buttondownBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Down].Command);
 			buttonleftBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Left].Command);
 			buttonrightBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right].Command);
-			buttonpedalBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command);
 			buttonldoorBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].Command);
 			buttonrdoorBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command);
+			buttonpedalBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command);
+			buttona2Box.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A2].Command);
+			buttonatsBox.SelectedIndex = Array.IndexOf(commandList, DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.ATS].Command);
 
 
 			// Set checkboxes
@@ -328,11 +350,6 @@ namespace DenshaDeGoInput
 			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Right].Command = buttonrightBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonrightBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
-		private void buttonpedalBox_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command = buttonpedalBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonpedalBox.SelectedIndex - 1) : Translations.Command.None;
-		}
-
 		private void buttonldoorBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].Command = buttonldoorBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonldoorBox.SelectedIndex - 1) : Translations.Command.None;
@@ -341,6 +358,21 @@ namespace DenshaDeGoInput
 		private void buttonrdoorBox_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command = buttonrdoorBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonrdoorBox.SelectedIndex - 1) : Translations.Command.None;
+		}
+
+		private void buttonpedalBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command = buttonpedalBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonpedalBox.SelectedIndex - 1) : Translations.Command.None;
+		}
+
+		private void buttona2Box_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.A2].Command = buttona2Box.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttona2Box.SelectedIndex - 1) : Translations.Command.None;
+		}
+
+		private void buttonatsBox_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			DenshaDeGoInput.ButtonCommands[(int)InputTranslator.ControllerButton.ATS].Command = buttonatsBox.SelectedIndex != 0 ? Translations.CommandInfos.Keys.ElementAt(buttonatsBox.SelectedIndex - 1) : Translations.Command.None;
 		}
 
 		private void convertnotchesCheck_CheckedChanged(object sender, EventArgs e)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2Ddgo.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2Ddgo.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2Ddgo.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2Ddgo.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -29,9 +29,9 @@ using OpenTK.Input;
 namespace DenshaDeGoInput
 {
 	/// <summary>
-	/// Class representing a PlayStation 2 controller
+	/// Class representing a PlayStation 2 Densha de GO! controller
 	/// </summary>
-	internal class Ps2Controller : Controller
+	internal class Ps2DdgoController : Controller
 	{
 		/// <summary>A cached list of supported connected controllers.</summary>
 		private static readonly Dictionary<Guid, Controller> cachedControllers = new Dictionary<Guid, Controller>();
@@ -39,11 +39,11 @@ namespace DenshaDeGoInput
 		private static readonly string[] controllerIds =
 		{
 			// TCPP-20009 (Type II)
-			"0ae4:0004",
+			"0ae4:0004:0000",
 			// TCPP-20011 (Shinkansen)
-			"0ae4:0005",
+			"0ae4:0005:0000",
 			// TCPP-20014 (Ryojouhen)
-			"0ae4:0007"
+			"0ae4:0007:0000"
 		};
 
 		/// <summary>The min/max byte for each brake notch, from Released to Emergency. Each notch consists of two bytes.</summary>
@@ -62,13 +62,12 @@ namespace DenshaDeGoInput
 		private byte[] outputBuffer;
 
 		/// <summary>
-		/// Initializes an Unbalance controller.
+		/// Initializes PS2 Densha de GO! controller.
 		/// </summary>
-		internal Ps2Controller(ControllerButtons buttons, byte[] buttonBytes, byte[] brake, byte[] power)
+		internal Ps2DdgoController(ControllerButtons buttons, byte[] buttonBytes, byte[] brake, byte[] power)
 		{
 			ControllerName = string.Empty;
 			IsConnected = false;
-			RequiresCalibration = false;
 			BrakeNotches = brake.Length / 2 - 2;
 			PowerNotches = power.Length / 2 - 1;
 			brakeBytes = brake;
@@ -233,11 +232,12 @@ namespace DenshaDeGoInput
 			foreach (KeyValuePair<Guid, LibUsb.UsbController> usbController in LibUsb.GetSupportedControllers())
 			{
 				Guid guid = usbController.Key;
-				ControllerID id = new ControllerID(guid);
-				string name = usbController.Value.ControllerName;
 
-				if (!cachedControllers.ContainsKey(guid))
+				if (!cachedControllers.ContainsKey(guid) && usbController.Value.IsConnected)
 				{
+					ControllerID id = new ControllerID(usbController.Value.VendorID, usbController.Value.ProductID, usbController.Value.Revision);
+					string name = usbController.Value.ControllerName;
+
 					// TCPP-20009 (Type II)
 					if (id.Type == ControllerType.PS2TypeII)
 					{
@@ -245,7 +245,7 @@ namespace DenshaDeGoInput
 						byte[] buttonBytes = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
 						byte[] brakeBytes = { 0x79, 0x79, 0x8A, 0x8A, 0x94, 0x94, 0x9A, 0x9A, 0xA2, 0xA2, 0xA8, 0xA8, 0xAF, 0xAF, 0xB2, 0xB2, 0xB5, 0xB5, 0xB9, 0xB9 };
 						byte[] powerBytes = { 0x81, 0x81, 0x6D, 0x6D, 0x54, 0x54, 0x3F, 0x3F, 0x21, 0x21, 0x00, 0x00 };
-						Ps2Controller newcontroller = new Ps2Controller(buttons, buttonBytes, brakeBytes, powerBytes)
+						Ps2DdgoController newcontroller = new Ps2DdgoController(buttons, buttonBytes, brakeBytes, powerBytes)
 						{
 							// 6 bytes for input, 2 for output
 							Guid = guid,
@@ -263,7 +263,7 @@ namespace DenshaDeGoInput
 						byte[] buttonBytes = { 0x10, 0x20, 0x8, 0x4, 0x2, 0x1, 0x0, 0x0 };
 						byte[] brakeBytes = { 0x1C, 0x1C, 0x38, 0x38, 0x54, 0x54, 0x70, 0x70, 0x8B, 0x8B, 0xA7, 0xA7, 0xC3, 0xC3, 0xDF, 0xDF, 0xFB, 0xFB };
 						byte[] powerBytes = { 0x12, 0x12, 0x24, 0x24, 0x36, 0x36, 0x48, 0x48, 0x5A, 0x5A, 0x6C, 0x6C, 0x7E, 0x7E, 0x90, 0x90, 0xA2, 0xA2, 0xB4, 0xB4, 0xC6, 0xC6, 0xD7, 0xD7, 0xE9, 0xE9, 0xFB, 0xFB };
-						Ps2Controller newcontroller = new Ps2Controller(buttons, buttonBytes, brakeBytes, powerBytes)
+						Ps2DdgoController newcontroller = new Ps2DdgoController(buttons, buttonBytes, brakeBytes, powerBytes)
 						{
 							// 6 bytes for input, 8 for output
 							Guid = guid,
@@ -281,7 +281,7 @@ namespace DenshaDeGoInput
 						byte[] buttonBytes = { 0x20, 0x40, 0x4, 0x2, 0x1, 0x0, 0x10, 0x8 };
 						byte[] brakeBytes = { 0x23, 0x2C, 0x2D, 0x3E, 0x3F, 0x4E, 0x4F, 0x63, 0x64, 0x8A, 0x8B, 0xB0, 0xB1, 0xD4, 0xD5, 0xDF };
 						byte[] powerBytes = { 0x0, 0x0, 0x3C, 0x3C, 0x78, 0x78, 0xB4, 0xB4, 0xF0, 0xF0 };
-						Ps2Controller newcontroller = new Ps2Controller(buttons, buttonBytes, brakeBytes, powerBytes)
+						Ps2DdgoController newcontroller = new Ps2DdgoController(buttons, buttonBytes, brakeBytes, powerBytes)
 						{
 							// 8 bytes for input, no output
 							Guid = guid,
@@ -293,10 +293,11 @@ namespace DenshaDeGoInput
 						cachedControllers.Add(guid, newcontroller);
 					}
 				}
-
-				// Update connection status and name
-				cachedControllers[guid].IsConnected = usbController.Value.IsConnected;
-				cachedControllers[guid].ControllerName = name;
+				// Update connection status
+				if (cachedControllers.ContainsKey(guid))
+				{
+					cachedControllers[guid].IsConnected = usbController.Value.IsConnected;
+				}
 			}
 			return cachedControllers;
 		}

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
@@ -80,7 +80,7 @@ namespace DenshaDeGoInput
 			// Sync input/output data
 			LibUsb.SyncController(Guid, inputBuffer, outputBuffer);
 
-			ushort buttonData = inputBuffer[2];
+			ushort buttonData = BitConverter.ToUInt16( new byte[2] { inputBuffer[2], inputBuffer[3] }, 0);
 			byte handle = inputBuffer[1];
 			byte reverser = (byte)(handle >> 4 & 0xF);
 
@@ -135,6 +135,22 @@ namespace DenshaDeGoInput
 						break;
 				}
 			}
+
+			// Buttons
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Select]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Start] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Start]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.A]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.B]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.C]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.D]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.ATS] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.ATS]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A2] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.A2]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+
+			// D-pad
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Up]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Down]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Left]) != 0 ? ButtonState.Pressed : ButtonState.Released;
+			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (buttonData & buttonMask[(int)InputTranslator.ControllerButton.Right]) != 0 ? ButtonState.Pressed : ButtonState.Released;
 		}
 
 		/// <summary>
@@ -163,8 +179,8 @@ namespace DenshaDeGoInput
 					// SOTP-031201 (MTC P4/B7)
 					if (id.Type == ControllerType.PS2MTCP4B7)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
-						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad | ControllerButtons.ATS | ControllerButtons.A2;
+						ushort[] buttonMask = { 0x200, 0x100, 0x4, 0x10, 0x20, 0x2, 0x0, 0x0, 0x400, 0x800, 0x1000, 0x2000, 0x0, 0x1, 0x8 };
 						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 7, 4, true)
 						{
 							// 4 bytes for input
@@ -180,8 +196,8 @@ namespace DenshaDeGoInput
 					// SOTP-031201 (MTC P4/B2-B7)
 					if (id.Type == ControllerType.PS2MTCP4B2B7)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
-						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad | ControllerButtons.ATS | ControllerButtons.A2;
+						ushort[] buttonMask = { 0x200, 0x100, 0x4, 0x10, 0x20, 0x2, 0x0, 0x0, 0x400, 0x800, 0x1000, 0x2000, 0x0, 0x1, 0x8 };
 						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 6, 4, true)
 						{
 							// 4 bytes for input
@@ -197,8 +213,8 @@ namespace DenshaDeGoInput
 					// SOTP-031201 (MTC P5/B7)
 					if (id.Type == ControllerType.PS2MTCP5B7)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
-						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad | ControllerButtons.ATS | ControllerButtons.A2;
+						ushort[] buttonMask = { 0x200, 0x100, 0x4, 0x10, 0x20, 0x2, 0x0, 0x0, 0x400, 0x800, 0x1000, 0x2000, 0x0, 0x1, 0x8 };
 						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 7, 5, true)
 						{
 							// 4 bytes for input
@@ -213,8 +229,8 @@ namespace DenshaDeGoInput
 					// SOTP-031201 (MTC P13/B7)
 					if (id.Type == ControllerType.PS2MTCP13B7)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
-						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad | ControllerButtons.ATS | ControllerButtons.A2;
+						ushort[] buttonMask = { 0x200, 0x100, 0x4, 0x10, 0x20, 0x2, 0x0, 0x0, 0x400, 0x800, 0x1000, 0x2000, 0x0, 0x1, 0x8 };
 						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 13, 4, true)
 						{
 							// 4 bytes for input
@@ -229,8 +245,8 @@ namespace DenshaDeGoInput
 					// COTM-02001 (Train Mascon)
 					if (id.Type == ControllerType.PS2TrainMascon)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
-						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad | ControllerButtons.ATS | ControllerButtons.A2;
+						ushort[] buttonMask = { 0x200, 0x100, 0x4, 0x10, 0x20, 0x2, 0x0, 0x0, 0x400, 0x800, 0x1000, 0x2000, 0x0, 0x1, 0x8 };
 						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 5, 5, true)
 						{
 							// 4 bytes for input

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Ps2TS.cs
@@ -1,0 +1,256 @@
+﻿//Simplified BSD License (BSD-2-Clause)
+//
+//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Collections.Generic;
+using OpenTK.Input;
+
+namespace DenshaDeGoInput
+{
+	/// <summary>
+	/// Class representing a PlayStation 2 Train Simulator controller
+	/// </summary>
+	internal class Ps2TSController : Controller
+	{
+		/// <summary>A cached list of supported connected controllers.</summary>
+		private static readonly Dictionary<Guid, Controller> cachedControllers = new Dictionary<Guid, Controller>();
+
+		private static readonly string[] controllerIds =
+		{
+			// SOTP-031201 (MTC P4/B7)
+			"0ae4:0101:012c",
+			// SOTP-031201 (MTC P4/B2-B7)
+			"0ae4:0101:0190",
+			// SOTP-031201 (MTC P5/B7)
+			"0ae4:0101:0320",
+			// SOTP-031201 (MTC P13/B7)
+			"0ae4:0101:03e8",
+			// COTM-02001 (Train Mascon)
+			"1c06:77a7:0000"
+		};
+
+		/// <summary>The button mask for the buttons. Follows order in InputTranslator.</summary>
+		private readonly ushort[] buttonMask;
+
+		/// <summary>An array with raw input data from the controller.</summary>
+		private byte[] inputBuffer;
+
+		/// <summary>An array with raw output data for the controller.</summary>
+		private byte[] outputBuffer;
+
+		/// <summary>
+		/// Initializes PS2 Train Simulator controller.
+		/// </summary>
+		internal Ps2TSController(ControllerButtons buttons, ushort[] buttonBytes, int brakeNotches, int powerNotches, bool reverser)
+		{
+			ControllerName = string.Empty;
+			IsConnected = false;
+			BrakeNotches = brakeNotches;
+			PowerNotches = powerNotches;
+			Buttons = buttons;
+			buttonMask = buttonBytes;
+		}
+
+		/// <summary>
+		/// Reads the input from the controller.
+		/// </summary>
+		internal override void ReadInput()
+		{
+			// Sync input/output data
+			LibUsb.SyncController(Guid, inputBuffer, outputBuffer);
+
+			ushort buttonData = inputBuffer[2];
+			byte handle = inputBuffer[1];
+			byte reverser = (byte)(handle >> 4 & 0xF);
+
+			// If the controller has a reverser, we need to remove low nibble
+			if (HasReverser)
+			{
+				handle = (byte)(handle & 0xF);
+			}
+
+			// Handle must be a value between 1 and maximum notch (emergency + brake + neutral + power)
+			if (handle > 0 && handle < BrakeNotches + PowerNotches + 3)
+			{
+				int emergencyNotch = 1;
+				int neutralNotch = emergencyNotch + BrakeNotches + 1;
+
+				if (handle == emergencyNotch)
+				{
+					InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
+					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+				}
+				else if (handle < neutralNotch)
+				{
+					InputTranslator.BrakeNotch = (InputTranslator.BrakeNotches)(neutralNotch - handle);
+					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+				}
+				else if (handle > neutralNotch)
+				{
+					InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
+					InputTranslator.PowerNotch = (InputTranslator.PowerNotches)(handle - neutralNotch);
+				}
+				else
+				{
+					InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
+					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
+				}
+			}
+
+			if (HasReverser)
+			{
+				switch (reverser)
+				{
+					case 2:
+					case 8:
+						InputTranslator.ReverserPosition = InputTranslator.ReverserPositions.Forward;
+						break;
+					case 1:
+					case 4:
+						InputTranslator.ReverserPosition = InputTranslator.ReverserPositions.Backward;
+						break;
+					default:
+						InputTranslator.ReverserPosition = InputTranslator.ReverserPositions.N;
+						break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Configures the supported controllers with LibUsb.
+		/// </summary>
+		internal static void ConfigureControllers()
+		{
+			LibUsb.AddSupportedControllers(controllerIds);
+		}
+
+		/// <summary>
+		/// Gets the list of connected controllers
+		/// </summary>
+		/// <returns>The list of controllers handled by this class.</returns>
+		internal static Dictionary<Guid, Controller> GetControllers()
+		{
+			foreach (KeyValuePair<Guid, LibUsb.UsbController> usbController in LibUsb.GetSupportedControllers())
+			{
+				Guid guid = usbController.Key;
+
+				if (!cachedControllers.ContainsKey(guid) && usbController.Value.IsConnected)
+				{
+					ControllerID id = new ControllerID(usbController.Value.VendorID, usbController.Value.ProductID, usbController.Value.Revision);
+					string name = usbController.Value.ControllerName;
+
+					// SOTP-031201 (MTC P4/B7)
+					if (id.Type == ControllerType.PS2MTCP4B7)
+					{
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
+						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 7, 4, true)
+						{
+							// 4 bytes for input
+							Guid = guid,
+							Id = id,
+							ControllerName = name,
+							HasReverser = true,
+							inputBuffer = new byte[] { 0x1, 0x0, 0x0, 0x0 },
+							outputBuffer = new byte[0]
+						};
+						cachedControllers.Add(guid, newcontroller);
+					}
+					// SOTP-031201 (MTC P4/B2-B7)
+					if (id.Type == ControllerType.PS2MTCP4B2B7)
+					{
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
+						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 6, 4, true)
+						{
+							// 4 bytes for input
+							Guid = guid,
+							Id = id,
+							ControllerName = name,
+							HasReverser = true,
+							inputBuffer = new byte[] { 0x1, 0x0, 0x0, 0x0 },
+							outputBuffer = new byte[0]
+						};
+						cachedControllers.Add(guid, newcontroller);
+					}
+					// SOTP-031201 (MTC P5/B7)
+					if (id.Type == ControllerType.PS2MTCP5B7)
+					{
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
+						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 7, 5, true)
+						{
+							// 4 bytes for input
+							Guid = guid,
+							Id = id,
+							ControllerName = name,
+							inputBuffer = new byte[] { 0x1, 0x0, 0x0, 0x0 },
+							outputBuffer = new byte[0]
+						};
+						cachedControllers.Add(guid, newcontroller);
+					}
+					// SOTP-031201 (MTC P13/B7)
+					if (id.Type == ControllerType.PS2MTCP13B7)
+					{
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
+						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 13, 4, true)
+						{
+							// 4 bytes for input
+							Guid = guid,
+							Id = id,
+							ControllerName = name,
+							inputBuffer = new byte[] { 0x1, 0x0, 0x0, 0x0 },
+							outputBuffer = new byte[0]
+						};
+						cachedControllers.Add(guid, newcontroller);
+					}
+					// COTM-02001 (Train Mascon)
+					if (id.Type == ControllerType.PS2TrainMascon)
+					{
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.Pedal | ControllerButtons.DPad;
+						ushort[] buttonMask = { 0x10, 0x20, 0x2, 0x1, 0x4, 0x8, 0x0, 0x0 };
+						Ps2TSController newcontroller = new Ps2TSController(buttons, buttonMask, 5, 5, true)
+						{
+							// 4 bytes for input
+							Guid = guid,
+							Id = id,
+							ControllerName = name,
+							HasReverser = true,
+							inputBuffer = new byte[] { 0x1, 0x0, 0x0, 0x0 },
+							outputBuffer = new byte[0]
+						};
+						cachedControllers.Add(guid, newcontroller);
+					}
+				}
+				// Update connection status
+				if (cachedControllers.ContainsKey(guid))
+				{
+					cachedControllers[guid].IsConnected = usbController.Value.IsConnected;
+				}
+			}
+			return cachedControllers;
+		}
+	}
+}

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Unbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Unbalance.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -156,8 +156,9 @@ namespace DenshaDeGoInput
 
 				if (!cachedControllers.ContainsKey(guid))
 				{
+					JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
 					// DGC-255/DGOC-44U/P&P
-					if (id.Type == ControllerType.PCTwoHandle)
+					if (id.Type == ControllerType.PCTwoHandle && capabilities.ButtonCount >= 6 && capabilities.AxisCount >= 2)
 					{
 						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad;
 						int[] buttonIndices = { 4, 5, 1, 0, 2, 3, -1, -1 };
@@ -174,7 +175,7 @@ namespace DenshaDeGoInput
 						cachedControllers.Add(guid, newcontroller);
 					}
 					// DRC-184/DYC-288
-					if (id.Type == ControllerType.PCRyojouhen)
+					if (id.Type == ControllerType.PCRyojouhen && capabilities.ButtonCount >= 7 && capabilities.AxisCount >= 2)
 					{
 						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.LDoor | ControllerButtons.RDoor | ControllerButtons.DPad;
 						int[] buttonIndices = { 5, 6, 2, 1, 0, -1, 4, 3 };

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Unbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Unbalance.cs
@@ -39,8 +39,8 @@ namespace DenshaDeGoInput
 		/// <summary>The OpenTK joystick index for this controller.</summary>
 		private int joystickIndex;
 
-		/// <summary>Whether the controller supports a D-Pad using Select+A/B/C/D.</summary>
-		private readonly bool comboDpad;
+		/// <summary>Whether the controller has a hat switch.</summary>
+		private readonly bool hasHat;
 
 		/// <summary>The min/max byte for each brake notch, from Released to Emergency. Each notch consists of two bytes.</summary>
 		private readonly byte[] brakeBytes;
@@ -54,18 +54,17 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Initializes an Unbalance controller.
 		/// </summary>
-		internal UnbalanceController(ControllerButtons buttons, int[] buttonIndices, bool combo, byte[] brake, byte[] power)
+		internal UnbalanceController(ControllerButtons buttons, int[] buttonIndices, bool hat, byte[] brake, byte[] power)
 		{
 			ControllerName = string.Empty;
 			IsConnected = false;
-			RequiresCalibration = false;
 			BrakeNotches = brake.Length / 2 - 2;
 			PowerNotches = power.Length / 2 - 1;
 			brakeBytes = brake;
 			powerBytes = power;
 			Buttons = buttons;
 			buttonIndex = buttonIndices;
-			comboDpad = combo;
+			hasHat = hat;
 		}
 
 		/// <summary>
@@ -113,35 +112,32 @@ namespace DenshaDeGoInput
 			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.LDoor] = joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.LDoor]);
 			InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.RDoor] = joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.RDoor]);
 
-			if (Buttons.HasFlag(ControllerButtons.DPad))
+			if (hasHat)
 			{
-				if (comboDpad)
-				{
-					// On some controllers, check for Select+A/B/C/D combo
-					bool dPadUp = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.D]));
-					bool dPadDown = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.B]));
-					bool dPadLeft = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.A]));
-					bool dPadRight = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.C]));
-					bool dPadAny = dPadUp || dPadDown || dPadLeft || dPadRight;
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (ButtonState)(dPadUp ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (ButtonState)(dPadDown ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (ButtonState)(dPadLeft ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (ButtonState)(dPadRight ? 1 : 0);
-					// Disable original buttons if necessary
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] ^= (ButtonState)(dPadAny ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] ^= (ButtonState)(dPadLeft ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] ^= (ButtonState)(dPadDown ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] ^= (ButtonState)(dPadRight ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] ^= (ButtonState)(dPadUp ? 1 : 0);
-				}
-				else
-				{
-					// On other controllers, read the first hat
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsUp ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsDown ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
-					InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
-				}
+				// Read the first hat
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsUp ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsDown ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsLeft ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (ButtonState)(joystick.GetHat(JoystickHat.Hat0).IsRight ? 1 : 0);
+			}
+			else
+			{
+				// Check for Select+A/B/C/D combo
+				bool dPadUp = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.D]));
+				bool dPadDown = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.B]));
+				bool dPadLeft = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.A]));
+				bool dPadRight = Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.Select])) && Convert.ToBoolean(joystick.GetButton(buttonIndex[(int)InputTranslator.ControllerButton.C]));
+				bool dPadAny = dPadUp || dPadDown || dPadLeft || dPadRight;
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Up] = (ButtonState)(dPadUp ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Down] = (ButtonState)(dPadDown ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Left] = (ButtonState)(dPadLeft ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Right] = (ButtonState)(dPadRight ? 1 : 0);
+				// Disable original buttons if necessary
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.Select] ^= (ButtonState)(dPadAny ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.A] ^= (ButtonState)(dPadLeft ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.B] ^= (ButtonState)(dPadDown ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.C] ^= (ButtonState)(dPadRight ? 1 : 0);
+				InputTranslator.ControllerButtons[(int)InputTranslator.ControllerButton.D] ^= (ButtonState)(dPadUp ? 1 : 0);
 			}
 		}
 
@@ -156,23 +152,18 @@ namespace DenshaDeGoInput
 				Guid guid = Joystick.GetGuid(i);
 				ControllerID id = new ControllerID(guid);
 				string name = Joystick.GetName(i);
-				bool comboDpad = name == "TAITO Densha de Go! Plug & Play";
+				bool hasHat = Joystick.GetCapabilities(i).HatCount > 0;
 
 				if (!cachedControllers.ContainsKey(guid))
 				{
 					// DGC-255/DGOC-44U/P&P
 					if (id.Type == ControllerType.PCTwoHandle)
 					{
-						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D;
-						if (Joystick.GetCapabilities(i).HatCount > 0 || comboDpad)
-						{
-							// DGC-255 and P&P have a D-pad
-							buttons = buttons | ControllerButtons.DPad;
-						}
+						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.DPad;
 						int[] buttonIndices = { 4, 5, 1, 0, 2, 3, -1, -1 };
 						byte[] brakeBytes = { 0x78, 0x7A, 0x89, 0x8B, 0x93, 0x95, 0x99, 0x9B, 0xA1, 0xA3, 0xA7, 0xA9, 0xAE, 0xB0, 0xB1, 0xB3, 0xB4, 0xB6, 0xB8, 0xBA };
 						byte[] powerBytes = { 0x80, 0x82, 0x6C, 0x6E, 0x53, 0x55, 0x3E, 0x40, 0x20, 0x22, 0x0, 0x2 };
-						UnbalanceController newcontroller = new UnbalanceController(buttons, buttonIndices, comboDpad, brakeBytes, powerBytes)
+						UnbalanceController newcontroller = new UnbalanceController(buttons, buttonIndices, hasHat, brakeBytes, powerBytes)
 						{
 							Guid = guid,
 							Id = id,
@@ -189,7 +180,7 @@ namespace DenshaDeGoInput
 						int[] buttonIndices = { 5, 6, 2, 1, 0, -1, 4, 3 };
 						byte[] brakeBytes = { 0x23, 0x2C, 0x2D, 0x3E, 0x3F, 0x4E, 0x4F, 0x63, 0x64, 0x8A, 0x8B, 0xB0, 0xB1, 0xD4, 0xD5, 0xDF };
 						byte[] powerBytes = { 0x0, 0x2, 0x3B, 0x3D, 0x77, 0x79, 0xB3, 0xB5, 0xEF, 0xF1 };
-						UnbalanceController newcontroller = new UnbalanceController(buttons, buttonIndices, comboDpad, brakeBytes, powerBytes)
+						UnbalanceController newcontroller = new UnbalanceController(buttons, buttonIndices, hasHat, brakeBytes, powerBytes)
 						{
 							Guid = guid,
 							Id = id,

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Zuiki.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Zuiki.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -129,8 +129,9 @@ namespace DenshaDeGoInput
 
 				if (!cachedControllers.ContainsKey(guid))
 				{
+					JoystickCapabilities capabilities = Joystick.GetCapabilities(i);
 					// ZKNS-001
-					if (id.Type == ControllerType.Zuiki)
+					if (id.Type == ControllerType.Zuiki && capabilities.ButtonCount == 14 && capabilities.AxisCount == 4 && capabilities.HatCount >= 1)
 					{
 						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.LDoor | ControllerButtons.RDoor | ControllerButtons.DPad;
 						int[] buttonIndices = { 8, 9, 0, 1, 2, 3, 4, 5 };

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.Zuiki.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.Zuiki.cs
@@ -55,7 +55,6 @@ namespace DenshaDeGoInput
 		{
 			ControllerName = string.Empty;
 			IsConnected = false;
-			RequiresCalibration = false;
 			BrakeNotches = brake.Length / 2 - 2;
 			PowerNotches = power.Length / 2 - 1;
 			brakeBytes = brake;
@@ -131,7 +130,7 @@ namespace DenshaDeGoInput
 				if (!cachedControllers.ContainsKey(guid))
 				{
 					// ZKNS-001
-					if (id.Type == ControllerType.Zuki)
+					if (id.Type == ControllerType.Zuiki)
 					{
 						ControllerButtons buttons = ControllerButtons.Select | ControllerButtons.Start | ControllerButtons.A | ControllerButtons.B | ControllerButtons.C | ControllerButtons.D | ControllerButtons.LDoor | ControllerButtons.RDoor | ControllerButtons.DPad;
 						int[] buttonIndices = { 8, 9, 0, 1, 2, 3, 4, 5 };

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -192,13 +192,13 @@ namespace DenshaDeGoInput
 							break;
 						case 0x33dd:
 							// Zuiki Inc
-							if (PID == 0x0001 || PID == 0x0002)
+							if (PID >= 0x0001 && PID <= 0x0004)
 							{
 								return ControllerType.Zuiki;
 							}
-							// Zuiki Inc 
+							// Something from Zuiki Inc, probably a future mascon
 							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Zuiki Inc. PID " + PID + " - Please report this.");
-							break;
+							return ControllerType.Zuiki;
 						case 0x0ae4:
 							// Taito Corp
 							switch (PID)

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -105,6 +105,13 @@ namespace DenshaDeGoInput
 			protected set;
 		}
 
+		/// <summary>Whether the controller has a reverser</summary>
+		protected internal bool HasReverser
+		{
+			get;
+			protected set;
+		}
+
 		internal Controller()
 		{
 			Guid = Guid.Empty;
@@ -112,6 +119,7 @@ namespace DenshaDeGoInput
 			ControllerName = string.Empty;
 			IsConnected = false;
 			RequiresCalibration = false;
+			HasReverser = false;
 			Buttons = ControllerButtons.None;
 		}
 
@@ -126,11 +134,13 @@ namespace DenshaDeGoInput
 		internal class ControllerID
 		{
 			/// <summary>The Vendor ID</summary>
-			internal readonly string VID;
+			internal readonly int VID;
 			/// <summary>The Product ID</summary>
-			internal readonly string PID;
+			internal readonly int PID;
+			/// <summary>The Revision</summary>
+			internal readonly int Rev;
 
-			/// <summary>Gets a controller's vendor and product ID.</summary>
+			/// <summary>Sets a controller's vendor and product ID from an OpenTK GUID.</summary>
 			/// <param name="guid">The OpenTK GUID of the joystick.</param>
 			internal ControllerID(Guid guid)
 			{
@@ -139,20 +149,25 @@ namespace DenshaDeGoInput
 				switch (DenshaDeGoInput.CurrentHost.Platform)
 				{
 					case OpenBveApi.Hosts.HostPlatform.MicrosoftWindows:
-						VID = id.Substring(4, 4);
-						PID = id.Substring(0, 4);
+						VID = Convert.ToInt32(id.Substring(4, 4), 16);
+						PID = Convert.ToInt32(id.Substring(0, 4), 16);
 						break;
 					default:
-						VID = id.Substring(10, 2) + id.Substring(8, 2);
-						PID = id.Substring(18, 2) + id.Substring(16, 2);
+						VID = Convert.ToInt32(id.Substring(10, 2) + id.Substring(8, 2), 16);
+						PID = Convert.ToInt32(id.Substring(18, 2) + id.Substring(16, 2), 16);
 						break;
 				}
 			}
 
+			internal ControllerID(int vid, int pid, int rev)
+			{
+				VID = vid;
+				PID = pid;
+				Rev = rev;
+			}
+
 			internal ControllerID()
 			{
-				VID = string.Empty;
-				PID = string.Empty;
 			}
 
 
@@ -162,40 +177,62 @@ namespace DenshaDeGoInput
 				{
 					switch (VID)
 					{
-						case "0f0d":
+						case 0x0f0d:
 							// Hori Inc
-							if (PID == "00c1")
+							if (PID == 0x00c1)
 							{
-								return ControllerType.Zuki;
+								return ControllerType.Zuiki;
 							}
 							// May actually be a USB fight stick, but if we get the PIDs for these we can block them
-							DenshaDeGoInput.CurrentHost.AddMessage("Densha DeGo! Input: Unrecognised Hori Inc. PID " + PID + " - Please report this.");
+							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Hori Inc. PID " + PID + " - Please report this.");
 							break;
-						case "33dd":
-							// Zuki Inc
-							if (PID == "0001" || PID == "0002")
+						case 0x33dd:
+							// Zuiki Inc
+							if (PID == 0x0001 || PID == 0x0002)
 							{
-								return ControllerType.Zuki;
+								return ControllerType.Zuiki;
 							}
-							// Zuki Inc 
-							DenshaDeGoInput.CurrentHost.AddMessage("Densha DeGo! Input: Unrecognised Zuki Inc. PID " + PID + " - Please report this.");
+							// Zuiki Inc 
+							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Zuiki Inc. PID " + PID + " - Please report this.");
 							break;
-						case "0ae4":
+						case 0x0ae4:
 							// Taito Corp
 							switch (PID)
 							{
-								case "0003":
+								case 0x0003:
 									return ControllerType.PCTwoHandle;
-								case "0004":
+								case 0x0004:
 									return ControllerType.PS2TypeII;
-								case "0005":
+								case 0x0005:
 									return ControllerType.PS2Shinkansen;
-								case "0007":
+								case 0x0007:
 									return ControllerType.PS2Ryojouhen;
-								case "0008":
+								case 0x0008:
 									return ControllerType.PCRyojouhen;
+								case 0x0101:
+									switch (Rev)
+									{
+										case 300:
+											return ControllerType.PS2MTCP4B7;
+										case 400:
+											return ControllerType.PS2MTCP4B2B7;
+										case 800:
+											return ControllerType.PS2MTCP5B7;
+										case 1000:
+											return ControllerType.PS2MTCP13B7;
+									}
+									break;
 							}
-							DenshaDeGoInput.CurrentHost.AddMessage("Densha DeGo! Input: Unrecognised Taito Corp. PID " + PID + " - Please report this.");
+							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Taito Corp. PID " + PID + " - Please report this.");
+							break;
+						case 0x1c06:
+							// Pony Canyon
+							if (PID == 0x77a7)
+							{
+								return ControllerType.PS2TrainMascon;
+							}
+							// Pony Canyon 
+							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Pony Canyon PID " + PID + " - Please report this.");
 							break;
 
 					}
@@ -205,13 +242,13 @@ namespace DenshaDeGoInput
 			}
 		}
 
-		/// <summary>The types of known controller</summary>
+		/// <summary>The types of known controllers</summary>
 		internal enum ControllerType
 		{
-			/// <summary>Classic controllers, connected via pad adaptor</summary>
+			/// <summary>Classic controllers, connected via USB adapter</summary>
 			GenericUSB,
-			/// <summary>Zuki Controller for Switch</summary>
-			Zuki,
+			/// <summary>Zuiki One Handle Controller for Switch</summary>
+			Zuiki,
 			// ** PS2 USB Controllers **
 			/// <summary>TCPP-20009 (Type II)</summary>
 			PS2TypeII,
@@ -219,8 +256,17 @@ namespace DenshaDeGoInput
 			PS2Shinkansen,
 			/// <summary>TCPP-20014 (Ryojouhen)</summary>
 			PS2Ryojouhen,
+			/// <summary>COTM-02001 (Train Mascon</summary>
+			PS2TrainMascon,
+			/// <summary>SOTP-031201 (MTC with P4/B7 cartridge)</summary>
+			PS2MTCP4B7,
+			/// <summary>SOTP-031201 (MTC with P4/B2-B7 cartridge)</summary>
+			PS2MTCP4B2B7,
+			/// <summary>SOTP-031201 (MTC with P5/B7 cartridge)</summary>
+			PS2MTCP5B7,
+			/// <summary>SOTP-031201 (MTC with P13/B7 cartridge)</summary>
+			PS2MTCP13B7,
 			// ** Unbalance Controllers **
-
 			/// <summary>DGC-255 / DGOC-44U (Normally PC Two-Handle)</summary>
 			PCTwoHandle,
 			/// <summary>DRC-184 / DYC288 (Ryojouhen controller for PC)</summary>

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -56,6 +56,10 @@ namespace DenshaDeGoInput
 			LDoor = 256,
 			/// <summary>The right doors button</summary>
 			RDoor = 512,
+			/// <summary>The ATS button</summary>
+			ATS = 1024,
+			/// <summary>The A2 button</summary>
+			A2 = 2048,
 		}
 
 		/// <summary>The buttons the controller has</summary>

--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -196,7 +196,7 @@ namespace DenshaDeGoInput
 							{
 								return ControllerType.Zuiki;
 							}
-							// Something from Zuiki Inc, probably a future mascon
+							// Something from Zuiki Inc, probably a future mascon revision
 							DenshaDeGoInput.CurrentHost.AddMessage("Densha de GO! Input: Unrecognised Zuiki Inc. PID " + PID + " - Please report this.");
 							return ControllerType.Zuiki;
 						case 0x0ae4:

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -1,6 +1,6 @@
 //Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -130,19 +130,24 @@ namespace DenshaDeGoInput
 		private bool reverserMoved;
 
 		/// <summary>
-		/// An array with the command indices configured for each brake notch.
+		/// An array with the commands configured for each brake notch.
 		/// </summary>
-		private static readonly int[] brakeCommands = new int[10];
+		private static readonly InputControl[] brakeCommands = new InputControl[10];
 
 		/// <summary>
-		/// An array with the command indices configured for each power notch.
+		/// An array with the commands configured for each power notch.
 		/// </summary>
-		private static readonly int[] powerCommands = new int[14];
+		private static readonly InputControl[] powerCommands = new InputControl[14];
 
 		/// <summary>
-		/// An array with the command for each button.
+		/// An array with the commands configured for each reverser notch.
 		/// </summary>
-		internal static int[] ButtonCommands = new int[13];
+		private static readonly InputControl[] reverserCommands = new InputControl[3];
+
+		/// <summary>
+		/// An array with the commands configured for each button.
+		/// </summary>
+		internal static InputControl[] ButtonCommands = new InputControl[13];
 
 
 		/// <summary>
@@ -195,30 +200,8 @@ namespace DenshaDeGoInput
 			// Create the config form
 			configForm = new Config();
 
-			// Define the list of commands
-			// We allocate 50 slots per handle plus one slot per command
-			int commandCount = Translations.CommandInfos.Count;
-			Controls = new InputControl[100 + commandCount];
-			// Brake notches
-			for (int i = 0; i < 50; i++)
-			{
-				Controls[i].Command = Translations.Command.BrakeAnyNotch;
-				Controls[i].Option = i;
-			}
-			// Power notches
-			for (int i = 50; i < 100; i++)
-			{
-				Controls[i].Command = Translations.Command.PowerAnyNotch;
-				Controls[i].Option = i - 50;
-			}
-			// Other commands
-			for (int i = 0; i < commandCount; i++)
-			{
-				Controls[i + 100].Command = (Translations.Command)i;
-			}
-
-			// Configure the mappings for the buttons and notches
-			ConfigureMappings();
+			// Initialize controls
+			Controls = new InputControl[brakeCommands.Length + powerCommands.Length + reverserCommands.Length + ButtonCommands.Length];
 
 			return true;
 		}
@@ -243,20 +226,19 @@ namespace DenshaDeGoInput
 			// Brake handle (release)
 			if (brakeHandleMoved)
 			{
-				KeyUp(this, new InputEventArgs(Controls[brakeCommands[(int)InputTranslator.BrakeNotch]]));
+				KeyUp(this, new InputEventArgs(brakeCommands[(int)InputTranslator.BrakeNotch]));
 				brakeHandleMoved = false;
 			}
 			// Power handle (release)
 			if (powerHandleMoved)
 			{
-				KeyUp(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
+				KeyUp(this, new InputEventArgs(powerCommands[(int)InputTranslator.PowerNotch]));
 				powerHandleMoved = false;
 			}
 			// Reverser (release)
 			if (reverserMoved)
 			{
-				InputControl control = new InputControl { Command = Translations.Command.ReverserAnyPostion };
-				KeyUp(this, new InputEventArgs(control));
+				KeyUp(this, new InputEventArgs(reverserCommands[(int)InputTranslator.ReverserPosition + 1]));
 				reverserMoved = false;
 			}
 
@@ -274,7 +256,7 @@ namespace DenshaDeGoInput
 			{
 				if (InputTranslator.ControllerButtons[i] == OpenTK.Input.ButtonState.Released && previousButtonState[i] == OpenTK.Input.ButtonState.Pressed)
 				{
-					KeyUp(this, new InputEventArgs(Controls[100 + ButtonCommands[i]]));
+					KeyUp(this, new InputEventArgs(ButtonCommands[i]));
 				}
 			}
 
@@ -283,20 +265,19 @@ namespace DenshaDeGoInput
 				// Brake handle (apply)
 				if (InputTranslator.BrakeNotch != InputTranslator.PreviousBrakeNotch || loading)
 				{
-					KeyDown(this, new InputEventArgs(Controls[brakeCommands[(int)InputTranslator.BrakeNotch]]));
+					KeyDown(this, new InputEventArgs(brakeCommands[(int)InputTranslator.BrakeNotch]));
 					brakeHandleMoved = true;
 				}
 				// Power handle (apply)
 				if (InputTranslator.PowerNotch != InputTranslator.PreviousPowerNotch || loading)
 				{
-					KeyDown(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
+					KeyDown(this, new InputEventArgs(powerCommands[(int)InputTranslator.PowerNotch]));
 					powerHandleMoved = true;
 				}
 				// Reverser (apply)
 				if (InputTranslator.ReverserPosition != InputTranslator.PreviousReverserPosition || loading)
 				{
-					InputControl control = new InputControl { Command = Translations.Command.ReverserAnyPostion, Option = (int)InputTranslator.ReverserPosition };
-					KeyDown(this, new InputEventArgs(control));
+					KeyDown(this, new InputEventArgs(reverserCommands[(int)InputTranslator.ReverserPosition + 1]));
 					reverserMoved = true;
 				}
 				// Buttons (apply)
@@ -304,7 +285,7 @@ namespace DenshaDeGoInput
 				{
 					if (InputTranslator.ControllerButtons[i] == OpenTK.Input.ButtonState.Pressed && previousButtonState[i] == OpenTK.Input.ButtonState.Released)
 					{
-						KeyDown(this, new InputEventArgs(Controls[100 + ButtonCommands[i]]));
+						KeyDown(this, new InputEventArgs(ButtonCommands[i]));
 					}
 				}
 			}
@@ -398,29 +379,33 @@ namespace DenshaDeGoInput
 				// Brake notches
 				if (MapHoldBrake && TrainSpecs.HasHoldBrake)
 				{
-					brakeCommands[0] = 0;
-					brakeCommands[1] = 100 + (int)Translations.Command.HoldBrake;
+					brakeCommands[0].Command = Translations.Command.BrakeAnyNotch;
+					brakeCommands[0].Option = 0;
+					brakeCommands[1].Command = Translations.Command.HoldBrake;
 					for (int i = 2; i <= controllerBrakeNotches + 1; i++)
 					{
-						brakeCommands[i] = i - 1;
+						brakeCommands[i].Command = Translations.Command.BrakeAnyNotch;
+						brakeCommands[i].Option = i - 1;
 					}
 				}
 				else
 				{
 					for (int i = 0; i <= controllerBrakeNotches + 1; i++)
 					{
-						brakeCommands[i] = i;
+						brakeCommands[i].Command = Translations.Command.BrakeAnyNotch;
+						brakeCommands[i].Option = i;
 					}
 				}
 				// Emergency brake, only if the train has the same or less notches than the controller
 				if (TrainSpecs.BrakeNotches <= controllerBrakeNotches)
 				{
-					brakeCommands[(int)InputTranslator.BrakeNotches.Emergency] = 100 + (int)Translations.Command.BrakeEmergency;
+					brakeCommands[(int)InputTranslator.BrakeNotches.Emergency].Command = Translations.Command.BrakeEmergency;
 				}
 				// Power notches
 				for (int i = 0; i <= controllerPowerNotches; i++)
 				{
-					powerCommands[i] = i;
+					powerCommands[i].Command = Translations.Command.PowerAnyNotch;
+					powerCommands[i].Option = i;
 				}
 			}
 			else
@@ -430,22 +415,24 @@ namespace DenshaDeGoInput
 				if (MapHoldBrake && TrainSpecs.HasHoldBrake)
 				{
 					double brakeStep = (TrainSpecs.BrakeNotches - 1) / (double)(controllerBrakeNotches - 1);
-					brakeCommands[0] = 0;
-					brakeCommands[1] = 100 + (int)Translations.Command.HoldBrake;
+					brakeCommands[0].Command = Translations.Command.BrakeAnyNotch;
+					brakeCommands[0].Option = 0;
+					brakeCommands[1].Command = Translations.Command.HoldBrake;
 					for (int i = 2; i < controllerBrakeNotches + 1; i++)
 					{
-						brakeCommands[i] = (int)Math.Round(brakeStep * (i - 1), MidpointRounding.AwayFromZero);
-						if (i > 0 && brakeCommands[i] == 0)
+						brakeCommands[i].Command = Translations.Command.BrakeAnyNotch;
+						brakeCommands[i].Option = (int)Math.Round(brakeStep * (i - 1), MidpointRounding.AwayFromZero);
+						if (i > 0 && brakeCommands[i].Option == 0)
 						{
-							brakeCommands[i] = 1;
+							brakeCommands[i].Option = 1;
 						}
 						if (KeepMaxMin && i == 2)
 						{
-							brakeCommands[i] = 1;
+							brakeCommands[i].Option = 1;
 						}
 						if (KeepMaxMin && i == controllerBrakeNotches)
 						{
-							brakeCommands[i] = TrainSpecs.BrakeNotches - 1;
+							brakeCommands[i].Option = TrainSpecs.BrakeNotches - 1;
 						}
 					}
 				}
@@ -454,39 +441,41 @@ namespace DenshaDeGoInput
 					double brakeStep = TrainSpecs.BrakeNotches / (double)controllerBrakeNotches;
 					for (int i = 0; i < controllerBrakeNotches + 1; i++)
 					{
-						brakeCommands[i] = (int)Math.Round(brakeStep * i, MidpointRounding.AwayFromZero);
-						if (i > 0 && brakeCommands[i] == 0)
+						brakeCommands[i].Command = Translations.Command.BrakeAnyNotch;
+						brakeCommands[i].Option = (int)Math.Round(brakeStep * i, MidpointRounding.AwayFromZero);
+						if (i > 0 && brakeCommands[i].Option == 0)
 						{
-							brakeCommands[i] = 1;
+							brakeCommands[i].Option = 1;
 						}
 						if (KeepMaxMin && i == 1)
 						{
-							brakeCommands[i] = 1;
+							brakeCommands[i].Option = 1;
 						}
 						if (KeepMaxMin && i == controllerBrakeNotches)
 						{
-							brakeCommands[i] = TrainSpecs.BrakeNotches;
+							brakeCommands[i].Option = TrainSpecs.BrakeNotches;
 						}
 					}
 				}
 				// Emergency brake
-				brakeCommands[(int)InputTranslator.BrakeNotches.Emergency] = 100 + (int)Translations.Command.BrakeEmergency;
+				brakeCommands[(int)InputTranslator.BrakeNotches.Emergency].Command = Translations.Command.BrakeEmergency;
 				// Power notches
 				double powerStep = TrainSpecs.PowerNotches / (double)controllerPowerNotches;
 				for (int i = 0; i < controllerPowerNotches + 1; i++)
 				{
-					powerCommands[i] = (int)Math.Round(powerStep * i, MidpointRounding.AwayFromZero);
-					if (i > 0 && powerCommands[i] == 0)
+					powerCommands[i].Command = Translations.Command.PowerAnyNotch;
+					powerCommands[i].Option = (int)Math.Round(powerStep * i, MidpointRounding.AwayFromZero);
+					if (i > 0 && powerCommands[i].Option == 0)
 					{
-						powerCommands[i] = 1;
+						powerCommands[i].Option = 1;
 					}
 					if (KeepMaxMin && i == 1)
 					{
-						powerCommands[i] = 1;
+						powerCommands[i].Option = 1;
 					}
 					if (KeepMaxMin && i == controllerPowerNotches)
 					{
-						powerCommands[i] = TrainSpecs.PowerNotches;
+						powerCommands[i].Option = TrainSpecs.PowerNotches;
 					}
 				}
 			}
@@ -497,9 +486,27 @@ namespace DenshaDeGoInput
 				double brakeStep = 3 / (double)(controllerBrakeNotches);
 				for (int i = 1; i < controllerBrakeNotches + 1; i++)
 				{
+					brakeCommands[i].Command = Translations.Command.BrakeAnyNotch;
 					int notch = ((int)Math.Round(brakeStep * i, MidpointRounding.AwayFromZero) - 1);
-					brakeCommands[i] = notch >= 0 ? notch : 0;
+					brakeCommands[i].Option = notch >= 0 ? notch : 0;
 				}
+			}
+
+			for (int i = 0; i < 3; i++)
+			{
+				reverserCommands[i].Command = Translations.Command.ReverserAnyPostion;
+				reverserCommands[i].Option = i - 1;
+			}
+
+			// Pass commands to the main program
+			brakeCommands.CopyTo(Controls, 0);
+			powerCommands.CopyTo(Controls, brakeCommands.Length);
+			reverserCommands.CopyTo(Controls, brakeCommands.Length + powerCommands.Length);
+			ButtonCommands.CopyTo(Controls, brakeCommands.Length + powerCommands.Length + reverserCommands.Length);
+
+			for (int i = 0; i < Controls.Length; i++)
+			{
+				Console.WriteLine("Command: " + Controls[i].Command.ToString() + ", Option: " + Controls[i].Option.ToString());
 			}
 		}
 
@@ -615,118 +622,105 @@ namespace DenshaDeGoInput
 									{
 										case "select":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Select] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Select].Command = parsedCommand;
 												}
 											}
 											break;
 										case "start":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Start] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Start].Command = parsedCommand;
 												}
 											}
 											break;
 										case "a":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.A] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.A].Command = parsedCommand;
 												}
 											}
 											break;
 										case "b":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.B] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.B].Command = parsedCommand;
 												}
 											}
 											break;
 										case "c":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.C] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.C].Command = parsedCommand;
 												}
 											}
 											break;
 										case "d":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.D] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.D].Command = parsedCommand;
 												}
 											}
 											break;
 										case "up":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Up] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Up].Command = parsedCommand;
 												}
 											}
 											break;
 										case "down":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Down] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Down].Command = parsedCommand;
 												}
 											}
 											break;
 										case "left":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Left] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Left].Command = parsedCommand;
 												}
 											}
 											break;
 										case "right":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Right] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Right].Command = parsedCommand;
 												}
 											}
 											break;
 										case "pedal":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.Pedal] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].Command = parsedCommand;
 												}
 											}
 											break;
 										case "ldoor":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.LDoor] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].Command = parsedCommand;
 												}
 											}
 											break;
 										case "rdoor":
 											{
-												int a;
-												if (int.TryParse(Value, out a))
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
-													ButtonCommands[(int)InputTranslator.ControllerButton.RDoor] = a;
+													ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command = parsedCommand;
 												}
 											}
 											break;
@@ -899,19 +893,13 @@ namespace DenshaDeGoInput
 				Builder.AppendLine("map_hold_brake = " + MapHoldBrake.ToString(Culture).ToLower());
 				Builder.AppendLine();
 				Builder.AppendLine("[buttons]");
-				Builder.AppendLine("select = " + ButtonCommands[(int)InputTranslator.ControllerButton.Select].ToString(Culture));
-				Builder.AppendLine("start = " + ButtonCommands[(int)InputTranslator.ControllerButton.Start].ToString(Culture));
-				Builder.AppendLine("a = " + ButtonCommands[(int)InputTranslator.ControllerButton.A].ToString(Culture));
-				Builder.AppendLine("b = " + ButtonCommands[(int)InputTranslator.ControllerButton.B].ToString(Culture));
-				Builder.AppendLine("c = " + ButtonCommands[(int)InputTranslator.ControllerButton.C].ToString(Culture));
-				Builder.AppendLine("d = " + ButtonCommands[(int)InputTranslator.ControllerButton.D].ToString(Culture));
-				Builder.AppendLine("up = " + ButtonCommands[(int)InputTranslator.ControllerButton.Up].ToString(Culture));
-				Builder.AppendLine("down = " + ButtonCommands[(int)InputTranslator.ControllerButton.Down].ToString(Culture));
-				Builder.AppendLine("left = " + ButtonCommands[(int)InputTranslator.ControllerButton.Left].ToString(Culture));
-				Builder.AppendLine("right = " + ButtonCommands[(int)InputTranslator.ControllerButton.Right].ToString(Culture));
-				Builder.AppendLine("pedal = " + ButtonCommands[(int)InputTranslator.ControllerButton.Pedal].ToString(Culture));
-				Builder.AppendLine("ldoor = " + ButtonCommands[(int)InputTranslator.ControllerButton.LDoor].ToString(Culture));
-				Builder.AppendLine("rdoor = " + ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].ToString(Culture));
+				for (int i = 0; i < ButtonCommands.Length; i++)
+				{
+					if (ButtonCommands[i].Command != Translations.Command.None)
+					{
+						Builder.AppendLine(((InputTranslator.ControllerButton)i).ToString().ToLower() + " = " + Translations.CommandInfos.TryGetInfo(ButtonCommands[i].Command).Name);
+					}
+				}
 				Builder.AppendLine();
 				Builder.AppendLine("[classic]");
 				Builder.AppendLine("hat = " + ClassicController.UsesHat.ToString(Culture).ToLower());

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -1,6 +1,6 @@
 //Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -125,6 +125,11 @@ namespace DenshaDeGoInput
 		private bool powerHandleMoved;
 
 		/// <summary>
+		/// Whether the reverser has been moved.
+		/// </summary>
+		private bool reverserMoved;
+
+		/// <summary>
 		/// An array with the command indices configured for each brake notch.
 		/// </summary>
 		private static readonly int[] brakeCommands = new int[10];
@@ -247,6 +252,13 @@ namespace DenshaDeGoInput
 				KeyUp(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 				powerHandleMoved = false;
 			}
+			// Reverser (release)
+			if (reverserMoved)
+			{
+				InputControl control = new InputControl { Command = Translations.Command.ReverserAnyPostion };
+				KeyUp(this, new InputEventArgs(control));
+				reverserMoved = false;
+			}
 
 			// Update input from controller
 			InputTranslator.Update();
@@ -279,6 +291,13 @@ namespace DenshaDeGoInput
 				{
 					KeyDown(this, new InputEventArgs(Controls[50 + powerCommands[(int)InputTranslator.PowerNotch]]));
 					powerHandleMoved = true;
+				}
+				// Reverser (apply)
+				if (InputTranslator.ReverserPosition != InputTranslator.PreviousReverserPosition || loading)
+				{
+					InputControl control = new InputControl { Command = Translations.Command.ReverserAnyPostion, Option = (int)InputTranslator.ReverserPosition };
+					KeyDown(this, new InputEventArgs(control));
+					reverserMoved = true;
 				}
 				// Buttons (apply)
 				for (int i = 0; i < ButtonCommands.Length; i++)

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.cs
@@ -147,7 +147,7 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// An array with the commands configured for each button.
 		/// </summary>
-		internal static InputControl[] ButtonCommands = new InputControl[13];
+		internal static InputControl[] ButtonCommands = new InputControl[15];
 
 
 		/// <summary>
@@ -721,6 +721,22 @@ namespace DenshaDeGoInput
 												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
 												{
 													ButtonCommands[(int)InputTranslator.ControllerButton.RDoor].Command = parsedCommand;
+												}
+											}
+											break;
+										case "ats":
+											{
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
+												{
+													ButtonCommands[(int)InputTranslator.ControllerButton.ATS].Command = parsedCommand;
+												}
+											}
+											break;
+										case "a2":
+											{
+												if (Enum.TryParse(Value.Replace("_", string.Empty), true, out Translations.Command parsedCommand))
+												{
+													ButtonCommands[(int)InputTranslator.ControllerButton.A2].Command = parsedCommand;
 												}
 											}
 											break;

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
@@ -69,8 +69,9 @@
     <Compile Include="Controller.cs" />
     <Compile Include="Controller.Classic.cs" />
     <Compile Include="Controller.Unbalance.cs" />
-    <Compile Include="Controller.Ps2.cs" />
+    <Compile Include="Controller.Ps2Ddgo.cs" />
     <Compile Include="Controller.Zuiki.cs" />
+    <Compile Include="Controller.Ps2TS.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Config.resx">
@@ -90,6 +91,12 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Drivers\Type2.cfg">
       <LogicalName>type2_driver</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Drivers\TrainMascon.cfg">
+      <LogicalName>trainmascon_driver</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Drivers\MTC.cfg">
+      <LogicalName>mtc_driver</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
+++ b/source/InputDevicePlugins/DenshaDeGoInput/DenshaDeGoInput.csproj
@@ -23,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,7 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=3.3.3.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">

--- a/source/InputDevicePlugins/DenshaDeGoInput/Drivers/99-ps2-train-controllers.rules
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Drivers/99-ps2-train-controllers.rules
@@ -1,4 +1,4 @@
-# This rule allows non-root access to Densha de GO! controllers for the Sony PlayStation 2
+# This rule allows non-root access to Densha de GO! and Ongakukan Train Simulator controllers for the Sony PlayStation 2
 
 # Type II controller
 SUBSYSTEM=="usb", ATTR{idVendor}=="0ae4", ATTR{idProduct}=="0004", MODE="0666"
@@ -8,3 +8,9 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0ae4", ATTR{idProduct}=="0005", MODE="0666"
 
 # Ryojouhen controller
 SUBSYSTEM=="usb", ATTR{idVendor}=="0ae4", ATTR{idProduct}=="0007", MODE="0666"
+
+# Train Mascon
+SUBSYSTEM=="usb", ATTR{idVendor}=="1c06", ATTR{idProduct}=="77a7", MODE="0666"
+
+# Multi Train Controller
+SUBSYSTEM=="usb", ATTR{idVendor}=="0ae4", ATTR{idProduct}=="0101", MODE="0666"

--- a/source/InputDevicePlugins/DenshaDeGoInput/Drivers/MTC.cfg
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Drivers/MTC.cfg
@@ -1,0 +1,5 @@
+# Multi Train Controller driver for Zadig
+[device]
+  Description = "MULTI_TRAIN_CONTROLLER"
+  VID = 0x0AE4
+  PID = 0x0101

--- a/source/InputDevicePlugins/DenshaDeGoInput/Drivers/TrainMascon.cfg
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Drivers/TrainMascon.cfg
@@ -1,0 +1,5 @@
+# Train Mascon driver for Zadig
+[device]
+  Description = "TRAIN_MASCON"
+  VID = 0x1C06
+  PID = 0x77A7

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,6 +1,6 @@
 //Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2021, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:
@@ -101,6 +101,19 @@ namespace DenshaDeGoInput
 		};
 
 		/// <summary>
+		/// Enumeration representing reverser positions.
+		/// </summary>
+		internal enum ReverserPositions
+		{
+			/// <summary>Reverser is set to N</summary>
+			N = 0,
+			/// <summary>Reverser is set to forward</summary>
+			Forward = 1,
+			/// <summary>Reverser is set to backward</summary>
+			Backward = -1,
+		};
+
+		/// <summary>
 		/// Enumeration representing controller buttons.
 		/// </summary>
 		internal enum ControllerButton
@@ -149,6 +162,11 @@ namespace DenshaDeGoInput
 		internal static PowerNotches PowerNotch;
 
 		/// <summary>
+		/// The current reverser position reported by the controller.
+		/// </summary>
+		internal static ReverserPositions ReverserPosition;
+
+		/// <summary>
 		/// The previous brake notch reported by the controller.
 		/// </summary>
 		internal static BrakeNotches PreviousBrakeNotch;
@@ -157,6 +175,11 @@ namespace DenshaDeGoInput
 		/// The previous power notch reported by the controller.
 		/// </summary>
 		internal static PowerNotches PreviousPowerNotch;
+
+		/// <summary>
+		/// The previous reverser position reported by the controller.
+		/// </summary>
+		internal static ReverserPositions PreviousReverserPosition;
 
 		/// <summary>
 		/// The GUID of the active controller.
@@ -173,7 +196,8 @@ namespace DenshaDeGoInput
 		/// </summary>
 		internal static void Load()
 		{
-			Ps2Controller.ConfigureControllers();
+			Ps2DdgoController.ConfigureControllers();
+			Ps2TSController.ConfigureControllers();
 		}
 
 		/// <summary>
@@ -207,8 +231,20 @@ namespace DenshaDeGoInput
 		/// </summary>
 		public static void RefreshControllers()
 		{
-			// PlayStation 2 controllers
-			foreach (KeyValuePair<Guid, Controller> controller in Ps2Controller.GetControllers())
+			// PlayStation 2 Densha de GO! controllers
+			foreach (KeyValuePair<Guid, Controller> controller in Ps2DdgoController.GetControllers())
+			{
+				if (!Controllers.ContainsKey(controller.Key))
+				{
+					Controllers.Add(controller.Key, controller.Value);
+				}
+				else
+				{
+					Controllers[controller.Key] = controller.Value;
+				}
+			}
+			// PlayStation 2 Train Simulator controllers
+			foreach (KeyValuePair<Guid, Controller> controller in Ps2TSController.GetControllers())
 			{
 				if (!Controllers.ContainsKey(controller.Key))
 				{
@@ -291,6 +327,7 @@ namespace DenshaDeGoInput
 			// Store the current notches so we can later tell if they have been moved
 			PreviousBrakeNotch = BrakeNotch;
 			PreviousPowerNotch = PowerNotch;
+			PreviousReverserPosition = ReverserPosition;
 
 			Controllers[ActiveControllerGuid].ReadInput();
 		}

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,6 +1,6 @@
 //Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2020-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2020-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -144,12 +144,16 @@ namespace DenshaDeGoInput
 			Right = 11,
 			/// <summary>Pedal button</summary>
 			Pedal = 12,
+			/// <summary>ATS button</summary>
+			ATS = 13,
+			/// <summary>A2 button</summary>
+			A2 = 14,
 		}
 
 		/// <summary>
 		/// The current state of the controller's buttons.
 		/// </summary>
-		internal static ButtonState[] ControllerButtons = new ButtonState[13];
+		internal static ButtonState[] ControllerButtons = new ButtonState[15];
 
 		/// <summary>
 		/// The current brake notch reported by the controller.

--- a/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
@@ -42,6 +42,8 @@ namespace DenshaDeGoInput
 			internal readonly int VendorID;
 			/// <summary>The USB product ID</summary>
 			internal readonly int ProductID;
+			/// <summary>The USB revision</summary>
+			internal readonly int Revision;
 			/// <summary>Backing property containing the cached controller name</summary>
 			private string controllerName;
 			/// <summary>An array to be sent to the controller upon unload</summary>
@@ -59,13 +61,15 @@ namespace DenshaDeGoInput
 
 			/// <summary>
 			/// Initializes a controller
-			/// <param name="vid">A string representing the vendor ID.</param>
-			/// <param name="pid">A string representing the product ID.</param>
+			/// <param name="vid">An int representing the vendor ID.</param>
+			/// <param name="pid">An int representing the product ID.</param>
+			/// <param name="rev">An int representing the revision.</param>
 			/// </summary>
-			internal UsbController(int vid, int pid)
+			internal UsbController(int vid, int pid, int rev)
 			{
 				VendorID = vid;
 				ProductID = pid;
+				Revision = rev;
 				controllerName = string.Empty;
 				UnloadBuffer = new byte[0];
 				IsConnected = false;
@@ -91,7 +95,7 @@ namespace DenshaDeGoInput
 							if (string.IsNullOrEmpty(controllerName))
 							{
 								// The name may be blank, use VID+PID
-								controllerName = VendorID.ToString("X4") + ":" + ProductID.ToString("X4");
+								controllerName = VendorID.ToString("X4") + ":" + ProductID.ToString("X4") + ":" + Revision.ToString("D4");
 							}
 						}
 					}

--- a/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.UsbController.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2021-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2021-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:

--- a/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.cs
@@ -22,15 +22,15 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using LibUsbDotNet;
 using LibUsbDotNet.Info;
 using LibUsbDotNet.Main;
 using OpenBveApi;
 using OpenBveApi.Interface;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading;
 
 namespace DenshaDeGoInput
 {
@@ -74,19 +74,9 @@ namespace DenshaDeGoInput
 			{
 				int vid = int.Parse(id.Substring(0, 4), NumberStyles.HexNumber);
 				int pid = int.Parse(id.Substring(5, 4), NumberStyles.HexNumber);
-				Guid guid;
-				switch (DenshaDeGoInput.CurrentHost.Platform)
-				{
-					case OpenBveApi.Hosts.HostPlatform.MicrosoftWindows:
-						guid = new Guid(id.Substring(5, 4) + id.Substring(0, 4) + "-ffff-ffff-ffff-ffffffffffff");
-						break;
-					default:
-						string vendor = id.Substring(2, 2) + id.Substring(0, 2);
-						string product = id.Substring(7, 2) + id.Substring(5, 2);
-						guid = new Guid("ffffffff-" + vendor + "-ffff-" + product + "-ffffffffffff");
-						break;
-				}
-				UsbController controller = new UsbController(vid, pid);
+				int rev = int.Parse(id.Substring(10, 4), NumberStyles.HexNumber);
+				Guid guid = new Guid(id.Substring(5, 4) + id.Substring(0, 4) + "-" + id.Substring(10, 4) + "-ffff-ffff-ffffffffffff");
+				UsbController controller = new UsbController(vid, pid, rev);
 				if (!supportedUsbControllers.ContainsKey(guid))
 				{
 					// Add new controller
@@ -149,7 +139,14 @@ namespace DenshaDeGoInput
 					if (controller.ControllerDevice == null || !controller.IsConnected)
 					{
 						// The device is not configured, try to find it
-						controller.ControllerDevice = UsbDevice.OpenUsbDevice(new UsbDeviceFinder(controller.VendorID, controller.ProductID));
+						if (controller.Revision != 0)
+						{
+							controller.ControllerDevice = UsbDevice.OpenUsbDevice(new UsbDeviceFinder(controller.VendorID, controller.ProductID, controller.Revision));
+						}
+						else
+						{
+							controller.ControllerDevice = UsbDevice.OpenUsbDevice(new UsbDeviceFinder(controller.VendorID, controller.ProductID));
+						}
 					}
 					if (controller.ControllerDevice == null)
 					{
@@ -163,15 +160,12 @@ namespace DenshaDeGoInput
 							// Search for input endpoint and open endpoint reader
 							ReadEndpointID ep = ReadEndpointID.Ep01;
 							UsbConfigInfo config = controller.ControllerDevice.Configs[0];
-							if (config.InterfaceInfoList[0].Descriptor.Class == LibUsbDotNet.Descriptors.ClassCodeType.Hid)
+							foreach (UsbEndpointInfo endpoint in config.InterfaceInfoList[0].EndpointInfoList)
 							{
-								foreach (UsbEndpointInfo endpoint in config.InterfaceInfoList[0].EndpointInfoList)
+								if ((endpoint.Descriptor.EndpointID & 0x80) == 0x80)
 								{
-									if ((endpoint.Descriptor.EndpointID & 0x80) == 0x80)
-									{
-										ep = (ReadEndpointID)endpoint.Descriptor.EndpointID;
-										break;
-									}
+									ep = (ReadEndpointID)endpoint.Descriptor.EndpointID;
+									break;
 								}
 							}
 							controller.ControllerReader = controller.ControllerDevice.OpenEndpointReader(ep);

--- a/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/LibUsb.cs
@@ -1,6 +1,6 @@
 ﻿//Simplified BSD License (BSD-2-Clause)
 //
-//Copyright (c) 2021-2023, Marc Riera, The OpenBVE Project
+//Copyright (c) 2021-2024, Marc Riera, The OpenBVE Project
 //
 //Redistribution and use in source and binary forms, with or without
 //modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
### New features

- Add support for the Multi Train Controller (all cartridges).
- Add support for the Train Mascon.

### Bug fixes

- Add more PIDs from Zuiki and allow unrecognised PIDs as long as they have the required capabilities (fixes #995).
- Check for minimum capabilities for OpenTK joysticks, in case a malformed joystick with the same VID/PID is used.
- Internal refactor of control handling to pass the main program only the commands actually used (fixes buttons not working in some cases).

### Breaking changes

- Assigned commands for buttons are now stored by ID instead of index, requiring the user to define them from scratch when updating from a previous version.
- udev rules need to be installed again for the Multi Train Controller/Train Mascon to work.