### PR TITLE
Add RailIndex function for objects

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -524,14 +524,14 @@ namespace LibRender2
 			Initialize();
 		}
 
-		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition, double Brightness)
+		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, WorldProperties Properties, double BlockLength)
 		{
 			Matrix4D Translate = Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z);
 			Matrix4D Rotate = (Matrix4D)new Transformation(LocalTransformation, WorldTransformation);
-			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, BlockLength, TrackPosition, Brightness);
+			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, BlockLength);
 		}
 
-		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition, double Brightness)
+		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, WorldProperties Properties, double BlockLength)
 		{
 			if (Prototype == null)
 			{
@@ -579,21 +579,21 @@ namespace LibRender2
 			switch (AccurateObjectDisposal)
 			{
 				case ObjectDisposalMode.Accurate:
-					startingDistance += (float)TrackPosition;
-					endingDistance += (float)TrackPosition;
-					double z = BlockLength * Math.Floor(TrackPosition / BlockLength);
-					StartingDistance = Math.Min(z - BlockLength, startingDistance);
-					EndingDistance = Math.Max(z + 2.0 * BlockLength, endingDistance);
-					startingDistance = (float)(BlockLength * Math.Floor(StartingDistance / BlockLength));
-					endingDistance = (float)(BlockLength * Math.Ceiling(EndingDistance / BlockLength));
+					startingDistance += (float)Properties.TrackPosition;
+					endingDistance += (float)Properties.TrackPosition;
+					double z = BlockLength * Math.Floor(Properties.TrackPosition / BlockLength);
+					Properties.StartingDistance = Math.Min(z - BlockLength, startingDistance);
+					Properties.EndingDistance = Math.Max(z + 2.0 * BlockLength, endingDistance);
+					startingDistance = (float)(BlockLength * Math.Floor(Properties.StartingDistance / BlockLength));
+					endingDistance = (float)(BlockLength * Math.Ceiling(Properties.EndingDistance / BlockLength));
 					break;
 				case ObjectDisposalMode.Legacy:
-					startingDistance = (float)StartingDistance;
-					endingDistance = (float)EndingDistance;
+					startingDistance = (float)Properties.StartingDistance;
+					endingDistance = (float)Properties.EndingDistance;
 					break;
 				case ObjectDisposalMode.Mechanik:
-					startingDistance = (float) StartingDistance;
-					endingDistance = (float) EndingDistance + 1500;
+					startingDistance = (float)Properties.StartingDistance;
+					endingDistance = (float)Properties.EndingDistance + 1500;
 					if (startingDistance < 0)
 					{
 						startingDistance = 0;
@@ -605,7 +605,7 @@ namespace LibRender2
 				Prototype = Prototype,
 				Translation = Translate,
 				Rotate = Rotate,
-				Brightness = Brightness,
+				Brightness = Properties.Brightness,
 				StartingDistance = startingDistance,
 				EndingDistance = endingDistance,
 				WorldPosition = Position

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -524,14 +524,14 @@ namespace LibRender2
 			Initialize();
 		}
 
-		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, WorldProperties Properties, double BlockLength)
+		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, WorldProperties Properties, double BlockLength)
 		{
 			Matrix4D Translate = Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z);
 			Matrix4D Rotate = (Matrix4D)new Transformation(LocalTransformation, WorldTransformation);
-			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, BlockLength);
+			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, Properties, BlockLength);
 		}
 
-		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, WorldProperties Properties, double BlockLength)
+		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, WorldProperties Properties, double BlockLength)
 		{
 			if (Prototype == null)
 			{
@@ -565,8 +565,8 @@ namespace LibRender2
 					}
 				}
 
-				startingDistance += (float)AccurateObjectDisposalZOffset;
-				endingDistance += (float)AccurateObjectDisposalZOffset;
+				startingDistance += (float)Properties.AccurateObjectDisposalZOffset;
+				endingDistance += (float)Properties.AccurateObjectDisposalZOffset;
 			}
 
 			const double minBlockLength = 20.0;

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -348,14 +348,14 @@ namespace ObjectViewer {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, 25.0, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, Properties, 25.0);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, 25.0, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, Properties, 25.0);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -348,14 +348,14 @@ namespace ObjectViewer {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, Properties, 25.0);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, Properties, 25.0);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, Properties, 25.0);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, Properties, 25.0);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -316,7 +316,7 @@ namespace ObjectViewer {
 				    {
 					    if (CurrentHost.LoadObject(Files[i], Encoding.UTF8, out UnifiedObject o))
 					    {
-						    o.CreateObject(Vector3.Zero, 0.0, 0.0, 0.0);
+						    o.CreateObject(Vector3.Zero, new WorldProperties());
 					    }
 					    
 				    }

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -87,7 +87,7 @@ namespace OpenBve.Graphics
 			Program.FileSystem.AppendToLogFile("Renderer initialised successfully.");
 		}
 		
-		internal int CreateStaticObject(UnifiedObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition, double Brightness)
+		internal int CreateStaticObject(UnifiedObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, WorldProperties Properties, double BlockLength)
 		{
 			StaticObject obj = Prototype as StaticObject;
 			if (obj == null)
@@ -95,7 +95,7 @@ namespace OpenBve.Graphics
 				Interface.AddMessage(MessageType.Error, false, "Attempted to use an animated object where only static objects are allowed.");
 				return -1;
 			}
-			return base.CreateStaticObject(obj, Position, WorldTransformation, LocalTransformation, AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, BlockLength, TrackPosition, Brightness);
+			return base.CreateStaticObject(obj, Position, WorldTransformation, LocalTransformation, AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, BlockLength);
 		}
 
 		public override void UpdateViewport(int Width, int Height)

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -95,7 +95,7 @@ namespace OpenBve.Graphics
 				Interface.AddMessage(MessageType.Error, false, "Attempted to use an animated object where only static objects are allowed.");
 				return -1;
 			}
