### PR TITLE
New: Allow coupling

### DIFF
--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -1594,6 +1594,12 @@
 					<trans-unit id="fixed_uncouple">
 						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
+					<trans-unit id="couple_front">
+						<source>Coupled [number] of cars to the front of the train.</source>
+					</trans-unit>
+					<trans-unit id="couple_rear">
+						<source>Coupled [number] of cars to the rear of the train.</source>
+					</trans-unit>
 				</group>
 				<group id="score">
 					<trans-unit id="overspeed">

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -424,7 +424,7 @@ namespace ObjectViewer {
 			throw new NotImplementedException();
 		}
 
-		public override AbstractTrain[] Trains
+		public override IEnumerable<AbstractTrain> Trains
 		{
 			get
 			{

--- a/source/ObjectViewer/InterfaceS.cs
+++ b/source/ObjectViewer/InterfaceS.cs
@@ -17,7 +17,7 @@ namespace ObjectViewer {
 		
 		internal static void Reset()
 		{
-			Program.TrainManager.Trains = new TrainBase[] { };
+			Program.TrainManager.Trains = new List<TrainBase>();
 			TrainManager.PlayerTrain = null;
 			Interface.LogMessages.Clear();
 			Program.CurrentHost.ClearErrors();

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -315,7 +315,7 @@ namespace ObjectViewer {
 						    if (Program.CurrentHost.Plugins[j].Train != null && Program.CurrentHost.Plugins[j].Train.CanLoadTrain(currentTrainFolder))
 						    {
 							    Control[] dummyControls = new Control[0];
-								TrainManager.Trains = new[] { new TrainBase(TrainState.Available) };
+								TrainManager.Trains = new[] { new TrainBase(TrainState.Available, TrainType.LocalPlayerTrain) };
 								AbstractTrain playerTrain = TrainManager.Trains[0];
 								Program.CurrentHost.Plugins[j].Train.LoadTrain(Encoding.UTF8, currentTrainFolder, ref playerTrain, ref dummyControls);
 								TrainManager.PlayerTrain = TrainManager.Trains[0];

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -315,7 +315,7 @@ namespace ObjectViewer {
 						    if (Program.CurrentHost.Plugins[j].Train != null && Program.CurrentHost.Plugins[j].Train.CanLoadTrain(currentTrainFolder))
 						    {
 							    Control[] dummyControls = new Control[0];
-								TrainManager.Trains = new[] { new TrainBase(TrainState.Available, TrainType.LocalPlayerTrain) };
+								TrainManager.Trains = new List<TrainBase> { new TrainBase(TrainState.Available, TrainType.LocalPlayerTrain) };
 								AbstractTrain playerTrain = TrainManager.Trains[0];
 								Program.CurrentHost.Plugins[j].Train.LoadTrain(Encoding.UTF8, currentTrainFolder, ref playerTrain, ref dummyControls);
 								TrainManager.PlayerTrain = TrainManager.Trains[0];

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -51,7 +51,7 @@ namespace ObjectViewer
 
 			ObjectManager.UpdateAnimatedWorldObjects(timeElapsed, false);
 
-			if (Program.TrainManager.Trains.Length != 0)
+			if (Program.TrainManager.Trains.Count != 0)
 			{
 				Program.TrainManager.Trains[0].UpdateObjects(timeElapsed, false);
 			}

--- a/source/ObjectViewer/Trains/NearestTrain.cs
+++ b/source/ObjectViewer/Trains/NearestTrain.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenBveApi.Trains;
 using TrainManager;
 using TrainManager.BrakeSystems;
@@ -107,7 +108,7 @@ namespace ObjectViewer.Trains
 		{
 			lock (LockObj)
 			{
-				IsExtensionsCfg = Program.TrainManager.Trains.Length != 0;
+				IsExtensionsCfg = Program.TrainManager.Trains.Count != 0;
 
 				if (IsExtensionsCfg)
 				{
@@ -175,8 +176,8 @@ namespace ObjectViewer.Trains
 					else
 					{
 						train = CreateDummyTrain();
-						Array.Resize(ref Program.TrainManager.Trains, 1);
-						Program.TrainManager.Trains[0] = train;
+						Program.TrainManager.Trains.Clear();
+						Program.TrainManager.Trains.Add(train);
 						TrainManagerBase.PlayerTrain = train;
 					}
 					Status.Apply(train);
@@ -190,7 +191,7 @@ namespace ObjectViewer.Trains
 					}
 					else
 					{
-						Program.TrainManager.Trains = new TrainBase[0];
+						Program.TrainManager.Trains = new List<TrainBase>();
 						TrainManagerBase.PlayerTrain = null;
 					}
 

--- a/source/ObjectViewer/Trains/NearestTrain.cs
+++ b/source/ObjectViewer/Trains/NearestTrain.cs
@@ -44,7 +44,7 @@ namespace ObjectViewer.Trains
 		/// <returns>A dummy train</returns>
 		private static TrainBase CreateDummyTrain()
 		{
-			TrainBase train = new TrainBase(TrainState.Available);
+			TrainBase train = new TrainBase(TrainState.Available, TrainType.LocalPlayerTrain);
 			train.Handles.Power = new PowerHandle(Specs.PowerNotches, Specs.PowerNotches, new double[] { }, new double[] { }, train);
 			if (Specs.IsAirBrake)
 			{
@@ -65,11 +65,11 @@ namespace ObjectViewer.Trains
 
 				if (Specs.IsAirBrake)
 				{
-					train.Cars[i].CarBrake = new AutomaticAirBrake(EletropneumaticBrakeType.None, train.Cars[i], 0.0, 0.0, new AccelerationCurve[] { });
+					train.Cars[i].CarBrake = new AutomaticAirBrake(EletropneumaticBrakeType.None, train.Cars[i]);
 				}
 				else
 				{
-					train.Cars[i].CarBrake = new ElectromagneticStraightAirBrake(EletropneumaticBrakeType.None, train.Cars[i], 0.0, 0.0, 0.0, 0.0, new AccelerationCurve[] { });
+					train.Cars[i].CarBrake = new ElectromagneticStraightAirBrake(EletropneumaticBrakeType.None, train.Cars[i]);
 				}
 
 				train.Cars[i].Specs.IsMotorCar = true;

--- a/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
+++ b/source/OpenBVE/Game/AI/AI.SimpleHuman.cs
@@ -987,7 +987,7 @@ namespace OpenBve
 				}
 
 				// trains ahead
-				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 				{
 					if (Program.TrainManager.Trains[i] != Train && Program.TrainManager.Trains[i].State == TrainState.Available)
 					{
@@ -1306,7 +1306,7 @@ namespace OpenBve
 				}
 
 				// trains ahead
-				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 				{
 					if (Program.TrainManager.Trains[i] != Train && Program.TrainManager.Trains[i].State == TrainState.Available)
 					{

--- a/source/OpenBVE/Game/Game.cs
+++ b/source/OpenBVE/Game/Game.cs
@@ -34,7 +34,7 @@ namespace OpenBve
 				Program.CurrentRoute.Tracks[key] = new Track();
 			}
 			// train manager
-			Program.TrainManager.Trains = new TrainBase[] { };
+			Program.TrainManager.Trains = new List<TrainBase>();
 			// game
 			Interface.LogMessages.Clear();
 			Program.CurrentHost.ClearErrors();

--- a/source/OpenBVE/Game/RouteInfoOverlay.cs
+++ b/source/OpenBVE/Game/RouteInfoOverlay.cs
@@ -66,9 +66,8 @@ namespace OpenBve
 			{
 			case state.map:
 				Program.Renderer.Rectangle.Draw(mapImage, origin, mapSize);
-				// get current train position
-				int n = Program.TrainManager.Trains.Length;
-				for (int i = 0; i < n; i++)
+					// get current train position
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 				{
 					int trainX = (int)Program.TrainManager.Trains[i].Cars[0].FrontAxle.Follower.WorldPosition.X;
 					int trainZ = (int)Program.TrainManager.Trains[i].Cars[0].FrontAxle.Follower.WorldPosition.Z;

--- a/source/OpenBVE/Game/TrainManager.cs
+++ b/source/OpenBVE/Game/TrainManager.cs
@@ -25,7 +25,7 @@ namespace OpenBve
 			{
 				return;
 			}
-			for (int i = 0; i < Trains.Length; i++) {
+			for (int i = 0; i < Trains.Count; i++) {
 				Trains[i].Update(TimeElapsed);
 			}
 
@@ -39,15 +39,13 @@ namespace OpenBve
 			if (!Game.MinimalisticSimulation & Interface.CurrentOptions.Collisions)
 			{
 				
-				//for (int i = 0; i < Trains.Length; i++) {
-				System.Threading.Tasks.Parallel.For(0, Trains.Length, i =>
-				{
+				for (int i = 0; i < Trains.Count; i++) {
 					// with other trains
 					if (Trains[i].State == TrainState.Available)
 					{
 						double a = Trains[i].FrontCarTrackPosition;
 						double b = Trains[i].RearCarTrackPosition;
-						for (int j = i + 1; j < Trains.Length; j++)
+						for (int j = i + 1; j < Trains.Count; j++)
 						{
 							if (Trains[j].State == TrainState.Available)
 							{
@@ -397,11 +395,20 @@ namespace OpenBve
 						}
 					}
 
-				});
+				}
 			}
+
+			for (int i = Trains.Count; i > 0; i--)
+			{
+				if (Trains[i].State == TrainState.Disposed)
+				{
+					Trains.RemoveAt(i);
+				}
+			}
+
 			// compute final angles and positions
 			//for (int i = 0; i < Trains.Length; i++) {
-			System.Threading.Tasks.Parallel.For(0, Trains.Length, i =>
+			System.Threading.Tasks.Parallel.For(0, Trains.Count, i =>
 			{
 				if (Trains[i].State != TrainState.Disposed & Trains[i].State != TrainState.Bogus)
 				{

--- a/source/OpenBVE/Game/TrainManager.cs
+++ b/source/OpenBVE/Game/TrainManager.cs
@@ -78,18 +78,39 @@ namespace OpenBve
 											Trains[j].Cars[0].FrontAxle.Follower.UpdateRelative(-e, false, false);
 
 											Trains[j].Cars[0].RearAxle.Follower.UpdateRelative(-e, false, false);
-											if (Interface.CurrentOptions.Derailments)
+											double f = 2.0 / (Trains[i].Cars[k].CurrentMass + Trains[j].Cars[0].CurrentMass);
+											double fi = Trains[j].Cars[0].CurrentMass * f;
+											double fj = Trains[i].Cars[k].CurrentMass * f;
+											double vi = v * fi;
+											double vj = v * fj;
+											if (vi > Trains[i].CriticalCollisionSpeedDifference)
 											{
-												double f = 2.0 / (Trains[i].Cars[k].CurrentMass + Trains[j].Cars[0].CurrentMass);
-												double fi = Trains[j].Cars[0].CurrentMass * f;
-												double fj = Trains[i].Cars[k].CurrentMass * f;
-												double vi = v * fi;
-												double vj = v * fj;
-												if (vi > Trains[i].CriticalCollisionSpeedDifference)
+												if(Interface.CurrentOptions.Derailments)
 													Trains[i].Derail(k, TimeElapsed);
-												if (vj > Trains[j].CriticalCollisionSpeedDifference)
+											}
+											else if (vj > Trains[j].CriticalCollisionSpeedDifference)
+											{
+												if(Interface.CurrentOptions.Derailments)
 													Trains[j].Derail(i, TimeElapsed);
 											}
+											else
+											{
+												if (Trains[i].IsPlayerTrain)
+												{
+													Trains[i].Couple(Trains[j], false);
+													Trains[j].Dispose();
+													continue;
+												}
+												else if (Trains[j].IsPlayerTrain)
+												{
+													Trains[j].Couple(Trains[i], true);
+													Trains[i].Dispose();
+													continue;
+												}
+
+											}
+													
+											
 
 											// adjust cars for train i
 											for (int h = Trains[i].Cars.Length - 2; h >= 0; h--)
@@ -106,11 +127,11 @@ namespace OpenBve
 													Trains[i].Cars[h].RearAxle.Follower.UpdateRelative(-d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0 / (Trains[i].Cars[h + 1].CurrentMass + Trains[i].Cars[h].CurrentMass);
-														double fi = Trains[i].Cars[h + 1].CurrentMass * f;
-														double fj = Trains[i].Cars[h].CurrentMass * f;
-														double vi = v * fi;
-														double vj = v * fj;
+														f = 2.0 / (Trains[i].Cars[h + 1].CurrentMass + Trains[i].Cars[h].CurrentMass);
+														fi = Trains[i].Cars[h + 1].CurrentMass * f;
+														fj = Trains[i].Cars[h].CurrentMass * f;
+														vi = v * fi;
+														vj = v * fj;
 														if (vi > Trains[i].CriticalCollisionSpeedDifference)
 															Trains[i].Derail(h + 1, TimeElapsed);
 														if (vj > Trains[j].CriticalCollisionSpeedDifference)
@@ -137,11 +158,11 @@ namespace OpenBve
 													Trains[j].Cars[h].RearAxle.Follower.UpdateRelative(d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0 / (Trains[j].Cars[h - 1].CurrentMass + Trains[j].Cars[h].CurrentMass);
-														double fi = Trains[j].Cars[h - 1].CurrentMass * f;
-														double fj = Trains[j].Cars[h].CurrentMass * f;
-														double vi = v * fi;
-														double vj = v * fj;
+														f = 2.0 / (Trains[j].Cars[h - 1].CurrentMass + Trains[j].Cars[h].CurrentMass);
+														fi = Trains[j].Cars[h - 1].CurrentMass * f;
+														fj = Trains[j].Cars[h].CurrentMass * f;
+														vi = v * fi;
+														vj = v * fj;
 														if (vi > Trains[j].CriticalCollisionSpeedDifference)
 															Trains[j].Derail(h - 1, TimeElapsed);
 														if (vj > Trains[j].CriticalCollisionSpeedDifference)
@@ -177,17 +198,36 @@ namespace OpenBve
 											Trains[i].Cars[0].RearAxle.Follower.UpdateRelative(-e, false, false);
 											Trains[j].Cars[k].FrontAxle.Follower.UpdateRelative(e, false, false);
 											Trains[j].Cars[k].RearAxle.Follower.UpdateRelative(e, false, false);
-											if (Interface.CurrentOptions.Derailments)
+											double f = 2.0 / (Trains[i].Cars[0].CurrentMass + Trains[j].Cars[k].CurrentMass);
+
+											double fi = Trains[j].Cars[k].CurrentMass * f;
+											double fj = Trains[i].Cars[0].CurrentMass * f;
+											double vi = v * fi;
+											double vj = v * fj;
+											if (vi > Trains[i].CriticalCollisionSpeedDifference)
 											{
-												double f = 2.0 / (Trains[i].Cars[0].CurrentMass + Trains[j].Cars[k].CurrentMass);
-												double fi = Trains[j].Cars[k].CurrentMass * f;
-												double fj = Trains[i].Cars[0].CurrentMass * f;
-												double vi = v * fi;
-												double vj = v * fj;
-												if (vi > Trains[i].CriticalCollisionSpeedDifference)
-													Trains[i].Derail(0, TimeElapsed);
-												if (vj > Trains[j].CriticalCollisionSpeedDifference)
+												if(Interface.CurrentOptions.Derailments)														
+													Trains[j].Derail(0, TimeElapsed);
+											}
+											else if (vj > Trains[j].CriticalCollisionSpeedDifference)
+											{
+												if(Interface.CurrentOptions.Derailments)
 													Trains[j].Derail(k, TimeElapsed);
+											}
+											else
+											{
+												if (Trains[i].IsPlayerTrain)
+												{
+													Trains[i].Couple(Trains[j], true);
+													Trains[j].Dispose();
+													continue;
+												}
+												else if (Trains[j].IsPlayerTrain)
+												{
+													Trains[j].Couple(Trains[i], false);
+													Trains[i].Dispose();
+													continue;
+												}
 											}
 
 											// adjust cars for train i
@@ -205,11 +245,11 @@ namespace OpenBve
 													Trains[i].Cars[h].RearAxle.Follower.UpdateRelative(d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0 / (Trains[i].Cars[h - 1].CurrentMass + Trains[i].Cars[h].CurrentMass);
-														double fi = Trains[i].Cars[h - 1].CurrentMass * f;
-														double fj = Trains[i].Cars[h].CurrentMass * f;
-														double vi = v * fi;
-														double vj = v * fj;
+														f = 2.0 / (Trains[i].Cars[h - 1].CurrentMass + Trains[i].Cars[h].CurrentMass);
+														fi = Trains[i].Cars[h - 1].CurrentMass * f;
+														fj = Trains[i].Cars[h].CurrentMass * f;
+														vi = v * fi;
+														vj = v * fj;
 														if (vi > Trains[i].CriticalCollisionSpeedDifference)
 															Trains[i].Derail(h - 1, TimeElapsed);
 														if (vj > Trains[i].CriticalCollisionSpeedDifference)
@@ -236,11 +276,11 @@ namespace OpenBve
 													Trains[j].Cars[h].RearAxle.Follower.UpdateRelative(-d, false, false);
 													if (Interface.CurrentOptions.Derailments)
 													{
-														double f = 2.0 / (Trains[j].Cars[h + 1].CurrentMass + Trains[j].Cars[h].CurrentMass);
-														double fi = Trains[j].Cars[h + 1].CurrentMass * f;
-														double fj = Trains[j].Cars[h].CurrentMass * f;
-														double vi = v * fi;
-														double vj = v * fj;
+														f = 2.0 / (Trains[j].Cars[h + 1].CurrentMass + Trains[j].Cars[h].CurrentMass);
+														fi = Trains[j].Cars[h + 1].CurrentMass * f;
+														fi = Trains[j].Cars[h].CurrentMass * f;
+														vi = v * fi;
+														vi = v * fj;
 														if (vi > Trains[i].CriticalCollisionSpeedDifference)
 															Trains[j].Derail(h + 1, TimeElapsed);
 														if (vj > Trains[j].CriticalCollisionSpeedDifference)

--- a/source/OpenBVE/Game/TrainManager.cs
+++ b/source/OpenBVE/Game/TrainManager.cs
@@ -400,9 +400,14 @@ namespace OpenBve
 
 			for (int i = Trains.Count; i > 0; i--)
 			{
-				if (Trains[i].State == TrainState.Disposed)
+				switch (Trains[i].State)
 				{
-					Trains.RemoveAt(i);
+					case TrainState.DisposePending:
+						Trains[i].State = TrainState.Disposed;
+						break;
+					case TrainState.Disposed:
+						Trains.RemoveAt(i);
+						break;
 				}
 			}
 
@@ -410,7 +415,7 @@ namespace OpenBve
 			//for (int i = 0; i < Trains.Length; i++) {
 			System.Threading.Tasks.Parallel.For(0, Trains.Count, i =>
 			{
-				if (Trains[i].State != TrainState.Disposed & Trains[i].State != TrainState.Bogus)
+				if (Trains[i].State < TrainState.DisposePending) 
 				{
 					for (int j = 0; j < Trains[i].Cars.Length; j++)
 					{
@@ -434,7 +439,7 @@ namespace OpenBve
 
 			System.Threading.Tasks.Parallel.For(0, TFOs.Length, i =>
 			{
-				if (TFOs[i].State != TrainState.Disposed & TFOs[i].State != TrainState.Bogus)
+				if (TFOs[i].State < TrainState.DisposePending)
 				{
 					ScriptedTrain t = (ScriptedTrain) TFOs[i];
 					foreach (var Car in t.Cars)

--- a/source/OpenBVE/Game/TrainManager.cs
+++ b/source/OpenBVE/Game/TrainManager.cs
@@ -95,13 +95,13 @@ namespace OpenBve
 											}
 											else
 											{
-												if (Trains[i].IsPlayerTrain)
+												if (Trains[i].IsPlayerTrain && Trains[j].Type == TrainType.StaticCars)
 												{
 													Trains[i].Couple(Trains[j], false);
 													Trains[j].Dispose();
 													continue;
 												}
-												else if (Trains[j].IsPlayerTrain)
+												if (Trains[j].IsPlayerTrain && Trains[i].Type == TrainType.StaticCars)
 												{
 													Trains[j].Couple(Trains[i], true);
 													Trains[i].Dispose();
@@ -216,13 +216,13 @@ namespace OpenBve
 											}
 											else
 											{
-												if (Trains[i].IsPlayerTrain)
+												if (Trains[i].IsPlayerTrain && Trains[j].Type == TrainType.StaticCars)
 												{
 													Trains[i].Couple(Trains[j], true);
 													Trains[j].Dispose();
 													continue;
 												}
-												else if (Trains[j].IsPlayerTrain)
+												if (Trains[j].IsPlayerTrain && Trains[i].Type == TrainType.StaticCars)
 												{
 													Trains[j].Couple(Trains[i], false);
 													Trains[i].Dispose();

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -477,7 +477,7 @@ namespace OpenBve
 			{
 				//Saving black-box failed, not really important
 			}
-			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+			for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 			{
 				if (Program.TrainManager.Trains[i].State != TrainState.Bogus)
 				{
@@ -703,7 +703,7 @@ namespace OpenBve
 				}
 			}
 			// initialize trains
-			for (int i = 0; i <  Program.TrainManager.Trains.Length; i++)
+			for (int i = 0; i <  Program.TrainManager.Trains.Count; i++)
 			{
 				Program.TrainManager.Trains[i].Initialize();
 				int s = Program.TrainManager.Trains[i].IsPlayerTrain ? PlayerFirstStationIndex : OtherFirstStationIndex;
@@ -773,7 +773,7 @@ namespace OpenBve
 				Program.CurrentRoute.UpdateAllSections();
 			}
 			// move train in position
-			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+			for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 			{
 				double p;
 				if (Program.TrainManager.Trains[i].IsPlayerTrain)
@@ -844,7 +844,7 @@ namespace OpenBve
 			}
 			
 			// signalling sections
-			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+			for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 			{
 				int s = Program.TrainManager.Trains[i].CurrentSectionIndex;
 				if (Program.CurrentRoute.Sections.Length > Program.TrainManager.Trains[i].CurrentSectionIndex)
@@ -1108,9 +1108,9 @@ namespace OpenBve
 						trainProgress = Program.CurrentHost.Plugins[i].Train.CurrentProgress;
 					}
 				}
-				double trainProgressWeight = 1.0 / Program.TrainManager.Trains.Length;
+				double trainProgressWeight = 1.0 / Program.TrainManager.Trains.Count;
 				double finalTrainProgress;
-				if (Program.TrainManager.Trains.Length != 0)
+				if (Program.TrainManager.Trains.Count != 0)
 				{
 					//Trains are not loaded until after the route
 					finalTrainProgress = (Loading.CurrentTrain * trainProgressWeight) + trainProgressWeight * trainProgress;

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -16,6 +16,7 @@ using OpenBveApi.Sounds;
 using OpenBveApi.Textures;
 using OpenBveApi.Trains;
 using OpenBveApi.World;
+using OpenTK.Graphics.OpenGL;
 using RouteManager2.MessageManager;
 using SoundManager;
 using TrainManager.Trains;
@@ -640,16 +641,16 @@ namespace OpenBve {
 		}
 
 		// ReSharper disable once CoVariantArrayConversion
-		public override AbstractTrain[] Trains => Program.TrainManager.Trains;
+		public override IEnumerable<AbstractTrain> Trains => Program.TrainManager.Trains;
 			
 			
 
 		public override void AddTrain(AbstractTrain ReferenceTrain, AbstractTrain NewTrain, bool Preccedes)
 		{
-			Array.Resize(ref Program.TrainManager.Trains, Program.TrainManager.Trains.Length + 1);
+			
 			int trainIndex = -1;
 			// find index of train within trainmanager array
-			for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+			for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 			{
 				if (Program.TrainManager.Trains[i] == ReferenceTrain)
 				{
@@ -665,16 +666,11 @@ namespace OpenBve {
 
 			if (trainIndex == -1)
 			{
-				Program.TrainManager.Trains[Program.TrainManager.Trains.Length - 1] = (TrainBase)NewTrain;
+				Program.TrainManager.Trains.Add((TrainBase)NewTrain);
 			}
 			else
 			{
-				for (int i = Program.TrainManager.Trains.Length - 2; i > trainIndex; i--)
-				{
-					Program.TrainManager.Trains[i + 1] = Program.TrainManager.Trains[i];
-				}
-
-				Program.TrainManager.Trains[trainIndex + 1] = (TrainBase)NewTrain;
+				Program.TrainManager.Trains.Insert(trainIndex, (TrainBase)NewTrain);
 			}
 
 		}
@@ -696,7 +692,7 @@ namespace OpenBve {
 
 			if(Train is TrainBase baseTrain)
 			{
-				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 				{
 					if (Program.TrainManager.Trains[i] != baseTrain & Program.TrainManager.Trains[i].State == TrainState.Available & baseTrain.Cars.Length > 0)
 					{
@@ -718,7 +714,7 @@ namespace OpenBve {
 		{
 			AbstractTrain closestTrain = null;
 			double trainDistance = double.MaxValue;
-			for (int j = 0; j < Program.TrainManager.Trains.Length; j++)
+			for (int j = 0; j < Program.TrainManager.Trains.Count; j++)
 			{
 				if (Program.TrainManager.Trains[j].State == TrainState.Available)
 				{

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -272,7 +273,7 @@ namespace OpenBve {
 			try {
 				LoadEverythingThreaded();
 			} catch (Exception ex) {
-				for (int i = 0; i < Program.TrainManager.Trains.Length; i++) {
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++) {
 					if (Program.TrainManager.Trains[i] != null && Program.TrainManager.Trains[i].Plugin != null) {
 						if (Program.TrainManager.Trains[i].Plugin.LastException != null) {
 							Interface.AddMessage(MessageType.Critical, false, "The train plugin " + Program.TrainManager.Trains[i].Plugin.PluginTitle + " caused a critical error in the route and train loader: " + Program.TrainManager.Trains[i].Plugin.LastException.Message);
@@ -390,25 +391,28 @@ namespace OpenBve {
 			Program.FileSystem.AppendToLogFile("Route file loaded successfully.");
 			// initialize trains
 			Thread.Sleep(1); if (Cancel) return;
-			Program.TrainManager.Trains = new TrainBase[Program.CurrentRoute.PrecedingTrainTimeDeltas.Length + 1 + (Program.CurrentRoute.BogusPreTrainInstructions.Length != 0 ? 1 : 0)];
-			Program.TrainManager.Trains[0] = new TrainBase(TrainState.Pending, TrainType.LocalPlayerTrain);
-			TrainManagerBase.PlayerTrain = Program.TrainManager.Trains[0];
-			for (int k = 1; k < Program.TrainManager.Trains.Length; k++)
+			Program.TrainManager.Trains = new List<TrainBase>
 			{
-				if (k == Program.TrainManager.Trains.Length - 1 & Program.CurrentRoute.BogusPreTrainInstructions.Length != 0)
+				new TrainBase(TrainState.Pending, TrainType.LocalPlayerTrain)
+			};
+			TrainManagerBase.PlayerTrain = Program.TrainManager.Trains[0];
+
+			int totalAdditionalTrains = Program.CurrentRoute.PrecedingTrainTimeDeltas.Length + Program.CurrentRoute.BogusPreTrainInstructions.Length;
+
+			for (int i = 0; i < totalAdditionalTrains; i++)
+			{
+				if (i == Program.TrainManager.Trains.Count & Program.CurrentRoute.BogusPreTrainInstructions.Length != 0)
 				{
-					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Bogus, TrainType.PreTrain);
+					Program.TrainManager.Trains[i] = new TrainBase(TrainState.Bogus, TrainType.PreTrain);
 				}
 				else
 				{
-					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Pending, TrainType.PreTrain);
-				}			
+					Program.TrainManager.Trains[i] = new TrainBase(TrainState.Pending, TrainType.PreTrain);
+				}
 			}
-
-
-
+			
 			// load trains
-			for (int k = 0; k < Program.TrainManager.Trains.Length; k++) {
+			for (int k = 0; k < Program.TrainManager.Trains.Count; k++) {
 
 				AbstractTrain currentTrain = Program.TrainManager.Trains[k];
 				for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++)
@@ -450,7 +454,7 @@ namespace OpenBve {
 
 
 			CurrentTrain = 0;
-			for (int i = 0; i < Program.TrainManager.Trains.Length; i++) {
+			for (int i = 0; i < Program.TrainManager.Trains.Count; i++) {
 				if ( Program.TrainManager.Trains[i].State != TrainState.Bogus) {
 					if ( Program.TrainManager.Trains[i].IsPlayerTrain) {
 						if (Program.TrainManager.Trains[i].Plugin == null && !Program.TrainManager.Trains[i].LoadCustomPlugin(Program.TrainManager.Trains[i].TrainFolder, CurrentTrainEncoding)) {

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -391,19 +391,19 @@ namespace OpenBve {
 			// initialize trains
 			Thread.Sleep(1); if (Cancel) return;
 			Program.TrainManager.Trains = new TrainBase[Program.CurrentRoute.PrecedingTrainTimeDeltas.Length + 1 + (Program.CurrentRoute.BogusPreTrainInstructions.Length != 0 ? 1 : 0)];
-			for (int k = 0; k < Program.TrainManager.Trains.Length; k++)
+			Program.TrainManager.Trains[0] = new TrainBase(TrainState.Pending, TrainType.LocalPlayerTrain);
+			TrainManagerBase.PlayerTrain = Program.TrainManager.Trains[0];
+			for (int k = 1; k < Program.TrainManager.Trains.Length; k++)
 			{
 				if (k == Program.TrainManager.Trains.Length - 1 & Program.CurrentRoute.BogusPreTrainInstructions.Length != 0)
 				{
-					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Bogus);
+					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Bogus, TrainType.PreTrain);
 				}
 				else
 				{
-					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Pending);
-				}
-				
+					Program.TrainManager.Trains[k] = new TrainBase(TrainState.Pending, TrainType.PreTrain);
+				}			
 			}
-			TrainManagerBase.PlayerTrain = Program.TrainManager.Trains[Program.CurrentRoute.PrecedingTrainTimeDeltas.Length];
 
 
 
@@ -433,7 +433,7 @@ namespace OpenBve {
 				} else if (currentTrain.State != TrainState.Bogus) {
 					TrainBase train = currentTrain as TrainBase;
 					currentTrain.AI = new Game.SimpleHumanDriverAI(train, Interface.CurrentOptions.PrecedingTrainSpeedLimit);
-					currentTrain.TimetableDelta = Program.CurrentRoute.PrecedingTrainTimeDeltas[k];
+					currentTrain.TimetableDelta = Program.CurrentRoute.PrecedingTrainTimeDeltas[k - 1];
 					// ReSharper disable once PossibleNullReferenceException - Will always succeed 
 					train.Specs.DoorOpenMode = DoorMode.Manual;
 					train.Specs.DoorCloseMode = DoorMode.Manual;

--- a/source/OpenBVE/System/Program.cs
+++ b/source/OpenBVE/System/Program.cs
@@ -34,13 +34,13 @@ namespace OpenBve {
 		internal static ImageFileMachine CurrentCPUArchitecture;
 
 		/// <summary>The host API used by this program.</summary>
-		internal static Host CurrentHost = null;
+		internal static Host CurrentHost;
 
 		/// <summary>Information about the file system organization.</summary>
-		internal static FileSystem FileSystem = null;
+		internal static FileSystem FileSystem;
 		
 		/// <summary>If the program is to be restarted, this contains the command-line arguments that should be passed to the process, or a null reference otherwise.</summary>
-		internal static string RestartArguments = null;
+		internal static string RestartArguments;
 
 		/// <summary>The random number generator used by this program.</summary>
 		internal static readonly Random RandomNumberGenerator = new Random();
@@ -296,7 +296,7 @@ namespace OpenBve {
 							if (TrainManager.Trains[i] != null && TrainManager.Trains[i].Plugin != null) {
 								if (TrainManager.Trains[i].Plugin.LastException != null) {
 									CrashHandler.LoadingCrash(ex.Message, true);
-									MessageBox.Show("The train plugin " + TrainManager.Trains[i].Plugin.PluginTitle + " caused a runtime exception: " + TrainManager.Trains[i].Plugin.LastException.Message, Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Hand);
+									MessageBox.Show(@"The train plugin " + TrainManager.Trains[i].Plugin.PluginTitle + @" caused a runtime exception: " + TrainManager.Trains[i].Plugin.LastException.Message, Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Hand);
 									found = true;
 									RestartArguments = "";
 									break;
@@ -305,16 +305,16 @@ namespace OpenBve {
 						}
 						if (!found)
 						{
-							if (ex is System.DllNotFoundException)
+							if (ex is DllNotFoundException)
 							{
 								Interface.AddMessage(MessageType.Critical, false, "The required system library " + ex.Message + " was not found on the system.");
 								switch (ex.Message)
 								{
 									case "libopenal.so.1":
-										MessageBox.Show("openAL was not found on this system. \n Please install libopenal1 via your distribtion's package management system.", Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"program","title"}), MessageBoxButtons.OK, MessageBoxIcon.Hand);
+										MessageBox.Show(@"openAL was not found on this system. \n Please install libopenal1 via your distribtion's package management system.", Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"program","title"}), MessageBoxButtons.OK, MessageBoxIcon.Hand);
 										break;
 									default:
-										MessageBox.Show("The required system library " + ex.Message + " was not found on this system.", Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"program","title"}), MessageBoxButtons.OK, MessageBoxIcon.Hand);
+										MessageBox.Show(@"The required system library " + ex.Message + @" was not found on this system.", Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"program","title"}), MessageBoxButtons.OK, MessageBoxIcon.Hand);
 										break;
 								}
 							}

--- a/source/OpenBVE/System/Program.cs
+++ b/source/OpenBVE/System/Program.cs
@@ -288,14 +288,11 @@ namespace OpenBve {
 			// --- start the actual program ---
 			if (result.Start) {
 				if (Initialize()) {
-					#if !DEBUG
 					try {
-						#endif
 						MainLoop.StartLoopEx(result);
-						#if !DEBUG
 					} catch (Exception ex) {
 						bool found = false;
-						for (int i = 0; i < TrainManager.Trains.Length; i++) {
+						for (int i = 0; i < TrainManager.Trains.Count; i++) {
 							if (TrainManager.Trains[i] != null && TrainManager.Trains[i].Plugin != null) {
 								if (TrainManager.Trains[i].Plugin.LastException != null) {
 									CrashHandler.LoadingCrash(ex.Message, true);
@@ -329,7 +326,6 @@ namespace OpenBve {
 							RestartArguments = "";
 						}
 					}
-#endif
 				}
 				Deinitialize();
 			}

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Train\TrainStartMode.cs" />
     <Compile Include="Train\TrainState.cs" />
     <Compile Include="Train\TrainStopState.cs" />
+    <Compile Include="Train\TrainType.cs" />
     <Compile Include="Train\TravelDirection.cs" />
     <Compile Include="World\Orientation3.cs" />
     <Compile Include="Packages\Packages.cs" />

--- a/source/OpenBveApi/System/Hosts/HostInterface.cs
+++ b/source/OpenBveApi/System/Hosts/HostInterface.cs
@@ -663,7 +663,7 @@ namespace OpenBveApi.Hosts {
 		}
 
 		/// <summary>Returns the trains within the simulation</summary>
-		public virtual AbstractTrain[] Trains => null;
+		public virtual IEnumerable<AbstractTrain> Trains => null;
 
 		/// <summary>Gets the closest train to the specified train</summary>
 		/// <param name="Train">The specified train</param>

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -5,6 +5,8 @@ namespace OpenBveApi.Trains
 	/// <summary>An abstract train</summary>
 	public abstract class AbstractTrain
 	{
+		/// <summary>The type of the train</summary>
+		public TrainType Type;
 		/// <summary>The current state of the train</summary>
 		public TrainState State;
 		/// <summary>Holds the AI controlling the train if any</summary>

--- a/source/OpenBveApi/Train/AbstractTrain.cs
+++ b/source/OpenBveApi/Train/AbstractTrain.cs
@@ -82,6 +82,14 @@ namespace OpenBveApi.Trains
 
 		}
 
+        /// <summary>Couples another train to this train</summary>
+        /// <param name="Train">The train to couple</param>
+        /// <param name="Front">Whether the new train is coupled to the front</param>
+        public virtual void Couple(AbstractTrain Train, bool Front)
+		{
+		
+		}
+
 		/// <summary>Call this method to reverse (flip) the entire train</summary>
 		public virtual void Reverse(bool FlipInterior = false, bool FlipDriver = false)
 		{

--- a/source/OpenBveApi/Train/TrainState.cs
+++ b/source/OpenBveApi/Train/TrainState.cs
@@ -7,9 +7,12 @@
 		Pending = 0,
 		/// <summary>The train has been introduced into the simulation</summary>
 		Available = 1,
-		/// <summary>The train has traversed it's path, and has been disposed of by the simulation</summary>
-		Disposed = 2,
 		/// <summary>The train is a bogus (non-visble) train created via a .PreTrain command</summary>
-		Bogus = 3,
+		Bogus = 2,
+		/// <summary>The train is pending disposal</summary>
+		DisposePending = 3,
+		/// <summary>The train has traversed it's path, and has been disposed of by the simulation</summary>
+		Disposed = 4,
+		
 	}
 }

--- a/source/OpenBveApi/Train/TrainState.cs
+++ b/source/OpenBveApi/Train/TrainState.cs
@@ -10,6 +10,6 @@
 		/// <summary>The train has traversed it's path, and has been disposed of by the simulation</summary>
 		Disposed = 2,
 		/// <summary>The train is a bogus (non-visble) train created via a .PreTrain command</summary>
-		Bogus = 3
+		Bogus = 3,
 	}
 }

--- a/source/OpenBveApi/Train/TrainType.cs
+++ b/source/OpenBveApi/Train/TrainType.cs
@@ -1,0 +1,17 @@
+﻿namespace OpenBveApi.Trains
+{
+	/// <summary>The different types of train</summary>
+    public enum TrainType
+    {
+		/// <summary>The train is controlled by the local player</summary>
+		LocalPlayerTrain,
+		/// <summary>The train is controlled by a remote player</summary>
+		RemotePlayerTrain,
+		/// <summary>The train is controlled by legacy BVE PreTrain / RunInterval commands</summary>
+		PreTrain,
+		/// <summary>The train is controlled by a TFO script</summary>
+		ScriptedTrain,
+		/// <summary>The train consists of static cars and does not move independantly</summary>
+		StaticCars
+    }
+}

--- a/source/RouteViewer/GameR.cs
+++ b/source/RouteViewer/GameR.cs
@@ -39,7 +39,7 @@ namespace RouteViewer {
 			Program.CurrentRoute.Tracks = new Dictionary<int, Track>();
 			Program.CurrentRoute.Tracks.Add(0, new Track());
 			// train manager
-			Program.TrainManager.Trains = new TrainBase[] { };
+			Program.TrainManager.Trains = new List<TrainBase>();
 			// game
 			Interface.LogMessages.Clear();
 			Program.CurrentHost.ClearErrors();

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -545,7 +545,7 @@ namespace RouteViewer
 		}
 
 		// ReSharper disable once CoVariantArrayConversion
-		public override AbstractTrain[] Trains => Program.TrainManager.Trains;
+		public override IEnumerable<AbstractTrain> Trains => Program.TrainManager.Trains;
 
 		public override AbstractTrain ClosestTrain(AbstractTrain Train)
 		{
@@ -553,7 +553,7 @@ namespace RouteViewer
 			double bestLocation = double.MaxValue;
 			if(Train is TrainBase baseTrain)
 			{
-				for (int i = 0; i < Program.TrainManager.Trains.Length; i++)
+				for (int i = 0; i < Program.TrainManager.Trains.Count; i++)
 				{
 					if (Program.TrainManager.Trains[i] != baseTrain & Program.TrainManager.Trains[i].State == TrainState.Available & baseTrain.Cars.Length > 0)
 					{
@@ -574,7 +574,7 @@ namespace RouteViewer
 		{
 			AbstractTrain closestTrain = null;
 			double trainDistance = double.MaxValue;
-			for (int j = 0; j < Program.TrainManager.Trains.Length; j++)
+			for (int j = 0; j < Program.TrainManager.Trains.Count; j++)
 			{
 				if (Program.TrainManager.Trains[j].State == TrainState.Available)
 				{

--- a/source/RouteViewer/TrainManagerR.cs
+++ b/source/RouteViewer/TrainManagerR.cs
@@ -24,7 +24,7 @@ namespace RouteViewer {
 
 		// train
 		internal class Train : TrainBase {
-			internal Train() : base(TrainState.Pending)
+			internal Train() : base(TrainState.Pending, TrainType.LocalPlayerTrain)
 			{
 				Handles.Power = new PowerHandle(8, 8, new double[] {}, new double[] {}, this);
 				Handles.Brake = new BrakeHandle(8, 8, null, new double[] {}, new double[] {}, this);

--- a/source/TrainManager/Brake/AirBrake/AutomaticAirBrake.cs
+++ b/source/TrainManager/Brake/AirBrake/AutomaticAirBrake.cs
@@ -6,6 +6,14 @@ namespace TrainManager.BrakeSystems
 {
 	public class AutomaticAirBrake : CarBrake
 	{
+		public AutomaticAirBrake(EletropneumaticBrakeType type, CarBase car) : base(car)
+		{
+			electropneumaticBrakeType = type;
+			brakeControlSpeed = 0;
+			motorDeceleration = 0;
+			decelerationCurves = new AccelerationCurve[] { };
+		}
+
 		public AutomaticAirBrake(EletropneumaticBrakeType type, CarBase car, double BrakeControlSpeed, double MotorDeceleration, AccelerationCurve[] DecelerationCurves) : base(car)
 		{
 			electropneumaticBrakeType = type;

--- a/source/TrainManager/Brake/AirBrake/ElectromagneticStraightAirBrake.cs
+++ b/source/TrainManager/Brake/AirBrake/ElectromagneticStraightAirBrake.cs
@@ -7,6 +7,15 @@ namespace TrainManager.BrakeSystems
 {
 	public class ElectromagneticStraightAirBrake : CarBrake
 	{
+		public ElectromagneticStraightAirBrake(EletropneumaticBrakeType type, CarBase car) : base(car)
+		{
+			electropneumaticBrakeType = type;
+			brakeControlSpeed = 0;
+			motorDeceleration = 0;
+			motorDecelerationDelayUp = 0;
+			motorDecelerationDelayDown = 0;
+			decelerationCurves = new AccelerationCurve[] { };
+		}
 		public ElectromagneticStraightAirBrake(EletropneumaticBrakeType type, CarBase car, double BrakeControlSpeed, double MotorDeceleration, double MotorDecelerationDelayUp, double MotorDecelerationDelayDown, AccelerationCurve[] DecelerationCurves) : base(car)
 		{
 			electropneumaticBrakeType = type;

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -155,6 +155,7 @@ namespace TrainManager.Car
 			Flange = new Flange(this);
 			Run = new RunSounds(this);
 			Sounds = new CarSounds();
+			Coupler = new Coupler(0, 0, this, null, train);
 		}
 
 		/// <summary>Moves the car</summary>

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -375,25 +375,10 @@ namespace TrainManager.Car
 			lock (baseTrain.updateLock)
 			{
 				if (!Front && !Rear)
-				return;
-			}
-			// Create new train
-			TrainBase newTrain = new TrainBase(TrainState.Available, TrainType.StaticCars);
-			UncouplingBehaviour uncouplingBehaviour = UncouplingBehaviour.Emergency;
-			newTrain.Handles.Power = new PowerHandle(0, 0, new double[0], new double[0], newTrain);
-			newTrain.Handles.Brake = new BrakeHandle(0, 0, newTrain.Handles.EmergencyBrake, new double[0], new double[0], newTrain);
-			newTrain.Handles.HoldBrake = new HoldBrakeHandle(newTrain);
-			if (Front)
-			{
-				int totalPreceedingCars = trainCarIndex;
-				newTrain.Cars = new CarBase[trainCarIndex];
-				for (int i = 0; i < totalPreceedingCars; i++)
-				{
 					return;
-				}
 
 				// Create new train
-				TrainBase newTrain = new TrainBase(TrainState.Available);
+				TrainBase newTrain = new TrainBase(TrainState.Available, TrainType.StaticCars);
 				UncouplingBehaviour uncouplingBehaviour = UncouplingBehaviour.Emergency;
 				newTrain.Handles.Power = new PowerHandle(0, 0, new double[0], new double[0], newTrain);
 				newTrain.Handles.Brake = new BrakeHandle(0, 0, newTrain.Handles.EmergencyBrake, new double[0], new double[0], newTrain);

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -162,17 +162,17 @@ namespace TrainManager.Car
 		/// <param name="Delta">The delta to move</param>
 		public void Move(double Delta)
 		{
-			if (baseTrain.State != TrainState.Disposed)
+			if (baseTrain.State < TrainState.DisposePending)
 			{
 				FrontAxle.Follower.UpdateRelative(Delta, true, true);
 				FrontBogie.FrontAxle.Follower.UpdateRelative(Delta, true, true);
 				FrontBogie.RearAxle.Follower.UpdateRelative(Delta, true, true);
-				if (baseTrain.State != TrainState.Disposed)
+				if (baseTrain.State < TrainState.DisposePending)
 				{
 					RearAxle.Follower.UpdateRelative(Delta, true, true);
 					RearBogie.FrontAxle.Follower.UpdateRelative(Delta, true, true);
 					RearBogie.RearAxle.Follower.UpdateRelative(Delta, true, true);
-					if (baseTrain.State != TrainState.Disposed)
+					if (baseTrain.State < TrainState.DisposePending)
 					{
 						BeaconReceiver.UpdateRelative(Delta, true, false);
 					}

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -375,6 +375,19 @@ namespace TrainManager.Car
 			lock (baseTrain.updateLock)
 			{
 				if (!Front && !Rear)
+				return;
+			}
+			// Create new train
+			TrainBase newTrain = new TrainBase(TrainState.Available, TrainType.StaticCars);
+			UncouplingBehaviour uncouplingBehaviour = UncouplingBehaviour.Emergency;
+			newTrain.Handles.Power = new PowerHandle(0, 0, new double[0], new double[0], newTrain);
+			newTrain.Handles.Brake = new BrakeHandle(0, 0, newTrain.Handles.EmergencyBrake, new double[0], new double[0], newTrain);
+			newTrain.Handles.HoldBrake = new HoldBrakeHandle(newTrain);
+			if (Front)
+			{
+				int totalPreceedingCars = trainCarIndex;
+				newTrain.Cars = new CarBase[trainCarIndex];
+				for (int i = 0; i < totalPreceedingCars; i++)
 				{
 					return;
 				}

--- a/source/TrainManager/TrackFollowingObject/ScriptedTrain.cs
+++ b/source/TrainManager/TrackFollowingObject/ScriptedTrain.cs
@@ -18,7 +18,7 @@ namespace TrainManager.Trains
 		public double LeaveTime;
 		private double InternalTimerTimeElapsed;
 
-		public ScriptedTrain(TrainState state) : base(state)
+		public ScriptedTrain(TrainState state) : base(state, TrainType.ScriptedTrain)
 		{
 			SafetySystems.PassAlarm = new PassAlarm(PassAlarmType.None, null);
 		}

--- a/source/TrainManager/TrackFollowingObject/ScriptedTrain.cs
+++ b/source/TrainManager/TrackFollowingObject/ScriptedTrain.cs
@@ -26,7 +26,7 @@ namespace TrainManager.Trains
 		/// <summary>Disposes of the train</summary>
 		public override void Dispose()
 		{
-			State = TrainState.Disposed;
+			State = TrainState.DisposePending;
 			for (int i = 0; i < Cars.Length; i++)
 			{
 				Cars[i].ChangeCarSection(CarSectionType.NotVisible);

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -97,9 +97,10 @@ namespace TrainManager.Trains
 		/// <summary>The direction of travel on the current track</summary>
 		public TrackDirection CurrentDirection => TrainManagerBase.CurrentRoute.Tracks[Cars[DriverCar].FrontAxle.Follower.TrackIndex].Direction;
 
-		public TrainBase(TrainState state)
+		public TrainBase(TrainState state, TrainType type)
 		{
 			State = state;
+			Type = type;
 			Destination = TrainManagerBase.CurrentOptions.InitialDestination;
 			Station = -1;
 			RouteLimits = new[] { double.PositiveInfinity };

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -1084,6 +1084,7 @@ namespace TrainManager.Trains
 			{
 				throw new Exception("Attempted to couple to something that isn't a train");
 			}
+
 			int oldCars = Cars.Length;
 			/*
 			 * NOTE: Need to set the speeds to zero for *both* trains on coupling
@@ -1147,6 +1148,10 @@ namespace TrainManager.Trains
 			{
 				trainBase.Cars[i] = new CarBase(trainBase, i);
 			}
+
+
+			string message = Translations.GetInterfaceString(HostApplication.OpenBve, Front ? new[] { "notification", "couple_front" } : new[] { "notification", "couple_rear" }).Replace("[number]", trainBase.Cars.Length.ToString());
+			TrainManagerBase.currentHost.AddMessage(message, MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
 		}
 	}
 }

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -208,7 +208,7 @@ namespace TrainManager.Trains
 		/// <summary>Disposes of the train</summary>
 		public override void Dispose()
 		{
-			State = TrainState.Disposed;
+			State = TrainState.DisposePending;
 			for (int i = 0; i < Cars.Length; i++)
 			{
 				Cars[i].ChangeCarSection(CarSectionType.NotVisible);
@@ -453,7 +453,7 @@ namespace TrainManager.Trains
 			{
 				// move cars
 				Cars[i].Move(Cars[i].CurrentSpeed * TimeElapsed);
-				if (State == TrainState.Disposed)
+				if (State >= TrainState.DisposePending)
 				{
 					return;
 				}

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -1121,7 +1121,30 @@ namespace TrainManager.Trains
 				{
 					Cars[i].ChangeCarSection(CarSectionType.Exterior);
 				}
-					
+				Cars[i].FrontAxle.Follower.Train = this;
+				Cars[i].RearAxle.Follower.Train = this;
+				Cars[i].FrontBogie.FrontAxle.Follower.Train = this;
+				Cars[i].FrontBogie.RearAxle.Follower.Train = this;
+				Cars[i].RearBogie.FrontAxle.Follower.Train = this;
+				Cars[i].RearBogie.RearAxle.Follower.Train = this;
+				if (i < Cars.Length - 1)
+				{
+					Cars[i].Coupler.connectedCar = Cars[i + 1];
+				}
+			}
+
+			Cars[0].BeaconReceiver.Train = this;
+
+			/*
+			 * Reset properties for 'old' train to empty cars
+			 * 
+			 * Due to multi-threading, we can't guarantee
+			 * that something isn't trying to access the cars
+			 * array until the *next* complete frame.
+			 */
+			for (int i = 0; i < trainBase.Cars.Length; i++)
+			{
+				trainBase.Cars[i] = new CarBase(trainBase, i);
 			}
 		}
 	}

--- a/source/TrainManager/TrainManager.cs
+++ b/source/TrainManager/TrainManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using LibRender2;
 using OpenBveApi;
 using OpenBveApi.FileSystem;
@@ -22,7 +23,7 @@ namespace TrainManager
 		internal static Random RandomNumberGenerator = new Random();
 
 		/// <summary>The list of trains available in the simulation.</summary>
-		public TrainBase[] Trains = { };
+		public List<TrainBase> Trains = new List<TrainBase>();
 		/// <summary>A reference to the train of the Trains element that corresponds to the player's train.</summary>
 		public static TrainBase PlayerTrain = null;
 		/// <summary>The list of TrackFollowingObject available on other tracks in the simulation.</summary>
@@ -43,7 +44,7 @@ namespace TrainManager
 		/// <summary>Un-derails all trains within the simulation</summary>
 		public void UnderailTrains()
 		{
-			System.Threading.Tasks.Parallel.For(0, Trains.Length, i =>
+			System.Threading.Tasks.Parallel.For(0, Trains.Count, i =>
 			{
 				UnderailTrain(Trains[i]);
 			});
@@ -71,7 +72,7 @@ namespace TrainManager
 		/// <param name="ForceUpdate">Whether this is a forced update</param>
 		public void UpdateTrainObjects(double TimeElapsed, bool ForceUpdate)
 		{
-			for (int i = 0; i < Trains.Length; i++)
+			for (int i = 0; i < Trains.Count; i++)
 			{
 				Trains[i].UpdateObjects(TimeElapsed, ForceUpdate);
 			}


### PR DESCRIPTION
This PR allows us to couple to loose cars that we've previously dropped.

Currently, driving into a train with both at less than the critical collision speed (this is a fixed 8km/h value) will couple us.

Heavy WIP, but now appears to be working correctly.

### TODO:
* Trains need a way of distinguishing what they are. TFOs have this already by virtue of being a different type, but it's not quite right.
* Need to implement a 'do you wish to couple' yes / no dialog.
* It would be useful to allow us to place loose cars independantly on the route (sidings etc) so we could pick them up - Cars from the train.xml format would seem to fit this bill, as they should contain most if not all of the properties required. Would also require a new routefile command (Single XML, containing all loose cars??) Possibly for a later PR.

### Glitches:
* ~~Beacon reciever will likely be broken.~~
* ~~Seem to need to switch back to exterior view again to get our coupled car to show.~~
* ~~It's possible to couple with a preceeding train stopped at a station. This shouldn't happen.~~
* ~~We should remove a disposed train from the list. Otherwise coupling / decoupling repeatedly causes the train list to grow exponentionally. Check if we rely on the length of this elsewhere???~~ Improved the logic, but this needs more testing.