### PR TITLE
WIP: Speed up BVE5 map loading

### DIFF
--- a/source/Plugins/Route.Bve5/MapParser.cs
+++ b/source/Plugins/Route.Bve5/MapParser.cs
@@ -118,11 +118,7 @@ namespace Route.Bve5
 
 		private static void ConvertToBlock(string FileName, bool PreviewOnly, MapData ParseData, out RouteData RouteData)
 		{
-			RouteData = new RouteData
-			{
-				Blocks = new List<Block>(),
-				TrackKeyList = new List<string>()
-			};
+			RouteData = new RouteData();
 			// The player track
 			RouteData.TrackKeyList.Add("0");
 
@@ -179,11 +175,11 @@ namespace Route.Bve5
 			ConfirmRepeater(PreviewOnly, ParseData, RouteData);
 			ConfirmSection(PreviewOnly, ParseData, RouteData);
 			ConfirmSignal(PreviewOnly, ParseData, RouteData);
-			ConfirmBeacon(PreviewOnly, ParseData, RouteData.Blocks);
+			ConfirmBeacon(PreviewOnly, ParseData, RouteData);
 			ConfirmSpeedLimit(PreviewOnly, ParseData, RouteData);
 			ConfirmPreTrain(PreviewOnly, ParseData);
 			ConfirmLight(PreviewOnly, ParseData);
-			ConfirmCabIlluminance(PreviewOnly, ParseData, RouteData.Blocks);
+			ConfirmCabIlluminance(PreviewOnly, ParseData, RouteData);
 			ConfirmIrregularity(PreviewOnly, RouteData.Blocks);
 			ConfirmAdhesion(PreviewOnly, RouteData.Blocks);
 			ConfirmSound(PreviewOnly, ParseData, RouteData);

--- a/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
@@ -733,7 +733,7 @@ namespace Route.Bve5
 				if (j >= 0)
 				{
 					double p = Plugin.CurrentRoute.Stations[i].Stops[j].TrackPosition + Plugin.CurrentRoute.Stations[i].Stops[j].ForwardTolerance;
-					int k = Data.Blocks.FindLastIndex(Block => Block.StartingDistance <= p);
+					int k = Data.sortedBlocks.FindBlockIndex(p);
 					if (k != -1)
 					{
 						double d = p - Data.Blocks[k].StartingDistance;

--- a/source/Plugins/Route.Bve5/MapParser/ConfirmComponents.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ConfirmComponents.cs
@@ -34,7 +34,7 @@ namespace Route.Bve5
 {
 	static partial class Bve5ScenarioParser
 	{
-		private static void ConfirmCurve(List<Block> Blocks)
+		private static void ConfirmCurve(IList<Block> Blocks)
 		{
 			// Set a tentative value to a block that has not been decided.
 			for (int i = 1; i < Blocks.Count; i++)
@@ -139,7 +139,7 @@ namespace Route.Bve5
 			}
 		}
 
-		private static void ConfirmGradient(List<Block> Blocks)
+		private static void ConfirmGradient(IList<Block> Blocks)
 		{
 			// Set a tentative value to a block that has not been decided.
 			for (int i = 1; i < Blocks.Count; i++)
@@ -246,7 +246,7 @@ namespace Route.Bve5
 
 		private static void ConfirmTrack(RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			for (int j = 0; j < RouteData.TrackKeyList.Count; j++)
 			{
@@ -428,7 +428,7 @@ namespace Route.Bve5
 				return;
 			}
 
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			foreach (var Statement in ParseData.Statements)
 			{
@@ -457,7 +457,7 @@ namespace Route.Bve5
 
 						if (RailIndex != -1)
 						{
-							int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+							int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 
 							if (Blocks[BlockIndex].FreeObj[RailIndex] == null)
 							{
@@ -500,9 +500,9 @@ namespace Route.Bve5
 
 						if (RailsIndex[0] != -1 && RailsIndex[1] > 0)
 						{
-							int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+							int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 
-							Blocks[BlockIndex].Cracks.Add(new Crack
+								Blocks[BlockIndex].Cracks.Add(new Crack
 							{
 								TrackPosition = Statement.Distance,
 								Key = Statement.Key,
@@ -644,12 +644,12 @@ namespace Route.Bve5
 				RailIndex = 0;
 			}
 
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 			int LoopCount = 0;
 
 			for (double i = Repeater.StartingDistance; i < Repeater.EndingDistance; i += Repeater.Interval)
 			{
-				int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= i);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(i);
 
 				if (Blocks[BlockIndex].FreeObj[RailIndex] == null)
 				{
@@ -691,7 +691,7 @@ namespace Route.Bve5
 				return;
 			}
 
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			foreach (var Statement in ParseData.Statements)
 			{
@@ -709,7 +709,7 @@ namespace Route.Bve5
 					{
 						double?[] aspects = new double?[d.SignalAspects.Count];
 						d.SignalAspects.CopyTo(aspects, 0); // Yuck: Stored as nullable doubles
-						int Index = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+						int Index = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 						Blocks[Index].Sections.Add(new Section
 						{
 							TrackPosition = Statement.Distance,
@@ -750,7 +750,7 @@ namespace Route.Bve5
 				return;
 			}
 
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			foreach (var Statement in ParseData.Statements)
 			{
@@ -781,7 +781,7 @@ namespace Route.Bve5
 
 				if (RailIndex != -1)
 				{
-					int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+					int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 
 					if (Blocks[BlockIndex].Signals[RailIndex] == null)
 					{
@@ -812,7 +812,7 @@ namespace Route.Bve5
 			}
 		}
 
-		private static void ConfirmBeacon(bool PreviewOnly, MapData ParseData, List<Block> Blocks)
+		private static void ConfirmBeacon(bool PreviewOnly, MapData ParseData, RouteData RouteData)
 		{
 			if (PreviewOnly)
 			{
@@ -832,13 +832,13 @@ namespace Route.Bve5
 				object TempSection = d.Section;
 				object SendData = d.Senddata;
 
-				int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 
 				int Section = Convert.ToInt32(TempSection);
 				int CurrentSection = 0;
 				for (int i = BlockIndex; i >= 0; i--)
 				{
-					CurrentSection += Blocks[i].Sections.Count(s => s.TrackPosition <= Statement.Distance);
+					CurrentSection += RouteData.Blocks[i].Sections.Count(s => s.TrackPosition <= Statement.Distance);
 				}
 
 				if (Section < -1)
@@ -850,7 +850,7 @@ namespace Route.Bve5
 					Section += CurrentSection;
 				}
 
-				Blocks[BlockIndex].Transponders.Add(new Transponder
+				RouteData.Blocks[BlockIndex].Transponders.Add(new Transponder
 				{
 					TrackPosition = Statement.Distance,
 					Type = Convert.ToInt32(Type),
@@ -867,7 +867,7 @@ namespace Route.Bve5
 				return;
 			}
 
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			foreach (var Statement in ParseData.Statements)
 			{
@@ -878,7 +878,7 @@ namespace Route.Bve5
 
 				double Speed = Statement.GetArgumentValueAsDouble(ArgumentName.V);
 
-				int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 				Blocks[BlockIndex].Limits.Add(new Limit
 				{
 					TrackPosition = Statement.Distance,
@@ -1023,7 +1023,7 @@ namespace Route.Bve5
 			}
 		}
 
-		private static void ConfirmCabIlluminance(bool PreviewOnly, MapData ParseData, List<Block> Blocks)
+		private static void ConfirmCabIlluminance(bool PreviewOnly, MapData ParseData, RouteData RouteData)
 		{
 			if (PreviewOnly)
 			{
@@ -1049,8 +1049,8 @@ namespace Route.Bve5
 					Value = Value < 0.0f ? 0.0f : 1.0f;
 				}
 
-				int BlockIndex = Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
-				Blocks[BlockIndex].BrightnessChanges.Add(new Brightness
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
+				RouteData.Blocks[BlockIndex].BrightnessChanges.Add(new Brightness
 				{
 					TrackPosition = Statement.Distance,
 					Value = Value
@@ -1058,7 +1058,7 @@ namespace Route.Bve5
 			}
 		}
 
-		private static void ConfirmIrregularity(bool PreviewOnly, List<Block> Blocks)
+		private static void ConfirmIrregularity(bool PreviewOnly, IList<Block> Blocks)
 		{
 			if (PreviewOnly)
 			{
@@ -1084,7 +1084,7 @@ namespace Route.Bve5
 			}
 		}
 
-		private static void ConfirmAdhesion(bool PreviewOnly, List<Block> Blocks)
+		private static void ConfirmAdhesion(bool PreviewOnly, IList<Block> Blocks)
 		{
 			if (PreviewOnly)
 			{
@@ -1124,7 +1124,7 @@ namespace Route.Bve5
 					continue;
 				}
 
-				int BlockIndex = RouteData.Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 				RouteData.Blocks[BlockIndex].SoundEvents.Add(new Sound
 				{
 					TrackPosition = Statement.Distance,
@@ -1151,7 +1151,7 @@ namespace Route.Bve5
 				double X = Statement.GetArgumentValueAsDouble(ArgumentName.X);
 				double Y = Statement.GetArgumentValueAsDouble(ArgumentName.Y);
 
-				int BlockIndex = RouteData.Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 				RouteData.Blocks[BlockIndex].SoundEvents.Add(new Sound
 				{
 					TrackPosition = Statement.Distance,
@@ -1179,7 +1179,7 @@ namespace Route.Bve5
 
 				object Index = Statement.GetArgumentValue(ArgumentName.Index);
 
-				int BlockIndex = RouteData.Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 				RouteData.Blocks[BlockIndex].RunSounds.Add(new TrackSound
 				{
 					TrackPosition = Statement.Distance,
@@ -1204,7 +1204,7 @@ namespace Route.Bve5
 
 				object Index = Statement.GetArgumentValue(ArgumentName.Index);
 
-				int BlockIndex = RouteData.Blocks.FindLastIndex(Block => Block.StartingDistance <= Statement.Distance);
+				int BlockIndex = RouteData.sortedBlocks.FindBlockIndex(Statement.Distance);
 				RouteData.Blocks[BlockIndex].FlangeSounds.Add(new TrackSound
 				{
 					TrackPosition = Statement.Distance,

--- a/source/Plugins/Route.Bve5/MapParser/ConvertComponents.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ConvertComponents.cs
@@ -228,7 +228,7 @@ namespace Route.Bve5
 
 		private static void ConvertGradient(Statement Statement, RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			{
 				dynamic d = Statement;
@@ -375,7 +375,7 @@ namespace Route.Bve5
 
 		private static void ConvertTrack(MapData ParseData, RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			// Own track is excluded.
 			for (int railIndex = 1; railIndex < RouteData.TrackKeyList.Count; railIndex++)
@@ -840,7 +840,7 @@ namespace Route.Bve5
 
 		private static void ConvertFog(Statement Statement, RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			{
 				switch (Statement.FunctionName)
@@ -947,7 +947,7 @@ namespace Route.Bve5
 
 		private static void ConvertIrregularity(Statement Statement, RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 			{
 
 
@@ -983,7 +983,7 @@ namespace Route.Bve5
 
 		private static void ConvertAdhesion(Statement Statement, RouteData RouteData)
 		{
-			List<Block> Blocks = RouteData.Blocks;
+			IList<Block> Blocks = RouteData.Blocks;
 
 			{
 

--- a/source/Plugins/Route.Bve5/MapParser/ConvertComponents.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ConvertComponents.cs
@@ -30,7 +30,6 @@ using Bve5_Parsing.MapGrammar.EvaluateData;
 using OpenBveApi.Colors;
 using OpenBveApi.Objects;
 using OpenBveApi.Routes;
-using OpenBveApi.Sounds;
 using RouteManager2.Stations;
 
 namespace Route.Bve5
@@ -41,7 +40,7 @@ namespace Route.Bve5
 		{
 			{
 				dynamic d = Statement;
-
+				RouteData.FindOrAddBlock(Statement.Distance);
 				switch (Statement.FunctionName)
 				{
 					case MapFunctionName.SetGauge:
@@ -63,9 +62,8 @@ namespace Route.Bve5
 						break;
 					case MapFunctionName.BeginTransition:
 						{
-							int blockIndex = RouteData.FindOrAddBlock(Statement.Distance);
-							RouteData.Blocks[blockIndex].Rails[0].CurveInterpolateStart = true;
-							RouteData.Blocks[blockIndex].Rails[0].CurveTransitionStart = true;
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveTransitionStart = true;
 						}
 						break;
 					case MapFunctionName.Begin:
@@ -80,18 +78,16 @@ namespace Route.Bve5
 								Cant = Convert.ToDouble(Cant) / 1000.0;
 							}
 
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							RouteData.Blocks[Index].CurrentTrackState.CurveRadius = Convert.ToDouble(Radius);
-							RouteData.Blocks[Index].CurrentTrackState.CurveCant = Math.Abs(Convert.ToDouble(Cant)) * Math.Sign(Convert.ToDouble(Radius));
-							RouteData.Blocks[Index].Rails[0].CurveInterpolateStart = true;
-							RouteData.Blocks[Index].Rails[0].CurveTransitionEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].CurrentTrackState.CurveRadius = Convert.ToDouble(Radius);
+							RouteData.sortedBlocks[Statement.Distance].CurrentTrackState.CurveCant = Math.Abs(Convert.ToDouble(Cant)) * Math.Sign(Convert.ToDouble(Radius));
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveTransitionEnd = true;
 						}
 						break;
 					case MapFunctionName.End:
 						{
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							RouteData.Blocks[Index].Rails[0].CurveInterpolateStart = true;
-							RouteData.Blocks[Index].Rails[0].CurveTransitionEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].Rails[0].CurveTransitionEnd = true;
 						}
 						break;
 					case MapFunctionName.Interpolate:
@@ -131,8 +127,7 @@ namespace Route.Bve5
 					case MapFunctionName.Turn:
 						{
 							object Slope = d.Slope;
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							RouteData.Blocks[Index].Turn = Convert.ToDouble(Slope);
+							RouteData.sortedBlocks[Statement.Distance].Turn = Convert.ToDouble(Slope);
 						}
 						break;
 				}
@@ -232,13 +227,13 @@ namespace Route.Bve5
 
 			{
 				dynamic d = Statement;
+				RouteData.FindOrAddBlock(Statement.Distance);
 				switch (Statement.FunctionName)
 				{
 					case MapFunctionName.BeginTransition:
 						{
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							Blocks[Index].GradientInterpolateStart = true;
-							Blocks[Index].GradientTransitionStart = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientTransitionStart = true;
 						}
 						break;
 					case MapFunctionName.Begin:
@@ -246,17 +241,15 @@ namespace Route.Bve5
 					case MapFunctionName.Pitch:
 						{
 							object Gradient = Statement.FunctionName == MapFunctionName.Pitch ? d.Rate : d.Gradient;
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							Blocks[Index].Pitch = Convert.ToDouble(Gradient) / 1000.0;
-							Blocks[Index].GradientInterpolateStart = true;
-							Blocks[Index].GradientTransitionEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].Pitch = Convert.ToDouble(Gradient) / 1000.0;
+							RouteData.sortedBlocks[Statement.Distance].GradientInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientTransitionEnd = true;
 						}
 						break;
 					case MapFunctionName.End:
 						{
-							int Index = RouteData.FindOrAddBlock(Statement.Distance);
-							Blocks[Index].GradientInterpolateStart = true;
-							Blocks[Index].GradientTransitionEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientTransitionEnd = true;
 						}
 						break;
 					case MapFunctionName.Interpolate:
@@ -278,10 +271,10 @@ namespace Route.Bve5
 								Gradient = d.Gradient;
 							}
 
-							Blocks[Index].Pitch = Convert.ToDouble(Gradient) / 1000.0;
-							Blocks[Index].GradientInterpolateStart = true;
-							Blocks[Index].GradientInterpolateEnd = true;
-							Blocks[Index].GradientTransitionEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].Pitch = Convert.ToDouble(Gradient) / 1000.0;
+							RouteData.sortedBlocks[Statement.Distance].GradientInterpolateStart = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientInterpolateEnd = true;
+							RouteData.sortedBlocks[Statement.Distance].GradientTransitionEnd = true;
 						}
 						break;
 				}

--- a/source/Plugins/Route.Bve5/MapParser/Functions.cs
+++ b/source/Plugins/Route.Bve5/MapParser/Functions.cs
@@ -23,6 +23,7 @@
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -396,6 +397,70 @@ namespace Route.Bve5
 				x *= t;
 				y *= t;
 			}
+		}
+
+		public static int FindIndex<T>(this IList<T> source, Predicate<T> match)
+		{
+			for (int i = 0; i < source.Count; i++)
+			{
+				if (match(source[i]))
+				{
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		public static int FindIndex<T>(this IList<T> source, int startIndex, Predicate<T> match)
+		{
+			for (int i = startIndex; i < source.Count; i++)
+			{
+				if (match(source[i]))
+				{
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		public static int FindBlockIndex<T>(this SortedList<double, T> source, double distance)
+		{
+			if (source.ContainsKey(distance))
+			{
+				return source.IndexOfKey(distance);
+			}
+			for (int i = source.Count - 1; i > 0; i--)
+			{
+				if (source.Keys[i] <= distance)
+				{
+					return i;
+				}
+			}
+			return 0;
+		}
+
+		public static int FindLastIndex<T>(this IList<T> source, int startIndex, Predicate<T> match)
+		{
+			for (int i = startIndex; i > 0; i--)
+			{
+				if (match(source[i]))
+				{
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		public static int FindLastIndex<T>(this IList<T> source, int startIndex, int count, Predicate<T> match)
+		{
+			for (int i = startIndex; i > Math.Max(0, startIndex - count); i--)
+			{
+				if (match(source[i]))
+				{
+					return i;
+				}
+			}
+			return 0;
 		}
 	}
 }

--- a/source/Plugins/Route.Bve5/MapParser/RouteData.cs
+++ b/source/Plugins/Route.Bve5/MapParser/RouteData.cs
@@ -22,6 +22,7 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using System;
 using System.Collections.Generic;
 
 namespace Route.Bve5
@@ -30,8 +31,10 @@ namespace Route.Bve5
 	{
 		private class RouteData
 		{
-			internal List<string> TrackKeyList;
-			internal List<Block> Blocks;
+			internal readonly List<string> TrackKeyList;
+			internal readonly SortedList<double, Block> sortedBlocks;
+
+			internal IList<Block> Blocks => sortedBlocks.Values;
 			internal List<Station> StationList;
 			internal ObjectDictionary Objects;
 			internal List<Background> Backgrounds;
@@ -45,34 +48,39 @@ namespace Route.Bve5
 
 			internal double[] SignalSpeeds;
 
+			internal RouteData()
+			{
+				sortedBlocks = new SortedList<double, Block>();
+				TrackKeyList = new List<string>();
+			}
+
 			internal int FindOrAddBlock(double Distance)
 			{
-				int Index = Blocks.FindIndex(x => x.StartingDistance == Distance);
-				if (Index == -1)
+				if (sortedBlocks.ContainsKey(Distance))
 				{
-					Block NewBlock = new Block
-					{
-						Rails = new Rail[TrackKeyList.Count],
-						StartingDistance = Distance,
-						CurrentTrackState =
-						{
-							StartingTrackPosition = Distance
-						},
-						FreeObj = new List<FreeObj>[TrackKeyList.Count],
-						Cracks = new List<Crack>(),
-						Sections = new List<Section>(),
-						Signals = new List<Signal>[TrackKeyList.Count],
-						Transponders = new List<Transponder>(),
-						Limits = new List<Limit>(),
-						BrightnessChanges = new List<Brightness>(),
-						SoundEvents = new List<Sound>(),
-						RunSounds = new List<TrackSound>(),
-						FlangeSounds = new List<TrackSound>()
-					};
-					Index = Blocks.FindLastIndex(x => x.StartingDistance < Distance) + 1;
-					Blocks.Insert(Index, NewBlock);
+					return sortedBlocks.IndexOfKey(Distance);
 				}
-				return Index;
+				Block NewBlock = new Block
+				{
+					Rails = new Rail[TrackKeyList.Count],
+					StartingDistance = Distance,
+					CurrentTrackState =
+					{
+						StartingTrackPosition = Distance
+					},
+					FreeObj = new List<FreeObj>[TrackKeyList.Count],
+					Cracks = new List<Crack>(),
+					Sections = new List<Section>(),
+					Signals = new List<Signal>[TrackKeyList.Count],
+					Transponders = new List<Transponder>(),
+					Limits = new List<Limit>(),
+					BrightnessChanges = new List<Brightness>(),
+					SoundEvents = new List<Sound>(),
+					RunSounds = new List<TrackSound>(),
+					FlangeSounds = new List<TrackSound>()
+				};
+				sortedBlocks.Add(Distance, NewBlock);
+				return sortedBlocks.IndexOfKey(Distance);
 			}
 		}
 	}


### PR DESCRIPTION
BVE5 route loading is somewhat slower than I'd like at the minute.

Major issues:
1. BVE5_Parsing makes *very* heavy use of reflection, and I suspect went somewhat overboard with the number of types and casts. Future re-design project.....
2. Route.BVE5 has a lot of lists. These need to be inserted into at specific indexes, and are cloned into temp lists, both of which are slow. Need to be converted to ordered lists, and preferably the temp list cloning eliminated entirely.
3. Cycling through the list of statements is slow (as a result of the reflection issues in no 1), and this should be eliminated entirely wherever possible.