-			return base.CreateStaticObject(obj, Position, WorldTransformation, LocalTransformation, AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, BlockLength);
+			return base.CreateStaticObject(obj, Position, WorldTransformation, LocalTransformation, AccurateObjectDisposal, Properties, BlockLength);
 		}
 
 		public override void UpdateViewport(int Width, int Height)

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -473,14 +473,14 @@ namespace OpenBve {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -473,14 +473,14 @@ namespace OpenBve {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Properties, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, Properties, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/OpenBveApi/Objects/Helpers/WorldProperties.cs
+++ b/source/OpenBveApi/Objects/Helpers/WorldProperties.cs
@@ -1,0 +1,42 @@
+﻿namespace OpenBveApi.Objects
+{
+	/// <summary>A helper struct describing the world properties of an object</summary>
+    public struct WorldProperties
+    {
+		/// <summary>The key of the rail on which the object is placed</summary>
+		public int RailKey;
+		/// <summary>The absolute track position at which the object is placed</summary>
+		public double TrackPosition;
+		/// <summary>The track distance at which this is displayed by the renderer</summary>
+		public double StartingDistance;
+		/// <summary>The ending distance at which this is hidden by the renderer</summary>
+		public double EndingDistance;
+		/// <summary>The brightness value of this object</summary>
+		public double Brightness;
+		/// <summary>The index of the signalling section this object is attached to</summary>
+		public int SectionIndex;
+
+		/// <summary>Creates a new instance of this struct</summary>
+		public WorldProperties(int railKey, double trackPosition, double startingDistance, double endingDistance, int sectionIndex = -1, double brightness = 1.0)
+		{
+			RailKey = railKey;
+			TrackPosition = trackPosition;
+			StartingDistance = startingDistance;
+			EndingDistance = endingDistance;
+			Brightness = brightness;
+			SectionIndex = sectionIndex;
+		}
+
+		/// <summary>Creates a new instance of this struct</summary>
+		public WorldProperties(double trackPosition, int sectionIndex, double brightness)
+		{
+			RailKey = 0;
+			TrackPosition = trackPosition;
+			SectionIndex = sectionIndex;
+			Brightness = brightness;
+			// Mechanik visibility- not used
+			StartingDistance = 0; 
+			EndingDistance = 0;
+		}
+    }
+}

--- a/source/OpenBveApi/Objects/Helpers/WorldProperties.cs
+++ b/source/OpenBveApi/Objects/Helpers/WorldProperties.cs
@@ -15,6 +15,9 @@
 		public double Brightness;
 		/// <summary>The index of the signalling section this object is attached to</summary>
 		public int SectionIndex;
+		/// <summary>The Z-Offset used for accurate object disposal</summary>
+		/// <remarks>This is only valid for child objects contained within an animated container</remarks>
+		public double AccurateObjectDisposalZOffset;
 
 		/// <summary>Creates a new instance of this struct</summary>
 		public WorldProperties(int railKey, double trackPosition, double startingDistance, double endingDistance, int sectionIndex = -1, double brightness = 1.0)
@@ -25,6 +28,7 @@
 			EndingDistance = endingDistance;
 			Brightness = brightness;
 			SectionIndex = sectionIndex;
+			AccurateObjectDisposalZOffset = 0;
 		}
 
 		/// <summary>Creates a new instance of this struct</summary>
@@ -37,6 +41,7 @@
 			// Mechanik visibility- not used
 			StartingDistance = 0; 
 			EndingDistance = 0;
+			AccurateObjectDisposalZOffset = 0;
 		}
     }
 }

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject.cs
@@ -737,14 +737,15 @@ namespace OpenBveApi.Objects
 			}
 		}
 
-		/// <summary>Creates the animated object within the game world</summary>
-		/// <param name="Position">The absolute position</param>
-		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
-		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="sectionIndex">The index of the section if placed using a SigF command</param>
-		/// <param name="TrackPosition">The absolute track position</param>
-		/// <param name="Brightness">The brightness value at the track position</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, int sectionIndex, double TrackPosition, double Brightness)
+        /// <summary>Creates the animated object within the game world</summary>
+        /// <param name="Position">The absolute position</param>
+        /// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
+        /// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
+        /// <param name="sectionIndex">The index of the section if placed using a SigF command</param>
+        /// <param name="railIndex">The rail index the object is placed on</param>
+        /// <param name="TrackPosition">The absolute track position</param>
+        /// <param name="Brightness">The brightness value at the track position</param>
+        public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
 
 			int a = currentHost.AnimatedWorldObjectsUsed;
@@ -762,11 +763,11 @@ namespace OpenBveApi.Objects
 					Up = FinalTransformation.Y,
 					Side = FinalTransformation.X,
 					Object = o,
-					TrackPosition = TrackPosition,
+					TrackPosition = Properties.TrackPosition,
 				};
 
-				currentObject.FrontAxleFollower.TrackPosition = TrackPosition + FrontAxlePosition;
-				currentObject.RearAxleFollower.TrackPosition = TrackPosition + RearAxlePosition;
+				currentObject.FrontAxleFollower.TrackPosition = Properties.TrackPosition + FrontAxlePosition;
+				currentObject.RearAxleFollower.TrackPosition = Properties.TrackPosition + RearAxlePosition;
 				currentObject.FrontAxlePosition = FrontAxlePosition;
 				currentObject.RearAxlePosition = RearAxlePosition;
 				currentObject.FrontAxleFollower.UpdateWorldCoordinates(false);
@@ -779,7 +780,7 @@ namespace OpenBveApi.Objects
 					}
 				}
 
-				currentObject.Object.internalObject.Brightness = Brightness;
+				currentObject.Object.internalObject.Brightness = Properties.Brightness;
 
 				double r = 0.0;
 				for (int i = 0; i < currentObject.Object.States.Length; i++)
@@ -800,7 +801,7 @@ namespace OpenBveApi.Objects
 			{
 				var o = this.Clone();
 				currentHost.CreateDynamicObject(ref o.internalObject);
-				o.SectionIndex = sectionIndex;
+				o.SectionIndex = Properties.SectionIndex;
 				AnimatedWorldObject currentObject = new AnimatedWorldObject(currentHost)
 				{
 					Position = Position,
@@ -808,8 +809,8 @@ namespace OpenBveApi.Objects
 					Up = FinalTransformation.Y,
 					Side = FinalTransformation.X,
 					Object = o,
-					SectionIndex = sectionIndex,
-					TrackPosition = TrackPosition,
+					SectionIndex = Properties.SectionIndex,
+					TrackPosition = Properties.TrackPosition,
 				};
 				for (int i = 0; i < currentObject.Object.States.Length; i++)
 				{
@@ -819,7 +820,7 @@ namespace OpenBveApi.Objects
 					}
 				}
 
