### PR TITLE
Change: Standardize date format in logs

### DIFF
--- a/source/OpenBVE/System/Functions/CrashHandler.cs
+++ b/source/OpenBVE/System/Functions/CrashHandler.cs
@@ -94,7 +94,7 @@ namespace OpenBve
 			using (StreamWriter outputFile = new StreamWriter(CrashLog))
             {
                 //Basic information
-                outputFile.WriteLine(DateTime.Now);
+                outputFile.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
                 outputFile.WriteLine("OpenBVE " + Application.ProductVersion + " Crash Log");
                 var Platform = "Unknown";
                 if (OpenTK.Configuration.RunningOnWindows)
@@ -187,7 +187,7 @@ namespace OpenBve
 			using (StreamWriter outputFile = new StreamWriter(CrashLog))
             {
                 //Basic information
-                outputFile.WriteLine(DateTime.Now);
+                outputFile.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
                 outputFile.WriteLine("OpenBVE " + Application.ProductVersion + " Crash Log");
                 var Platform = "Unknown";
                 if (OpenTK.Configuration.RunningOnWindows)

--- a/source/OpenBveApi/System/FileSystem.cs
+++ b/source/OpenBveApi/System/FileSystem.cs
@@ -466,7 +466,7 @@ namespace OpenBveApi.FileSystem {
 			try
 			{
 				string file = System.IO.Path.Combine(SettingsFolder, "log.txt");
-				File.WriteAllText(file, @"OpenBVE Log: " + DateTime.Now + Environment.NewLine + @"Program Version: " + version + Environment.NewLine + Environment.NewLine, new UTF8Encoding(true));
+				File.WriteAllText(file, @"OpenBVE Log: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + Environment.NewLine + @"Program Version: " + version + Environment.NewLine + Environment.NewLine, new UTF8Encoding(true));
 			}
 			catch
 			{

--- a/source/TrainEditor2/Models/App.cs
+++ b/source/TrainEditor2/Models/App.cs
@@ -809,7 +809,7 @@ namespace TrainEditor2.Models
 			}
 
 			StringBuilder builder = new StringBuilder();
-			builder.AppendLine($"TrainEditor2 Log: {DateTime.Now}");
+			builder.AppendLine($"TrainEditor2 Log: {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")}");
 
 			foreach (string message in Interface.LogMessages.Select(x => $"{x.Type.ToString()}: {x.Text}"))
 			{


### PR DESCRIPTION
This PR changes the date format to `yyyy-MM-dd HH:mm:ss` when printed in OpenBVE Logs/Crash Logs, as oppose to the current behavior which varies between system locales.
This should reduce ambiguity, especially relating to places with **mm/dd** vs **dd/mm** (Not that it has happened in a puzzling manner... yet, but seems like a good idea anyway)