### PR TITLE
Fix Wine support for Densha de GO! Input

### DIFF
--- a/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/Controller.cs
@@ -153,6 +153,7 @@ namespace DenshaDeGoInput
 				switch (DenshaDeGoInput.CurrentHost.Platform)
 				{
 					case OpenBveApi.Hosts.HostPlatform.MicrosoftWindows:
+					case OpenBveApi.Hosts.HostPlatform.WINE:
 						VID = Convert.ToInt32(id.Substring(4, 4), 16);
 						PID = Convert.ToInt32(id.Substring(0, 4), 16);
 						break;


### PR DESCRIPTION
Because there are platform differences regarding joystick GUID format in OpenTK and Wine was not accounted for, OpenBVE has been unable to detect certain Densha de GO! controllers when running under Wine.

This ensures joystick GUIDs are treated like under Windows if the host platform is Wine.