-				currentObject.Object.internalObject.Brightness = Brightness;
+				currentObject.Object.internalObject.Brightness = Properties.Brightness;
 
 				double r = 0.0;
 				for (int i = 0; i < currentObject.Object.States.Length; i++)

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
@@ -24,8 +24,7 @@ namespace OpenBveApi.Objects
 
 			/// <inheritdoc/>
 			public override void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation,
-				int SectionIndex, double StartingDistance, double EndingDistance,
-				double TrackPosition, double Brightness, bool DuplicateMaterials = false)
+				WorldProperties Properties, bool DuplicateMaterials = false)
 			{
 				bool[] free = new bool[Objects.Length];
 				bool anyfree = false;
@@ -67,11 +66,11 @@ namespace OpenBveApi.Objects
 								mat *= transformationMatrix;
 								double zOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
 								
-								currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), zOffset, StartingDistance, EndingDistance, TrackPosition, Brightness);
+								currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), zOffset, Properties);
 							}
 							else
 							{
-								Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition, Brightness);
+								Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, Properties);
 							}
 						}
 					}
@@ -82,7 +81,7 @@ namespace OpenBveApi.Objects
 					{
 						if (Objects[i].States.Length != 0)
 						{
-							Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition, Brightness);
+							Objects[i].CreateObject(Position, WorldTransformation, LocalTransformation, Properties);
 						}
 					}
 				}
@@ -100,8 +99,8 @@ namespace OpenBveApi.Objects
 					Vector3 v = Sounds[i].Position;
 					v.Rotate(LocalTransformation);
 					v.Rotate(WorldTransformation);
-					(Sounds[i] as WorldSound)?.CreateSound(Position + v, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition);
-					(Sounds[i] as AnimatedWorldObjectStateSound)?.Create(Position + v, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition, Brightness);
+					(Sounds[i] as WorldSound)?.CreateSound(Position + v, WorldTransformation, LocalTransformation, Properties);
+					(Sounds[i] as AnimatedWorldObjectStateSound)?.Create(Position + v, WorldTransformation, LocalTransformation, Properties);
 				}
 			}
 

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObjectCollection.cs
@@ -64,9 +64,8 @@ namespace OpenBveApi.Objects
 								Matrix4D mat = Matrix4D.Identity;
 								mat *= Objects[i].States[0].Translation;
 								mat *= transformationMatrix;
-								double zOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
-								
-								currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), zOffset, Properties);
+								Properties.AccurateObjectDisposalZOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
+								currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), Properties);
 							}
 							else
 							{

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedWorldObject.StateSound.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedWorldObject.StateSound.cs
@@ -141,7 +141,7 @@ namespace OpenBveApi.Objects
 		/// <param name="FinalSectionIndex">The index of the section if placed using a SigF command</param>
 		/// <param name="FinalTrackPosition">The absolute track position</param>
 		/// <param name="Brightness">The brightness value at the track position</param>
-		public void Create(Vector3 WorldPosition, Transformation WorldTransformation, Transformation LocalTransformation, int FinalSectionIndex, double FinalTrackPosition, double Brightness)
+		public void Create(Vector3 WorldPosition, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
 			int a = currentHost.AnimatedWorldObjectsUsed;
 			Transformation FinalTransformation = new Transformation(LocalTransformation, WorldTransformation);
@@ -151,8 +151,8 @@ namespace OpenBveApi.Objects
 			currentObject.Direction = FinalTransformation.Z;
 			currentObject.Up = FinalTransformation.Y;
 			currentObject.Side = FinalTransformation.X;
-			currentObject.Object.SectionIndex = FinalSectionIndex;
-			currentObject.TrackPosition = FinalTrackPosition;
+			currentObject.Object.SectionIndex = Properties.SectionIndex;
+			currentObject.TrackPosition = Properties.TrackPosition;
 			for (int i = 0; i < currentObject.Object.States.Length; i++)
 			{
 				if (currentObject.Object.States[i].Prototype == null)
@@ -161,7 +161,7 @@ namespace OpenBveApi.Objects
 				}
 			}
 
-			currentObject.Object.internalObject.Brightness = Brightness;
+			currentObject.Object.internalObject.Brightness = Properties.Brightness;
 
 			double r = 0.0;
 			for (int i = 0; i < currentObject.Object.States.Length; i++)

--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -472,7 +472,7 @@ namespace OpenBveApi.Objects
 		public override void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation,
 			WorldProperties Properties, bool DuplicateMaterials = false)
 		{
-			currentHost.CreateStaticObject(this, Position, WorldTransformation, LocalTransformation, 0.0, Properties);
+			currentHost.CreateStaticObject(this, Position, WorldTransformation, LocalTransformation, Properties);
 		}
 
 		/// <inheritdoc />

--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -470,10 +470,9 @@ namespace OpenBveApi.Objects
 
 		/// <summary>Callback function to create the object within the world</summary>
 		public override void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation,
-			int SectionIndex, double StartingDistance, double EndingDistance,
-			double TrackPosition, double Brightness, bool DuplicateMaterials = false)
+			WorldProperties Properties, bool DuplicateMaterials = false)
 		{
-			currentHost.CreateStaticObject(this, Position, WorldTransformation, LocalTransformation, 0.0, StartingDistance, EndingDistance, TrackPosition, Brightness);
+			currentHost.CreateStaticObject(this, Position, WorldTransformation, LocalTransformation, 0.0, Properties);
 		}
 
 		/// <inheritdoc />

--- a/source/OpenBveApi/Objects/ObjectTypes/UnifiedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/UnifiedObject.cs
@@ -8,48 +8,28 @@ namespace OpenBveApi.Objects
 	{
 		/// <summary>Creates the object within the worldspace without using track based transforms</summary>
 		/// <param name="Position">The world position</param>
-		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
-		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
-		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, double StartingDistance, double EndingDistance, double TrackPosition)
+		/// <param name="Properties">The world properties of the object</param>
+		public void CreateObject(Vector3 Position, WorldProperties Properties)
 		{
-			CreateObject(Position, Transformation.NullTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
+			CreateObject(Position, Transformation.NullTransformation, Transformation.NullTransformation, Properties);
 		}
 
 		/// <summary>Creates the object within the worldspace using a single track based transforms</summary>
 		/// <param name="Position">The world position</param>
 		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
-		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
-		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
-		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, double StartingDistance, double EndingDistance, double TrackPosition)
+		/// <param name="Properties">The world properties of the object</param>
+		public void CreateObject(Vector3 Position, Transformation WorldTransformation, WorldProperties Properties)
 		{
-			CreateObject(Position, WorldTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
+			CreateObject(Position, WorldTransformation, Transformation.NullTransformation, Properties);
 		}
 
 		/// <summary>Creates the object within the world</summary>
 		/// <param name="Position">The world position</param>
 		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
 		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
-		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
-		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double StartingDistance, double EndingDistance, double TrackPosition)
-		{
-			CreateObject(Position, WorldTransformation, LocalTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
-		}
-
-		/// <summary>Creates the object within the world</summary>
-		/// <param name="Position">The world position</param>
-		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
-		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="SectionIndex">The section index (If placed via Track.SigF)</param>
-		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
-		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
-		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		/// <param name="Brightness">The brightness value of this object</param>
+		/// <param name="Properties">The world properties of the object</param>
 		/// <param name="DuplicateMaterials">Whether the materials are to be duplicated (Not set when creating BVE4 signals)</param>
-		public abstract void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, int SectionIndex, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness, bool DuplicateMaterials = false);
+		public abstract void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties, bool DuplicateMaterials = false);
 
 		/// <summary>Call this method to optimize the object</summary>
 		/// <param name="PreserveVerticies">Whether duplicate verticies are to be preserved (Takes less time)</param>

--- a/source/OpenBveApi/Objects/ObjectTypes/WorldSound.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/WorldSound.cs
@@ -58,15 +58,15 @@ namespace OpenBveApi.Objects
 		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
 		/// <param name="SectionIndex">The index of the section if placed using a SigF command</param>
 		/// <param name="trackPosition">The absolute track position</param>
-		public void CreateSound(Vector3 position, Transformation WorldTransformation, Transformation LocalTransformation, int SectionIndex, double trackPosition)
+		public void CreateSound(Vector3 position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
 			int a = currentHost.AnimatedWorldObjectsUsed;
 			WorldSound snd = (WorldSound)Clone();
 			snd.Position = position;
-			snd.TrackPosition = trackPosition;
-			snd.currentTrackPosition = trackPosition;
+			snd.TrackPosition = Properties.TrackPosition;
+			snd.currentTrackPosition = Properties.TrackPosition;
 			snd.Follower = new TrackFollower(currentHost);
-			snd.Follower.UpdateAbsolute(trackPosition, true, true);
+			snd.Follower.UpdateAbsolute(Properties.TrackPosition, true, true);
 
 			currentHost.AnimatedWorldObjects[a] = snd;
 			currentHost.AnimatedWorldObjectsUsed++;

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Objects\Helpers\Material.cs" />
     <Compile Include="Objects\Helpers\MeshBuilder.cs" />
     <Compile Include="Objects\Helpers\ModelExporter.cs" />
+    <Compile Include="Objects\Helpers\WorldProperties.cs" />
     <Compile Include="Objects\Mesh.cs" />
     <Compile Include="Objects\MeshFace.cs" />
     <Compile Include="Objects\MeshFaceVertex.cs" />

--- a/source/OpenBveApi/System/Hosts/HostInterface.cs
+++ b/source/OpenBveApi/System/Hosts/HostInterface.cs
@@ -382,13 +382,9 @@ namespace OpenBveApi.Hosts {
 		/// <param name="Position">The world position</param>
 		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
 		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="AccurateObjectDisposalZOffset">The offset for accurate Z-disposal</param>
-		/// <param name="StartingDistance">The absolute route based starting distance for the object</param>
-		/// <param name="EndingDistance">The absolute route based ending distance for the object</param>
-		/// <param name="TrackPosition">The absolute route based track position</param>
-		/// <param name="Brightness">The brightness value at this track position</param>
+		/// <param name="Properties">The world properties of the object</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
 			return -1;
 		}
@@ -402,13 +398,9 @@ namespace OpenBveApi.Hosts {
 		/// </param>
 		/// <param name="Rotate">The rotation matrix to apply</param>
 		/// <param name="Translate">The translation matrix to apply</param>
-		/// <param name="AccurateObjectDisposalZOffset">The offset for accurate Z-disposal</param>
-		/// <param name="StartingDistance">The absolute route based starting distance for the object</param>
-		/// <param name="EndingDistance">The absolute route based ending distance for the object</param>
-		/// <param name="TrackPosition">The absolute route based track position</param>
-		/// <param name="Brightness">The brightness value at this track position</param>
+		/// <param name="Properties">The world properties of the object</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, WorldProperties Properties)
 		{
 			return -1;
 		}

--- a/source/OpenBveApi/System/Hosts/HostInterface.cs
+++ b/source/OpenBveApi/System/Hosts/HostInterface.cs
@@ -388,7 +388,7 @@ namespace OpenBveApi.Hosts {
 		/// <param name="TrackPosition">The absolute route based track position</param>
 		/// <param name="Brightness">The brightness value at this track position</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
 			return -1;
 		}
@@ -408,7 +408,7 @@ namespace OpenBveApi.Hosts {
 		/// <param name="TrackPosition">The absolute route based track position</param>
 		/// <param name="Brightness">The brightness value at this track position</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
 			return -1;
 		}

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -628,7 +628,7 @@ namespace CsvRwRouteParser
 					int gi = Data.Blocks[i].Cycle[ci];
 					if (Data.Structure.Ground.ContainsKey(gi))
 					{
-						Data.Structure.Ground[Data.Blocks[i].Cycle[ci]].CreateObject(Position + new Vector3(0.0, -Data.Blocks[i].Height, 0.0), GroundTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Data.Structure.Ground[Data.Blocks[i].Cycle[ci]].CreateObject(Position + new Vector3(0.0, -Data.Blocks[i].Height, 0.0), GroundTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 				// ground-aligned free objects
@@ -636,13 +636,13 @@ namespace CsvRwRouteParser
 				{
 					for (int j = 0; j < Data.Blocks[i].GroundFreeObj.Count; j++)
 					{
-						Data.Blocks[i].GroundFreeObj[j].CreateGroundAligned(Data.Structure.FreeObjects, Position, GroundTransformation, Direction, Data.Blocks[i].Height, StartingDistance, EndingDistance);
+						Data.Blocks[i].GroundFreeObj[j].CreateGroundAligned(Data.Structure.FreeObjects, Position, GroundTransformation, Direction, Data.Blocks[i].Height, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 				if (!PreviewOnly && Data.Structure.WeatherObjects.ContainsKey(Data.Blocks[i].WeatherObject))
 				{
 					UnifiedObject obj = Data.Structure.WeatherObjects[Data.Blocks[i].WeatherObject];
-					obj.CreateObject(Position, GroundTransformation, Data.Blocks[i].Height, StartingDistance, EndingDistance);
+					obj.CreateObject(Position, GroundTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 				}
 				// rail-aligned objects
 				{
@@ -781,7 +781,7 @@ namespace CsvRwRouteParser
 							{
 								if (Data.Structure.RailObjects[Data.Blocks[i].RailType[railKey]] != null)
 								{
-									Data.Structure.RailObjects[Data.Blocks[i].RailType[railKey]].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+									Data.Structure.RailObjects[Data.Blocks[i].RailType[railKey]].CreateObject(pos, RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance));
 								}
 							}
 
@@ -826,13 +826,13 @@ namespace CsvRwRouteParser
 							// walls
 							if (Data.Blocks[i].RailWall.ContainsKey(railKey))
 							{
-								Data.Blocks[i].RailWall[railKey].Create(pos, RailTransformation, StartingDistance, EndingDistance);
+								Data.Blocks[i].RailWall[railKey].Create(pos, RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance));
 							}
 
 							// dikes
 							if (Data.Blocks[i].RailDike.ContainsKey(railKey))
 							{
-								Data.Blocks[i].RailDike[railKey].Create(pos, RailTransformation, StartingDistance, EndingDistance);
+								Data.Blocks[i].RailDike[railKey].Create(pos, RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance));
 							}
 
 							// sounds
@@ -850,13 +850,13 @@ namespace CsvRwRouteParser
 								// primary rail
 								if (Data.Blocks[i].Forms[k].PrimaryRail == railKey)
 								{
-									Data.Blocks[i].Forms[k].CreatePrimaryRail(Data.Blocks[i], Data.Blocks[i + 1], pos, RailTransformation, StartingDistance, EndingDistance, FileName);
+									Data.Blocks[i].Forms[k].CreatePrimaryRail(Data.Blocks[i], Data.Blocks[i + 1], pos, RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance), FileName);
 								}
 
 								// secondary rail
 								if (Data.Blocks[i].Forms[k].SecondaryRail == railKey)
 								{
-									Data.Blocks[i].Forms[k].CreateSecondaryRail(Data.Blocks[i], pos, RailTransformation, StartingDistance, EndingDistance, FileName);
+									Data.Blocks[i].Forms[k].CreateSecondaryRail(Data.Blocks[i], pos, RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance), FileName);
 								}
 							}
 
@@ -871,7 +871,7 @@ namespace CsvRwRouteParser
 							{
 								for (int k = 0; k < Data.Blocks[i].RailFreeObj[railKey].Count; k++)
 								{
-									Data.Blocks[i].RailFreeObj[railKey][k].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, StartingDistance, EndingDistance);
+									Data.Blocks[i].RailFreeObj[railKey][k].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance));
 								}
 							}
 
@@ -889,7 +889,7 @@ namespace CsvRwRouteParser
 									// patterns key off rail 0
 									while (Data.Blocks[i].PatternObjs[key].LastPlacement + Data.Blocks[i].PatternObjs[key].Interval < (i + 1) * Data.BlockInterval)
 									{
-										if (!Data.Blocks[i].PatternObjs[key].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, StartingDistance, EndingDistance))
+										if (!Data.Blocks[i].PatternObjs[key].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, new WorldProperties(railKey, StartingDistance, StartingDistance, EndingDistance)))
 										{
 											break;
 										}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
@@ -49,7 +49,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackL[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 				else if (d0 > 0.0)
@@ -61,7 +61,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackR[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
@@ -49,7 +49,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackL[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 				else if (d0 > 0.0)
@@ -61,7 +61,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackR[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
@@ -75,7 +75,7 @@ namespace CsvRwRouteParser
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, RailTransformation, Transformation.NullTransformation, Properties);
 				}
 
 				if (RoofType > 0)
@@ -95,7 +95,7 @@ namespace CsvRwRouteParser
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, RailTransformation, Transformation.NullTransformation, Properties);
 					}
 				}
 			}
@@ -116,7 +116,7 @@ namespace CsvRwRouteParser
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, RailTransformation, Transformation.NullTransformation, Properties);
 				}
 
 				if (RoofType > 0)
@@ -136,7 +136,7 @@ namespace CsvRwRouteParser
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, RailTransformation, Transformation.NullTransformation, Properties);
 					}
 				}
 			}
@@ -172,7 +172,7 @@ namespace CsvRwRouteParser
 						else
 						{
 							StaticObject FormC = (StaticObject) Structure.FormCL[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, Properties);
 						}
 
 						if (RoofType > 0)
@@ -193,7 +193,7 @@ namespace CsvRwRouteParser
 							else
 							{
 								StaticObject RoofC = (StaticObject) Structure.RoofCL[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, Properties);
 							}
 						}
 					}
@@ -215,7 +215,7 @@ namespace CsvRwRouteParser
 						else
 						{
 							StaticObject FormC = (StaticObject) Structure.FormCR[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, Properties);
 						}
 
 						if (RoofType > 0)
@@ -236,7 +236,7 @@ namespace CsvRwRouteParser
 							else
 							{
 								StaticObject RoofC = (StaticObject) Structure.RoofCR[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
+								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, Properties);
 							}
 						}
 					}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
@@ -33,27 +33,27 @@ namespace CsvRwRouteParser
 
 		internal readonly StructureData Structure;
 		private readonly CultureInfo Culture = CultureInfo.InvariantCulture;
-		internal void CreatePrimaryRail(Block currentBlock, Block nextBlock, Vector3 pos, Transformation RailTransformation, double StartingDistance, double EndingDistance, string FileName)
+		internal void CreatePrimaryRail(Block currentBlock, Block nextBlock, Vector3 pos, Transformation RailTransformation, WorldProperties Properties, string FileName)
 		{
 			
 			if (SecondaryRail == Form.SecondaryRailStub)
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormL[FormType].CreateObject(pos, RailTransformation, Properties);
 					if (RoofType > 0)
 					{
 						if (!Structure.RoofL.ContainsKey(RoofType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+							Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, Properties);
 						}
 					}
 				}
@@ -62,40 +62,40 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormL[FormType].CreateObject(pos, RailTransformation, Properties);
 				}
 
 				if (!Structure.FormCL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, Properties);
 					}
 
 					if (!Structure.RoofCL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 					}
 				}
 			}
@@ -103,40 +103,40 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormR[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormR[FormType].CreateObject(pos, RailTransformation, Properties);
 				}
 
 				if (!Structure.FormCR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Properties);
 					}
 
 					if (!Structure.RoofCR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 					}
 				}
 			}
@@ -148,7 +148,7 @@ namespace CsvRwRouteParser
 				int s = SecondaryRail;
 				if (s < 0 || !currentBlock.Rails.ContainsKey(s) || !currentBlock.Rails[s].RailStarted)
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName);
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName);
 				}
 				else
 				{
@@ -158,42 +158,42 @@ namespace CsvRwRouteParser
 					{
 						if (!Structure.FormL.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.FormL[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+							Structure.FormL[FormType].CreateObject(pos, RailTransformation, Properties);
 						}
 
 						if (!Structure.FormCL.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
 							StaticObject FormC = (StaticObject) Structure.FormCL[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 						}
 
 						if (RoofType > 0)
 						{
 							if (!Structure.RoofL.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
-								Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+								Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, Properties);
 							}
 
 							if (!Structure.RoofCL.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
 								StaticObject RoofC = (StaticObject) Structure.RoofCL[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 							}
 						}
 					}
@@ -201,42 +201,42 @@ namespace CsvRwRouteParser
 					{
 						if (!Structure.FormR.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.FormR[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+							Structure.FormR[FormType].CreateObject(pos, RailTransformation, Properties);
 						}
 
 						if (!Structure.FormCR.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
 							StaticObject FormC = (StaticObject) Structure.FormCR[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+							Plugin.CurrentHost.CreateStaticObject(FormC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 						}
 
 						if (RoofType > 0)
 						{
 							if (!Structure.RoofR.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
-								Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+								Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Properties);
 							}
 
 							if (!Structure.RoofCR.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
 								StaticObject RoofC = (StaticObject) Structure.RoofCR[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, 1.0);
+								Plugin.CurrentHost.CreateStaticObject(RoofC, pos, RailTransformation, Transformation.NullTransformation, 0.0, Properties);
 							}
 						}
 					}
@@ -245,7 +245,7 @@ namespace CsvRwRouteParser
 
 		}
 
-		internal void CreateSecondaryRail(Block currentBlock, Vector3 pos, Transformation RailTransformation, double StartingDistance, double EndingDistance, string FileName)
+		internal void CreateSecondaryRail(Block currentBlock, Vector3 pos, Transformation RailTransformation, WorldProperties Properties, string FileName)
 		{
 			double px = 0.0;
 			if (currentBlock.Rails.ContainsKey(PrimaryRail))
@@ -257,22 +257,22 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormL[FormType].CreateObject(pos, RailTransformation, Properties);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, Properties);
 					}
 				}
 			}
@@ -280,22 +280,22 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormR[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormR[FormType].CreateObject(pos, RailTransformation, Properties);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + Properties.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Transformation.NullTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Transformation.NullTransformation, Properties);
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
@@ -26,20 +26,20 @@ namespace CsvRwRouteParser
 			Roll = roll;
 		}
 
-		internal void CreateRailAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		internal void CreateRailAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation RailTransformation, WorldProperties Properties)
 		{
-			double dz = TrackPosition - StartingDistance;
+			double dz = TrackPosition - Properties.StartingDistance;
 			WorldPosition += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
 			FreeObjects.TryGetValue(Type, out UnifiedObject obj);
-			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, TrackPosition);
+			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(Yaw, Pitch, Roll), Properties);
 		}
 
-		internal void CreateGroundAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation GroundTransformation, Vector2 Direction, double Height, double StartingDistance, double EndingDistance)
+		internal void CreateGroundAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation GroundTransformation, Vector2 Direction, double Height, WorldProperties Properties)
 		{
-			double d = TrackPosition - StartingDistance;
+			double d = TrackPosition - Properties.StartingDistance;
 			Vector3 wpos = WorldPosition + new Vector3(Direction.X * d + Direction.Y * Position.X, Position.Y - Height, Direction.Y * d - Direction.X * Position.X);
 			FreeObjects.TryGetValue(Type, out UnifiedObject obj);
-			obj?.CreateObject(wpos, GroundTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, TrackPosition);
+			obj?.CreateObject(wpos, GroundTransformation, new Transformation(Yaw, Pitch, Roll), Properties);
 		}
 	}
 }

--- a/source/Plugins/Route.CsvRw/Structures/Route/PatternObj.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/PatternObj.cs
@@ -37,7 +37,7 @@ namespace CsvRwRouteParser
 			return p;
 		}
 
-		internal bool CreateRailAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		internal bool CreateRailAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation RailTransformation, WorldProperties Properties)
 		{
 			if (Types.Length == 0)
 			{
@@ -48,12 +48,12 @@ namespace CsvRwRouteParser
 				LastType = 0;
 			}
 			LastPlacement += Interval;
-			double dz = LastPlacement - StartingDistance;
+			double dz = LastPlacement - Properties.StartingDistance;
 			WorldPosition += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
 			FreeObjects.TryGetValue(Types[LastType], out UnifiedObject obj);
 			if (obj != null)
 			{
-				obj.CreateObject(WorldPosition, RailTransformation, new Transformation(), StartingDistance, EndingDistance, LastPlacement);
+				obj.CreateObject(WorldPosition, RailTransformation, new Transformation(), Properties);
 			}
 
 			if (Types.Length > 1)

--- a/source/Plugins/Route.CsvRw/Structures/Route/Pole.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Pole.cs
@@ -32,12 +32,12 @@ namespace CsvRwRouteParser
 				{
 					if (Location <= 0.0)
 					{
-						Poles[0][Type].CreateObject(WorldPosition, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Poles[0][Type].CreateObject(WorldPosition, RailTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 					else
 					{
 						UnifiedObject Pole = Poles[0][Type].Mirror();
-						Pole.CreateObject(WorldPosition, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Pole.CreateObject(WorldPosition, RailTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 					}
 				}
 				else
@@ -52,7 +52,7 @@ namespace CsvRwRouteParser
 					double sz = -Direction.X;
 					Vector3 wpos = WorldPosition + new Vector3(sx * dx + w.X * dz, sy * dx + w.Y * dz, sz * dx + w.Z * dz);
 					int type = Type;
-					Poles[m][type].CreateObject(wpos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Poles[m][type].CreateObject(wpos, RailTransformation, new WorldProperties(0, StartingDistance, StartingDistance, EndingDistance));
 				}
 			}
 		}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Station.Stop.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Station.Stop.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 using RouteManager2.Stations;
 
@@ -34,7 +35,7 @@ namespace CsvRwRouteParser
 				{
 					return;
 				}
-				CompatibilityObjects.StopPost.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+				CompatibilityObjects.StopPost.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 			}
 		}
 

--- a/source/Plugins/Route.CsvRw/Structures/Route/WallDike.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/WallDike.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 
 namespace CsvRwRouteParser
@@ -31,7 +32,7 @@ namespace CsvRwRouteParser
 			return w;
 		}
 
-		internal void Create(Vector3 pos, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		internal void Create(Vector3 pos, Transformation RailTransformation, WorldProperties Properties)
 		{
 			if (!Exists)
 			{
@@ -41,7 +42,7 @@ namespace CsvRwRouteParser
 			{
 				if (leftObjects.ContainsKey(Type))
 				{
-					leftObjects[Type].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);	
+					leftObjects[Type].CreateObject(pos, RailTransformation, Properties);	
 				}
 				
 			}
@@ -49,7 +50,7 @@ namespace CsvRwRouteParser
 			{
 				if (rightObjects.ContainsKey(Type))
 				{
-					rightObjects[Type].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					rightObjects[Type].CreateObject(pos, RailTransformation, Properties);
 				}
 				
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Signals/Signal.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/Signal.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 using RouteManager2.SignalManager;
 
@@ -30,13 +31,13 @@ namespace CsvRwRouteParser
 				 */
 				Vector3 wpos2 = new Vector3(wpos);
 				wpos2 += Position.X * RailTransformation.X + dz * RailTransformation.Z;
-				CompatibilityObjects.SignalPost.CreateObject(wpos2, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, Brightness);
+				CompatibilityObjects.SignalPost.CreateObject(wpos2, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, TrackPosition, StartingDistance, EndingDistance, -1, Brightness));
 			}
 			if (ShowObject)
 			{
 				// signal object
 				wpos += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
-				SignalObject.Create(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), SectionIndex, StartingDistance, EndingDistance, TrackPosition, Brightness);
+				SignalObject.Create(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new WorldProperties(0, TrackPosition, StartingDistance, EndingDistance, SectionIndex, Brightness));
 			}
 		}
 

--- a/source/Plugins/Route.CsvRw/Structures/Signals/SignalData.BVE4.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/SignalData.BVE4.cs
@@ -20,7 +20,7 @@ namespace CsvRwRouteParser
 		internal Texture[] SignalTextures;
 		internal Texture[] GlowTextures;
 
-		public override void Create(Vector3 wpos, Transformation RailTransformation, Transformation LocalTransformation, int SectionIndex, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override void Create(Vector3 wpos, Transformation RailTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
 			if (SignalTextures.Length != 0)
 			{
@@ -112,7 +112,7 @@ namespace CsvRwRouteParser
 
 				aoc.Objects[0].StateFunction = new FunctionScript(Plugin.CurrentHost, expr, false);
 				aoc.Objects[0].RefreshRate = 1.0 + 0.01 * Plugin.RandomNumberGenerator.NextDouble();
-				aoc.CreateObject(wpos, RailTransformation, LocalTransformation, SectionIndex, StartingDistance, EndingDistance, TrackPosition, 1.0);
+				aoc.CreateObject(wpos, RailTransformation, LocalTransformation, Properties);
 			}
 		}
 	}

--- a/source/Plugins/Route.CsvRw/Structures/Signals/Transponder.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/Transponder.cs
@@ -89,11 +89,11 @@ namespace CsvRwRouteParser
 				double tpos = TrackPosition;
 				if (BeaconStructureIndex == -2)
 				{
-					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), -1, StartingDistance, EndingDistance, tpos, Brightness);
+					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, Brightness));
 				}
 				else
 				{
-					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, tpos);
+					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new WorldProperties(0, tpos, StartingDistance, EndingDistance));
 				}
 			}
 		}

--- a/source/Plugins/Route.CsvRw/Structures/Trains/DestinationEvent.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/DestinationEvent.cs
@@ -43,7 +43,7 @@ namespace CsvRwRouteParser
 				double dz = TrackPosition - StartingDistance;
 				wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
 				double tpos = TrackPosition;
-				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, tpos);
+				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new WorldProperties(0, tpos, StartingDistance, EndingDistance));
 			}
 		}
 }

--- a/source/Plugins/Route.CsvRw/Structures/Trains/HornBlow.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/HornBlow.cs
@@ -40,7 +40,7 @@ namespace CsvRwRouteParser
 				double dz = TrackPosition - StartingDistance;
 				wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
 				double tpos = TrackPosition;
-				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, tpos);
+				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new WorldProperties(0, tpos, StartingDistance, EndingDistance));
 			}
 		}
 	}

--- a/source/Plugins/Route.CsvRw/Structures/Trains/Limit.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/Limit.cs
@@ -42,7 +42,7 @@ namespace CsvRwRouteParser
 				{
 					return;
 				}
-				CompatibilityObjects.LimitPostInfinite.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+				CompatibilityObjects.LimitPostInfinite.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos,StartingDistance, EndingDistance, -1, b));
 			}
 			else
 			{
@@ -52,7 +52,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostLeft.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+					CompatibilityObjects.LimitPostLeft.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 				}
 				else if (Cource > 0)
 				{
@@ -60,7 +60,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostRight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+					CompatibilityObjects.LimitPostRight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 				}
 				else
 				{
@@ -68,7 +68,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostStraight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+					CompatibilityObjects.LimitPostStraight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 				}
 
 				double lim = Speed / UnitOfSpeed;
@@ -87,7 +87,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), new TextureParameters(null, null), out o.Mesh.Materials[0].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 					}
 					else
 					{
@@ -117,7 +117,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), new TextureParameters(null, null), out o.Mesh.Materials[1].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 					}
 					else
 					{
@@ -152,7 +152,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), new TextureParameters(null, null), out o.Mesh.Materials[2].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new WorldProperties(0, tpos, StartingDistance, EndingDistance, -1, b));
 					}
 					else
 					{

--- a/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
+++ b/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
@@ -770,7 +770,7 @@ namespace MechanikRouteParser
 					Transformation t = new Transformation(Math.Atan2(worldDirection.X, worldDirection.Y), 0, 0);
 					for (int j = 0; j < currentRouteData.Blocks[i].Objects.Count; j++)
 					{
-						AvailableObjects[currentRouteData.Blocks[i].Objects[j].objectIndex].Object.CreateObject(worldPosition + eyePosition, t, StartingDistance, StartingDistance + 25, 100);
+						AvailableObjects[currentRouteData.Blocks[i].Objects[j].objectIndex].Object.CreateObject(worldPosition + eyePosition, t, new WorldProperties(0, 100, StartingDistance, StartingDistance + 25));
 					}
 					foreach (Semaphore signal in currentRouteData.Blocks[i].Signals)
 					{
@@ -811,8 +811,8 @@ namespace MechanikRouteParser
 						{
 							nextHeldAtRed = true;
 						}
-						
-						signal.Object().CreateObject(worldPosition + eyePosition, t, Transformation.NullTransformation, s + 1, StartingDistance, 1.0);
+
+						signal.Object().CreateObject(worldPosition + eyePosition, t, Transformation.NullTransformation, new WorldProperties(StartingDistance, s+ 1, 1.0));
 					}
 
 					if (currentRouteData.Blocks[i].HornBlow)

--- a/source/RouteManager2/SignalManager/SignalObject.Animated.cs
+++ b/source/RouteManager2/SignalManager/SignalObject.Animated.cs
@@ -20,9 +20,9 @@ namespace RouteManager2.SignalManager
 		private readonly UnifiedObject Object;
 
 		/// <summary>Creates the object within the game world</summary>
-		public override void Create(Vector3 wpos, Transformation railTransformation, Transformation localTransformation, int sectionIndex, double startingDistance, double endingDistance, double trackPosition, double brightness)
+		public override void Create(Vector3 wpos, Transformation railTransformation, Transformation localTransformation, WorldProperties properties)
 		{
-			Object.CreateObject(wpos, railTransformation, localTransformation, sectionIndex, startingDistance, endingDistance, trackPosition, 1.0);
+			Object.CreateObject(wpos, railTransformation, localTransformation, properties);
 		}
 	}
 }

--- a/source/RouteManager2/SignalManager/SignalObject.Compatability.cs
+++ b/source/RouteManager2/SignalManager/SignalObject.Compatability.cs
@@ -30,7 +30,7 @@ namespace RouteManager2.SignalManager
 			this.currentHost = Host;
 		}
 
-		public override void Create(Vector3 wpos, Transformation railTransformation, Transformation localTransformation, int sectionIndex, double startingDistance, double endingDistance, double trackPosition, double brightness)
+		public override void Create(Vector3 wpos, Transformation railTransformation, Transformation localTransformation, WorldProperties properties)
 		{
 			if (AspectNumbers.Length != 0)
 			{
@@ -59,7 +59,7 @@ namespace RouteManager2.SignalManager
 				}
 				aoc.Objects[0].StateFunction = new FunctionScript(currentHost, expr, false);
 				aoc.Objects[0].RefreshRate = 1.0 + 0.01 * new Random().NextDouble();
-				aoc.CreateObject(wpos, railTransformation, localTransformation, sectionIndex, startingDistance, endingDistance, trackPosition, brightness);
+				aoc.CreateObject(wpos, railTransformation, localTransformation, properties);
 			}
 		}
 

--- a/source/RouteManager2/SignalManager/SignalObject.cs
+++ b/source/RouteManager2/SignalManager/SignalObject.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 
 namespace RouteManager2.SignalManager
@@ -6,7 +7,7 @@ namespace RouteManager2.SignalManager
 	/// <summary>An abstract signal object - All signals must inherit from this class</summary>
 	public abstract class SignalObject
 	{
-		public virtual void Create(Vector3 wpos, Transformation RailTransformation, Transformation LocalTransformation, int SectionIndex, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public virtual void Create(Vector3 wpos, Transformation RailTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{}
 	}
 }

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -482,14 +482,14 @@ namespace RouteViewer
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainManager.Train)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, Brightness);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -482,14 +482,14 @@ namespace RouteViewer
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainManager.Train)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Properties, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, WorldProperties Properties)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, WorldProperties Properties)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, Properties, Program.CurrentRoute.BlockLength);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, Properties, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)


### PR DESCRIPTION
https://github.com/leezer3/OpenBVE/issues/1009

Unfinished WIP.

### Current progress:
The creation of objects (in master) uses a large number of parameters, which are often passed through two or three levels of function calls.
This refactors them into a single helper struct. 
Next job is to save the rail index in the animated object, and provide an appropriate function accessor for them.

### Risks:
Minor, however this changes a lot of places. If we manage to get the starting / ending distances bugged somewhere, this is likely to lead to visibility gliches.
Needs careful testing....