### PR TITLE
Translation Files Cleanup

### DIFF
--- a/assets/Languages/ca-ES.xlf
+++ b/assets/Languages/ca-ES.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ca-ES">
 		<body>
 			<group id="language">
@@ -86,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -125,7 +126,7 @@
 					</trans-unit>
 					<trans-unit id="updates_invalid">
 						<source>A connection to the server could be established. Unfortunately, the version information could not be retrieved.</source>
-						<target>S'ha pogut establir la connexió amb el servidor, però no s'ha pogut obtenir la informació de la versió.</target>
+						<target>S&apos;ha pogut establir la connexió amb el servidor, però no s&apos;ha pogut obtenir la informació de la versió.</target>
 					</trans-unit>
 					<trans-unit id="updates_old">
 						<source>You already have the latest version.</source>
@@ -149,11 +150,11 @@
 					</trans-unit>
 					<trans-unit id="reportbug">
 						<source>Report Problem</source>
-						<target>Informa d'un error</target>
+						<target>Informa d&apos;un error</target>
 					</trans-unit>
 					<trans-unit id="about">
 						<source>About</source>
-						<target>Quant a l'OpenBVE</target>
+						<target>Quant a l&apos;OpenBVE</target>
 					</trans-unit>
 				</group>
 				<group id="mode">
@@ -177,7 +178,7 @@
 				<group id="errors">
 					<trans-unit id="critical_file">
 						<source>A critical error occured whilst parsing the [file] file</source>
-						<target>S'ha produït un error crític en processar el fitxer «[file]»</target>
+						<target>S&apos;ha produït un error crític en processar el fitxer «[file]»</target>
 					</trans-unit>
 					<trans-unit id="filesystem_invalid">
 						<source>The file system configuration could not be accessed or is invalid due to the following reason:</source>
@@ -189,19 +190,19 @@
 					</trans-unit>
 					<trans-unit id="controls_missing">
 						<source>No control configuration files found.</source>
-						<target>No s'han trobat fitxers de configuració de controls.</target>
+						<target>No s&apos;han trobat fitxers de configuració de controls.</target>
 					</trans-unit>
 					<trans-unit id="controls_oldversion">
 						<source>An older key-configuration file was found.</source>
-						<target>S'ha trobat un fitxer antic de configuració de controls.</target>
+						<target>S&apos;ha trobat un fitxer antic de configuració de controls.</target>
 					</trans-unit>
 					<trans-unit id="controls_reset">
 						<source>The current key-configuration has been reset to defaults.</source>
-						<target>S'ha reinicialitzat la configuració de controls actual als valors per defecte.</target>
+						<target>S&apos;ha reinicialitzat la configuració de controls actual als valors per defecte.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_oldversion">
 						<source>The default key assingment file is an older version or corrupt.</source>
-						<target>El fitxer de configuració de controls per defecte és d'una versió anterior o està malmès.</target>
+						<target>El fitxer de configuració de controls per defecte és d&apos;una versió anterior o està malmès.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_missing">
 						<source>The default key assignment file does not exist.</source>
@@ -209,23 +210,23 @@
 					</trans-unit>
 					<trans-unit id="controls_ingame">
 						<source>You are currently running on the [platform] backend. Please use the in-game menu to configure any joystick based controls.</source>
-						<target>Esteu executant l'OpenBVE amb [platform]. Utilitzeu el menú intern del simulador per configurar els controls amb una palanca de control.</target>
+						<target>Esteu executant l&apos;OpenBVE amb [platform]. Utilitzeu el menú intern del simulador per configurar els controls amb una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_version">
 						<source>OpenAL 1.1 is required. You seem to have version 1.0.</source>
-						<target>Es requereix l'OpenAL 1.1. Sembla que teniu instal·lada la versió 1.0.</target>
+						<target>Es requereix l&apos;OpenAL 1.1. Sembla que teniu instal·lada la versió 1.0.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_context">
 						<source>The OpenAL context could not be created.</source>
-						<target>No s'ha pogut crear el context de l'OpenAL.</target>
+						<target>No s&apos;ha pogut crear el context de l&apos;OpenAL.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_device">
 						<source>The OpenAL sound device could not be opened.</source>
-						<target>No s'ha pogut obrir el dispositiu de so de l'OpenAL.</target>
+						<target>No s&apos;ha pogut obrir el dispositiu de so de l&apos;OpenAL.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch1">
 						<source>An error occured whilst attempting to switch to fullscreen mode.</source>
-						<target>S'ha produït un error en canviar al mode de pantalla completa.</target>
+						<target>S&apos;ha produït un error en canviar al mode de pantalla completa.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch2">
 						<source>Please check your fullscreen resolution settings.</source>
@@ -233,30 +234,27 @@
 					</trans-unit>
 					<trans-unit id="route_corrupt_withtrack">
 						<source>The selected route is corrupt: \r\n WithTrack section missing.</source>
-						<target>La ruta seleccionada està malmesa: \r\n No s'ha trobat la secció «WithTrack».</target>
+						<target>La ruta seleccionada està malmesa: \r\n No s&apos;ha trobat la secció «WithTrack».</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_nostations">
 						<source>The selected route is corrupt: \r\n No stations defined.</source>
-						<target>La ruta seleccionada està malmesa: \r\n No s'ha definit cap estació.</target>
+						<target>La ruta seleccionada està malmesa: \r\n No s&apos;ha definit cap estació.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_noobjects">
 						<source>The selected route is corrupt: \r\n No objects defined.</source>
-						<target>La ruta seleccionada està malmesa: \r\n No s'ha definit cap objecte.</target>
+						<target>La ruta seleccionada està malmesa: \r\n No s&apos;ha definit cap objecte.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_missingobjects">
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-						<target>La ruta seleccionada està malmesa. \r\n No s'han pogut trobar tots els objectes definits.</target>
-					</trans-unit>
-					<trans-unit id="route_corrupt_missingobjects">
-						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
+						<target>La ruta seleccionada està malmesa. \r\n No s&apos;han pogut trobar tots els objectes definits.</target>
 					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
-						<target>No s'ha pogut carregar l'extensió del tren «[plugin]».</target>
+						<target>No s&apos;ha pogut carregar l&apos;extensió del tren «[plugin]».</target>
 					</trans-unit>
 					<trans-unit id="plugin_failure2">
 						<source>The built-in ATS/ ATC systems will be used instead, which may cause issues.</source>
-						<target>S'utilitzaran els sistemes ATS/ATC per defecte, que podrien ser incompatibles.</target>
+						<target>S&apos;utilitzaran els sistemes ATS/ATC per defecte, que podrien ser incompatibles.</target>
 					</trans-unit>
 					<trans-unit id="package_filename_empty">
 						<source>Attempted to create a package with an empty filename.</source>
@@ -272,7 +270,7 @@
 					</trans-unit>
 					<trans-unit id="package_file_generic">
 						<source>Failed to create the following file: \r \n</source>
-						<target>No s'ha pogut crear el fitxer següent: \r \n</target>
+						<target>No s&apos;ha pogut crear el fitxer següent: \r \n</target>
 					</trans-unit>
 					<trans-unit id="security_checkaccess">
 						<source>Please check that this path is accessible.</source>
@@ -280,7 +278,13 @@
 					</trans-unit>
 					<trans-unit id="security_badlocation">
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
-						<target>Si intenteu instal·lar extensions en la carpeta «Fitxers del programa» o «ProgramData», pot ser que necessiteu permisos d'administrador. \r\n\r\n No es recomana per raons de seguretat.</target>
+						<target>Si intenteu instal·lar extensions en la carpeta «Fitxers del programa» o «ProgramData», pot ser que necessiteu permisos d&apos;administrador. \r\n\r\n No es recomana per raons de seguretat.</target>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -337,7 +341,7 @@
 					</trans-unit>
 					<trans-unit id="route_processing">
 						<source>Processing route, please wait.....</source>
-						<target>S'està processant la ruta, espereu...</target>
+						<target>S&apos;està processant la ruta, espereu...</target>
 					</trans-unit>
 					<trans-unit id="train">
 						<source>Train</source>
@@ -358,10 +362,6 @@
 					<trans-unit id="train_recently">
 						<source>Recently used</source>
 						<target>Recents</target>
-					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Tren per defecte</target>
 					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
@@ -393,11 +393,11 @@
 					</trans-unit>
 					<trans-unit id="train_notfound">
 						<source>The default train could not be found:\r\n\r\n</source>
-						<target>No s'ha trobat el tren per defecte:\r\n\r\n</target>
+						<target>No s&apos;ha trobat el tren per defecte:\r\n\r\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
 						<source>--- This train uses a safety system plugin which cannot be used on your operating system. The built-in safety systems ATS/ATC will be used instead, which might cause operational problems. ---</source>
-						<target>--- Aquest tren utilitza una extensió de sistemes de seguretat incompatible amb el vostre sistema operatiu. S'utilitzaran els sistemes ATS/ATC per defecte, que podrien ser incompatibles. ---</target>
+						<target>--- Aquest tren utilitza una extensió de sistemes de seguretat incompatible amb el vostre sistema operatiu. S&apos;utilitzaran els sistemes ATS/ATC per defecte, que podrien ser incompatibles. ---</target>
 					</trans-unit>
 					<trans-unit id="start">
 						<source>Start</source>
@@ -409,6 +409,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Inicia</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -538,7 +547,7 @@
 					</trans-unit>
 					<trans-unit id="processing">
 						<source>Processing, please wait...</source>
-						<target>S'està processant el paquet, espereu...</target>
+						<target>S&apos;està processant el paquet, espereu...</target>
 					</trans-unit>
 					<trans-unit id="unknown_file">
 						<source>Unknown File...</source>
@@ -602,11 +611,11 @@
 					</trans-unit>
 					<trans-unit id="install_header">
 						<source>Install a Package</source>
-						<target>Instal·lació d'un paquet</target>
+						<target>Instal·lació d&apos;un paquet</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>Aquest fitxer no és un paquet vàlid per a l'OpenBVE.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Aquest fitxer no és un paquet vàlid per a l&apos;OpenBVE.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -626,7 +635,7 @@
 					</trans-unit>
 					<trans-unit id="install_success">
 						<source>Package installation was successful.</source>
-						<target>S'ha instal·lat el paquet correctament.</target>
+						<target>S&apos;ha instal·lat el paquet correctament.</target>
 					</trans-unit>
 					<trans-unit id="install_success_header">
 						<source>Installation Successful</source>
@@ -638,11 +647,11 @@
 					</trans-unit>
 					<trans-unit id="install_failure">
 						<source>Unfortunately, package installation failed.</source>
-						<target>S'ha produït un error en instal·lar el paquet.</target>
+						<target>S&apos;ha produït un error en instal·lar el paquet.</target>
 					</trans-unit>
 					<trans-unit id="install_failure_header">
 						<source>Package Installation Failed</source>
-						<target>Error d'instal·lació</target>
+						<target>Error d&apos;instal·lació</target>
 					</trans-unit>
 					<trans-unit id="install_select">
 						<source>Select Package......</source>
@@ -694,7 +703,7 @@
 					</trans-unit>
 					<trans-unit id="creation_header">
 						<source>Create a Package</source>
-						<target>Creació d'un paquet</target>
+						<target>Creació d&apos;un paquet</target>
 					</trans-unit>
 					<trans-unit id="creation_saveas_button">
 						<source>Save As...</source>
@@ -717,8 +726,8 @@
 						<target>Suprimeix</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -742,9 +751,9 @@
 					</trans-unit>
 					<trans-unit id="creation_new_guid">
 						<source>The new package has been assigned the following GUID:</source>
-						<target>S'ha assignat l'identificador següent al paquet nou:</target>
+						<target>S&apos;ha assignat l&apos;identificador següent al paquet nou:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -769,7 +778,7 @@
 					</trans-unit>
 					<trans-unit id="creation_success">
 						<source>Package creation was successful.</source>
-						<target>S'ha creat el paquet correctament.</target>
+						<target>S&apos;ha creat el paquet correctament.</target>
 					</trans-unit>
 					<trans-unit id="creation_success_header">
 						<source>Package Creation Successful</source>
@@ -777,11 +786,11 @@
 					</trans-unit>
 					<trans-unit id="creation_success_files">
 						<source>The following files were added to your package:</source>
-						<target>S'han afegit els fitxers següents al paquet:</target>
+						<target>S&apos;han afegit els fitxers següents al paquet:</target>
 					</trans-unit>
 					<trans-unit id="creation_failure">
 						<source>Unfortunately, creation of your package failed.</source>
-						<target>S'ha produït un error en crear el paquet.</target>
+						<target>S&apos;ha produït un error en crear el paquet.</target>
 					</trans-unit>
 					<trans-unit id="creation_failure_header">
 						<source>Package Creation Failed</source>
@@ -789,7 +798,7 @@
 					</trans-unit>
 					<trans-unit id="creation_failure_error">
 						<source>The following error was encountered:</source>
-						<target>S'ha trobat el problema següent:</target>
+						<target>S&apos;ha trobat el problema següent:</target>
 					</trans-unit>
 					<trans-unit id="creation_proceed">
 						<source>Proceed......</source>
@@ -805,11 +814,11 @@
 					</trans-unit>
 					<trans-unit id="creation_new_id">
 						<source>The new package has been assigned the following GUID:</source>
-						<target>S'ha assignat l'identificador següent al paquet nou:</target>
+						<target>S&apos;ha assignat l&apos;identificador següent al paquet nou:</target>
 					</trans-unit>
 					<trans-unit id="creation_replace_id">
 						<source>Replacing the package with the following GUID:</source>
-						<target>Es reemplaçarà el paquet amb l'identificador següent:</target>
+						<target>Es reemplaçarà el paquet amb l&apos;identificador següent:</target>
 					</trans-unit>
 					<trans-unit id="creation_save">
 						<source>Save Package</source>
@@ -857,7 +866,7 @@
 					</trans-unit>
 					<trans-unit id="uninstall_failure">
 						<source>Unfortunately, uninstallation of this package failed.</source>
-						<target>S'ha produït un error en desinstal·lar el paquet.</target>
+						<target>S&apos;ha produït un error en desinstal·lar el paquet.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_failure_header">
 						<source>Uninstallation Failed</source>
@@ -865,7 +874,7 @@
 					</trans-unit>
 					<trans-unit id="uninstall_success">
 						<source>Uninstallation of this package was successful.</source>
-						<target>S'ha desinstal·lat el paquet correctament.</target>
+						<target>S&apos;ha desinstal·lat el paquet correctament.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_success_header">
 						<source>Uninstallation Successful</source>
@@ -885,7 +894,7 @@
 					</trans-unit>
 					<trans-unit id="uninstall_missing_xml">
 						<source>Unable to uninstall the selected package. \r\n XML file list missing.</source>
-						<target>No s'ha pogut desinstal·lar el paquet seleccionat. \r\n No s'ha trobat la llista de fitxers XML.</target>
+						<target>No s&apos;ha pogut desinstal·lar el paquet seleccionat. \r\n No s&apos;ha trobat la llista de fitxers XML.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_database_remove">
 						<source>Do you wish to remove this package from the database?</source>
@@ -893,7 +902,7 @@
 					</trans-unit>
 					<trans-unit id="database_save_error">
 						<source>An error occured whilst saving the package database. \r\n Please check for write permissions.</source>
-						<target>S'ha produït un error en desar la base de dades de paquets. \r\n Comproveu els permisos d'escriptura.</target>
+						<target>S&apos;ha produït un error en desar la base de dades de paquets. \r\n Comproveu els permisos d&apos;escriptura.</target>
 					</trans-unit>
 					<trans-unit id="version_new">
 						<source>New version:</source>
@@ -929,7 +938,7 @@
 					</trans-unit>
 					<trans-unit id="error_replace">
 						<source>Replace</source>
-						<target>Reemplaça'l</target>
+						<target>Reemplaça&apos;l</target>
 					</trans-unit>
 					<trans-unit id="button_next">
 						<source>Next &gt;</source>
@@ -945,7 +954,7 @@
 					</trans-unit>
 					<trans-unit id="button_ok">
 						<source>OK</source>
-						<target>D'acord</target>
+						<target>D&apos;acord</target>
 					</trans-unit>
 					<trans-unit id="button_install">
 						<source>Install</source>
@@ -977,15 +986,15 @@
 					</trans-unit>
 					<trans-unit id="file_generic">
 						<source>Failed to create the following file: \r \n</source>
-						<target>No s'ha pogut crear el fitxer següent: \r \n</target>
+						<target>No s&apos;ha pogut crear el fitxer següent: \r \n</target>
 					</trans-unit>
 					<trans-unit id="database_newer_expected">
 						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
-						<target>Sembla que la versió de la base de dades de paquets és més recent que l'admesa per aquesta còpia de l'OpenBVE.</target>
+						<target>Sembla que la versió de la base de dades de paquets és més recent que l&apos;admesa per aquesta còpia de l&apos;OpenBVE.</target>
 					</trans-unit>
 					<trans-unit id="database_invalid_xml">
 						<source>The package database XML was invalid, and has been re-created.</source>
-						<target>El format XML de la base de dades de paquets no era vàlid i s'ha recreat.</target>
+						<target>El format XML de la base de dades de paquets no era vàlid i s&apos;ha recreat.</target>
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
@@ -1111,7 +1120,7 @@
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab">
 						<source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
-						<target>Feu clic aquí per a habilitar la captura de la palanca de control i seleccionar automàticament l'eix, el botó o el control direccional desitjat.</target>
+						<target>Feu clic aquí per a habilitar la captura de la palanca de control i seleccionar automàticament l&apos;eix, el botó o el control direccional desitjat.</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_normal">
 						<source>Press a button or move an axis or hat into the desired direction...</source>
@@ -1237,75 +1246,75 @@
 					</trans-unit>
 					<trans-unit id="notdetected">
 						<source>No RailDriver controllers detected.</source>
-						<target>No s'ha detectat cap dispositiu RailDriver.</target>
+						<target>No s&apos;ha detectat cap dispositiu RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="config_error">
 						<source>Error loading RailDriver calibration file.</source>
-						<target>S'ha produït un error en carregar el fitxer de calibratge de RailDriver.</target>
+						<target>S&apos;ha produït un error en carregar el fitxer de calibratge de RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
 						<target>Seleccioneu «Següent» per a iniciar el calibratge.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Moveu la palanca de l'inversor a la posició màxima de marxa enrere i seleccioneu «Següent».</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca de l&apos;inversor a la posició màxima de marxa enrere i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Moveu la palanca de l'inversor a la posició màxima de marxa endavant i seleccioneu «Següent».</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca de l&apos;inversor a la posició màxima de marxa endavant i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
 						<target>Moveu el regulador combinat a la posició màxima de tracció i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
 						<target>Moveu el regulador combinat a la posició màxima de fre i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Moveu la palanca de fre dinàmic a la posició d'alliberament i seleccioneu «Següent».</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca de fre dinàmic a la posició d&apos;alliberament i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Moveu la palanca de fre dinàmic a la posició d'emergència i seleccioneu «Següent».</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca de fre dinàmic a la posició d&apos;emergència i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Moveu la palanca de fre independent a la posició d'alliberament i seleccioneu «Següent».</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca de fre independent a la posició d&apos;alliberament i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
 						<target>Moveu la palanca de fre independent a la posició màxima de fre i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Moveu la palanca d'alliberament de frens a la posició d'alliberament i seleccioneu «Següent».</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Moveu la palanca d&apos;alliberament de frens a la posició d&apos;alliberament i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Moveu i manteniu la palanca d'alliberament de frens a la posició màxima de fre i seleccioneu «Següent».</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Moveu i manteniu la palanca d&apos;alliberament de frens a la posició màxima de fre i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Apagueu l'interruptor de l'eixugaparabrisa i seleccioneu «Següent».</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Apagueu l&apos;interruptor de l&apos;eixugaparabrisa i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Enceneu l'interruptor de l'eixugaparabrisa i seleccioneu «Següent».</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Enceneu l&apos;interruptor de l&apos;eixugaparabrisa i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Apagueu l'interruptor dels fars i seleccioneu «Següent».</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Apagueu l&apos;interruptor dels fars i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Enceneu l'interruptor dels fars i seleccioneu «Següent».</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Enceneu l&apos;interruptor dels fars i seleccioneu «Següent».</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
-						<target>S'ha completat el calibratge.</target>
+						<target>S&apos;ha completat el calibratge.</target>
 					</trans-unit>
 				</group>
 				<group id="options">
@@ -1502,7 +1511,7 @@
 					</trans-unit>
 					<trans-unit id="misc_controls_ebaxis">
 						<source>Allow EB on brake axis</source>
-						<target>Fre d'emergència en l'eix del fre</target>
+						<target>Fre d&apos;emergència en l&apos;eix del fre</target>
 					</trans-unit>
 					<trans-unit id="misc_sound">
 						<source>Sound</source>
@@ -1534,11 +1543,11 @@
 					</trans-unit>
 					<trans-unit id="verbosity_warningmessages">
 						<source>Show warning messages</source>
-						<target>Mostra els missatges d'avís</target>
+						<target>Mostra els missatges d&apos;avís</target>
 					</trans-unit>
 					<trans-unit id="verbosity_errormessages">
 						<source>Show error messages</source>
-						<target>Mostra els missatges d'error</target>
+						<target>Mostra els missatges d&apos;error</target>
 					</trans-unit>
 					<trans-unit id="verbosity_accessibilityaids">
 						<source>Accessibility Aids</source>
@@ -1574,7 +1583,7 @@
 					</trans-unit>
 					<trans-unit id="other_timetable_mode">
 						<source>Timetable mode:</source>
-						<target>Mode d'horari:</target>
+						<target>Mode d&apos;horari:</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_none">
 						<source>None</source>
@@ -1590,7 +1599,7 @@
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_prefercustom">
 						<source>Prefer custom timetable</source>
-						<target>Prefereix l'horari personalitzat</target>
+						<target>Prefereix l&apos;horari personalitzat</target>
 					</trans-unit>
 					<trans-unit id="package_choose">
 						<source>Choose...</source>
@@ -1598,15 +1607,15 @@
 					</trans-unit>
 					<trans-unit id="package_route_directory">
 						<source>Route installation directory:</source>
-						<target>Carpeta d'instal·lació de rutes:</target>
+						<target>Carpeta d&apos;instal·lació de rutes:</target>
 					</trans-unit>
 					<trans-unit id="package_train_directory">
 						<source>Train installation directory:</source>
-						<target>Carpeta d'instal·lació de trens:</target>
+						<target>Carpeta d&apos;instal·lació de trens:</target>
 					</trans-unit>
 					<trans-unit id="package_other_directory">
 						<source>Other items installation directory:</source>
-						<target>Carpeta d'instal·lació d'altres paquets:</target>
+						<target>Carpeta d&apos;instal·lació d&apos;altres paquets:</target>
 					</trans-unit>
 					<trans-unit id="package_compression">
 						<source>Package compression format:</source>
@@ -1630,7 +1639,7 @@
 					</trans-unit>
 					<trans-unit id="kiosk_mode_timer">
 						<source>Control Timeout (s)</source>
-						<target>Temps d'espera dels controls (segons)</target>
+						<target>Temps d&apos;espera dels controls (segons)</target>
 					</trans-unit>
 					<trans-unit id="hud_size">
 						<source>HUD Size</source>
@@ -1662,11 +1671,11 @@
 					</trans-unit>
 					<trans-unit id="input_device_plugin">
 						<source>Input Device Plugin</source>
-						<target>Extensions de dispositius d'entrada</target>
+						<target>Extensions de dispositius d&apos;entrada</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_warning">
 						<source>WARNING: If you enable Input Device Plugin(s), these may conflict with one or more controls.</source>
-						<target>AVÍS: si habiliteu les extensions de dispositius d'entrada, poden entrar en conflicte amb un o més controls.</target>
+						<target>AVÍS: si habiliteu les extensions de dispositius d&apos;entrada, poden entrar en conflicte amb un o més controls.</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_name">
 						<source>Name</source>
@@ -1702,7 +1711,7 @@
 					</trans-unit>
 					<trans-unit id="input_device_plugin_switch">
 						<source>Enable this Input Device Plugin</source>
-						<target>Habilita aquesta extensió de dispositiu d'entrada</target>
+						<target>Habilita aquesta extensió de dispositiu d&apos;entrada</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_config">
 						<source>Config</source>
@@ -1718,15 +1727,18 @@
 					</trans-unit>
 					<trans-unit id="xobject_parser">
 						<source>X Object Parser</source>
-						<target>Processador d'objectes X</target>
+						<target>Processador d&apos;objectes X</target>
 					</trans-unit>
 					<trans-unit id="objobject_parser">
 						<source>OBJ Object Parser</source>
-						<target>Processador d'objectes OBJ</target>
+						<target>Processador d&apos;objectes OBJ</target>
 					</trans-unit>
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 						<target>Senyals per defecte:</target>
+					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
 					</trans-unit>
 				</group>
 				<group id="dialog">
@@ -1817,15 +1829,15 @@
 				<group id="loading">
 					<trans-unit id="loading">
 						<source>Loading</source>
-						<target>S'està carregant...</target>
+						<target>S&apos;està carregant...</target>
 					</trans-unit>
 					<trans-unit id="loading_route">
 						<source>Loading route...</source>
-						<target>S'està carregant la ruta...</target>
+						<target>S&apos;està carregant la ruta...</target>
 					</trans-unit>
 					<trans-unit id="loading_train">
 						<source>Loading train...</source>
-						<target>S'està carregant el tren...</target>
+						<target>S&apos;està carregant el tren...</target>
 					</trans-unit>
 					<trans-unit id="almost">
 						<source>Almost ready to start</source>
@@ -1833,15 +1845,15 @@
 					</trans-unit>
 					<trans-unit id="almost_filesnotfound">
 						<source>Files not found:</source>
-						<target>No s'han trobat els fitxers següents:</target>
+						<target>No s&apos;han trobat els fitxers següents:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
 						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
-						<target>S'han detectat alguns problemes en carregar la ruta i el tren.\r\n\r\nCom que no s'han trobat alguns fitxers, pot ser que la ruta o el tren no apareguin de la manera desitjada. Proveu de tornar a baixar la ruta i el tren per comprovar que teniu una distribució completa.\r\n\r\nLa llista de conflictes següent us pot proporcionar informació addicional. Feu clic en el botó «Ignora» per a iniciar la ruta igualment.</target>
+						<target>S&apos;han detectat alguns problemes en carregar la ruta i el tren.\r\n\r\nCom que no s&apos;han trobat alguns fitxers, pot ser que la ruta o el tren no apareguin de la manera desitjada. Proveu de tornar a baixar la ruta i el tren per comprovar que teniu una distribució completa.\r\n\r\nLa llista de conflictes següent us pot proporcionar informació addicional. Feu clic en el botó «Ignora» per a iniciar la ruta igualment.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
 						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
-						<target>S'han detectat alguns problemes en carregar la ruta i el tren. Si en sou el creador, valdria la pena fer una ullada a la llista de conflictes següent.\r\n\r\nSi sou un usuari normal, podeu fer clic en «Ignora» per a iniciar la simulació.</target>
+						<target>S&apos;han detectat alguns problemes en carregar la ruta i el tren. Si en sou el creador, valdria la pena fer una ullada a la llista de conflictes següent.\r\n\r\nSi sou un usuari normal, podeu fer clic en «Ignora» per a iniciar la simulació.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1883,7 +1895,7 @@
 					</trans-unit>
 					<trans-unit id="stationname">
 						<source>Station name</source>
-						<target>Nom de l'estació</target>
+						<target>Nom de l&apos;estació</target>
 					</trans-unit>
 					<trans-unit id="arrivaltime">
 						<source>Arrival</source>
@@ -1905,7 +1917,7 @@
 					</trans-unit>
 					<trans-unit id="signal_stop">
 						<source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
-						<target>Heu ultrapassat un senyal d'aturada. Apliqueu immediatament els frens d'emergència i atureu completament el tren.</target>
+						<target>Heu ultrapassat un senyal d&apos;aturada. Apliqueu immediatament els frens d&apos;emergència i atureu completament el tren.</target>
 					</trans-unit>
 					<trans-unit id="signal_overspeed">
 						<source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
@@ -1925,7 +1937,7 @@
 					</trans-unit>
 					<trans-unit id="route_nextsection_aspect">
 						<source>Next signal in [distance], with aspect [aspect]</source>
-						<target>Pròxim senyal en [distance] amb l'aspecte [aspect]</target>
+						<target>Pròxim senyal en [distance] amb l&apos;aspecte [aspect]</target>
 					</trans-unit>
 					<trans-unit id="route_nextstation">
 						<source>Next station is [name] in [distance]</source>
@@ -1941,7 +1953,7 @@
 					</trans-unit>
 					<trans-unit id="station_arrival_early">
 						<source>You have arrived at [name] and are [time] early.</source>
-						<target>Heu arribat a [name] amb [time] d'antelació.</target>
+						<target>Heu arribat a [name] amb [time] d&apos;antelació.</target>
 					</trans-unit>
 					<trans-unit id="station_overrun">
 						<source>Overrun: [difference] m.</source>
@@ -1953,7 +1965,7 @@
 					</trans-unit>
 					<trans-unit id="station_terminal">
 						<source>This is the terminal station.</source>
-						<target>Aquesta és l'estació terminal.</target>
+						<target>Aquesta és l&apos;estació terminal.</target>
 					</trans-unit>
 					<trans-unit id="station_deadline">
 						<source>Departure is expected in [time].</source>
@@ -1969,11 +1981,11 @@
 					</trans-unit>
 					<trans-unit id="station_depart_closedoors">
 						<source>Boarding complete. You may close the doors now.</source>
-						<target>S'ha completat l'embarcament. Ara podeu tancar les portes.</target>
+						<target>S&apos;ha completat l&apos;embarcament. Ara podeu tancar les portes.</target>
 					</trans-unit>
 					<trans-unit id="station_depart">
 						<source>Boarding complete.</source>
-						<target>S'ha completat l'embarcament.</target>
+						<target>S&apos;ha completat l&apos;embarcament.</target>
 					</trans-unit>
 					<trans-unit id="station_passed">
 						<source>You have passed [name] where you should have stopped.</source>
@@ -1984,7 +1996,7 @@
 						<target>Heu sortit de [name] amb les portes obertes. Atureu-vos immediatament.</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>La velocitat actual del tren és de [speed]</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2056,6 +2068,21 @@
 						<source>Mouse grab: off</source>
 						<target>Rotació de la càmera amb el ratolí: desactivada</target>
 					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
+					</trans-unit>
 				</group>
 				<group id="score">
 					<trans-unit id="overspeed">
@@ -2084,7 +2111,7 @@
 					</trans-unit>
 					<trans-unit id="station_arrived">
 						<source>Arrived at station</source>
-						<target>Arribada a l'estació</target>
+						<target>Arribada a l&apos;estació</target>
 					</trans-unit>
 					<trans-unit id="station_perfecttime">
 						<source>Perfect time bonus</source>
@@ -2104,7 +2131,7 @@
 					</trans-unit>
 					<trans-unit id="station_departure">
 						<source>Premature departure</source>
-						<target>Sortida abans d'hora</target>
+						<target>Sortida abans d&apos;hora</target>
 					</trans-unit>
 					<trans-unit id="station_total">
 						<source>Total</source>
@@ -2217,7 +2244,7 @@
 					</trans-unit>
 					<trans-unit id="assign">
 						<source>Please press any key or move a joystick axis to set this control...</source>
-						<target>Premeu qualsevol tecla o moveu un eix d'una palanca de control per a configurar aquest control...</target>
+						<target>Premeu qualsevol tecla o moveu un eix d&apos;una palanca de control per a configurar aquest control...</target>
 					</trans-unit>
 					<trans-unit id="keyboard">
 						<source>Keyboard</source>
@@ -2242,6 +2269,16 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Assignació actual:</target>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Tren per defecte</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2295,7 +2332,7 @@
 					</trans-unit>
 					<trans-unit id="eb">
 						<source>EB</source>
-						<target>FRE D'EMERGÈNCIA</target>
+						<target>FRE D&apos;EMERGÈNCIA</target>
 					</trans-unit>
 					<trans-unit id="constspeed">
 						<source>CONST SPEED</source>
@@ -2380,11 +2417,11 @@
 					</trans-unit>
 					<trans-unit id="power_halfaxis">
 						<source>Controls power for trains with two handles on half of a joystick axis</source>
-						<target>Controla el regulador en els trens amb dues manetes amb la meitat de l'eix d'una palanca de control.</target>
+						<target>Controla el regulador en els trens amb dues manetes amb la meitat de l&apos;eix d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="power_fullaxis">
 						<source>Controls power for trains with two handles on a full joystick axis</source>
-						<target>Controla el regulador en els trens amb dues manetes amb l'eix complet d'una palanca de control.</target>
+						<target>Controla el regulador en els trens amb dues manetes amb l&apos;eix complet d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="brake_decrease">
 						<source>Decreases brake by one notch for trains with two handles</source>
@@ -2402,15 +2439,15 @@
 					</trans-unit>
 					<trans-unit id="brake_halfaxis">
 						<source>Controls brake for trains with two handles on half of a joystick axis</source>
-						<target>Controla el fre en els trens amb dues manetes amb la meitat de l'eix d'una palanca de control.</target>
+						<target>Controla el fre en els trens amb dues manetes amb la meitat de l&apos;eix d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="brake_fullaxis">
 						<source>Controls brake for trains with two handles on a full joystick axis</source>
-						<target>Controla el fre en els trens amb dues manetes amb l'eix complet d'una palanca de control.</target>
+						<target>Controla el fre en els trens amb dues manetes amb l&apos;eix complet d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="brake_emergency">
 						<source>Activates emergency brakes for trains with two handles</source>
-						<target>Activa el fre d'emergència en els trens amb dues manetes.</target>
+						<target>Activa el fre d&apos;emergència en els trens amb dues manetes.</target>
 					</trans-unit>
 					<trans-unit id="single_power">
 						<source>Moves handle toward power by one notch for trains with one handle</source>
@@ -2426,23 +2463,23 @@
 					</trans-unit>
 					<trans-unit id="single_emergency">
 						<source>Activates emergency brake for trains with one handle</source>
-						<target>Activa el fre d'emergència en els trens amb una maneta.</target>
+						<target>Activa el fre d&apos;emergència en els trens amb una maneta.</target>
 					</trans-unit>
 					<trans-unit id="single_fullaxis">
 						<source>Controls power and brake for trains with one handle on a full joystick axis</source>
-						<target>Controla el regulador i el fre en els trens amb una maneta amb l'eix complet d'una palanca de control.</target>
+						<target>Controla el regulador i el fre en els trens amb una maneta amb l&apos;eix complet d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="power_any_notch">
 						<source>Adjusts the power notch directly from a command option value.</source>
-						<target>Ajusta la posició de tracció del regulador directament a partir del valor d'una opció d'ordre.</target>
+						<target>Ajusta la posició de tracció del regulador directament a partir del valor d&apos;una opció d&apos;ordre.</target>
 					</trans-unit>
 					<trans-unit id="brake_any_notch">
 						<source>Adjusts the brake notch directly from a command option value.</source>
-						<target>Ajusta la posició de fre del regulador directament a partir del valor d'una opció d'ordre.</target>
+						<target>Ajusta la posició de fre del regulador directament a partir del valor d&apos;una opció d&apos;ordre.</target>
 					</trans-unit>
 					<trans-unit id="reverser_any_position">
 						<source>Adjusts the reverser directly from a command option value.</source>
-						<target>Ajusta la posició de l'inversor directament a partir del valor d'una opció d'ordre.</target>
+						<target>Ajusta la posició de l&apos;inversor directament a partir del valor d&apos;una opció d&apos;ordre.</target>
 					</trans-unit>
 					<trans-unit id="hold_brake">
 						<source>Hold Brake</source>
@@ -2450,19 +2487,19 @@
 					</trans-unit>
 					<trans-unit id="reverser_forward">
 						<source>Moves reverser forward by one notch</source>
-						<target>Mou l'inversor una posició endavant.</target>
+						<target>Mou l&apos;inversor una posició endavant.</target>
 					</trans-unit>
 					<trans-unit id="reverser_backward">
 						<source>Moves reverser backward by one notch</source>
-						<target>Mou l'inversor una posició enrere.</target>
+						<target>Mou l&apos;inversor una posició enrere.</target>
 					</trans-unit>
 					<trans-unit id="reverser_fullaxis">
 						<source>Controls reverser on a full joystick axis</source>
-						<target>Controla l'inversor amb l'eix complet d'una palanca de control.</target>
+						<target>Controla l&apos;inversor amb l&apos;eix complet d&apos;una palanca de control.</target>
 					</trans-unit>
 					<trans-unit id="doors_left">
 						<source>Opens or closes the left doors</source>
-						<target>Obre o tanca les portes de l'esquerra.</target>
+						<target>Obre o tanca les portes de l&apos;esquerra.</target>
 					</trans-unit>
 					<trans-unit id="doors_right">
 						<source>Opens or closes the right doors</source>
@@ -2577,15 +2614,15 @@
 						<target>Funció P del sistema de seguretat.</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Canvia a la vista interior del tren.</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>Canvia a la vista interior del tren, però sense mostrar la cabina.</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Canvia a la vista exterior del tren.</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2606,7 +2643,7 @@
 					</trans-unit>
 					<trans-unit id="camera_move_left">
 						<source>Moves the camera left</source>
-						<target>Mou la càmera a l'esquerra.</target>
+						<target>Mou la càmera a l&apos;esquerra.</target>
 					</trans-unit>
 					<trans-unit id="camera_move_right">
 						<source>Moves the camera right</source>
@@ -2622,7 +2659,7 @@
 					</trans-unit>
 					<trans-unit id="camera_rotate_left">
 						<source>Rotates the camera left</source>
-						<target>Gira la càmera a l'esquerra.</target>
+						<target>Gira la càmera a l&apos;esquerra.</target>
 					</trans-unit>
 					<trans-unit id="camera_rotate_right">
 						<source>Rotates the camera right</source>
@@ -2654,11 +2691,11 @@
 					</trans-unit>
 					<trans-unit id="camera_poi_previous">
 						<source>Jumps to the previous point of interest in the route.</source>
-						<target>Salta al punt d'interès anterior de la ruta.</target>
+						<target>Salta al punt d&apos;interès anterior de la ruta.</target>
 					</trans-unit>
 					<trans-unit id="camera_poi_next">
 						<source>Jumps to the next point of interest in the route.</source>
-						<target>Salta al punt d'interès següent de la ruta.</target>
+						<target>Salta al punt d&apos;interès següent de la ruta.</target>
 					</trans-unit>
 					<trans-unit id="camera_reset">
 						<source>Resets the camera view to default values</source>
@@ -2670,15 +2707,15 @@
 					</trans-unit>
 					<trans-unit id="timetable_toggle">
 						<source>Toggles through different timetable modes</source>
-						<target>Canvia entre els diferents modes d'horari.</target>
+						<target>Canvia entre els diferents modes d&apos;horari.</target>
 					</trans-unit>
 					<trans-unit id="timetable_up">
 						<source>Scrolls the timetable up</source>
-						<target>Mou l'horari amunt.</target>
+						<target>Mou l&apos;horari amunt.</target>
 					</trans-unit>
 					<trans-unit id="timetable_down">
 						<source>Scrolls the timetable down</source>
-						<target>Mou l'horari avall.</target>
+						<target>Mou l&apos;horari avall.</target>
 					</trans-unit>
 					<trans-unit id="menu_activate">
 						<source>Displays the in-game menu</source>
@@ -2694,7 +2731,7 @@
 					</trans-unit>
 					<trans-unit id="menu_enter">
 						<source>Performs the selected command within the in-game menu</source>
-						<target>Realitza l'ordre seleccionada en el menú intern.</target>
+						<target>Realitza l&apos;ordre seleccionada en el menú intern.</target>
 					</trans-unit>
 					<trans-unit id="menu_back">
 						<source>Goes back within the in-game menu</source>
@@ -2718,7 +2755,7 @@
 					</trans-unit>
 					<trans-unit id="misc_timefactor">
 						<source>Toggles through different time acceleration factors</source>
-						<target>Canvia entre diferents factors d'acceleració temporal.</target>
+						<target>Canvia entre diferents factors d&apos;acceleració temporal.</target>
 					</trans-unit>
 					<trans-unit id="misc_fps">
 						<source>Shows or hides the frame rate display</source>
@@ -2746,7 +2783,7 @@
 					</trans-unit>
 					<trans-unit id="misc_interface">
 						<source>Toggles through different interface modes</source>
-						<target>Canvia entre diferents modes d'interfície.</target>
+						<target>Canvia entre diferents modes d&apos;interfície.</target>
 					</trans-unit>
 					<trans-unit id="misc_backface">
 						<source>Activates or deactivates backface culling</source>
@@ -2770,7 +2807,7 @@
 					</trans-unit>
 					<trans-unit id="debug_ats">
 						<source>Shows or hides plugin debug output</source>
-						<target>Mostra o oculta la sortida de depuració de l'extensió.</target>
+						<target>Mostra o oculta la sortida de depuració de l&apos;extensió.</target>
 					</trans-unit>
 					<trans-unit id="debug_touch_mode">
 						<source>Shows or hides the touch range</source>
@@ -2778,11 +2815,11 @@
 					</trans-unit>
 					<trans-unit id="route_information">
 						<source>Shows or hides the route information window</source>
-						<target>Mostra o amaga la finestra d'informació de la ruta.</target>
+						<target>Mostra o amaga la finestra d&apos;informació de la ruta.</target>
 					</trans-unit>
 					<trans-unit id="show_events">
 						<source>Shows or hides event markers (For developers)</source>
-						<target>Mostra o amaga els marcadors d'esdeveniment (per a desenvolupadors).</target>
+						<target>Mostra o amaga els marcadors d&apos;esdeveniment (per a desenvolupadors).</target>
 					</trans-unit>
 					<trans-unit id="debug_renderer_mode">
 						<source>Toggles the renderer</source>
@@ -2790,11 +2827,11 @@
 					</trans-unit>
 					<trans-unit id="wiper_speed_up">
 						<source>Increases the speed of the windscreen wipers</source>
-						<target>Incrementa la velocitat de l'eixugaparabrisa.</target>
+						<target>Incrementa la velocitat de l&apos;eixugaparabrisa.</target>
 					</trans-unit>
 					<trans-unit id="wiper_speed_down">
 						<source>Decreases the speed of the windscreen wipers</source>
-						<target>Redueix la velocitat de l'eixugaparabrisa.</target>
+						<target>Redueix la velocitat de l&apos;eixugaparabrisa.</target>
 					</trans-unit>
 					<trans-unit id="fill_fuel">
 						<source>Fills fuel</source>
@@ -2806,11 +2843,11 @@
 					</trans-unit>
 					<trans-unit id="live_steam_injector">
 						<source>Activates or deactivates the live steam injector</source>
-						<target>Activa o desactiva l'injector de vapor viu.</target>
+						<target>Activa o desactiva l&apos;injector de vapor viu.</target>
 					</trans-unit>
 					<trans-unit id="exhaust_steam_injector">
 						<source>Activates or deactivates the exhaust steam injector</source>
-						<target>Activa o desactiva l'injector de vapor d'escapament.</target>
+						<target>Activa o desactiva l&apos;injector de vapor d&apos;escapament.</target>
 					</trans-unit>
 					<trans-unit id="increase_cutoff">
 						<source>Increases the cutoff</source>
@@ -2855,6 +2892,24 @@
 					<trans-unit id="raildriver_speed_units">
 						<source>Toggles the RailDriver speed display units.</source>
 						<target>Canvia les unitats de visualització de la velocitat de RailDriver.</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3438,15 +3493,15 @@
 					</trans-unit>
 					<trans-unit id="calibrate_button">
 						<source>Hold the [button] button in the controller and press OK.</source>
-						<target>Manteniu premut el botó [button] del comandament i premeu «D'acord».</target>
+						<target>Manteniu premut el botó [button] del comandament i premeu «D&apos;acord».</target>
 					</trans-unit>
 					<trans-unit id="calibrate_brake">
 						<source>Move the brake handle to [notch] and press OK.</source>
-						<target>Moveu la maneta de fre a [notch] i premeu «D'acord».</target>
+						<target>Moveu la maneta de fre a [notch] i premeu «D&apos;acord».</target>
 					</trans-unit>
 					<trans-unit id="calibrate_power">
 						<source>Move the power handle to [notch] and press OK.</source>
-						<target>Moveu la maneta de tracció a [notch] i premeu «D'acord».</target>
+						<target>Moveu la maneta de tracció a [notch] i premeu «D&apos;acord».</target>
 					</trans-unit>
 					<trans-unit id="label_up">
 						<source>UP</source>
@@ -3478,7 +3533,7 @@
 					</trans-unit>
 					<trans-unit id="linkLabel_driver">
 						<source>My controller is not detected or does not work properly</source>
-						<target>No s'ha detectat el meu comandament o no funciona correctament</target>
+						<target>No s&apos;ha detectat el meu comandament o no funciona correctament</target>
 					</trans-unit>
 					<trans-unit id="help_title">
 						<source>Help</source>
@@ -3490,7 +3545,7 @@
 					</trans-unit>
 					<trans-unit id="help_controller2_label">
 						<source>My PS2 controller is not detected</source>
-						<target>No s'ha detectat el meu comandament per a PS2</target>
+						<target>No s&apos;ha detectat el meu comandament per a PS2</target>
 					</trans-unit>
 					<trans-unit id="help_windows_label">
 						<source>Windows</source>
@@ -3501,15 +3556,11 @@
 						<target>Linux</target>
 					</trans-unit>
 					<trans-unit id="help_controller1_textbox">
-						<source>If your non-USB controller is not providing correct input:
-
-1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller
-to separate buttons to avoid compatibility issues.
-2. Calibrate the controller from the configuration window, if necessary.</source>
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
 						<target>Si el vostre comandament no USB no proporciona una entrada correcta:
 
-1. Assegureu-vos que l'adaptador USB funcioni. Idealment, l'adaptador hauria d'assignar els botons de direcció
-d'un comandament estàndard a botons independents per evitar problemes de compatibilitat.
+1. Assegureu-vos que l&apos;adaptador USB funcioni. Idealment, l&apos;adaptador hauria d&apos;assignar els botons de direcció
+d&apos;un comandament estàndard a botons independents per evitar problemes de compatibilitat.
 2. Calibreu el comandament des de la finestra de configuració, si cal.</target>
 					</trans-unit>
 					<trans-unit id="help_controller2_textbox">
@@ -3517,22 +3568,17 @@ d'un comandament estàndard a botons independents per evitar problemes de compat
 						<target>Si el comandament per a PS2 no apareix a la llista, seguiu els passos següents:</target>
 					</trans-unit>
 					<trans-unit id="help_windows_textbox">
-						<source>1. Extract the Windows drivers.
-2. Download and run Zadig.
-3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).
-4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
 						<target>1. Extraieu els controladors per al Windows.
 2. Baixeu i executeu el Zadig.
 3. Carregueu el fitxer CFG corresponent per al vostre dispositiu («Device &gt; Load Preset Device»).
 4. Premeu «Install Driver» i espereu que finalitzi la instal·lació.</target>
 					</trans-unit>
 					<trans-unit id="help_linux_textbox">
-						<source>1. Extract the Linux udev file.
-2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).
-3. Reboot or reload udev rules manually.</source>
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
 						<target>1. Extraieu el fitxer udev per al Linux.
 2. Copieu el fitxer a «/etc/udev/rules.d/» (es necessiten permisos de root).
-3. Reinicieu l'ordinador o torneu a carregar les regles udev manualment.</target>
+3. Reinicieu l&apos;ordinador o torneu a carregar les regles udev manualment.</target>
 					</trans-unit>
 					<trans-unit id="help_zadig_button">
 						<source>Get Zadig</source>
@@ -3548,25 +3594,47 @@ d'un comandament estàndard a botons independents per evitar problemes de compat
 					</trans-unit>
 					<trans-unit id="help_ok_button">
 						<source>OK</source>
-						<target>D'acord</target>
+						<target>D&apos;acord</target>
 					</trans-unit>
 					<trans-unit id="help_libusb_symlink">
-						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.
-Please follow the following instructions:
-
-1. Check that the &quot;libusb-1.0&quot; package is installed.
-2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;
-3. Open the directory in the terminal.
-4. Check this location to see if &quot;libusb-1.0.so&quot; exists.
-5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
-						<target>Sembla que no teniu el LibUsb o que no s'ha creat un enllaç simbòlic correcte per a la càrrega en temps d'execució.
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+						<target>Sembla que no teniu el LibUsb o que no s&apos;ha creat un enllaç simbòlic correcte per a la càrrega en temps d&apos;execució.
 Seguiu les instruccions següents:
 
 1. Comproveu que tingueu instal·lat el paquet «libusb-1.0».
-2. Cerqueu la ubicació del fitxer «libusb-1.0.so.0». En les versions recents de l'Ubuntu i el Debian és probable que sigui «/lib/x86_64-linu-gnu/».
+2. Cerqueu la ubicació del fitxer «libusb-1.0.so.0». En les versions recents de l&apos;Ubuntu i el Debian és probable que sigui «/lib/x86_64-linu-gnu/».
 3. Obriu el directori en el terminal.
 4. Comproveu si en aquesta ubicació existeix el fitxer |libusb-1.0.so».
-5. Si el fitxer no existeix, cal crear l'enllaç simbòlic adequat executant l'ordre següent des del terminal: «sudo ln -s libusb-1.0.so.0 libusb-1.0.so».</target>
+5. Si el fitxer no existeix, cal crear l&apos;enllaç simbòlic adequat executant l&apos;ordre següent des del terminal: «sudo ln -s libusb-1.0.so.0 libusb-1.0.so».</target>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3596,7 +3664,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 					<trans-unit id="open_message">
 						<source>Do you want to save data before opening another train?</source>
-						<target>Voleu desar les dades abans d'obrir un altre tren?</target>
+						<target>Voleu desar les dades abans d&apos;obrir un altre tren?</target>
 					</trans-unit>
 					<trans-unit id="close_message">
 						<source>Do you want to save data before closing?</source>
@@ -3808,7 +3876,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 					<trans-unit id="separated_interlocked_reverser">
 						<source>Separated (Reverser Interlocked)</source>
-						<target>Independent (bloquejat amb l'inversor)</target>
+						<target>Independent (bloquejat amb l&apos;inversor)</target>
 					</trans-unit>
 					<trans-unit id="brake_notches_error_message">
 						<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
@@ -3912,7 +3980,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 					<trans-unit id="door_open_mode">
 						<source>DoorOpenMode:</source>
-						<target>Mode d'obertura de portes:</target>
+						<target>Mode d&apos;obertura de portes:</target>
 					</trans-unit>
 					<trans-unit id="door_close_mode">
 						<source>DoorCloseMode:</source>
@@ -4010,7 +4078,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 					<trans-unit id="edit">
 						<source>Edit mode</source>
-						<target>Mode d'edició</target>
+						<target>Mode d&apos;edició</target>
 					</trans-unit>
 					<trans-unit id="sound_index">
 						<source>SoundIndex:</source>
@@ -4075,8 +4143,8 @@ Seguiu les instruccions següents:
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Nota: Pot ser que les funcions d'aquesta pàgina requereixin com a mínim aquesta versió de l'openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Nota: Pot ser que les funcions d&apos;aquesta pàgina requereixin com a mínim aquesta versió de l&apos;OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4143,7 +4211,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 					<trans-unit id="misc_eb">
 						<source>Handle behaviour on EB:</source>
-						<target>Comportament dels controls quan s'aplica el fre d'emergència:</target>
+						<target>Comportament dels controls quan s&apos;aplica el fre d&apos;emergència:</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_no">
 						<source>No Action</source>
@@ -4194,13 +4262,10 @@ Seguiu les instruccions següents:
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
-							<target>Heu intentat obrir un tren. \n\n No es poden obrir directament.\n\n Utilitzeu la funció d'importació per a importar aquest tren al TrainEditor2.</target>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
+							<target>Heu intentat obrir un tren. \n\n No es poden obrir directament.\n\n Utilitzeu la funció d&apos;importació per a importar aquest tren al TrainEditor2.</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4212,6 +4277,9 @@ Seguiu les instruccions següents:
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4255,13 +4323,7 @@ Seguiu les instruccions següents:
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4279,21 +4341,6 @@ Seguiu les instruccions següents:
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4329,8 +4376,35 @@ Seguiu les instruccions següents:
 								<target>Blocking</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4351,9 +4425,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4384,15 +4455,6 @@ Seguiu les instruccions següents:
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4444,6 +4506,18 @@ Seguiu les instruccions següents:
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4451,12 +4525,28 @@ Seguiu les instruccions següents:
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>FrontAxle</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>RearAxle</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4493,19 +4583,6 @@ Seguiu les instruccions següents:
 							<source>DefinedAxles</source>
 							<target>DefinedAxles</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>FrontAxle</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>RearAxle</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>FrontBogie</target>
@@ -4568,9 +4645,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4614,6 +4688,9 @@ Seguiu les instruccions següents:
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>BrakeControlSpeed</target>
@@ -4640,6 +4717,17 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4658,15 +4746,15 @@ Seguiu les instruccions següents:
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4732,11 +4820,14 @@ Seguiu les instruccions següents:
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4878,9 +4969,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4906,13 +4994,16 @@ Seguiu les instruccions següents:
 								<target>Constant speed</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 								<target>Swap</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>Playback</target>
@@ -5009,11 +5100,11 @@ Seguiu les instruccions següents:
 							<target>A point already exists at the same x coordinate, do you want to overwrite it?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5027,12 +5118,34 @@ Seguiu les instruccions següents:
 							<target>Max</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5066,9 +5179,56 @@ Seguiu les instruccions següents:
 							<source>TransparentColor</source>
 							<target>TransparentColor</target>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+							<target>Number</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Capa</target>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Subject</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5088,70 +5248,12 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-							<target>Number</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target>Capa</target>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>Subject</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>DefinedRadius</target>
@@ -5177,17 +5279,6 @@ Seguiu les instruccions següents:
 							<source>DefinedOrigin</source>
 							<target>DefinedOrigin</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>InitialAngle</target>
@@ -5233,12 +5324,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5250,6 +5335,12 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5268,12 +5359,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5285,6 +5370,12 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5312,12 +5403,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5329,6 +5414,23 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5344,17 +5446,6 @@ Seguiu les instruccions següents:
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5363,9 +5454,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5377,6 +5465,9 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5391,9 +5482,6 @@ Seguiu les instruccions següents:
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5416,6 +5504,9 @@ Seguiu les instruccions següents:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>JumpScreen</target>
@@ -5431,9 +5522,128 @@ Seguiu les instruccions següents:
 							<source>CommandOption</source>
 							<target>CommandOption</target>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>File name has not been entered.</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>The specified key is already set.</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5451,64 +5661,8 @@ Seguiu les instruccions següents:
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>File name has not been entered.</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>The specified key is already set.</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5525,6 +5679,9 @@ Seguiu les instruccions següents:
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>Nivell</target>
@@ -5561,8 +5718,84 @@ Seguiu les instruccions següents:
 						<target>This value must be a {0}floating-point number.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>invalid_color</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/cs-CZ.xlf
+++ b/assets/Languages/cs-CZ.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="cs-CZ">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2016-03-08</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,10 +371,6 @@
 						<source>Recently used</source>
 						<target>Naposledy použité</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Výchozí</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Použít přidružený vlak k trati</target>
@@ -397,7 +399,7 @@
 						<target>Náhled:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Vlak přidružený k trati nenalezen.</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -415,6 +417,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Spusť</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -613,8 +624,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +736,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +763,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +999,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,7 +1138,7 @@
 						<target>Stiskněte tlačítko dle vaší volby nebo pohněte pákou v požadovaném směru...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Pohněte pákou v požadovaném směru pro snížení nebo zvýšení výkonu...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1244,64 +1264,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,12 +1862,12 @@
 						<target>Soubory nenalezeny:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Při načítání tratě a vlaku bylo nalezeno několik chyb.\r\n\r\nNěkteré soubory obsažené v trati a vlaku nebyly nalezeny, proto se ujistěte, zda máte staženy opravdu všechny součásti simulace.\r\n\r\nNásledující seznam chyb vám může poskytnout více informací. Kliknutím na tlačítko "Ignorovat" můžete pokračovat ve spuštění simulace.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Při načítání tratě a vlaku bylo nalezeno několik chyb.\r\n\r\nNěkteré soubory obsažené v trati a vlaku nebyly nalezeny, proto se ujistěte, zda máte staženy opravdu všechny součásti simulace.\r\n\r\nNásledující seznam chyb vám může poskytnout více informací. Kliknutím na tlačítko &quot;Ignorovat&quot; můžete pokračovat ve spuštění simulace.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Při načítání tratě a vlaku bylo nalezeno několik chyb. Pokud jste vývojářem tratí a vlaků, může vám následující seznam chyb poskytnout více informací.\r\n\r\nJako běžný uživatel můžete kliknutím na tlačítko "Ignorovat" pokračovat ve spuštění simulace.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Při načítání tratě a vlaku bylo nalezeno několik chyb. Pokud jste vývojářem tratí a vlaků, může vám následující seznam chyb poskytnout více informací.\r\n\r\nJako běžný uživatel můžete kliknutím na tlačítko &quot;Ignorovat&quot; pokračovat ve spuštění simulace.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Probíhá načítání. Čekejte prosím...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2018,7 +2056,7 @@
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
 						<source>This feature is not available in Expert mode.</source>
-						<target>Tato funkce není v obtížnosti "profesionál" k dispozici.</target>
+						<target>Tato funkce není v obtížnosti &quot;profesionál&quot; k dispozici.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
 						<source>The AI might be unable to fully operate this train.</source>
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Ovládání pomocí myši: VYP</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2176,7 +2229,7 @@
 					</trans-unit>
 					<trans-unit id="quit_question">
 						<source>Do you really want to quit?</source>
-						<target>Ukončit openBVE?</target>
+						<target>Ukončit OpenBVE?</target>
 					</trans-unit>
 					<trans-unit id="quit_no">
 						<source>No</source>
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Výchozí</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>P funkce zabezpečovacího systému</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Pohled ze stanoviště</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Pohled z venku, následuje vlak</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2651,7 +2720,7 @@
 					</trans-unit>
 					<trans-unit id="timetable_toggle">
 						<source>Toggles through different timetable modes</source>
-						<target>Zobrazení jízdního řádu bve4/openBVE/VYP (bve4 pokud je obsažen)</target>
+						<target>Zobrazení jízdního řádu bve4/OpenBVE/VYP (bve4 pokud je obsažen)</target>
 					</trans-unit>
 					<trans-unit id="timetable_up">
 						<source>Scrolls the timetable up</source>
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3367,6 +3460,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/de-CH.xlf
+++ b/assets/Languages/de-CH.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="de-CH">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>Jan Henning</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2011-12-23</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -218,11 +218,11 @@
 					</trans-unit>
 					<trans-unit id="sound_openal_context">
 						<source>The OpenAL context could not be created.</source>
-						<target>Der 'OpenAL context' konnte nicht eröffnet werden.</target>
+						<target>Der &apos;OpenAL context&apos; konnte nicht eröffnet werden.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_device">
 						<source>The OpenAL sound device could not be opened.</source>
-						<target>Das 'OpenAL sound device' konnte nicht geöffnet werden.</target>
+						<target>Das &apos;OpenAL sound device&apos; konnte nicht geöffnet werden.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch1">
 						<source>An error occured whilst attempting to switch to fullscreen mode.</source>
@@ -287,6 +287,12 @@
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Zuletzt benutzt</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Voreingestellter Zug</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Benutze den von der Strecke vorgegebenen Zug\r\n</target>
@@ -398,7 +400,7 @@
 						<target>Vorschau:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Der von der Strecke vorgegebene Zug wurde nicht gefunden:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,8 +1139,8 @@
 						<target>Drücke den gewünschten Knopf oder bewege eine Achse in die gewünschte Richtung...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Bewege die gewünschte Achse in Richtung "Erhöhen" bzw. "Beschleunigen"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Bewege die gewünschte Achse in Richtung &quot;Erhöhen&quot; bzw. &quot;Beschleunigen&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1725,6 +1745,12 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
+					<trans-unit id="font">
+						<source>Font:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1836,12 +1862,12 @@
 						<target>Dateien nicht gefunden:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Beim Laden der Strecke sind einige Probleme aufgetreten.\r\n\r\nDa einige Dateien nicht gefunden wurden, kann es zur Darstellungsproblemen kommen. Versuche, die Strecke und den Zug erneut herunterzuladen und zu installieren, um sicher zu stellen, dass du eine vollständige Installation besitzt.\r\n\r\nDie folgende Fehlerliste könnte weitere Informationen liefern. Wenn du das Spiel dennoch starten möchtest, klicke unten auf "Ignorieren".</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Beim Laden der Strecke sind einige Probleme aufgetreten.\r\n\r\nDa einige Dateien nicht gefunden wurden, kann es zur Darstellungsproblemen kommen. Versuche, die Strecke und den Zug erneut herunterzuladen und zu installieren, um sicher zu stellen, dass du eine vollständige Installation besitzt.\r\n\r\nDie folgende Fehlerliste könnte weitere Informationen liefern. Wenn du das Spiel dennoch starten möchtest, klicke unten auf &quot;Ignorieren&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Beim Laden der Strecke sind einige Probleme aufgetreten. Wenn du der Entwickler der Strecke/des Zuges bist, könnte es empfehlenswert sein, sich die folgende Fehlerliste anzusehen.\r\n\r\nWenn du ein normaler Benutzer bist, dann klicke unten auf "Ignorieren", um das Spiel zu starten.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Beim Laden der Strecke sind einige Probleme aufgetreten. Wenn du der Entwickler der Strecke/des Zuges bist, könnte es empfehlenswert sein, sich die folgende Fehlerliste anzusehen.\r\n\r\nWenn du ein normaler Benutzer bist, dann klicke unten auf &quot;Ignorieren&quot;, um das Spiel zu starten.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1971,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Simulation lädt. Bitte warten...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2036,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Kamerasteuerung mit der Maus aus</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2204,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2218,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Voreingestellter Zug</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2556,14 +2628,14 @@
 						<target>Die P-Funktion des Zugsicherungssystem</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Wechselt zur Innenansicht des Zuges</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Wechselt zur Aussenansicht des Zuges</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2824,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3117,7 +3213,7 @@
 					</trans-unit>
 					<trans-unit id="leftparen">
 						<source>Left parenthesis</source>
-						<target>("(")</target>
+						<target>(&quot;(&quot;)</target>
 					</trans-unit>
 					<trans-unit id="less">
 						<source>Less</source>
@@ -3141,7 +3237,7 @@
 					</trans-unit>
 					<trans-unit id="minus">
 						<source>Minus</source>
-						<target>'</target>
+						<target>&apos;</target>
 					</trans-unit>
 					<trans-unit id="mode">
 						<source>Alt Gr</source>
@@ -3189,7 +3285,7 @@
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>(")</target>
+						<target>(&quot;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3213,7 +3309,7 @@
 					</trans-unit>
 					<trans-unit id="rightparen">
 						<source>Right parenthesis</source>
-						<target>(")")</target>
+						<target>(&quot;)&quot;)</target>
 					</trans-unit>
 					<trans-unit id="rmeta">
 						<source>Right Meta</source>
@@ -3362,6 +3458,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3614,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3876,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3997,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4014,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4053,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4070,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4117,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4139,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4170,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4230,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4237,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4273,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4341,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4386,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4411,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4429,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4493,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4624,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4649,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4747,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4763,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4796,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4818,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4900,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4946,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4963,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4980,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4997,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5023,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5040,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5055,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5074,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5088,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5102,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5127,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5139,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5157,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5227,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5257,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/de-DE.xlf
+++ b/assets/Languages/de-DE.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="de-DE">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>Jan Henning</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2011-12-23</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -218,11 +218,11 @@
 					</trans-unit>
 					<trans-unit id="sound_openal_context">
 						<source>The OpenAL context could not be created.</source>
-						<target>Der 'OpenAL context' konnte nicht eröffnet werden.</target>
+						<target>Der &apos;OpenAL context&apos; konnte nicht eröffnet werden.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_device">
 						<source>The OpenAL sound device could not be opened.</source>
-						<target>Das 'OpenAL sound device' konnte nicht geöffnet werden.</target>
+						<target>Das &apos;OpenAL sound device&apos; konnte nicht geöffnet werden.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch1">
 						<source>An error occured whilst attempting to switch to fullscreen mode.</source>
@@ -287,6 +287,12 @@
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Zuletzt benutzt</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Voreingestellter Zug</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Benutze den von der Strecke vorgegebenen Zug\r\n</target>
@@ -398,7 +400,7 @@
 						<target>Vorschau:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Der von der Strecke vorgegebene Zug wurde nicht gefunden:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,7 +625,7 @@
 						<target>Paketinstallation</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 						<target>Diese Datei scheint kein korrektes OpenBVE-Paket zu sein.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
@@ -726,8 +737,8 @@
 						<target>Entfernen</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Das neue Paket hat folgende GUID erhalten:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Paketerstellung</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Erstellung folgender Datei fehlgeschlagen: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,8 +1138,8 @@
 						<target>Drücke den gewünschten Knopf oder bewege eine Achse in die gewünschte Richtung...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Bewege die gewünschte Achse in Richtung "Erhöhen" bzw. "Beschleunigen"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Bewege die gewünschte Achse in Richtung &quot;Erhöhen&quot; bzw. &quot;Beschleunigen&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1244,64 +1264,64 @@
 						<target>Fehler beim Laden der RailDriver-Konfigurationsdatei.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Bitte "weiter" drücken zum Start der Kalibrierung.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Bitte &quot;weiter&quot; drücken zum Start der Kalibrierung.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Richtungsschalter in Stellung "rückwärts" legen und "weiter" drücken.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Richtungsschalter in Stellung &quot;rückwärts&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Richtungsschalter in Stellung "vorwärts" legen und "weiter" drücken.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Richtungsschalter in Stellung &quot;vorwärts&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Fahr-/Bremshebel auf volle Zugkraft legen und "weiter" drücken.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Fahr-/Bremshebel auf volle Zugkraft legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Fahr-/Bremshebel in Schnellbremsstellung legen und "weiter" drücken.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Fahr-/Bremshebel in Schnellbremsstellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Dynamische Bremse in Lösestellung legen und "weiter" drücken.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Dynamische Bremse in Lösestellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Dynamische Bremse in Schnellbremsstellung legen und "weiter" drücken.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Dynamische Bremse in Schnellbremsstellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Führerbremsventil in Lösestellung legen und "weiter" drücken.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Führerbremsventil in Lösestellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Führerbremsventil in Schnellbremsstellung legen und "weiter" drücken.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Führerbremsventil in Schnellbremsstellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>"Bremse lösen" in Grundstellung legen und "weiter" drücken.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>&quot;Bremse lösen&quot; in Grundstellung legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>"Bremse lösen" betätigen und "weiter" drücken.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>&quot;Bremse lösen&quot; betätigen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Scheibenwischerschalter in "aus" legen und "weiter" drücken.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Scheibenwischerschalter in &quot;aus&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Scheibenwischerschalter in "ein" legen und "weiter" drücken.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Scheibenwischerschalter in &quot;ein&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Lichtschalter in "aus" legen und "weiter" drücken.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Lichtschalter in &quot;aus&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Lichtschalter in "ein" legen und "weiter" drücken.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Lichtschalter in &quot;ein&quot; legen und &quot;weiter&quot; drücken.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,12 +1862,12 @@
 						<target>Dateien nicht gefunden:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Beim Laden der Strecke sind einige Probleme aufgetreten.\r\n\r\nDa einige Dateien nicht gefunden wurden, kann es zur Darstellungsproblemen kommen. Versuche, die Strecke und den Zug erneut herunterzuladen und zu installieren, um sicher zu stellen, dass du eine vollständige Installation besitzt.\r\n\r\nDie folgende Fehlerliste könnte weitere Informationen liefern. Wenn du das Spiel dennoch starten möchtest, klicke unten auf "Ignorieren".</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Beim Laden der Strecke sind einige Probleme aufgetreten.\r\n\r\nDa einige Dateien nicht gefunden wurden, kann es zur Darstellungsproblemen kommen. Versuche, die Strecke und den Zug erneut herunterzuladen und zu installieren, um sicher zu stellen, dass du eine vollständige Installation besitzt.\r\n\r\nDie folgende Fehlerliste könnte weitere Informationen liefern. Wenn du das Spiel dennoch starten möchtest, klicke unten auf &quot;Ignorieren&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Beim Laden der Strecke sind einige Probleme aufgetreten. Wenn du der Entwickler der Strecke/des Zuges bist, könnte es empfehlenswert sein, sich die folgende Fehlerliste anzusehen.\r\n\r\nWenn du ein normaler Benutzer bist, dann klicke unten auf "Ignorieren", um das Spiel zu starten.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Beim Laden der Strecke sind einige Probleme aufgetreten. Wenn du der Entwickler der Strecke/des Zuges bist, könnte es empfehlenswert sein, sich die folgende Fehlerliste anzusehen.\r\n\r\nWenn du ein normaler Benutzer bist, dann klicke unten auf &quot;Ignorieren&quot;, um das Spiel zu starten.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Simulation lädt. Bitte warten...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Kamerasteuerung mit der Maus aus</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Aktuelle Zuordnung:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Voreingestellter Zug</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>Die P-Funktion des Zugsicherungssystem</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Wechselt zur Innenansicht des Zuges</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Wechselt zur Außenansicht des Zuges</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Hauptschalter</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3120,7 +3213,7 @@
 					</trans-unit>
 					<trans-unit id="leftparen">
 						<source>Left parenthesis</source>
-						<target>("(")</target>
+						<target>(&quot;(&quot;)</target>
 					</trans-unit>
 					<trans-unit id="less">
 						<source>Less</source>
@@ -3192,7 +3285,7 @@
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>(")</target>
+						<target>(&quot;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3216,7 +3309,7 @@
 					</trans-unit>
 					<trans-unit id="rightparen">
 						<source>Right parenthesis</source>
-						<target>(")")</target>
+						<target>(&quot;)&quot;)</target>
 					</trans-unit>
 					<trans-unit id="rmeta">
 						<source>Right Meta</source>
@@ -3365,6 +3458,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/en-GB.xlf
+++ b/assets/Languages/en-GB.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="en-GB">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2016-02-21</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,10 +371,6 @@
 						<source>Recently used</source>
 						<target>Recently used</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Route default</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Use the train suggested by the route</target>
@@ -397,7 +399,7 @@
 						<target>Preview:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>The default train could not be found:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -415,6 +417,16 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+						<target>Route default</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -613,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,8 +1139,8 @@
 						<target>Press a button or move an axis or hat into the desired direction...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Move an axis into the direction of "increase" or "power"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1244,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1727,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1838,12 +1862,12 @@
 						<target>Files not found:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1973,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Loading. Please wait...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2038,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Mouse grab: off</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2206,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2220,6 +2274,24 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Do you wish to use the default train?</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+						<target>No</target>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+						<target>Yes</target>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2508,13 +2580,13 @@
 						<source>The P function of the security system</source>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 					</trans-unit>
 					<trans-unit id="camera_track">
 						<source>Switches to the track view</source>
@@ -2731,6 +2803,9 @@
 					</trans-unit>
 					<trans-unit id="uncouple_rear">
 						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3271,6 +3346,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3521,6 +3744,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3783,8 +4012,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3904,12 +4133,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -3921,6 +4147,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -3960,13 +4189,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -3977,22 +4200,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4024,8 +4238,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4046,9 +4287,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4077,15 +4315,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4137,6 +4366,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4144,12 +4385,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4180,17 +4435,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4248,9 +4492,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4293,6 +4534,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4318,6 +4562,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4336,15 +4591,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4400,11 +4655,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4531,9 +4789,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4556,12 +4811,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4654,11 +4912,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4670,12 +4928,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4703,9 +4983,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4725,67 +5049,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4807,17 +5076,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4853,12 +5111,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4870,6 +5122,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4887,12 +5145,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4904,6 +5156,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -4930,12 +5188,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4947,6 +5199,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4962,17 +5231,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -4981,9 +5239,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4995,6 +5250,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5009,9 +5267,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5034,6 +5289,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5046,9 +5304,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5064,62 +5439,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5134,6 +5455,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5164,7 +5488,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US">
 		<body>
 			<group id="language">
@@ -68,10 +68,10 @@
 						<source>Save Bug Report</source>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -269,15 +269,6 @@
 					</trans-unit>
 					<trans-unit id="train_choose">
 						<source>Choose Train...</source>
-					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
 					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
@@ -482,7 +473,7 @@
 						<source>Install a Package</source>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -586,7 +577,7 @@
 					<trans-unit id="creation_new_guid">
 						<source>The new package has been assigned the following GUID:</source>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -966,49 +957,49 @@
 						<source>Error loading RailDriver calibration file.</source>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1530,7 +1521,7 @@
 						<source>You have passed [name] while still boarding. Please come to a complete hold immediately.</source>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 					</trans-unit>
 					<trans-unit id="loading">
 						<source>Loading. Please wait...</source>
@@ -1743,6 +1734,15 @@
 					</trans-unit>
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="switchmenu">
@@ -2021,13 +2021,13 @@
 						<source>The P function of the security system</source>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 					</trans-unit>
 					<trans-unit id="camera_track">
 						<source>Switches to the track view</source>
@@ -3178,7 +3178,7 @@
 						<source>Extended Features</source>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3279,9 +3279,6 @@
 							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -3293,6 +3290,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -3346,13 +3346,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -3370,21 +3364,6 @@
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -3416,6 +3395,24 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
 						</trans-unit>
@@ -3447,9 +3444,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -3478,15 +3472,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -3538,6 +3523,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -3545,12 +3542,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -3581,20 +3592,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-							<trans-unit id="mustbe_less">
-								<source>RearAxle must be less than FrontAxle.</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -3652,9 +3649,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -3697,6 +3691,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -3722,6 +3719,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -3743,26 +3751,12 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
-						<group id="edit_entry">
-							<trans-unit id="name">
-								<source>Edit entry</source>
-							</trans-unit>
-							<trans-unit id="up">
-								<source>Up</source>
-							</trans-unit>
-							<trans-unit id="down">
-								<source>Down</source>
-							</trans-unit>
-						</group>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -3818,11 +3812,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -3949,9 +3946,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -3980,6 +3974,9 @@
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4072,11 +4069,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4088,11 +4085,11 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="subject">
 						<trans-unit id="name">
 							<source>Subject</source>
@@ -4111,6 +4108,28 @@
 						</trans-unit>
 					</group>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4138,28 +4157,6 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
-							<trans-unit id="name">
-								<source>Center origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Track origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 					</group>
 					<group id="screen">
 						<trans-unit id="name">
@@ -4173,12 +4170,6 @@
 						</trans-unit>
 					</group>
 					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4190,6 +4181,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4204,12 +4201,6 @@
 						</trans-unit>
 					</group>
 					<group id="needle">
-						<trans-unit id="name">
-							<source>Needle</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4221,6 +4212,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Needle</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4242,17 +4250,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4288,12 +4285,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4305,6 +4296,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4322,12 +4319,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4339,6 +4330,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -4365,12 +4362,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4382,6 +4373,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4397,17 +4405,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -4416,9 +4413,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4430,6 +4424,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -4444,9 +4441,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4469,6 +4463,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -4480,9 +4477,6 @@
 						</trans-unit>
 					</group>
 					<group id="sound_command">
-						<trans-unit id="name">
-							<source>Sound and command</source>
-						</trans-unit>
 						<group id="tree">
 							<trans-unit id="touch_element">
 								<source>Touch element</source>
@@ -4495,20 +4489,11 @@
 							</trans-unit>
 						</group>
 						<group id="edit_entry">
-							<trans-unit id="name">
-								<source>Edit entry</source>
-							</trans-unit>
-							<trans-unit id="sound">
-								<source>Sound</source>
-							</trans-unit>
 							<group id="sound">
 								<trans-unit id="index">
 									<source>Index</source>
 								</trans-unit>
 							</group>
-							<trans-unit id="command">
-								<source>Command</source>
-							</trans-unit>
 							<group id="command">
 								<trans-unit id="name">
 									<source>Key</source>
@@ -4517,10 +4502,68 @@
 									<source>Option</source>
 								</trans-unit>
 							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -4536,57 +4579,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>X</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>Y</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>Z</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
 				</group>
 				<group id="import_export">
-					<trans-unit id="import_name">
-						<source>Import</source>
-					</trans-unit>
-					<trans-unit id="export_name">
-						<source>Export</source>
-					</trans-unit>
 					<group id="train">
 						<trans-unit id="name">
 							<source>Train setting file</source>
@@ -4626,6 +4620,12 @@
 							<source>Sound.xml</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
 					<trans-unit id="folder">
 						<source>Folder</source>
 					</trans-unit>
@@ -4634,9 +4634,6 @@
 					</trans-unit>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -4651,6 +4648,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -4683,12 +4683,6 @@
 					<trans-unit id="invalid_color">
 						<source>Invalid HEX color</source>
 					</trans-unit>
-					<!--trans-unit id="empty_filename">
-						<source>File name has not been entered.</source>
-					</trans-unit>
-					<trans-unit id="key_exist">
-						<source>The specified key is already set.</source>
-					</trans-unit-->
 					<trans-unit id="number_exist">
 						<source>The specified number is already set.</source>
 					</trans-unit>

--- a/assets/Languages/es-ES.xlf
+++ b/assets/Languages/es-ES.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="es-ES">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>Marc Riera Irigoyen</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2016-03-06</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Seleccionado anteriormente</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Predeterminado por la ruta</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Usar el tren sugerido por la ruta</target>
@@ -398,7 +400,7 @@
 						<target>Vista previa:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>No se ha encontrado el tren sugerido por la ruta:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Comenzar</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,7 +625,7 @@
 						<target>Instalar un paquete</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 						<target>Este archivo no es un paquete de OpenBVE válido.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
@@ -726,8 +737,8 @@
 						<target>Eliminar</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>El nuevo paquete tiene asignado el GUID siguiente:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Crear un paquete</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>No se ha podido crear el archivo siguiente: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,7 +1139,7 @@
 						<target>Presione el botón o mueva el eje en la dirección deseada...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Mueva un eje en la dirección deseada para abrir el regulador...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,12 +1862,12 @@
 						<target>Archivos no encontrados:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Se han encontrado varias incidencias durante la carga de la ruta/tren.\r\n\r\nComo algunos archivos no se pueden encontrar, la ruta o el tren pueden ser no mostrados correctamente. Pruebe a descargar e instalar de nuevo la ruta o el tren para asegurarse de tener una instalación correcta.\r\n\r\nLa siguiente lista de incidencias muestra más información. De todas maneras, puede cargar la ruta igualmente haciendo click en "Ignorar".</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Se han encontrado varias incidencias durante la carga de la ruta/tren.\r\n\r\nComo algunos archivos no se pueden encontrar, la ruta o el tren pueden ser no mostrados correctamente. Pruebe a descargar e instalar de nuevo la ruta o el tren para asegurarse de tener una instalación correcta.\r\n\r\nLa siguiente lista de incidencias muestra más información. De todas maneras, puede cargar la ruta igualmente haciendo click en &quot;Ignorar&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Se han encontrado varias incidencias durante la carga de la ruta/tren. Si usted es el desarrollador de la ruta/tren, sería recomendable echar un vistazo a la lista de incidencias.\r\n\r\nComo usuario regular, puede hacer click en "Ignorar" para comenzar la simulación.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Se han encontrado varias incidencias durante la carga de la ruta/tren. Si usted es el desarrollador de la ruta/tren, sería recomendable echar un vistazo a la lista de incidencias.\r\n\r\nComo usuario regular, puede hacer click en &quot;Ignorar&quot; para comenzar la simulación.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Cargando. Por favor, espere...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Ratón: no</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/D</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Asignación actual:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Predeterminado por la ruta</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>La funcion &lt;P&gt; del sistema de seguridad</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Muestra la cámara interior (cabina)</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Muestra la cámara exterior</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2731,7 +2800,7 @@
 					</trans-unit>
 					<trans-unit id="misc_backface">
 						<source>Activates or deactivates backface culling</source>
-						<target>Activa/desactiva "backface culling"</target>
+						<target>Activa/desactiva &quot;backface culling&quot;</target>
 					</trans-unit>
 					<trans-unit id="misc_cpumode">
 						<source>Switches to or from reduced CPU mode</source>
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Activa o desactiva el disyuntor principal</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3367,6 +3460,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/fi-FI.xlf
+++ b/assets/Languages/fi-FI.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="fi-FI">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2012-04-13</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -129,7 +129,7 @@
 					</trans-unit>
 					<trans-unit id="updates_old">
 						<source>You already have the latest version.</source>
-						<target>Käytät jo uusinta versiota openBVE:stä.</target>
+						<target>Käytät jo uusinta versiota OpenBVE:stä.</target>
 					</trans-unit>
 					<trans-unit id="updates_new">
 						<source>The new version [version] ([date]) is available for download on the Official Homepage.</source>
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,10 +371,6 @@
 						<source>Recently used</source>
 						<target>Äskettäin käytetyt</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Reitin oletus</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Käytä reitin suosittamaa junaa</target>
@@ -397,7 +399,7 @@
 						<target>Esikatselu:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Oletusjunaa ei löytynyt:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -415,6 +417,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Aloita</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -613,8 +624,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +736,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +763,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +999,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,7 +1138,7 @@
 						<target>Paina painiketta tai siirrä akselia...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Siirrä akselia lisäyksen tai voimanlisäyksen suuntaan...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1244,64 +1264,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1727,6 +1747,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1838,12 +1861,12 @@
 						<target>Tiedostoja ei löytynyt:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Reitin ja junan latauksessa oli ongelmia.\r\n\r\nJoitain tiedostoja ei löytynyt, ja reitti tai juna saattaa toimia virheellisesti. Kokeile reitin ja junan uudelleenlataamusta varmistaaksesi, että sinulla on kaikki tarvittavat tiedostot. \r\n\r\nTämä lista antaa hieman lisätietoa. Voit silti aloittaa reitin painamalla alla olevaa "Unohda"-painiketta.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Reitin ja junan latauksessa oli ongelmia.\r\n\r\nJoitain tiedostoja ei löytynyt, ja reitti tai juna saattaa toimia virheellisesti. Kokeile reitin ja junan uudelleenlataamusta varmistaaksesi, että sinulla on kaikki tarvittavat tiedostot. \r\n\r\nTämä lista antaa hieman lisätietoa. Voit silti aloittaa reitin painamalla alla olevaa &quot;Unohda&quot;-painiketta.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Reitin ja junan latauksessa oli pieniä ongelmia. Jos olet reitin tai junan kehittäjä, suosittelemme teitä katsomaan seuraavan ongelmalistan.\r\n\r\nJos olet tavallinen käyttäjä, voit valita "Unohda"-painikkeen ja aloittaa pelin..</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Reitin ja junan latauksessa oli pieniä ongelmia. Jos olet reitin tai junan kehittäjä, suosittelemme teitä katsomaan seuraavan ongelmalistan.\r\n\r\nJos olet tavallinen käyttäjä, voit valita &quot;Unohda&quot;-painikkeen ja aloittaa pelin..</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1973,6 +1996,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Ladataan, odota hetki...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2038,6 +2076,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Kameran hiirikääntö: pois</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2206,7 +2259,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2220,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Reitin oletus</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2558,14 +2627,14 @@
 						<target>Turvajärjestelmän P-toiminto</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Vaihtaa junan sisänäkymään</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Vaihtaa junan ulkonäkymään</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2826,6 +2895,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3366,6 +3459,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3616,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3878,8 +4125,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3999,12 +4246,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4016,6 +4260,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4055,13 +4302,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4072,22 +4313,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4119,8 +4351,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4141,9 +4400,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4172,15 +4428,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4232,6 +4479,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4239,12 +4498,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4275,17 +4548,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4343,9 +4605,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4388,6 +4647,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4413,6 +4675,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4431,15 +4704,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4495,11 +4768,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4626,9 +4902,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4651,12 +4924,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4749,11 +5025,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4765,12 +5041,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4798,9 +5096,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4820,67 +5162,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4902,17 +5189,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4948,12 +5224,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4965,6 +5235,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4982,12 +5258,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4999,6 +5269,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5025,12 +5301,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5042,6 +5312,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5057,17 +5344,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5076,9 +5352,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5090,6 +5363,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5104,9 +5380,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5129,6 +5402,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5141,9 +5417,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5159,62 +5552,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5229,6 +5568,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5259,7 +5601,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/fr-FR.xlf
+++ b/assets/Languages/fr-FR.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="fr-FR">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2011-12-23</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -125,7 +125,7 @@
 					</trans-unit>
 					<trans-unit id="updates_invalid">
 						<source>A connection to the server could be established. Unfortunately, the version information could not be retrieved.</source>
-						<target>La connexion au serveur peut être établie, mais l'information concernant la version ne peut pas être récupérée.</target>
+						<target>La connexion au serveur peut être établie, mais l&apos;information concernant la version ne peut pas être récupérée.</target>
 					</trans-unit>
 					<trans-unit id="updates_old">
 						<source>You already have the latest version.</source>
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,13 +371,9 @@
 						<source>Recently used</source>
 						<target>Récemment utilisé</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Associé à l'itinéraire</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
-						<target>Utiliser le train associé à l'itinéraire</target>
+						<target>Utiliser le train associé à l&apos;itinéraire</target>
 					</trans-unit>
 					<trans-unit id="train_details">
 						<source>Details</source>
@@ -397,12 +399,12 @@
 						<target>Prévisualisation :</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
-						<target>Le train par défaut n'a pas été trouvé :\n\n</target>
+						<source>The default train could not be found:\r\n\r\n</source>
+						<target>Le train par défaut n&apos;a pas été trouvé :\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
 						<source>--- This train uses a safety system plugin which cannot be used on your operating system. The built-in safety systems ATS/ATC will be used instead, which might cause operational problems. ---</source>
-						<target>--- Le système de sécurité de ce train est basé sur un plugin non supporté par votre système d'exploitation. Le système de sécurité de type ATS/ATC inclus en standard qui sera utilisé en remplacement pourra provoquer des problèmes opérationnels. ---</target>
+						<target>--- Le système de sécurité de ce train est basé sur un plugin non supporté par votre système d&apos;exploitation. Le système de sécurité de type ATS/ATC inclus en standard qui sera utilisé en remplacement pourra provoquer des problèmes opérationnels. ---</target>
 					</trans-unit>
 					<trans-unit id="start">
 						<source>Start</source>
@@ -415,6 +417,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Démarrer</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -613,8 +624,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +736,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +763,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +999,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1111,15 +1131,15 @@
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab">
 						<source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
-						<target>Cliquer ici pour activer l'aquisition de la commande par le joystick.\r\n\r\nAuparavant, remettre tous les axes en position neutre et relâcher tous les boutons.</target>
+						<target>Cliquer ici pour activer l&apos;aquisition de la commande par le joystick.\r\n\r\nAuparavant, remettre tous les axes en position neutre et relâcher tous les boutons.</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_normal">
 						<source>Press a button or move an axis or hat into the desired direction...</source>
-						<target>Appuyer sur un bouton ou déplacer l'axe dans le sens désiré...</target>
+						<target>Appuyer sur un bouton ou déplacer l&apos;axe dans le sens désiré...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Déplacer l'axe de votre choix dans le sens correspondant au sens d'augmentation...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Déplacer l&apos;axe de votre choix dans le sens correspondant au sens d&apos;augmentation...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1244,64 +1264,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1323,7 +1343,7 @@
 					</trans-unit>
 					<trans-unit id="display_mode">
 						<source>Display mode</source>
-						<target>Mode d'affichage</target>
+						<target>Mode d&apos;affichage</target>
 					</trans-unit>
 					<trans-unit id="display_mode_window">
 						<source>Window mode</source>
@@ -1535,11 +1555,11 @@
 					</trans-unit>
 					<trans-unit id="verbosity_warningmessages">
 						<source>Show warning messages</source>
-						<target>Affiche les messages d'avertissement</target>
+						<target>Affiche les messages d&apos;avertissement</target>
 					</trans-unit>
 					<trans-unit id="verbosity_errormessages">
 						<source>Show error messages</source>
-						<target>Affiche les messages d'erreur</target>
+						<target>Affiche les messages d&apos;erreur</target>
 					</trans-unit>
 					<trans-unit id="verbosity_accessibilityaids">
 						<source>Accessibility Aids</source>
@@ -1727,6 +1747,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1823,7 +1846,7 @@
 					</trans-unit>
 					<trans-unit id="loading_route">
 						<source>Loading route...</source>
-						<target>Chargement de l'itinéraire...</target>
+						<target>Chargement de l&apos;itinéraire...</target>
 					</trans-unit>
 					<trans-unit id="loading_train">
 						<source>Loading train...</source>
@@ -1838,12 +1861,12 @@
 						<target>Fichiers non trouvés :</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Des problèmes ont été décelés lors du chargement de l'itinéraire et/ou du train.\r\n\r\nComme certains fichiers n'ont pas été trouvés, l'itinéraire ou le train peut ne pas apparaître comme voulu. Essayez de réinstaller les fichiers de l'itinéraire et/ou du train pour être sûr d'avoir la distribution complète.\r\n\r\nLa liste suivante peut donner des informations complémentaires. Vous pouvez quand même débuter l'itinéraire en cliquant sur le bouton "Ignorer" présent ci-dessous.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Des problèmes ont été décelés lors du chargement de l&apos;itinéraire et/ou du train.\r\n\r\nComme certains fichiers n&apos;ont pas été trouvés, l&apos;itinéraire ou le train peut ne pas apparaître comme voulu. Essayez de réinstaller les fichiers de l&apos;itinéraire et/ou du train pour être sûr d&apos;avoir la distribution complète.\r\n\r\nLa liste suivante peut donner des informations complémentaires. Vous pouvez quand même débuter l&apos;itinéraire en cliquant sur le bouton &quot;Ignorer&quot; présent ci-dessous.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Des problèmes ont été décelés lors du chargement de l'itinéraire et/ou du train.\r\n\r\nSi vous êtes un simple utilisateur, vous pouvez débuter l'itinéraire en cliquant sur le bouton "Ignorer" présent ci-dessous.\r\n\r\nSi vous être le développeur de l'itinéraire ou du train, cela pourrait valoir la peine de jeter un coup d'oeil au journal suivant.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Des problèmes ont été décelés lors du chargement de l&apos;itinéraire et/ou du train.\r\n\r\nSi vous êtes un simple utilisateur, vous pouvez débuter l&apos;itinéraire en cliquant sur le bouton &quot;Ignorer&quot; présent ci-dessous.\r\n\r\nSi vous être le développeur de l&apos;itinéraire ou du train, cela pourrait valoir la peine de jeter un coup d&apos;oeil au journal suivant.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1907,7 +1930,7 @@
 					</trans-unit>
 					<trans-unit id="signal_stop">
 						<source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
-						<target>Vous venez de passer un signal fermé. Arrêtez-vous immédiatement à l'aide du freinage d'urgence !</target>
+						<target>Vous venez de passer un signal fermé. Arrêtez-vous immédiatement à l&apos;aide du freinage d&apos;urgence !</target>
 					</trans-unit>
 					<trans-unit id="signal_overspeed">
 						<source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
@@ -1927,7 +1950,7 @@
 					</trans-unit>
 					<trans-unit id="station_arrival_early">
 						<source>You have arrived at [name] and are [time] early.</source>
-						<target>Vous êtes arrivé à [name] avec [time] d'avance.</target>
+						<target>Vous êtes arrivé à [name] avec [time] d&apos;avance.</target>
 					</trans-unit>
 					<trans-unit id="station_overrun">
 						<source>Overrun: [difference] m.</source>
@@ -1935,7 +1958,7 @@
 					</trans-unit>
 					<trans-unit id="station_underrun">
 						<source>Underrun: [difference] m.</source>
-						<target>Vous n'avez pas atteint le point d'arrêt de [difference] m.</target>
+						<target>Vous n&apos;avez pas atteint le point d&apos;arrêt de [difference] m.</target>
 					</trans-unit>
 					<trans-unit id="station_terminal">
 						<source>This is the terminal station.</source>
@@ -1947,11 +1970,11 @@
 					</trans-unit>
 					<trans-unit id="station_security">
 						<source>Please activate [system].</source>
-						<target>Activez s'il vous plaît le [system].</target>
+						<target>Activez s&apos;il vous plaît le [system].</target>
 					</trans-unit>
 					<trans-unit id="station_correct">
 						<source>Please correct your stop position.</source>
-						<target>Ajustez s'il vous plaît votre position d'arrêt.</target>
+						<target>Ajustez s&apos;il vous plaît votre position d&apos;arrêt.</target>
 					</trans-unit>
 					<trans-unit id="station_depart_closedoors">
 						<source>Boarding complete. You may close the doors now.</source>
@@ -1972,6 +1995,21 @@
 					<trans-unit id="loading">
 						<source>Loading. Please wait...</source>
 						<target>Chargement en cours. Merci de patienter...</target>
+					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
 					</trans-unit>
 				</group>
 				<group id="notification">
@@ -2017,11 +2055,11 @@
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
 						<source>This feature is not available in Expert mode.</source>
-						<target>Cette fonctionalité n'est pas disponible dans le mode Expert.</target>
+						<target>Cette fonctionalité n&apos;est pas disponible dans le mode Expert.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
 						<source>The AI might be unable to fully operate this train.</source>
-						<target>Le pilotage automatique n'est peut être pas totalement disponible sur ce train.</target>
+						<target>Le pilotage automatique n&apos;est peut être pas totalement disponible sur ce train.</target>
 					</trans-unit>
 					<trans-unit id="camerarestriction_on">
 						<source>Camera restriction: on</source>
@@ -2033,11 +2071,26 @@
 					</trans-unit>
 					<trans-unit id="mousegrab_on">
 						<source>Mouse grab: on</source>
-						<target>Rotations de la caméra à l'aide de la souris : activées</target>
+						<target>Rotations de la caméra à l&apos;aide de la souris : activées</target>
 					</trans-unit>
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
-						<target>Rotations de la caméra à l'aide de la souris : désactivées</target>
+						<target>Rotations de la caméra à l&apos;aide de la souris : désactivées</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2047,7 +2100,7 @@
 					</trans-unit>
 					<trans-unit id="redsignal">
 						<source>Passed red signal</source>
-						<target>Non-respect d'un feu rouge</target>
+						<target>Non-respect d&apos;un feu rouge</target>
 					</trans-unit>
 					<trans-unit id="toppling">
 						<source>Toppling</source>
@@ -2071,7 +2124,7 @@
 					</trans-unit>
 					<trans-unit id="station_perfecttime">
 						<source>Perfect time bonus</source>
-						<target>Bonus pour respect de l'horaire</target>
+						<target>Bonus pour respect de l&apos;horaire</target>
 					</trans-unit>
 					<trans-unit id="station_late">
 						<source>Late</source>
@@ -2206,7 +2259,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2220,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Associé à l&apos;itinéraire</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2353,27 +2422,27 @@
 				<group id="commands">
 					<trans-unit id="power_increase">
 						<source>Increases power by one notch for trains with two handles</source>
-						<target>Augmente la traction d'un cran sur les trains se conduisant avec deux manettes</target>
+						<target>Augmente la traction d&apos;un cran sur les trains se conduisant avec deux manettes</target>
 					</trans-unit>
 					<trans-unit id="power_decrease">
 						<source>Decreases power by one notch for trains with two handles</source>
-						<target>Diminue la traction d'un cran sur les trains se conduisant avec deux manettes</target>
+						<target>Diminue la traction d&apos;un cran sur les trains se conduisant avec deux manettes</target>
 					</trans-unit>
 					<trans-unit id="power_halfaxis">
 						<source>Controls power for trains with two handles on half of a joystick axis</source>
-						<target>Contrôle la traction sur les trains se conduisant avec deux manettes à l'aide un demi-axe du joystick</target>
+						<target>Contrôle la traction sur les trains se conduisant avec deux manettes à l&apos;aide un demi-axe du joystick</target>
 					</trans-unit>
 					<trans-unit id="power_fullaxis">
 						<source>Controls power for trains with two handles on a full joystick axis</source>
-						<target>Contrôle la traction sur les trains se conduisant avec deux manettes à l'aide un axe complet du joystick</target>
+						<target>Contrôle la traction sur les trains se conduisant avec deux manettes à l&apos;aide un axe complet du joystick</target>
 					</trans-unit>
 					<trans-unit id="brake_decrease">
 						<source>Decreases brake by one notch for trains with two handles</source>
-						<target>Augmente le freinage d'un cran sur les trains se conduisant avec deux manettes</target>
+						<target>Augmente le freinage d&apos;un cran sur les trains se conduisant avec deux manettes</target>
 					</trans-unit>
 					<trans-unit id="brake_increase">
 						<source>Increases brake by one notch for trains with two handles</source>
-						<target>Diminue le freinage d'un cran sur les trains se conduisant avec deux manettes</target>
+						<target>Diminue le freinage d&apos;un cran sur les trains se conduisant avec deux manettes</target>
 					</trans-unit>
 					<trans-unit id="locobrake_decrease">
 						<source>Decreases the locomotive brake by one notch</source>
@@ -2383,35 +2452,35 @@
 					</trans-unit>
 					<trans-unit id="brake_halfaxis">
 						<source>Controls brake for trains with two handles on half of a joystick axis</source>
-						<target>Contrôle le freinage sur les trains se conduisant avec deux manettes à l'aide un demi-axe du joystick</target>
+						<target>Contrôle le freinage sur les trains se conduisant avec deux manettes à l&apos;aide un demi-axe du joystick</target>
 					</trans-unit>
 					<trans-unit id="brake_fullaxis">
 						<source>Controls brake for trains with two handles on a full joystick axis</source>
-						<target>Contrôle le freinage sur les trains se conduisant avec deux manettes à l'aide un axe complet du joystick</target>
+						<target>Contrôle le freinage sur les trains se conduisant avec deux manettes à l&apos;aide un axe complet du joystick</target>
 					</trans-unit>
 					<trans-unit id="brake_emergency">
 						<source>Activates emergency brakes for trains with two handles</source>
-						<target>Active le freinage d'urgence sur les trains se conduisant avec deux manettes</target>
+						<target>Active le freinage d&apos;urgence sur les trains se conduisant avec deux manettes</target>
 					</trans-unit>
 					<trans-unit id="single_power">
 						<source>Moves handle toward power by one notch for trains with one handle</source>
-						<target>Augmente la traction d'un cran sur les trains se conduisant avec une seule manette</target>
+						<target>Augmente la traction d&apos;un cran sur les trains se conduisant avec une seule manette</target>
 					</trans-unit>
 					<trans-unit id="single_neutral">
 						<source>Moves handle toward neutral by one notch for trains with one handle</source>
-						<target>Diminue la traction ou le freinage d'un cran sur les trains se conduisant avec une seule manette</target>
+						<target>Diminue la traction ou le freinage d&apos;un cran sur les trains se conduisant avec une seule manette</target>
 					</trans-unit>
 					<trans-unit id="single_brake">
 						<source>Moves handle toward brake by one notch for trains with one handle</source>
-						<target>Augmente le freinage d'un cran sur les trains se conduisant avec une seule manette</target>
+						<target>Augmente le freinage d&apos;un cran sur les trains se conduisant avec une seule manette</target>
 					</trans-unit>
 					<trans-unit id="single_emergency">
 						<source>Activates emergency brake for trains with one handle</source>
-						<target>Active le freinage d'urgence sur les trains se conduisant avec une seule manette</target>
+						<target>Active le freinage d&apos;urgence sur les trains se conduisant avec une seule manette</target>
 					</trans-unit>
 					<trans-unit id="single_fullaxis">
 						<source>Controls power and brake for trains with one handle on a full joystick axis</source>
-						<target>Contrôle la traction et le freinage sur les trains se conduisant avec une seule manette à l'aide un axe complet du joystick</target>
+						<target>Contrôle la traction et le freinage sur les trains se conduisant avec une seule manette à l&apos;aide un axe complet du joystick</target>
 					</trans-unit>
 					<trans-unit id="power_any_notch">
 						<source>Adjusts the power notch directly from a command option value.</source>
@@ -2439,7 +2508,7 @@
 					</trans-unit>
 					<trans-unit id="reverser_fullaxis">
 						<source>Controls reverser on a full joystick axis</source>
-						<target>Contrôle la marche avant/arrière à l'aide un axe complet du joystick</target>
+						<target>Contrôle la marche avant/arrière à l&apos;aide un axe complet du joystick</target>
 					</trans-unit>
 					<trans-unit id="doors_left">
 						<source>Opens or closes the left doors</source>
@@ -2451,15 +2520,15 @@
 					</trans-unit>
 					<trans-unit id="horn_primary">
 						<source>Plays the primary horn</source>
-						<target>Actionne l'avertisseur sonore primaire</target>
+						<target>Actionne l&apos;avertisseur sonore primaire</target>
 					</trans-unit>
 					<trans-unit id="horn_secondary">
 						<source>Plays the secondary horn</source>
-						<target>Actionne l'avertisseur sonore secondaire</target>
+						<target>Actionne l&apos;avertisseur sonore secondaire</target>
 					</trans-unit>
 					<trans-unit id="horn_music">
 						<source>Plays or stops the music horn</source>
-						<target>Active/désactive l'avertisseur sonore musical</target>
+						<target>Active/désactive l&apos;avertisseur sonore musical</target>
 					</trans-unit>
 					<trans-unit id="device_constspeed">
 						<source>Activates or deactivates the constant speed device</source>
@@ -2558,14 +2627,14 @@
 						<target>Fonction P du système de sécurité</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Commute vers la vue intérieure au train</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Commute vers la vue extérieure au train</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2578,11 +2647,11 @@
 					</trans-unit>
 					<trans-unit id="camera_move_forward">
 						<source>Moves the camera forward</source>
-						<target>Déplace la caméra vers l'avant</target>
+						<target>Déplace la caméra vers l&apos;avant</target>
 					</trans-unit>
 					<trans-unit id="camera_move_backward">
 						<source>Moves the camera backward</source>
-						<target>Déplace la caméra vers l'arrière</target>
+						<target>Déplace la caméra vers l&apos;arrière</target>
 					</trans-unit>
 					<trans-unit id="camera_move_left">
 						<source>Moves the camera left</source>
@@ -2618,11 +2687,11 @@
 					</trans-unit>
 					<trans-unit id="camera_rotate_ccw">
 						<source>Rotates the camera counter-clockwise</source>
-						<target>Tourne la caméra dans le sens inverse des aiguilles d'une montre</target>
+						<target>Tourne la caméra dans le sens inverse des aiguilles d&apos;une montre</target>
 					</trans-unit>
 					<trans-unit id="camera_rotate_cw">
 						<source>Rotates the camera clockwise</source>
-						<target>Tourne la caméra dans le sens des aiguilles d'une montre</target>
+						<target>Tourne la caméra dans le sens des aiguilles d&apos;une montre</target>
 					</trans-unit>
 					<trans-unit id="camera_zoom_in">
 						<source>Zooms the camera in</source>
@@ -2634,11 +2703,11 @@
 					</trans-unit>
 					<trans-unit id="camera_poi_previous">
 						<source>Jumps to the previous point of interest in the route.</source>
-						<target>Va au précédent point d'intérêt de l'itinéraire</target>
+						<target>Va au précédent point d&apos;intérêt de l&apos;itinéraire</target>
 					</trans-unit>
 					<trans-unit id="camera_poi_next">
 						<source>Jumps to the next point of interest in the route.</source>
-						<target>Va au point d'intérêt suivant de l'itinéraire</target>
+						<target>Va au point d&apos;intérêt suivant de l&apos;itinéraire</target>
 					</trans-unit>
 					<trans-unit id="camera_reset">
 						<source>Resets the camera view to default values</source>
@@ -2650,15 +2719,15 @@
 					</trans-unit>
 					<trans-unit id="timetable_toggle">
 						<source>Toggles through different timetable modes</source>
-						<target>Permute entre les différents modes d'affichage des horaires</target>
+						<target>Permute entre les différents modes d&apos;affichage des horaires</target>
 					</trans-unit>
 					<trans-unit id="timetable_up">
 						<source>Scrolls the timetable up</source>
-						<target>Fait défiler l'horaire vers le haut</target>
+						<target>Fait défiler l&apos;horaire vers le haut</target>
 					</trans-unit>
 					<trans-unit id="timetable_down">
 						<source>Scrolls the timetable down</source>
-						<target>Fait défiler l'horaire vers le bas</target>
+						<target>Fait défiler l&apos;horaire vers le bas</target>
 					</trans-unit>
 					<trans-unit id="menu_activate">
 						<source>Displays the in-game menu</source>
@@ -2682,11 +2751,11 @@
 					</trans-unit>
 					<trans-unit id="misc_clock">
 						<source>Shows or hides the clock</source>
-						<target>Active/désactive l'affichage de l'horloge</target>
+						<target>Active/désactive l&apos;affichage de l&apos;horloge</target>
 					</trans-unit>
 					<trans-unit id="misc_speed">
 						<source>Toggles through different speed display modes</source>
-						<target>Permute entre les différents modes d'affichage de la vitesse</target>
+						<target>Permute entre les différents modes d&apos;affichage de la vitesse</target>
 					</trans-unit>
 					<trans-unit id="misc_gradient">
 						<source>Toggles through different gradient display modes</source>
@@ -2698,11 +2767,11 @@
 					</trans-unit>
 					<trans-unit id="misc_timefactor">
 						<source>Toggles through different time acceleration factors</source>
-						<target>Permute entre les différents facteurs d'accélération temporelle</target>
+						<target>Permute entre les différents facteurs d&apos;accélération temporelle</target>
 					</trans-unit>
 					<trans-unit id="misc_fps">
 						<source>Shows or hides the frame rate display</source>
-						<target>Active/désactive l'affichage du taux d'images par seconde</target>
+						<target>Active/désactive l&apos;affichage du taux d&apos;images par seconde</target>
 					</trans-unit>
 					<trans-unit id="misc_ai">
 						<source>Activates or deactivates the virtual driver (AI)</source>
@@ -2726,7 +2795,7 @@
 					</trans-unit>
 					<trans-unit id="misc_interface">
 						<source>Toggles through different interface modes</source>
-						<target>Permute entre les différents modes d'interface</target>
+						<target>Permute entre les différents modes d&apos;interface</target>
 					</trans-unit>
 					<trans-unit id="misc_backface">
 						<source>Activates or deactivates backface culling</source>
@@ -2734,7 +2803,7 @@
 					</trans-unit>
 					<trans-unit id="misc_cpumode">
 						<source>Switches to or from reduced CPU mode</source>
-						<target>Active/désactive le mode d'utilisation basse du CPU</target>
+						<target>Active/désactive le mode d&apos;utilisation basse du CPU</target>
 					</trans-unit>
 					<trans-unit id="debug_wireframe">
 						<source>Activates or deactivates wireframe mode</source>
@@ -2742,11 +2811,11 @@
 					</trans-unit>
 					<trans-unit id="debug_normals">
 						<source>Shows or hides vertex normals</source>
-						<target>Active/désactive l'affichage des normales des vertex</target>
+						<target>Active/désactive l&apos;affichage des normales des vertex</target>
 					</trans-unit>
 					<trans-unit id="debug_brake_systems">
 						<source>Shows or hides brake system debug output</source>
-						<target>Active/désactive l'affichage des informations de débogage du système de freinage</target>
+						<target>Active/désactive l&apos;affichage des informations de débogage du système de freinage</target>
 					</trans-unit>
 					<trans-unit id="debug_ats">
 						<source>Shows or hides plugin debug output</source>
@@ -2826,6 +2895,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3239,7 +3332,7 @@
 					</trans-unit>
 					<trans-unit id="slash">
 						<source>Slash</source>
-						<target>Point d'exclamation</target>
+						<target>Point d&apos;exclamation</target>
 					</trans-unit>
 					<trans-unit id="space">
 						<source>Space</source>
@@ -3364,6 +3457,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>W</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3616,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3878,8 +4125,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3999,12 +4246,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4016,6 +4260,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4055,13 +4302,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4072,22 +4313,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4119,8 +4351,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4141,9 +4400,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4172,15 +4428,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4232,6 +4479,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4239,12 +4498,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4275,17 +4548,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4343,9 +4605,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4388,6 +4647,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4413,6 +4675,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4431,15 +4704,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4495,11 +4768,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4626,9 +4902,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4651,12 +4924,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4749,11 +5025,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4765,12 +5041,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4798,9 +5096,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4820,67 +5162,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4902,17 +5189,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4948,12 +5224,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4965,6 +5235,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4982,12 +5258,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4999,6 +5269,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5025,12 +5301,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5042,6 +5312,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5057,17 +5344,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5076,9 +5352,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5090,6 +5363,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5104,9 +5380,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5129,6 +5402,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5141,9 +5417,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5159,62 +5552,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5229,6 +5568,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5259,7 +5601,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/hu-HU.xlf
+++ b/assets/Languages/hu-HU.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="hu-HU">
 		<body>
 			<group id="language">
@@ -16,15 +16,15 @@
 					<target>Phonteus Nevolius</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
-					<target state="translated">2020-04-16</target>
+					<source>2019-06-29</source>
+					<target>2020-04-16</target>
 				</trans-unit>
 			</group>
 			<group id="openbve">
 				<group id="program">
 					<trans-unit id="title">
 						<source>OpenBVE</source>
-						<target state="translated">OpenBVE</target>
+						<target>OpenBVE</target>
 					</trans-unit>
 				</group>
 				<group id="about">
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -110,7 +110,7 @@
 					</trans-unit>
 					<trans-unit id="controls">
 						<source>Customize controls</source>
-						<target state="translated">Kezelés testreszabása</target>
+						<target>Kezelés testreszabása</target>
 					</trans-unit>
 					<trans-unit id="options">
 						<source>Options</source>
@@ -190,27 +190,27 @@
 					</trans-unit>
 					<trans-unit id="controls_missing">
 						<source>No control configuration files found.</source>
-						<target state="translated">Nem található kezelőeszköz konfigurációs fájl.</target>
+						<target>Nem található kezelőeszköz konfigurációs fájl.</target>
 					</trans-unit>
 					<trans-unit id="controls_oldversion">
 						<source>An older key-configuration file was found.</source>
-						<target state="translated">Egy régebbi kezelőeszköz konfigurációs fájlt találtunk.</target>
+						<target>Egy régebbi kezelőeszköz konfigurációs fájlt találtunk.</target>
 					</trans-unit>
 					<trans-unit id="controls_reset">
 						<source>The current key-configuration has been reset to defaults.</source>
-						<target state="translated">A jelenlegi kezelőeszköz konfigurációt visszaállítottuk az alapértelmezettre.</target>
+						<target>A jelenlegi kezelőeszköz konfigurációt visszaállítottuk az alapértelmezettre.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_oldversion">
 						<source>The default key assingment file is an older version or corrupt.</source>
-						<target state="translated">Az alapértelmezett kezelőeszköz konfigurációs fájl régebbi verziójú vagy sérült.</target>
+						<target>Az alapértelmezett kezelőeszköz konfigurációs fájl régebbi verziójú vagy sérült.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_missing">
 						<source>The default key assignment file does not exist.</source>
-						<target state="translated">Az alapértelmezett kezelőeszköz konfigurációs fájl nem létezik.</target>
+						<target>Az alapértelmezett kezelőeszköz konfigurációs fájl nem létezik.</target>
 					</trans-unit>
 					<trans-unit id="controls_ingame">
 						<source>You are currently running on the [platform] backend. Please use the in-game menu to configure any joystick based controls.</source>
-						<target state="translated">Ön jelenleg a [platform] rendszert használja. Kérjük, használja a játék közbeni menüt a joystick alapú kezelőeszközök konfigurálására.</target>
+						<target>Ön jelenleg a [platform] rendszert használja. Kérjük, használja a játék közbeni menüt a joystick alapú kezelőeszközök konfigurálására.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_version">
 						<source>OpenAL 1.1 is required. You seem to have version 1.0.</source>
@@ -238,11 +238,11 @@
 					</trans-unit>
 					<trans-unit id="route_corrupt_nostations">
 						<source>The selected route is corrupt: \r\n No stations defined.</source>
-						<target state="translated">A kiválasztott pálya hibás: \r\n Nincsenek állomások.</target>
+						<target>A kiválasztott pálya hibás: \r\n Nincsenek állomások.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_noobjects">
 						<source>The selected route is corrupt: \r\n No objects defined.</source>
-						<target state="translated">A kiválasztott pálya hibás: \r\n Nincsenek objektumok.</target>
+						<target>A kiválasztott pálya hibás: \r\n Nincsenek objektumok.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_missingobjects">
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
@@ -257,19 +257,19 @@
 					</trans-unit>
 					<trans-unit id="package_filename_empty">
 						<source>Attempted to create a package with an empty filename.</source>
-						<target state="translated">Üres fájlnévvel próbált csomagot létrehozni.</target>
+						<target>Üres fájlnévvel próbált csomagot létrehozni.</target>
 					</trans-unit>
 					<trans-unit id="package_directory_missing">
 						<source>The directory in which you attempted to save the package file does not exist: \r \n</source>
-						<target state="translated">A könyvtár ahova a csomagot menteni próbálta nem létezik: \r \n</target>
+						<target>A könyvtár ahova a csomagot menteni próbálta nem létezik: \r \n</target>
 					</trans-unit>
 					<trans-unit id="package_directory_nowrite">
 						<source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
-						<target state="translated">Nincs írásjogosultság a csomag mentésére megadott könyvtárhoz: \r \n</target>
+						<target>Nincs írásjogosultság a csomag mentésére megadott könyvtárhoz: \r \n</target>
 					</trans-unit>
 					<trans-unit id="package_file_generic">
 						<source>Failed to create the following file: \r \n</source>
-						<target state="translated">Nem sikerült létrehozni a fájlt: \r \n</target>
+						<target>Nem sikerült létrehozni a fájlt: \r \n</target>
 					</trans-unit>
 					<trans-unit id="security_checkaccess">
 						<source>Please check that this path is accessible.</source>
@@ -287,6 +287,12 @@
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Legutóbbiak</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Alapértelmezett vonat</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>A pályában beállított alapértelmezett vonat használata</target>
@@ -392,14 +394,14 @@
 					</trans-unit>
 					<trans-unit id="train_settings_reverseconsist">
 						<source>Reverse Consist:</source>
-						<target state="translated">Vonat fordítva:</target>
+						<target>Vonat fordítva:</target>
 					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Előnézet:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>A kiválasztott vonat nem található:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -417,6 +419,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Indítás</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -615,8 +626,8 @@
 						<target>Csomag telepítése</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>Úgy tűnik, ez a fájl nem egy érvényes openBVE csomag.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Úgy tűnik, ez a fájl nem egy érvényes OpenBVE csomag.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -727,8 +738,8 @@
 						<target>Eltávolítás</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -754,7 +765,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Az új csomag a következő GUID azonosítót kapta:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Csomag létrehozása</target>
 					</trans-unit>
@@ -808,7 +819,7 @@
 					</trans-unit>
 					<trans-unit id="creation_invalid_nofiles">
 						<source>No files were selected to package- Please retry.</source>
-						<target state="translated">Nem jelölt ki fájlokat a csomaghoz. Próbálja újra.</target>
+						<target>Nem jelölt ki fájlokat a csomaghoz. Próbálja újra.</target>
 					</trans-unit>
 					<trans-unit id="creation_invalid_filename">
 						<source>The selected filename is invalid- Please retry.</source>
@@ -984,17 +995,26 @@
 					</trans-unit>
 					<trans-unit id="directory_nowrite">
 						<source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
-						<target state="translated">Nincs írásjogosultság a könyvtárhoz, ahova menteni kívánta a fájlt: \r \n</target>
+						<target>Nincs írásjogosultság a könyvtárhoz, ahova menteni kívánta a fájlt: \r \n</target>
 					</trans-unit>
 					<trans-unit id="file_generic">
 						<source>Failed to create the following file: \r \n</source>
 						<target>Nem sikerült létrehozni a következő fájlt: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
 						<source>Customize controls</source>
-						<target state="translated">Kezelés testreszabása</target>
+						<target>Kezelés testreszabása</target>
 					</trans-unit>
 					<trans-unit id="list_command">
 						<source>Command</source>
@@ -1022,11 +1042,11 @@
 					</trans-unit>
 					<trans-unit id="list_assignment">
 						<source>Assignment</source>
-						<target state="translated">Hozzárendelés</target>
+						<target>Hozzárendelés</target>
 					</trans-unit>
 					<trans-unit id="list_option">
 						<source>Command Option</source>
-						<target state="translated">Parancs opció</target>
+						<target>Parancs opció</target>
 					</trans-unit>
 					<trans-unit id="add">
 						<source>Add control</source>
@@ -1069,7 +1089,7 @@
 					</trans-unit>
 					<trans-unit id="selection_command_option">
 						<source>Command Option:</source>
-						<target state="translated">Parancs opció:</target>
+						<target>Parancs opció:</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard">
 						<source>Keyboard:</source>
@@ -1109,7 +1129,7 @@
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment">
 						<source>Assignment:</source>
-						<target state="translated">Hozzárendelés:</target>
+						<target>Hozzárendelés:</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab">
 						<source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
@@ -1120,8 +1140,8 @@
 						<target>Nyomjon meg egy gombot vagy mozdítsa el a kart egy irányba...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Mozdítsa el a kart a "növekvő" irányába (Menetfokozatok beállításakor a menetfokozatok emelkedésének irányába, fékbeállításnál a fékfokozatok emelkedésének irányába)...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Mozdítsa el a kart a &quot;növekvő&quot; irányába (Menetfokozatok beállításakor a menetfokozatok emelkedésének irányába, fékbeállításnál a fékfokozatok emelkedésének irányába)...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1246,64 +1266,64 @@
 						<target>Hiba a RailDriver kalibrációs fájl betöltésekor.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Kattintson a 'Next' gombra a kalibrálás megkezdéséhez.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Kattintson a &apos;Next&apos; gombra a kalibrálás megkezdéséhez.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Állítsa az irányváltót teljesen hátra állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Állítsa az irányváltót teljesen hátra állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Állítsa az irányváltót teljesen előre állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Állítsa az irányváltót teljesen előre állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Állítsa a kombinált menet / fékkart teljesen menet állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Állítsa a kombinált menet / fékkart teljesen menet állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Állítsa a kombinált menet / fékkart teljesen fék állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Állítsa a kombinált menet / fékkart teljesen fék állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Állítsa a dinamikus fékkart nyitott állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Állítsa a dinamikus fékkart nyitott állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Állítsa a dinamikus fékkart vészfék állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Állítsa a dinamikus fékkart vészfék állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Állítsa a független fékkart nyitott állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Állítsa a független fékkart nyitott állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Állítsa a független fékkart teljes fék állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Állítsa a független fékkart teljes fék állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Állítsa a mozdonyfékkioldót alaphelyzetbe és nyomja meg a 'Next' gombot.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Állítsa a mozdonyfékkioldót alaphelyzetbe és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Állítsa a mozdonyfékkioldót fékoldás állásba, tartsa ott, majd nyomja meg a 'Next' gombot.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Állítsa a mozdonyfékkioldót fékoldás állásba, tartsa ott, majd nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Állítsa az ablaktörlő kapcsolóját OFF állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Állítsa az ablaktörlő kapcsolóját OFF állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Állítsa az ablaktörlő kapcsolóját FULL állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Állítsa az ablaktörlő kapcsolóját FULL állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Állítsa a fényszóró kapcsolóját OFF állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Állítsa a fényszóró kapcsolóját OFF állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Állítsa a fényszóró kapcsolóját FULL állásba és nyomja meg a 'Next' gombot.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Állítsa a fényszóró kapcsolóját FULL állásba és nyomja meg a &apos;Next&apos; gombot.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1557,7 +1577,7 @@
 					</trans-unit>
 					<trans-unit id="advanced_is_use_new_renderer">
 						<source>Enable the new renderer</source>
-						<target state="translated">Új renderer bekapcsolása</target>
+						<target>Új renderer bekapcsolása</target>
 					</trans-unit>
 					<trans-unit id="advanced_disable_displaylists">
 						<source>Disable OpenGL display lists</source>
@@ -1669,51 +1689,51 @@
 					</trans-unit>
 					<trans-unit id="input_device_plugin">
 						<source>Input Device Plugin</source>
-						<target state="translated">Bemeneti eszköz pluginok</target>
+						<target>Bemeneti eszköz pluginok</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_warning">
 						<source>WARNING: If you enable Input Device Plugin(s), these may conflict with one or more controls.</source>
-						<target state="translated">FIGYELEM: Ha engedélyez bemeneti eszköz plugin(ok)at az konfliktust okozhat egy vagy több kezelési beállítással.</target>
+						<target>FIGYELEM: Ha engedélyez bemeneti eszköz plugin(ok)at az konfliktust okozhat egy vagy több kezelési beállítással.</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_name">
 						<source>Name</source>
-						<target state="translated">Név</target>
+						<target>Név</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status">
 						<source>Status</source>
-						<target state="translated">Állapot</target>
+						<target>Állapot</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_failure">
 						<source>Failure</source>
-						<target state="translated">Hiba</target>
+						<target>Hiba</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_disable">
 						<source>Disable</source>
-						<target state="translated">Ki</target>
+						<target>Ki</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_enable">
 						<source>Enable</source>
-						<target state="translated">Be</target>
+						<target>Be</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_version">
 						<source>Version</source>
-						<target state="translated">Verzió</target>
+						<target>Verzió</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_provider">
 						<source>Provider</source>
-						<target state="translated">Készítő</target>
+						<target>Készítő</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_file_name">
 						<source>File Name</source>
-						<target state="translated">Fájlnév</target>
+						<target>Fájlnév</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_switch">
 						<source>Enable this Input Device Plugin</source>
-						<target state="translated">Kijelölt plugin bekapcsolása</target>
+						<target>Kijelölt plugin bekapcsolása</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_config">
 						<source>Config</source>
-						<target state="translated">Beállítások</target>
+						<target>Beállítások</target>
 					</trans-unit>
 					<trans-unit id="panel2_extended">
 						<source>Enable Panel2 Extended Mode</source>
@@ -1729,6 +1749,9 @@
 					</trans-unit>
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
+					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
 					</trans-unit>
 				</group>
 				<group id="dialog">
@@ -1841,12 +1864,12 @@
 						<target>A következő fájl nem található:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>A pálya és a vonat betöltése közben hibák merültek fel.\r\n\r\nMivel néhány fájl nem található, elképzelhető, hogy a pálya vagy a vonat nem megfelelően jelenik meg. Próbálja meg újra letölteni a pályát és a vonatot.\r\n\r\nA következő lista összegzi a hibákat. Mindemellett a "Mellőz" gombra kattintva elindíthatja a játékot.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>A pálya és a vonat betöltése közben hibák merültek fel.\r\n\r\nMivel néhány fájl nem található, elképzelhető, hogy a pálya vagy a vonat nem megfelelően jelenik meg. Próbálja meg újra letölteni a pályát és a vonatot.\r\n\r\nA következő lista összegzi a hibákat. Mindemellett a &quot;Mellőz&quot; gombra kattintva elindíthatja a játékot.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>A pálya és a vonat betöltése közben hibák merültek fel. Ha ön a pálya vagy a vonat készítője, a következő lista hasznos információt adhat a hibák forrásával kapcsolatban.\r\n\r\nFelhasználóként a "Mellőz" gombra kattintva indíthatja el a játékot.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>A pálya és a vonat betöltése közben hibák merültek fel. Ha ön a pálya vagy a vonat készítője, a következő lista hasznos információt adhat a hibák forrásával kapcsolatban.\r\n\r\nFelhasználóként a &quot;Mellőz&quot; gombra kattintva indíthatja el a játékot.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1976,6 +1999,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Betöltés. Kérem, várjon...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2041,6 +2079,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Egér kikapcsolva</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2174,7 +2227,7 @@
 					</trans-unit>
 					<trans-unit id="quit">
 						<source>Quit</source>
-						<target state="translated">Kilépés az OpenBVE-ből</target>
+						<target>Kilépés az OpenBVE-ből</target>
 					</trans-unit>
 					<trans-unit id="quit_question">
 						<source>Do you really want to quit?</source>
@@ -2194,7 +2247,7 @@
 					</trans-unit>
 					<trans-unit id="customize_controls">
 						<source>Customise controls</source>
-						<target state="translated">Kezelés testreszabása</target>
+						<target>Kezelés testreszabása</target>
 					</trans-unit>
 					<trans-unit id="assign">
 						<source>Please press any key or move a joystick axis to set this control...</source>
@@ -2209,7 +2262,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2223,6 +2276,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Jelenlegi beállítás:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Alapértelmezett vonat</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2418,19 +2487,19 @@
 					</trans-unit>
 					<trans-unit id="power_any_notch">
 						<source>Adjusts the power notch directly from a command option value.</source>
-						<target state="translated">A menetfokozatot közvetlenül a megadott értékre állítja.</target>
+						<target>A menetfokozatot közvetlenül a megadott értékre állítja.</target>
 					</trans-unit>
 					<trans-unit id="brake_any_notch">
 						<source>Adjusts the brake notch directly from a command option value.</source>
-						<target state="translated">A fékfokozatot közvetlenül a megadott értékre állítja.</target>
+						<target>A fékfokozatot közvetlenül a megadott értékre állítja.</target>
 					</trans-unit>
 					<trans-unit id="reverser_any_position">
 						<source>Adjusts the reverser directly from a command option value.</source>
-						<target state="translated">Az irányváltót közvetlenül a megadott állásba állítja.</target>
+						<target>Az irányváltót közvetlenül a megadott állásba állítja.</target>
 					</trans-unit>
 					<trans-unit id="hold_brake">
 						<source>Hold Brake</source>
-						<target state="translated">Fék tartása</target>
+						<target>Fék tartása</target>
 					</trans-unit>
 					<trans-unit id="reverser_forward">
 						<source>Moves reverser forward by one notch</source>
@@ -2442,7 +2511,7 @@
 					</trans-unit>
 					<trans-unit id="reverser_fullaxis">
 						<source>Controls reverser on a full joystick axis</source>
-						<target state="translated">Irányváltó joysticken</target>
+						<target>Irányváltó joysticken</target>
 					</trans-unit>
 					<trans-unit id="doors_left">
 						<source>Opens or closes the left doors</source>
@@ -2561,15 +2630,15 @@
 						<target>A biztonsági rendszer P funkciója</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Belső kameranézetre vált</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
-						<target state="translated">Belső nézetre vált, de a vezetőállás nem jelenik meg.</target>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
+						<target>Belső nézetre vált, de a vezetőállás nem jelenik meg.</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Külső kameranézetre vált</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2758,7 +2827,7 @@
 					</trans-unit>
 					<trans-unit id="debug_touch_mode">
 						<source>Shows or hides the touch range</source>
-						<target state="translated">Mutatja vagy elrejti az érintés területét</target>
+						<target>Mutatja vagy elrejti az érintés területét</target>
 					</trans-unit>
 					<trans-unit id="route_information">
 						<source>Shows or hides the route information window</source>
@@ -2831,6 +2900,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Be- és kikapcsolja a főmegszakítót</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3196,7 +3289,7 @@
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>["]</target>
+						<target>[&quot;]</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3371,6 +3464,154 @@
 						<target>Y</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3396,15 +3637,15 @@
 					</trans-unit>
 					<trans-unit id="new_message">
 						<source>Do you want to save data before creating a new train?</source>
-						<target state="translated">El akarja menteni az adatokat új vonat létrehozása előtt?</target>
+						<target>El akarja menteni az adatokat új vonat létrehozása előtt?</target>
 					</trans-unit>
 					<trans-unit id="open_message">
 						<source>Do you want to save data before opening another train?</source>
-						<target state="translated">El akarja menteni az adatokat új vonat megnyitása előtt?</target>
+						<target>El akarja menteni az adatokat új vonat megnyitása előtt?</target>
 					</trans-unit>
 					<trans-unit id="close_message">
 						<source>Do you want to save data before closing?</source>
-						<target state="translated">El akarja menteni az adatokat bezárás előtt?</target>
+						<target>El akarja menteni az adatokat bezárás előtt?</target>
 					</trans-unit>
 					<trans-unit id="properties_one">
 						<source>Properties (1)</source>
@@ -3418,11 +3659,11 @@
 				<group id="performance">
 					<trans-unit id="performance">
 						<source>Performance</source>
-						<target state="translated">Teljesítmény</target>
+						<target>Teljesítmény</target>
 					</trans-unit>
 					<trans-unit id="deceleration">
 						<source>Deceleration:</source>
-						<target state="translated">Lassulás</target>
+						<target>Lassulás</target>
 					</trans-unit>
 					<trans-unit id="static_friction">
 						<source>CoefficientOfStaticFriction:</source>
@@ -3621,6 +3862,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3883,8 +4130,8 @@
 						<target>További funkciók</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4004,12 +4251,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4021,6 +4265,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4060,13 +4307,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4077,22 +4318,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4124,8 +4356,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4146,9 +4405,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4177,15 +4433,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4237,6 +4484,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4244,12 +4503,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4280,17 +4553,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4348,9 +4610,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4393,6 +4652,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4418,6 +4680,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4436,15 +4709,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4500,11 +4773,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4631,9 +4907,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4656,12 +4929,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4754,11 +5030,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4770,12 +5046,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4803,9 +5101,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4825,67 +5167,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4907,17 +5194,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4953,12 +5229,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4970,6 +5240,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4987,12 +5263,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5004,6 +5274,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5030,12 +5306,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5047,6 +5317,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5062,17 +5349,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5081,9 +5357,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5095,6 +5368,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5109,9 +5385,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5134,6 +5407,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5146,9 +5422,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5164,62 +5557,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5234,6 +5573,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5264,7 +5606,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/id-ID.xlf
+++ b/assets/Languages/id-ID.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="id-ID">
 		<body>
 			<group id="language">
@@ -72,12 +73,12 @@
 						<source>Save Bug Report</source>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -236,9 +237,6 @@
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
 						<target>Rute yang dipilih tidak dapat dibuka: \r\n Objek rute tidak dapat ditemukan.</target>
 					</trans-unit>
-					<trans-unit id="route_corrupt_missingobjects">
-						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
 						<target>Tidak dapat membaca plugin [plugin].</target>
@@ -270,6 +268,9 @@
 					<trans-unit id="security_badlocation">
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
 						<target>Saat menginstal add-on di folder Program Files atau ProgramData, sistem mungkin meminta izin administrator. \r\n\r\n Tidak direkomendasikan untuk melakukannya.</target>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -336,18 +337,6 @@
 						<source>Choose Train...</source>
 						<target>Pilih rangkaian kereta...</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-						<target>Gunakan rangkaian yang dianjurkan?</target>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-						<target>Tidak</target>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
-						<target>Ya</target>
-					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
 						<target>Pilihan:</target>
@@ -413,6 +402,9 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Mulai</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -609,7 +601,7 @@
 						<target>Instal add-on baru</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 						<target>File ini tidak terlihat seperti file add-ons untuk OpenBVE.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
@@ -721,8 +713,8 @@
 						<target>Hapus</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -748,7 +740,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Add-on baru telah dibuat dengan GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -1248,64 +1240,64 @@
 						<target>Error saat membuka file kalibrasi RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Tekan 'Lanjut' untuk mulai kalibrasi.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Tekan &apos;Lanjut&apos; untuk mulai kalibrasi.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Ubah reverser ke arah mundur dan pilih 'lanjut'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Ubah reverser ke arah mundur dan pilih &apos;lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Ubah reverser ke arah maju dan pilih 'lanjut'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Ubah reverser ke arah maju dan pilih &apos;lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Ubah tuas single ke arah full power lalu pilih 'Lanjut'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Ubah tuas single ke arah full power lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Ubah tuas single ke arah rem penuh lalu pilih 'Lanjut'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Ubah tuas single ke arah rem penuh lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Geser tuas rem dinamis ke arah RELEASE lalu pilih 'Lanjut'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Geser tuas rem dinamis ke arah RELEASE lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Geser tuas rem dinamis ke arah EMEREGENCY lalu pilih 'Lanjut'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Geser tuas rem dinamis ke arah EMEREGENCY lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Geser tuas rem independen ke arah RELEASE lalu pilih 'Lanjut'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Geser tuas rem independen ke arah RELEASE lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Geser tuas rem independen ke arah FULL lalu pilih 'Lanjut'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Geser tuas rem independen ke arah FULL lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Geser tuas bail-off ke arah RELEASE lalu pilih 'Lanjut'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Geser tuas bail-off ke arah RELEASE lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Geser dan tahan tuas bail-off ke arah FULL lalu pilih 'Lanjut'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Geser dan tahan tuas bail-off ke arah FULL lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Ubah posisi wiper ker arah MATI lalu pilih 'Lanjut'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Ubah posisi wiper ker arah MATI lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Ubah posisi wiper ke posisi FULL lalu pilih 'Lanjut'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Ubah posisi wiper ke posisi FULL lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Ubah posisi lampu ke posisi OFF lalu pilih 'Lanjut'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Ubah posisi lampu ke posisi OFF lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Ubah posisi lampu ke posisi FULL lalu pilih 'Lanjut'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Ubah posisi lampu ke posisi FULL lalu pilih &apos;Lanjut&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1841,11 +1833,11 @@
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
 						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
-						<target>Error saat mencoba loading rute dan kereta. \r\n\r\nBeberapa file hilang sehingga mungkin rute atau kereta tidak muncul seperti yang seharusnya. Cobalah download rute dan kereta lagi untuk memastikan tidak ada file yang tertinggal. \r\n\r\nTekan 'Abaikan' untuk tetap memainkan rute dan kereta ini.</target>
+						<target>Error saat mencoba loading rute dan kereta. \r\n\r\nBeberapa file hilang sehingga mungkin rute atau kereta tidak muncul seperti yang seharusnya. Cobalah download rute dan kereta lagi untuk memastikan tidak ada file yang tertinggal. \r\n\r\nTekan &apos;Abaikan&apos; untuk tetap memainkan rute dan kereta ini.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
 						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
-						<target>Error saat mencoba loading rute dan kereta. \r\n\r\nBeberapa file tidak ditemukan. Jika anda kreator add-on ini, cek pesan error yang tersedia. \r\n\r\nTekan 'Abaikan' untuk tetap memainkan rute dan kereta ini.</target>
+						<target>Error saat mencoba loading rute dan kereta. \r\n\r\nBeberapa file tidak ditemukan. Jika anda kreator add-on ini, cek pesan error yang tersedia. \r\n\r\nTekan &apos;Abaikan&apos; untuk tetap memainkan rute dan kereta ini.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1988,7 +1980,7 @@
 						<target>Berangkat dari [name] saat masih naik-turun penumpang. Hentikan kereta sekarang!</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>Kecepatan kereta [speed]</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2059,6 +2051,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Kamera mouse nonaktif</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2232,7 +2239,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>TidakAda</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2246,6 +2253,18 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Perintah:</target>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Gunakan rangkaian yang dianjurkan?</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+						<target>Tidak</target>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+						<target>Ya</target>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2579,15 +2598,15 @@
 						<target>Fungsi P</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Mode interior</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>Mode interior (tanpa panel)</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Mode eksterior</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2857,6 +2876,24 @@
 					<trans-unit id="raildriver_speed_units">
 						<source>Toggles the RailDriver speed display units.</source>
 						<target>Ganti satuan kecepatan di RailDriver</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3503,11 +3540,7 @@
 						<target>Linux</target>
 					</trans-unit>
 					<trans-unit id="help_controller1_textbox">
-						<source>If your non-USB controller is not providing correct input:
-
-1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller
-to separate buttons to avoid compatibility issues.
-2. Calibrate the controller from the configuration window, if necessary.</source>
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
 						<target>Jika controller selain input USB tidak bekerja dengan baik:
 
 1. Pastikan adapter USB berfungsi. Adapter seharusnya dapat menyesuaikan tombol dengan kontroller standar
@@ -3519,19 +3552,14 @@ untuk mengatur tombol dan menghindari masalah perangkat..
 						<target>Jika joypad PS2 tidak muncul, ikuti langkah berikut:</target>
 					</trans-unit>
 					<trans-unit id="help_windows_textbox">
-						<source>1. Extract the Windows drivers.
-2. Download and run Zadig.
-3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).
-4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
 						<target>1. Extract driver untuk Windows.
 2. Download dan install Zadig.
 3. Pilih file CFG yang tersedia untuk perangkat anda (&quot;Device &gt; Load Preset Device&quot;).
 4. Tekan &quot;Install Driver&quot; dan tunggu sampai selesai.</target>
 					</trans-unit>
 					<trans-unit id="help_linux_textbox">
-						<source>1. Extract the Linux udev file.
-2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).
-3. Reboot or reload udev rules manually.</source>
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
 						<target>1. Extract file Linux udev.
 2. Salin ke &quot;/etc/udev/rules.d/&quot; (wajib root).
 3. Nyalakan ulang udev rules.</target>
@@ -3553,14 +3581,7 @@ untuk mengatur tombol dan menghindari masalah perangkat..
 						<target>OK</target>
 					</trans-unit>
 					<trans-unit id="help_libusb_symlink">
-						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.
-Please follow the following instructions:
-
-1. Check that the &quot;libusb-1.0&quot; package is installed.
-2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;
-3. Open the directory in the terminal.
-4. Check this location to see if &quot;libusb-1.0.so&quot; exists.
-5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
 						<target>LibUsb mungkin hilang, atau tidak dapat digunakan dengan baik.
 Ikuti langkah berikut untuk mengatasinya:
 
@@ -3569,6 +3590,35 @@ Ikuti langkah berikut untuk mengatasinya:
 3. Buka direktori pada terminal.
 4. Cek pada folder tersebut apakah ada file &quot;libusb-1.0.so&quot;.
 5. Jika tidak ada, buat symlink dengan meng-input perintah berikut dari terminal : &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</target>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -4077,8 +4127,8 @@ Ikuti langkah berikut untuk mengatasinya:
 						<target>Fitur tambahan</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Catatan: Fitur ini hanya bisa dipakai di openBVE versi minimal:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Catatan: Fitur ini hanya bisa dipakai di OpenBVE versi minimal:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4196,13 +4246,10 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
-							<target>Anda mencoba membuka sebuah kereta. \n\n Tidak dapat membuka file ini. \n\n Gunakan perintah 'impor' untuk membuka file ini ke TrainEditor2.</target>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
+							<target>Anda mencoba membuka sebuah kereta. \n\n Tidak dapat membuka file ini. \n\n Gunakan perintah &apos;impor&apos; untuk membuka file ini ke TrainEditor2.</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4214,6 +4261,9 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4257,13 +4307,7 @@ Ikuti langkah berikut untuk mengatasinya:
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4281,21 +4325,6 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4331,8 +4360,35 @@ Ikuti langkah berikut untuk mengatasinya:
 								<target>Blocking</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4353,9 +4409,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4386,15 +4439,6 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4446,6 +4490,18 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4453,12 +4509,28 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>Ujung roda depan</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>Ujung roda belakang</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4495,19 +4567,6 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>DefinedAxles</source>
 							<target>Atur ujung roda</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>Ujung roda depan</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>Ujung roda belakang</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>Bogie depan</target>
@@ -4570,9 +4629,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4616,6 +4672,9 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>Kecepatan kontrol rem</target>
@@ -4642,6 +4701,17 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4660,15 +4730,15 @@ Ikuti langkah berikut untuk mengatasinya:
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4734,11 +4804,14 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4880,9 +4953,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4908,13 +4978,16 @@ Ikuti langkah berikut untuk mengatasinya:
 								<target>Kec. tetap</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 								<target>Tukar</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>Playback</target>
@@ -5011,11 +5084,11 @@ Ikuti langkah berikut untuk mengatasinya:
 							<target>Ada titik yang sama di posisi x, timpa saja?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5029,12 +5102,34 @@ Ikuti langkah berikut untuk mengatasinya:
 							<target>Maks</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5067,9 +5162,56 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>TransparentColor</source>
 							<target>Warna transparan</target>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+							<target>Angka</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Layer</target>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Subjek</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5089,70 +5231,12 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-							<target>Angka</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target>Layer</target>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>Subjek</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>DefinedRadius</target>
@@ -5178,17 +5262,6 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>DefinedOrigin</source>
 							<target>DefinedOrigin</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>Rotasi Awal</target>
@@ -5234,12 +5307,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5251,6 +5318,12 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5269,12 +5342,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5286,6 +5353,12 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5313,12 +5386,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5330,6 +5397,23 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5345,17 +5429,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5364,9 +5437,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5378,6 +5448,9 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5392,9 +5465,6 @@ Ikuti langkah berikut untuk mengatasinya:
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5417,6 +5487,9 @@ Ikuti langkah berikut untuk mengatasinya:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>JumpScreen</target>
@@ -5432,9 +5505,128 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>CommandOption</source>
 							<target>Opsi perintah</target>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>Nama file belum ditambahkan.</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>Tombol sudah dipakai.</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5452,64 +5644,8 @@ Ikuti langkah berikut untuk mengatasinya:
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>Nama file belum ditambahkan.</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>Tombol sudah dipakai.</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5526,6 +5662,9 @@ Ikuti langkah berikut untuk mengatasinya:
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>Level</target>
@@ -5562,8 +5701,84 @@ Ikuti langkah berikut untuk mengatasinya:
 						<target>This value must be a {0}floating-point number.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>Warna_tidak_valid</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/it-IT.xlf
+++ b/assets/Languages/it-IT.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="it-IT">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>mmg</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2016-02-22</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -130,7 +130,7 @@
 					</trans-unit>
 					<trans-unit id="updates_old">
 						<source>You already have the latest version.</source>
-						<target>Hai già l'ultima versione disponibile.</target>
+						<target>Hai già l&apos;ultima versione disponibile.</target>
 					</trans-unit>
 					<trans-unit id="updates_new">
 						<source>The new version [version] ([date]) is available for download on the Official Homepage.</source>
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Usati di recente</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Predefinito dal file della linea</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Utilizza il treno associato al file della linea</target>
@@ -398,12 +400,12 @@
 						<target>Anteprima:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Impossibile trovare il treno previsto dal file della linea:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
 						<source>--- This train uses a safety system plugin which cannot be used on your operating system. The built-in safety systems ATS/ATC will be used instead, which might cause operational problems. ---</source>
-						<target>--- Questo treno prevede un plugin per il sistema di sicurezza non compatibile col tuo sistema operativo. Viene quindi usato il sistema di sicurezza standard ATS/ATC, che può' causare problemi nella guida. ---</target>
+						<target>--- Questo treno prevede un plugin per il sistema di sicurezza non compatibile col tuo sistema operativo. Viene quindi usato il sistema di sicurezza standard ATS/ATC, che può&apos; causare problemi nella guida. ---</target>
 					</trans-unit>
 					<trans-unit id="start">
 						<source>Start</source>
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Avvio</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1112,15 +1132,15 @@
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab">
 						<source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
-						<target>Premi qui per abilitare il joystick all'uso dei controlli.\r\n\r\nPosiziona prima la leva al centro e rilascia tutti i pulsanti.</target>
+						<target>Premi qui per abilitare il joystick all&apos;uso dei controlli.\r\n\r\nPosiziona prima la leva al centro e rilascia tutti i pulsanti.</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_normal">
 						<source>Press a button or move an axis or hat into the desired direction...</source>
 						<target>Premi il pulsante scelto o muovi la leva nella direzione voluta</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Muovi la leva nella direzione di "incremento della potenza"</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Muovi la leva nella direzione di &quot;incremento della potenza&quot;</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,12 +1862,12 @@
 						<target>File non trovato:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Sono stati trovati alcuni problemi caricando lo scenario e il treno.\r\n\r\nPoiché alcuni file non sono stati trovati, lo scenario e il treno possono apparire diversi da quanto atteso. Prova a riscaricare i pacchetti di installazione in modo da esser sicuro che siano completi.\r\n\r\nL'elenco dei problemi riscontrati che segue contiene ulteriori informazioni. Puoi comunque avviare la simulazione selezionando "Ignora".</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Sono stati trovati alcuni problemi caricando lo scenario e il treno.\r\n\r\nPoiché alcuni file non sono stati trovati, lo scenario e il treno possono apparire diversi da quanto atteso. Prova a riscaricare i pacchetti di installazione in modo da esser sicuro che siano completi.\r\n\r\nL&apos;elenco dei problemi riscontrati che segue contiene ulteriori informazioni. Puoi comunque avviare la simulazione selezionando &quot;Ignora&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Sono stati trovati alcuni problemi caricando lo scenario e il treno.\r\n\r\nSe sei uno sviluppatore di scenari o treni, potrebbe esserti d'aiuto la lettura dell'elenco dei problemi ricontrati che segue.\r\n\r\nSe sei un utente finale, puoi avviare comunque la simulazione selezionando "Ignora".</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Sono stati trovati alcuni problemi caricando lo scenario e il treno.\r\n\r\nSe sei uno sviluppatore di scenari o treni, potrebbe esserti d&apos;aiuto la lettura dell&apos;elenco dei problemi ricontrati che segue.\r\n\r\nSe sei un utente finale, puoi avviare comunque la simulazione selezionando &quot;Ignora&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1908,7 +1931,7 @@
 					</trans-unit>
 					<trans-unit id="signal_stop">
 						<source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
-						<target>Hai superato un segnale d'arresto. Aziona subito il freno d'emergenza e arresta il treno.</target>
+						<target>Hai superato un segnale d&apos;arresto. Aziona subito il freno d&apos;emergenza e arresta il treno.</target>
 					</trans-unit>
 					<trans-unit id="signal_overspeed">
 						<source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
@@ -1932,11 +1955,11 @@
 					</trans-unit>
 					<trans-unit id="station_overrun">
 						<source>Overrun: [difference] m.</source>
-						<target>Punto d'arresto superato di [difference] m.</target>
+						<target>Punto d&apos;arresto superato di [difference] m.</target>
 					</trans-unit>
 					<trans-unit id="station_underrun">
 						<source>Underrun: [difference] m.</source>
-						<target>Mancano [difference] m al punto d'arresto.</target>
+						<target>Mancano [difference] m al punto d&apos;arresto.</target>
 					</trans-unit>
 					<trans-unit id="station_terminal">
 						<source>This is the terminal station.</source>
@@ -1973,6 +1996,21 @@
 					<trans-unit id="loading">
 						<source>Loading. Please wait...</source>
 						<target>Caricamento in corso. Attendere prego...</target>
+					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
 					</trans-unit>
 				</group>
 				<group id="notification">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Cattura mouse: off</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2160,7 +2213,7 @@
 					</trans-unit>
 					<trans-unit id="exit_question">
 						<source>Do you really want to exit to the main menu?</source>
-						<target>Confermi l'uscita al menu principale?</target>
+						<target>Confermi l&apos;uscita al menu principale?</target>
 					</trans-unit>
 					<trans-unit id="exit_no">
 						<source>No</source>
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Predefinito dal file della linea</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>Funzione P del dispositivo di sicurezza</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Passa alla vista interna</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Passa alla vista esterna</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2611,7 +2680,7 @@
 					</trans-unit>
 					<trans-unit id="camera_rotate_up">
 						<source>Rotates the camera up</source>
-						<target>Ruota la visuale verso l'alto</target>
+						<target>Ruota la visuale verso l&apos;alto</target>
 					</trans-unit>
 					<trans-unit id="camera_rotate_down">
 						<source>Rotates the camera down</source>
@@ -2651,15 +2720,15 @@
 					</trans-unit>
 					<trans-unit id="timetable_toggle">
 						<source>Toggles through different timetable modes</source>
-						<target>Commuta tra i differenti modi di visualizzazione dell'orario</target>
+						<target>Commuta tra i differenti modi di visualizzazione dell&apos;orario</target>
 					</trans-unit>
 					<trans-unit id="timetable_up">
 						<source>Scrolls the timetable up</source>
-						<target>Scorre l'orario verso l'alto</target>
+						<target>Scorre l&apos;orario verso l&apos;alto</target>
 					</trans-unit>
 					<trans-unit id="timetable_down">
 						<source>Scrolls the timetable down</source>
-						<target>Scorre l'orario verso il basso</target>
+						<target>Scorre l&apos;orario verso il basso</target>
 					</trans-unit>
 					<trans-unit id="menu_activate">
 						<source>Displays the in-game menu</source>
@@ -2675,7 +2744,7 @@
 					</trans-unit>
 					<trans-unit id="menu_enter">
 						<source>Performs the selected command within the in-game menu</source>
-						<target>Esegue l'opzione selezionata nel menu di gioco</target>
+						<target>Esegue l&apos;opzione selezionata nel menu di gioco</target>
 					</trans-unit>
 					<trans-unit id="menu_back">
 						<source>Goes back within the in-game menu</source>
@@ -2683,7 +2752,7 @@
 					</trans-unit>
 					<trans-unit id="misc_clock">
 						<source>Shows or hides the clock</source>
-						<target>Mostra o nasconde l'orologio</target>
+						<target>Mostra o nasconde l&apos;orologio</target>
 					</trans-unit>
 					<trans-unit id="misc_speed">
 						<source>Toggles through different speed display modes</source>
@@ -2727,7 +2796,7 @@
 					</trans-unit>
 					<trans-unit id="misc_interface">
 						<source>Toggles through different interface modes</source>
-						<target>Cambia l'interfaccia delle indicazioni in sovraimpressine</target>
+						<target>Cambia l&apos;interfaccia delle indicazioni in sovraimpressine</target>
 					</trans-unit>
 					<trans-unit id="misc_backface">
 						<source>Activates or deactivates backface culling</source>
@@ -2735,7 +2804,7 @@
 					</trans-unit>
 					<trans-unit id="misc_cpumode">
 						<source>Switches to or from reduced CPU mode</source>
-						<target>Attiva / disattiva l'uso ridotto della CPU</target>
+						<target>Attiva / disattiva l&apos;uso ridotto della CPU</target>
 					</trans-unit>
 					<trans-unit id="debug_wireframe">
 						<source>Activates or deactivates wireframe mode</source>
@@ -2743,7 +2812,7 @@
 					</trans-unit>
 					<trans-unit id="debug_normals">
 						<source>Shows or hides vertex normals</source>
-						<target>Visualizza / nasconde l'indicazione delle normali</target>
+						<target>Visualizza / nasconde l&apos;indicazione delle normali</target>
 					</trans-unit>
 					<trans-unit id="debug_brake_systems">
 						<source>Shows or hides brake system debug output</source>
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3367,6 +3460,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/ja-JP.xlf
+++ b/assets/Languages/ja-JP.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ja-JP">
 		<body>
 			<group id="language">
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -253,7 +253,7 @@
 					</trans-unit>
 					<trans-unit id="plugin_failure2">
 						<source>The built-in ATS/ ATC systems will be used instead, which may cause issues.</source>
-						<target>代わりにopenBVE付属のATS/ ATCプラグインを使用しますが、問題が起きる可能性があります。</target>
+						<target>代わりにOpenBVE付属のATS/ ATCプラグインを使用しますが、問題が起きる可能性があります。</target>
 					</trans-unit>
 					<trans-unit id="package_filename_empty">
 						<source>Attempted to create a package with an empty filename.</source>
@@ -287,6 +287,12 @@
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>前回使用</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>デフォルト</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>路線指定車両</target>
@@ -398,7 +400,7 @@
 						<target>プレビュー:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>指定された車両がありません:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>スタート</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,7 +625,7 @@
 						<target>パッケージをインストールする</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 						<target>選択されたファイルは、OpenBVEの有効なパッケージではありません。</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
@@ -726,8 +737,8 @@
 						<target>リストから削除</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>新しいパッケージは次のGUIDに割り当てられます:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>パッケージの作成</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>次のファイルの生成に失敗しました: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,7 +1139,7 @@
 						<target>設定したいボタンを押すか軸を設定したい方向に動かしてください...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>設定したい軸を「増加する方向」に動かしてください...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1245,63 +1265,63 @@
 						<target>RailDriverのキャリブレーションファイルの読み込み中にエラーが発生しました。</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
 						<target>「次へ」をクリックするとキャリブレーションを開始します。.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
 						<target>逆転器をREVERSEの位置に動かしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
 						<target>逆転器をFORWARDの位置に動かしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
 						<target>スロットルレバーをFULL(出力側)の位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
 						<target>スロットルレバーをFULL(ブレーキ側)の位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>自弁ブレーキレバーをRELEASEの位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
 						<target>自弁ブレーキレバーをEMERGENCYの位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>単弁ブレーキレバーをRELEASEの位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
 						<target>単弁ブレーキレバーをFULLの位置にしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
 						<target>Bail-off レバーをRELEASEにした状態を保って「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
 						<target>Bail-off レバーをFULLにした状態を保って「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
 						<target>ワイパースイッチをOFFにしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
 						<target>ワイパースイッチをFULLにしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
 						<target>前照灯スイッチをOFFにしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
 						<target>前照灯スイッチをFULLにしてから「次へ」をクリックしてください。</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,11 +1862,11 @@
 						<target>ファイルがありません:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
 						<target>ロード中に問題が発生しました。\r\n\r\n一部のファイルが見つからない場合、路線や車両が意図したように表示されない場合があります。路線や車両データをダウンロードし直して全てが揃っていることを確かめてください。\r\n\r\n以下のリストが問題解決の参考になります。無視をクリックして先に進むこともできます。</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
 						<target>路線と車両のロード中に問題が発生しました。開発者の場合は以下のリストが参考になりますが、\r\n\r\n一般ユーザの場合、この段階では無視を選択してゲームをスタートしてください。</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
@@ -1900,7 +1923,6 @@
 				<group id="message">
 					<trans-unit id="delimiter">
 						<source>\x20</source>
-						<target></target>
 					</trans-unit>
 					<trans-unit id="signal_proceed">
 						<source>You may proceed at [speed] [unit] with extreme caution.</source>
@@ -1974,6 +1996,21 @@
 						<source>Loading. Please wait...</source>
 						<target>ロード中。 しばらくお待ちください。</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2076,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>マウス操作: オフ</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2259,7 @@
 						<target>ジョイスティック</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>利用不可</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>現在の割り当て:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>デフォルト</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2627,14 @@
 						<target>運転保安装置機能P(車両に依存)</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>車内カメラ</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>車外カメラ</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2827,6 +2895,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>主回路断流器のON/OFF</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3367,6 +3459,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3617,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>運転者が扱えるブレーキノッチ段数は、ブレーキノッチ段数以下でなければなりません。</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4125,8 @@
 						<target>拡張機能</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>注意: このページの機能を使用するには、openBVEが次のバージョン以上である必要があります。:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>注意: このページの機能を使用するには、OpenBVEが次のバージョン以上である必要があります。:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4007,11 +4253,10 @@
 							<source>Exit</source>
 							<target>終了</target>
 						</trans-unit>
+						<trans-unit id="wrongtype">
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
+						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-						<target>言語</target>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4026,6 +4271,10 @@
 							<target>閉じる前に現在のデータを保存しますか?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+						<target>言語</target>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4076,15 +4325,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-						<target>全般設定</target>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-							<target>ハンドル</target>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4098,27 +4339,13 @@
 								<source>Combined</source>
 								<target>ワンハンドル</target>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-							<target>力行ノッチ段数</target>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-							<target>ブレーキノッチ段数</target>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-							<target>戻しノッチ段数</target>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-							<target>運転者が扱える力行ノッチ段数</target>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-							<target>運転者が扱えるブレーキノッチ段数</target>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4130,15 +4357,15 @@
 							</trans-unit>
 							<trans-unit id="power">
 								<source>Return power to neutral</source>
-								<target>マスコンを"切"位置に戻す</target>
+								<target>マスコンを&quot;切&quot;位置に戻す</target>
 							</trans-unit>
 							<trans-unit id="reverser">
 								<source>Return reverser to neutral</source>
-								<target>レバーサを"切"位置に戻す</target>
+								<target>レバーサを&quot;切&quot;位置に戻す</target>
 							</trans-unit>
 							<trans-unit id="power_reverser">
 								<source>Return power and reverser to neutral</source>
-								<target>マスコンとレバーサを"切"位置に戻す</target>
+								<target>マスコンとレバーサを&quot;切&quot;位置に戻す</target>
 							</trans-unit>
 						</group>
 						<group id="loco_brake_handle_type">
@@ -4159,9 +4386,42 @@
 								<target>客車からは遮断</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+							<target>ハンドル</target>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+							<target>力行ノッチ段数</target>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+							<target>ブレーキノッチ段数</target>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+							<target>戻しノッチ段数</target>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+							<target>運転者が扱える力行ノッチ段数</target>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+							<target>運転者が扱えるブレーキノッチ段数</target>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
 							<target>機関車のブレーキノッチ段数</target>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4187,10 +4447,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-							<target>装置</target>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4227,18 +4483,6 @@
 								<target>自動切替</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-							<target>Eb</target>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-							<target>定速</target>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-							<target>抑速</target>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4305,6 +4549,22 @@
 								<target>手動</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+							<target>装置</target>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+							<target>Eb</target>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+							<target>定速</target>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+							<target>抑速</target>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 							<target>ドアの幅</target>
@@ -4314,13 +4574,31 @@
 							<target>干渉物の最小幅</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+						<target>全般設定</target>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-						<target>車両設定</target>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="axle_mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+								<target>後車軸は前車軸未満でなければなりません。</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 							<target>全般</target>
@@ -4360,21 +4638,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-							<trans-unit id="axle_mustbe_less">
-								<source>RearAxle must be less than FrontAxle.</source>
-								<target>後車軸は前車軸未満でなければなりません。</target>
-							</trans-unit>							
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4444,10 +4707,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-							<target>ブレーキ</target>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4502,6 +4761,10 @@
 								<target>遅れ込め制御</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+							<target>ブレーキ</target>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>電制速度</target>
@@ -4534,6 +4797,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 							<target>遅れ時間</target>
@@ -4558,17 +4832,16 @@
 							<source>Value</source>
 							<target>値</target>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+						<target>車両設定</target>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-						<target>加速度設定</target>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-						<target>ノッチ</target>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4641,12 +4914,16 @@
 							<target>リセット</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+						<target>加速度設定</target>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+						<target>ノッチ</target>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-						<target>モーター音設定</target>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4810,10 +5087,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-							<target>再生設定</target>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4842,7 +5115,7 @@
 								<target>等速運動</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 								<target>加速度</target>
 							</trans-unit>
 							<trans-unit id="swap">
@@ -4850,6 +5123,10 @@
 								<target>入れ替え</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+							<target>再生設定</target>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>再生</target>
@@ -4967,12 +5244,12 @@
 							<target>既に同じx座標に点が存在しますが、上書きしますか?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+						<target>モーター音設定</target>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-						<target>連結器設定</target>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4987,13 +5264,35 @@
 							<target>最大</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+						<target>連結器設定</target>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-						<target>パネル設定</target>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5021,9 +5320,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5043,67 +5386,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -5125,17 +5413,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -5171,12 +5448,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5188,6 +5459,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5205,12 +5482,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5222,6 +5493,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5248,12 +5525,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5265,6 +5536,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5280,17 +5568,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5299,9 +5576,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5313,6 +5587,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5327,9 +5604,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5352,6 +5626,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5364,9 +5641,139 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+						<target>パネル設定</target>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+								<target>セクション選択</target>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+								<target>キー選択</target>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+									<target>位置</target>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+									<target>x座標</target>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+									<target>y座標</target>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+									<target>z座標</target>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+								<target>値入力</target>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+								<target>ファイル名</target>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+								<target>位置設定</target>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+							<target>エントリー編集</target>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>ファイル名は空欄にできません。</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>指定したキーは既に設定されています。</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 						<target>サウンド設定</target>
@@ -5386,75 +5793,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-							<target>エントリー編集</target>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-								<target>セクション選択</target>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-								<target>キー選択</target>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-								<target>値入力</target>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-								<target>ファイル名</target>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-								<target>位置設定</target>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-									<target>位置</target>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-									<target>x座標</target>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-									<target>y座標</target>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-									<target>z座標</target>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>ファイル名は空欄にできません。</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>指定したキーは既に設定されています。</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-						<target>ステータス</target>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5473,6 +5813,10 @@
 							<target>クリア</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+						<target>ステータス</target>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>レベル</target>
@@ -5508,7 +5852,7 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>{0}は16進数色を表していません。</target>
 					</trans-unit>
 					<trans-unit id="number_exist">
@@ -5516,12 +5860,79 @@
 						<target>指定された番号は既に追加されています。</target>
 					</trans-unit>
 					<trans-unit id="mustbe_greater_than">
-						<source>Max must be greater than or equal to the Min.</source>
+						<source>Max must be greater than or equal to Min.</source>
 						<target>MaxはMin以上でなければなりません。</target>
 					</trans-unit>
 					<trans-unit id="mustbe_less_than">
 						<source>Min must be less than the Max.</source>
 						<target>MinはMax未満でなければなりません。</target>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/ko-KR.xlf
+++ b/assets/Languages/ko-KR.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ko-KR">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>HIDDEN-CATCH ( hidcatch.subtitle.kr )</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2009-12-07</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>최근 기록</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>노선 설정</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>노선에서 지정한 차량 사용:</target>
@@ -398,7 +400,7 @@
 						<target>미리 보기:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>노선에 설정된 차량을 찾을 수 없습니다:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>시작</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,8 +1139,8 @@
 						<target>버튼을 누르거나 패드를 움직이십시오.</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>"증가" 또는 "가속" 방향으로 패드를 움직이십시오.</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>&quot;증가&quot; 또는 &quot;가속&quot; 방향으로 패드를 움직이십시오.</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,11 +1862,11 @@
 						<target>파일을 찾을 수 없음:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
 						<target>노선과 차량을 불러오던 중 문제가 발생했습니다.\r\n\r\n파일이 누락되었다면, 노선 또는 차량이 정상적으로 보이지 않을 것입니다. 완벽한 운행을 위해서는 노선과 차량을 다시 다운로드하십시오.\r\n\r\n다음 목록은 발생한 문제사항입니다. [무시]를 누르면 발생한 문제를 무시하고 운행할 수 있습니다.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
 						<target>노선과 차량을 불러오던 중 문제가 발생했습니다. 노선이나 차량 개발자라면, 다음 문제점들을 살펴보십시오.\r\n\r\n일반적인 사용자라면, [무시]를 누르고 운행할 수 있습니다.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>불러오고 있습니다. 잠시만 기다리십시오...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Mouse grab: off</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>노선 설정</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>운전 보안 장치 기능 P(차량에 따라 다름)</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>내부 시점</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>외부 시점</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3188,11 +3281,11 @@
 					</trans-unit>
 					<trans-unit id="quote">
 						<source>Quote</source>
-						<target>'</target>
+						<target>&apos;</target>
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>"</target>
+						<target>&quot;</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3365,6 +3458,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/ms_MY.xlf
+++ b/assets/Languages/ms_MY.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ms-MY">
 		<body>
 			<group id="language">
@@ -233,9 +234,6 @@
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
 						<target>Laluan yang dipilih adalah rosak: \r\n Tidak dapat mencari kesemua objek yang ditakrifkan.</target>
 					</trans-unit>
-					<trans-unit id="route_corrupt_missingobjects">
-						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
 						<target>Plugin kereta api [plugin] gagal dimuatkan.</target>
@@ -267,6 +265,9 @@
 					<trans-unit id="security_badlocation">
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
 						<target>Jika anda cuba memasang add-on dalam folder Program Files atau ProgramData, ini mungkin memerlukan kebenaran pentadbir. \r\n\r\n Ini tidak disyorkan atas sebab keselamatan.</target>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -333,18 +334,6 @@
 						<source>Choose Train...</source>
 						<target>Pilih kereta api...</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-						<target>Adakah anda ingin menggunakan kereta api asal?</target>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-						<target>Tidak</target>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
-						<target>Ya</target>
-					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
 						<target>Pemilihan</target>
@@ -410,6 +399,9 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Mula:</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -606,8 +598,8 @@
 						<target>Pasang Pakej</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>Fail tidak kelihatan seperti pakej openBVE yang sah.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Fail tidak kelihatan seperti pakej OpenBVE yang sah.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -744,7 +736,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Pakej baharu telah diberikan GUID berikut:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -1243,64 +1235,64 @@
 						<target>Ralat memuatkan fail penentukuran RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Sila tekan 'Seterusnya' untuk memulakan penentukuran.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Sila tekan &apos;Seterusnya&apos; untuk memulakan penentukuran.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Gerakkan tuil pengundur ke kedudukan terbalik penuh dan tekan 'Seterusnya'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil pengundur ke kedudukan terbalik penuh dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Gerakkan tuil pengundur ke kedudukan penuh ke hadapan dan tekan 'Seterusnya'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil pengundur ke kedudukan penuh ke hadapan dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Gerakkan tuil brek / pendikit gabungan ke kedudukan kuasa penuh dan tekan 'Seterusnya'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek / pendikit gabungan ke kedudukan kuasa penuh dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Gerakkan tuil brek / pendikit gabungan ke kedudukan brek penuh dan tekan 'Seterusnya'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek / pendikit gabungan ke kedudukan brek penuh dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Gerakkan tuil brek dinamik ke kedudukan pelepas dan tekan 'Seterusnya'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek dinamik ke kedudukan pelepas dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Gerakkan tuil brek dinamik ke kedudukan kecemasan dan tekan 'Seterusnya'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek dinamik ke kedudukan kecemasan dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Gerakkan tuil brek bebas ke kedudukan pelepas dan tekan 'Seterusnya'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek bebas ke kedudukan pelepas dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Gerakkan tuil brek bebas ke kedudukan penuh dan tekan 'Seterusnya'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil brek bebas ke kedudukan penuh dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Gerakkan tuil bail-off ke kedudukan pelepasan dan tekan 'Seterusnya'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Gerakkan tuil bail-off ke kedudukan pelepasan dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Gerakkan dan tahan tuil bail-off ke dalam kedudukan penuh dan tekan 'Seterusnya'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Gerakkan dan tahan tuil bail-off ke dalam kedudukan penuh dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Alihkan suis pengelap ke OFF dan tekan 'Seterusnya'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Alihkan suis pengelap ke OFF dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Alihkan suis pengelap ke PENUH dan tekan 'Seterusnya'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Alihkan suis pengelap ke PENUH dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Alihkan suis lampu ke OFF dan tekan 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Alihkan suis lampu ke OFF dan tekan &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Alihkan suis lampu kepada PENUH dan tekan 'Seterusnya'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Alihkan suis lampu kepada PENUH dan tekan &apos;Seterusnya&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1982,7 +1974,7 @@
 						<target>Anda telah melepasi [name] semasa masih mengambil penumpang. Sila datang ke kedudukan berhenti yang betul dengan segera.</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>Laju keretapi terkini ialah [speed]</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2053,6 +2045,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Rebut tetikus: mati</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2226,7 +2233,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2240,6 +2247,18 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Tugasan terkini:</target>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Adakah anda ingin menggunakan kereta api asal?</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+						<target>Tidak</target>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+						<target>Ya</target>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2573,15 +2592,15 @@
 						<target>Fungsi P sistem keselamatan</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Beralih ke pandangan dalaman kereta api</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>Beralih ke pandangan dalaman kereta api. Walau bagaimanapun, panel tidak dipaparkan.</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Beralih ke pandangan luar kereta api</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2851,6 +2870,24 @@
 					<trans-unit id="raildriver_speed_units">
 						<source>Toggles the RailDriver speed display units.</source>
 						<target>Menogel unit paparan kelajuan RailDriver.</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3497,11 +3534,7 @@
 						<target>Linux</target>
 					</trans-unit>
 					<trans-unit id="help_controller1_textbox">
-						<source>If your non-USB controller is not providing correct input:
-
-1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller
-to separate buttons to avoid compatibility issues.
-2. Calibrate the controller from the configuration window, if necessary.</source>
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
 						<target>Jika pengawal bukan USB anda tidak memberikan input yang betul:
 
 1. Pastikan penyesuai USB berfungsi. Sebaik-baiknya, penyesuai harus memetakan butang arah daripada pengawal standard
@@ -3513,19 +3546,14 @@ untuk memisahkan butang untuk mengelakkan masalah keserasian.
 						<target>Jika pengawal PS2 anda tidak muncul dalam senarai, ikuti langkah berikut:</target>
 					</trans-unit>
 					<trans-unit id="help_windows_textbox">
-						<source>1. Extract the Windows drivers.
-2. Download and run Zadig.
-3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).
-4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
 						<target>1. Ekstrak driver Windows.
 2. Muat turun dan jalankan Zadig.
 3. Muatkan fail CFG yang sesuai untuk peranti anda (&quot;Peranti &gt; Muatkan Peranti Pratetap&quot;).
 4. Tekan &quot;Install Driver&quot; dan tunggu pemasangan selesai.</target>
 					</trans-unit>
 					<trans-unit id="help_linux_textbox">
-						<source>1. Extract the Linux udev file.
-2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).
-3. Reboot or reload udev rules manually.</source>
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
 						<target>1. Ekstrak fail udev Linux.
 2. Salin fail ke &quot;/etc/udev/rules.d/&quot; (kebenaran root diperlukan).
 3. But semula atau muat semula peraturan udev secara manual.</target>
@@ -3547,14 +3575,7 @@ untuk memisahkan butang untuk mengelakkan masalah keserasian.
 						<target>OK</target>
 					</trans-unit>
 					<trans-unit id="help_libusb_symlink">
-						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.
-Please follow the following instructions:
-
-1. Check that the &quot;libusb-1.0&quot; package is installed.
-2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;
-3. Open the directory in the terminal.
-4. Check this location to see if &quot;libusb-1.0.so&quot; exists.
-5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
 						<target>LibUsb nampaknya hilang atau tidak dipautkan dengan betul untuk pemuatan masa jalan.
 Sila ikut arahan berikut:
 
@@ -3563,6 +3584,35 @@ Sila ikut arahan berikut:
 3. Buka direktori dalam terminal.
 4. Semak lokasi ini untuk melihat sama ada &quot;libusb-1.0.so&quot; wujud.
 5. Jika fail tidak wujud, kita mesti mencipta symlink yang sesuai dengan melaksanakan arahan berikut dari terminal ini: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</target>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -4071,8 +4121,8 @@ Sila ikut arahan berikut:
 						<target>Ciri Lanjutan</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Sila ambil perhatian: Ciri yang terdapat pada halaman ini mungkin memerlukan versi minimum openBVE berikut:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Sila ambil perhatian: Ciri yang terdapat pada halaman ini mungkin memerlukan versi minimum OpenBVE berikut:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4190,13 +4240,10 @@ Sila ikut arahan berikut:
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 							<target>Anda telah cuba membuka kereta api. \n\n Ini tidak boleh dibuka terus- \n\n Sila gunakan fungsi import untuk mengimport kereta api ini ke dalam TrainEditor2.</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4208,6 +4255,9 @@ Sila ikut arahan berikut:
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4251,13 +4301,7 @@ Sila ikut arahan berikut:
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4275,21 +4319,6 @@ Sila ikut arahan berikut:
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4325,8 +4354,35 @@ Sila ikut arahan berikut:
 								<target>Menyekat</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4347,9 +4403,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4380,15 +4433,6 @@ Sila ikut arahan berikut:
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4440,6 +4484,18 @@ Sila ikut arahan berikut:
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4447,12 +4503,28 @@ Sila ikut arahan berikut:
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>GandarDepan</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>GandarBelakang</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4489,19 +4561,6 @@ Sila ikut arahan berikut:
 							<source>DefinedAxles</source>
 							<target>GandarTertakrif</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>GandarDepan</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>GandarBelakang</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>BogieDepan</target>
@@ -4564,9 +4623,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4610,6 +4666,9 @@ Sila ikut arahan berikut:
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>KelajuanKawalanBrek</target>
@@ -4636,6 +4695,17 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4654,15 +4724,15 @@ Sila ikut arahan berikut:
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4728,11 +4798,14 @@ Sila ikut arahan berikut:
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4874,9 +4947,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4902,13 +4972,16 @@ Sila ikut arahan berikut:
 								<target>Kelajuan berterusan</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 								<target>Tukar</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>Mainbalik</target>
@@ -5005,11 +5078,11 @@ Sila ikut arahan berikut:
 							<target>Titik sudah wujud pada koordinat x yang sama, adakah anda mahu menulis gantinya?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5023,12 +5096,34 @@ Sila ikut arahan berikut:
 							<target>Max</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5061,9 +5156,56 @@ Sila ikut arahan berikut:
 							<source>TransparentColor</source>
 							<target>WarnaLutSinar</target>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+							<target>Nombor</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Lapisan</target>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Subjek</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5083,70 +5225,12 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-							<target>Nombor</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target>Lapisan</target>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>Subjek</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>JejariDitakrifkan</target>
@@ -5172,17 +5256,6 @@ Sila ikut arahan berikut:
 							<source>DefinedOrigin</source>
 							<target>AsalDitakrifkan</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>SuduAwal</target>
@@ -5228,12 +5301,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5245,6 +5312,12 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5263,12 +5336,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5280,6 +5347,12 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5307,12 +5380,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5324,6 +5391,23 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5339,17 +5423,6 @@ Sila ikut arahan berikut:
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5358,9 +5431,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5372,6 +5442,9 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5386,9 +5459,6 @@ Sila ikut arahan berikut:
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5411,6 +5481,9 @@ Sila ikut arahan berikut:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>LompatSkrin</target>
@@ -5426,9 +5499,128 @@ Sila ikut arahan berikut:
 							<source>CommandOption</source>
 							<target>PilihanPerintah</target>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>Nama fail tidak dimasukkan.</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>Kekunci yang ditentukan sudah ditetapkan.</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5446,64 +5638,8 @@ Sila ikut arahan berikut:
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>Nama fail tidak dimasukkan.</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>Kekunci yang ditentukan sudah ditetapkan.</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5520,6 +5656,9 @@ Sila ikut arahan berikut:
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>Tahap</target>
@@ -5555,8 +5694,84 @@ Sila ikut arahan berikut:
 						<target>Nilai ini mestilah {0}nombor titik-terapung.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>warna_tidaksah</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/nb_NO.xlf
+++ b/assets/Languages/nb_NO.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="nb-NO">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>Per-Henrik</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2020-07-21</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -124,160 +124,159 @@
 						<source>Check for updates</source>
 						<target>Sjekk etter oppdateringer</target>
 					</trans-unit>
-
 					<trans-unit id="updates_invalid">
-					  <source>A connection to the server could be established. Unfortunately, the version information could not be retrieved.</source>
-					  <target>Får tilkoblet serveren, men dessverre kan vi ikke hente ned versjonen.</target>
+						<source>A connection to the server could be established. Unfortunately, the version information could not be retrieved.</source>
+						<target>Får tilkoblet serveren, men dessverre kan vi ikke hente ned versjonen.</target>
 					</trans-unit>
 					<trans-unit id="updates_old">
-					  <source>You already have the latest version.</source>
-					  <target>Du har den nyeste versjonen.</target>
+						<source>You already have the latest version.</source>
+						<target>Du har den nyeste versjonen.</target>
 					</trans-unit>
 					<trans-unit id="updates_new">
-					  <source>The new version [version] ([date]) is available for download on the Official Homepage.</source>
-					  <target>Versjon [version] ([date]) er tilgjengelig for nedlasting på den offisielle nettsiden.</target>
+						<source>The new version [version] ([date]) is available for download on the Official Homepage.</source>
+						<target>Versjon [version] ([date]) er tilgjengelig for nedlasting på den offisielle nettsiden.</target>
 					</trans-unit>
 					<trans-unit id="updates_daily">
 						<source>The most recent nightly build from [date] is available for download.</source>
 						<target>The most recent nightly build from [date] is available for download.</target>
 					</trans-unit>
 					<trans-unit id="close">
-					  <source>Close</source>
-					  <target>Lukk</target>
+						<source>Close</source>
+						<target>Lukk</target>
 					</trans-unit>
 					<trans-unit id="packages">
-					  <source>Package Management</source>
-					  <target>Pakkehåndtering</target>
+						<source>Package Management</source>
+						<target>Pakkehåndtering</target>
 					</trans-unit>
 					<trans-unit id="reportbug">
-					  <source>Report Problem</source>
-					  <target>Rapporter et problem</target>
+						<source>Report Problem</source>
+						<target>Rapporter et problem</target>
 					</trans-unit>
 					<trans-unit id="about">
-					  <source>About</source>
-					  <target>Om</target>
+						<source>About</source>
+						<target>Om</target>
 					</trans-unit>
 				</group>
 				<group id="mode">
 					<trans-unit id="arcade">
-					  <source>Arcade</source>
-					  <target>Arkadespill</target>
+						<source>Arcade</source>
+						<target>Arkadespill</target>
 					</trans-unit>
 					<trans-unit id="normal">
-					  <source>Normal</source>
-					  <target>Normal</target>
+						<source>Normal</source>
+						<target>Normal</target>
 					</trans-unit>
 					<trans-unit id="expert">
-					  <source>Expert</source>
-					  <target>Ekspert</target>
+						<source>Expert</source>
+						<target>Ekspert</target>
 					</trans-unit>
 					<trans-unit id="unknown">
-					  <source>Unknown</source>
-					  <target>Ukjent</target>
+						<source>Unknown</source>
+						<target>Ukjent</target>
 					</trans-unit>
 				</group>
 				<group id="errors">
 					<trans-unit id="critical_file">
-					  <source>A critical error occured whilst parsing the [file] file</source>
-					  <target>En kritisk feil oppstod ved lasting av filen [file]</target>
+						<source>A critical error occured whilst parsing the [file] file</source>
+						<target>En kritisk feil oppstod ved lasting av filen [file]</target>
 					</trans-unit>
 					<trans-unit id="filesystem_invalid">
-					  <source>The file system configuration could not be accessed or is invalid due to the following reason:</source>
-					  <target>Filsystemkonfigurasjonen kunne ikke bli nådd på grunn av følgende grunn:</target>
+						<source>The file system configuration could not be accessed or is invalid due to the following reason:</source>
+						<target>Filsystemkonfigurasjonen kunne ikke bli nådd på grunn av følgende grunn:</target>
 					</trans-unit>
 					<trans-unit id="warning">
-					  <source>Warning:</source>
-					  <target>Advarsel:</target>
+						<source>Warning:</source>
+						<target>Advarsel:</target>
 					</trans-unit>
 					<trans-unit id="controls_missing">
-					  <source>No control configuration files found.</source>
-					  <target>Ingen kontrollkonfigurasjonsfiler funnet.</target>
+						<source>No control configuration files found.</source>
+						<target>Ingen kontrollkonfigurasjonsfiler funnet.</target>
 					</trans-unit>
 					<trans-unit id="controls_oldversion">
-					  <source>An older key-configuration file was found.</source>
-					  <target>En eldre knapp-konfigurasjonsfil var funnet.</target>
+						<source>An older key-configuration file was found.</source>
+						<target>En eldre knapp-konfigurasjonsfil var funnet.</target>
 					</trans-unit>
 					<trans-unit id="controls_reset">
-					  <source>The current key-configuration has been reset to defaults.</source>
-					  <target>Den nåværende knapp-konfigurasjonen har blitt satt tilbake til standard.</target>
+						<source>The current key-configuration has been reset to defaults.</source>
+						<target>Den nåværende knapp-konfigurasjonen har blitt satt tilbake til standard.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_oldversion">
-					  <source>The default key assingment file is an older version or corrupt.</source>
-					  <target>Filen med standard-knappeoppsettet oppsettet er en gammel versjon eller korrupt.</target>
+						<source>The default key assingment file is an older version or corrupt.</source>
+						<target>Filen med standard-knappeoppsettet oppsettet er en gammel versjon eller korrupt.</target>
 					</trans-unit>
 					<trans-unit id="controls_default_missing">
-					  <source>The default key assignment file does not exist.</source>
-					  <target>Filen med standard-knappeoppsettet fins ike.</target>
+						<source>The default key assignment file does not exist.</source>
+						<target>Filen med standard-knappeoppsettet fins ike.</target>
 					</trans-unit>
 					<trans-unit id="controls_ingame">
-					  <source>You are currently running on the [platform] backend. Please use the in-game menu to configure any joystick based controls.</source>
-					  <target>Du kjører nå [platform] backend. Bruk spill-menyen for å konfigurere joystick baserte kontroller.</target>
+						<source>You are currently running on the [platform] backend. Please use the in-game menu to configure any joystick based controls.</source>
+						<target>Du kjører nå [platform] backend. Bruk spill-menyen for å konfigurere joystick baserte kontroller.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_version">
-					  <source>OpenAL 1.1 is required. You seem to have version 1.0.</source>
-					  <target>OpenAL 1.1 er påkrevd. Du ser ut til å ha versjon 1.0.</target>
+						<source>OpenAL 1.1 is required. You seem to have version 1.0.</source>
+						<target>OpenAL 1.1 er påkrevd. Du ser ut til å ha versjon 1.0.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_context">
-					  <source>The OpenAL context could not be created.</source>
-					  <target>OpenAL-konteksten kunne ikke bli opprettet.</target>
+						<source>The OpenAL context could not be created.</source>
+						<target>OpenAL-konteksten kunne ikke bli opprettet.</target>
 					</trans-unit>
 					<trans-unit id="sound_openal_device">
-					  <source>The OpenAL sound device could not be opened.</source>
-					  <target>OpenAL driveren kunne ikke bli åpnet.</target>
+						<source>The OpenAL sound device could not be opened.</source>
+						<target>OpenAL driveren kunne ikke bli åpnet.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch1">
-					  <source>An error occured whilst attempting to switch to fullscreen mode.</source>
-					  <target>En feil oppstod mens programmet prøvde å bytte til fullskjermsmodus.</target>
+						<source>An error occured whilst attempting to switch to fullscreen mode.</source>
+						<target>En feil oppstod mens programmet prøvde å bytte til fullskjermsmodus.</target>
 					</trans-unit>
 					<trans-unit id="fullscreen_switch2">
-					  <source>Please check your fullscreen resolution settings.</source>
-					  <target>Sjekk fullskjermsinnstillingene.</target>
+						<source>Please check your fullscreen resolution settings.</source>
+						<target>Sjekk fullskjermsinnstillingene.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_withtrack">
-					  <source>The selected route is corrupt: \r\n WithTrack section missing.</source>
-					  <target>Den valgte ruten er korrupt: \r\n WithTrack seksjonen mangler.</target>
+						<source>The selected route is corrupt: \r\n WithTrack section missing.</source>
+						<target>Den valgte ruten er korrupt: \r\n WithTrack seksjonen mangler.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_nostations">
-					  <source>The selected route is corrupt: \r\n No stations defined.</source>
-					  <target>Den valgte ruten er korrupt: \r\n Ingen stasjoner er definert.</target>
+						<source>The selected route is corrupt: \r\n No stations defined.</source>
+						<target>Den valgte ruten er korrupt: \r\n Ingen stasjoner er definert.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_noobjects">
-					  <source>The selected route is corrupt: \r\n No objects defined.</source>
-					  <target>Den valgte ruten er korrupt: \r\n Ingen objekter er definert.</target>
+						<source>The selected route is corrupt: \r\n No objects defined.</source>
+						<target>Den valgte ruten er korrupt: \r\n Ingen objekter er definert.</target>
 					</trans-unit>
 					<trans-unit id="route_corrupt_missingobjects">
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
 					</trans-unit>
 					<trans-unit id="plugin_failure1">
-					  <source>The train plugin [plugin] failed to load.</source>
-					  <target>Tog-plugin [plugin] kunne ikke laste inn.</target>
+						<source>The train plugin [plugin] failed to load.</source>
+						<target>Tog-plugin [plugin] kunne ikke laste inn.</target>
 					</trans-unit>
 					<trans-unit id="plugin_failure2">
 						<source>The built-in ATS/ ATC systems will be used instead, which may cause issues.</source>
 					</trans-unit>
 					<trans-unit id="package_filename_empty">
-					  <source>Attempted to create a package with an empty filename.</source>
-					  <target>Forsøkte å opprette en pakke med tomt filnavn.</target>
+						<source>Attempted to create a package with an empty filename.</source>
+						<target>Forsøkte å opprette en pakke med tomt filnavn.</target>
 					</trans-unit>
 					<trans-unit id="package_directory_missing">
-					  <source>The directory in which you attempted to save the package file does not exist: \r \n</source>
-					  <target>Mappen du prøvde å lagre filen til pakken eksisterer ikke: \r \n</target>
+						<source>The directory in which you attempted to save the package file does not exist: \r \n</source>
+						<target>Mappen du prøvde å lagre filen til pakken eksisterer ikke: \r \n</target>
 					</trans-unit>
 					<trans-unit id="package_directory_nowrite">
-					  <source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
-					  <target>Mappen du prøvde å lagre filen til pakken til kan ikke skrives til: \r \n</target>
+						<source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
+						<target>Mappen du prøvde å lagre filen til pakken til kan ikke skrives til: \r \n</target>
 					</trans-unit>
 					<trans-unit id="package_file_generic">
-					  <source>Failed to create the following file: \r \n</source>
-					  <target>Det gikk ikke å lage følgende fil: \r \n</target>
+						<source>Failed to create the following file: \r \n</source>
+						<target>Det gikk ikke å lage følgende fil: \r \n</target>
 					</trans-unit>
 					<trans-unit id="security_checkaccess">
-					  <source>Please check that this path is accessible.</source>
-					  <target>Vennligst sjekk om denne fil-stien er tilgjengelig.</target>
+						<source>Please check that this path is accessible.</source>
+						<target>Vennligst sjekk om denne fil-stien er tilgjengelig.</target>
 					</trans-unit>
 					<trans-unit id="security_badlocation">
-					  <source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
-					  <target>Hvis du prøver å installere addons i Programfiler eller Programdata mappene, kan det hende at det krever administrator rettigheter. \r\n\r\n Dette er ikke anbefalt av sikkerhetsmessige grunner.</target>
+						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
+						<target>Hvis du prøver å installere addons i Programfiler eller Programdata mappene, kan det hende at det krever administrator rettigheter. \r\n\r\n Dette er ikke anbefalt av sikkerhetsmessige grunner.</target>
 					</trans-unit>
 					<trans-unit id="database_newer_expected">
 						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
@@ -288,195 +287,204 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
-				      </group>
-				      
-				      <group id="start">
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
+				</group>
+				<group id="start">
 					<trans-unit id="title">
-					  <source>Start new game</source>
-					  <target>Start nytt spill</target>
+						<source>Start new game</source>
+						<target>Start nytt spill</target>
 					</trans-unit>
 					<trans-unit id="route">
-					  <source>Route</source>
-					  <target>Rute</target>
+						<source>Route</source>
+						<target>Rute</target>
 					</trans-unit>
 					<trans-unit id="route_selection">
-					  <source>Selection</source>
-					  <target>Rutevalg</target>
+						<source>Selection</source>
+						<target>Rutevalg</target>
 					</trans-unit>
 					<trans-unit id="route_addons">
-					  <source>Add-ons</source>
-					  <target>Add-ons</target>
+						<source>Add-ons</source>
+						<target>Add-ons</target>
 					</trans-unit>
 					<trans-unit id="route_browse">
-					  <source>Browse manually</source>
-					  <target>Filutforsker</target>
+						<source>Browse manually</source>
+						<target>Filutforsker</target>
 					</trans-unit>
 					<trans-unit id="route_recently">
-					  <source>Recently used</source>
-					  <target>Sist brukt</target>
+						<source>Recently used</source>
+						<target>Sist brukt</target>
 					</trans-unit>
 					<trans-unit id="route_details">
-					  <source>Details</source>
-					  <target>Detaljer</target>
+						<source>Details</source>
+						<target>Detaljer</target>
 					</trans-unit>
 					<trans-unit id="route_description">
-					  <source>Description</source>
-					  <target>Beskrivelse</target>
+						<source>Description</source>
+						<target>Beskrivelse</target>
 					</trans-unit>
 					<trans-unit id="route_map">
-					  <source>Map</source>
-					  <target>Kart</target>
+						<source>Map</source>
+						<target>Kart</target>
 					</trans-unit>
 					<trans-unit id="route_gradient">
-					  <source>Gradient profile</source>
-					  <target>Høydeprofil</target>
+						<source>Gradient profile</source>
+						<target>Høydeprofil</target>
 					</trans-unit>
 					<trans-unit id="route_settings">
-					  <source>Settings</source>
-					  <target>Valg</target>
+						<source>Settings</source>
+						<target>Valg</target>
 					</trans-unit>
 					<trans-unit id="route_settings_encoding">
-					  <source>Encoding:</source>
-					  <target>Tegnsett:</target>
+						<source>Encoding:</source>
+						<target>Tegnsett:</target>
 					</trans-unit>
 					<trans-unit id="route_settings_encoding_preview">
-					    <source>Preview:</source>
-					    <target>Forhåndsvisning:</target>
-					  </trans-unit>
-					  <trans-unit id="route_processing">
-					    <source>Processing route, please wait.....</source>
-					    <target>Prosesserer rute, vennligst vent.....</target>
-					  </trans-unit>
-					  <trans-unit id="train">
-					    <source>Train</source>
-					    <target>Tog</target>
-					  </trans-unit>
-					  <trans-unit id="train_selection">
-					    <source>Selection</source>
-					    <target>Togvalg</target>
-					  </trans-unit>
-					  <trans-unit id="train_addons">
-					    <source>Add-ons</source>
-					    <target>Add-ons</target>
-					  </trans-unit>
-					  <trans-unit id="train_browse">
-					    <source>Browse manually</source>
-					    <target>Filutforsker</target>
-					  </trans-unit>
-					  <trans-unit id="train_recently">
-					    <source>Recently used</source>
-					    <target>Nylig brukt</target>
-					  </trans-unit>
-					  <trans-unit id="train_default">
-					    <source>Route default</source>
-					    <target>Standard for rute</target>
-					  </trans-unit>
-					  <trans-unit id="train_usedefault">
-					    <source>Use the train suggested by the route</source>
-					    <target>Bruk toget som er standard for rute</target>
-					  </trans-unit>
-					  <trans-unit id="train_details">
-					    <source>Details</source>
-					    <target>Detaljer</target>
-					  </trans-unit>
-					  <trans-unit id="train_description">
-					    <source>Description</source>
-					    <target>Beskrivelse</target>
-					  </trans-unit>
-					  <trans-unit id="train_settings">
-					    <source>Settings</source>
-					    <target>Valg</target>
-					  </trans-unit>
-					  <trans-unit id="train_settings_encoding">
-					    <source>Encoding:</source>
-					    <target>Tegnsett:</target>
-					  </trans-unit>
-					  <trans-unit id="train_settings_reverseconsist">
-					    <source>Reverse Consist:</source>
-					    <target>Snu toget</target>
-					  </trans-unit>
-					  <trans-unit id="train_settings_encoding_preview">
-					    <source>Preview:</source>
-					    <target>Forhåndsvisning:</target>
-					  </trans-unit>
-					  <trans-unit id="train_notfound">
-					    <source>The default train could not be found:\r\n\r\n</source>
-					    <target>Det forhåndsvalgte toget kunne ikke bli funnet:\r\n\r\n</target>
-					  </trans-unit>
-					  <trans-unit id="train_pluginnotsupported">
-					    <source>--- This train uses a safety system plugin which cannot be used on your operating system. The built-in safety systems ATS/ATC will be used instead, which might cause operational problems. ---</source>
-					    <target>--- Dette toget bruker en plugin for sikkerhets-systemer som ikke kan bli benyttet på ditt operativsystem. Det innebygde sikkerhetssystemet ATS/ATC vil bli brukt i stede for. Dette kan forårsake problemer. ---</target>
-					  </trans-unit>
-					  <trans-unit id="start">
-					    <source>Start</source>
-					    <target>Start</target>
-					  </trans-unit>
-					  <trans-unit id="start_mode">
-					    <source>Mode of driving:</source>
-					    <target>Kjøremodus:</target>
-					  </trans-unit>
-					  <trans-unit id="start_start">
-					    <source>Start</source>
-					    <target>Start</target>
-					  </trans-unit>
-					  
+						<source>Preview:</source>
+						<target>Forhåndsvisning:</target>
+					</trans-unit>
+					<trans-unit id="route_processing">
+						<source>Processing route, please wait.....</source>
+						<target>Prosesserer rute, vennligst vent.....</target>
+					</trans-unit>
+					<trans-unit id="train">
+						<source>Train</source>
+						<target>Tog</target>
+					</trans-unit>
+					<trans-unit id="train_selection">
+						<source>Selection</source>
+						<target>Togvalg</target>
+					</trans-unit>
+					<trans-unit id="train_addons">
+						<source>Add-ons</source>
+						<target>Add-ons</target>
+					</trans-unit>
+					<trans-unit id="train_browse">
+						<source>Browse manually</source>
+						<target>Filutforsker</target>
+					</trans-unit>
+					<trans-unit id="train_recently">
+						<source>Recently used</source>
+						<target>Nylig brukt</target>
+					</trans-unit>
+					<trans-unit id="train_usedefault">
+						<source>Use the train suggested by the route</source>
+						<target>Bruk toget som er standard for rute</target>
+					</trans-unit>
+					<trans-unit id="train_details">
+						<source>Details</source>
+						<target>Detaljer</target>
+					</trans-unit>
+					<trans-unit id="train_description">
+						<source>Description</source>
+						<target>Beskrivelse</target>
+					</trans-unit>
+					<trans-unit id="train_settings">
+						<source>Settings</source>
+						<target>Valg</target>
+					</trans-unit>
+					<trans-unit id="train_settings_encoding">
+						<source>Encoding:</source>
+						<target>Tegnsett:</target>
+					</trans-unit>
+					<trans-unit id="train_settings_reverseconsist">
+						<source>Reverse Consist:</source>
+						<target>Snu toget</target>
+					</trans-unit>
+					<trans-unit id="train_settings_encoding_preview">
+						<source>Preview:</source>
+						<target>Forhåndsvisning:</target>
+					</trans-unit>
+					<trans-unit id="train_notfound">
+						<source>The default train could not be found:\r\n\r\n</source>
+						<target>Det forhåndsvalgte toget kunne ikke bli funnet:\r\n\r\n</target>
+					</trans-unit>
+					<trans-unit id="train_pluginnotsupported">
+						<source>--- This train uses a safety system plugin which cannot be used on your operating system. The built-in safety systems ATS/ATC will be used instead, which might cause operational problems. ---</source>
+						<target>--- Dette toget bruker en plugin for sikkerhets-systemer som ikke kan bli benyttet på ditt operativsystem. Det innebygde sikkerhetssystemet ATS/ATC vil bli brukt i stede for. Dette kan forårsake problemer. ---</target>
+					</trans-unit>
+					<trans-unit id="start">
+						<source>Start</source>
+						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="start_mode">
+						<source>Mode of driving:</source>
+						<target>Kjøremodus:</target>
+					</trans-unit>
+					<trans-unit id="start_start">
+						<source>Start</source>
+						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
+					</trans-unit>
 				</group>
 				<group id="review">
 					<trans-unit id="title">
-					  <source>Review last game</source>
-					  <target>Gå gjennom siste spill</target>
+						<source>Review last game</source>
+						<target>Gå gjennom siste spill</target>
 					</trans-unit>
 					<trans-unit id="conditions">
-					  <source>Conditions</source>
-					  <target>Forhold</target>
+						<source>Conditions</source>
+						<target>Forhold</target>
 					</trans-unit>
 					<trans-unit id="conditions_route">
-					  <source>Route</source>
-					  <target>Rute</target>
+						<source>Route</source>
+						<target>Rute</target>
 					</trans-unit>
 					<trans-unit id="conditions_route_file">
-					  <source>Route file:</source>
-					  <target>Rutefil:</target>
+						<source>Route file:</source>
+						<target>Rutefil:</target>
 					</trans-unit>
 					<trans-unit id="conditions_train">
-					  <source>Train</source>
-					  <target>Tog</target>
+						<source>Train</source>
+						<target>Tog</target>
 					</trans-unit>
 					<trans-unit id="conditions_train_folder">
-					  <source>Train folder:</source>
-					  <target>Tog-mappe:</target>
+						<source>Train folder:</source>
+						<target>Tog-mappe:</target>
 					</trans-unit>
 					<trans-unit id="conditions_datetime">
-					  <source>Date and time</source>
-					  <target>Dato og tid</target>
+						<source>Date and time</source>
+						<target>Dato og tid</target>
 					</trans-unit>
 					<trans-unit id="conditions_datetime_date">
-					  <source>Date:</source>
-					  <target>Dato:</target>
+						<source>Date:</source>
+						<target>Dato:</target>
 					</trans-unit>
 					<trans-unit id="conditions_datetime_time">
-					  <source>Time:</source>
-					  <target>Tid:</target>
+						<source>Time:</source>
+						<target>Tid:</target>
 					</trans-unit>
 					<trans-unit id="score">
-					  <source>Score</source>
-					  <target>Poeng</target>
+						<source>Score</source>
+						<target>Poeng</target>
 					</trans-unit>
 					<trans-unit id="score_rating">
-					  <source>Rating</source>
-					  <target>Vurdering</target>
+						<source>Rating</source>
+						<target>Vurdering</target>
 					</trans-unit>
 					<trans-unit id="score_rating_mode">
-					  <source>Mode:</source>
-					  <target>Modus:</target>
+						<source>Mode:</source>
+						<target>Modus:</target>
 					</trans-unit>
 					<trans-unit id="score_rating_achieved">
-					  <source>Achieved:</source>
-					  <target>Oppnådd:</target>
+						<source>Achieved:</source>
+						<target>Oppnådd:</target>
 					</trans-unit>
 					<trans-unit id="score_rating_maximum">
-					  <source>Maximum:</source>
-					  <target>Maksimum:</target>
+						<source>Maximum:</source>
+						<target>Maksimum:</target>
 					</trans-unit>
 					<trans-unit id="score_rating_ratio">
 						<source>Ratio:</source>
@@ -485,612 +493,620 @@
 						<source>Log</source>
 					</trans-unit>
 					<trans-unit id="score_log_list_time">
-					  <source>Time</source>
-					  <target>Tid</target>
+						<source>Time</source>
+						<target>Tid</target>
 					</trans-unit>
 					<trans-unit id="score_log_list_position">
-					  <source>Position (m)</source>
-					  <target>Posisjon (m)</target>
+						<source>Position (m)</source>
+						<target>Posisjon (m)</target>
 					</trans-unit>
 					<trans-unit id="score_log_list_value">
-					  <source>Value</source>
-					  <target>Verdi</target>
+						<source>Value</source>
+						<target>Verdi</target>
 					</trans-unit>
 					<trans-unit id="score_log_list_cumulative">
-					  <source>Cumulative</source>
-					  <target>Kumulative</target>
+						<source>Cumulative</source>
+						<target>Kumulative</target>
 					</trans-unit>
 					<trans-unit id="score_log_list_reason">
-					  <source>Reason</source>
-					  <target>Årsak</target>
+						<source>Reason</source>
+						<target>Årsak</target>
 					</trans-unit>
 					<trans-unit id="score_log_penalties">
-					  <source>Show penalties only</source>
-					  <target>Se bare straffer</target>
+						<source>Show penalties only</source>
+						<target>Se bare straffer</target>
 					</trans-unit>
 					<trans-unit id="score_log_export">
-					  <source>Export...</source>
-					  <target>Eksporter...</target>
+						<source>Export...</source>
+						<target>Eksporter...</target>
 					</trans-unit>
 					<trans-unit id="blackbox">
-					  <source>Black box</source>
-					  <target>Blackbox</target>
+						<source>Black box</source>
+						<target>Blackbox</target>
 					</trans-unit>
 					<trans-unit id="blackbox_format">
-					  <source>Format:</source>
-					  <target>Format:</target>
+						<source>Format:</source>
+						<target>Format:</target>
 					</trans-unit>
 					<trans-unit id="blackbox_format_csv">
-					  <source>Comma-separated value</source>
-					  <target>Komma-separerte verdier</target>
+						<source>Comma-separated value</source>
+						<target>Komma-separerte verdier</target>
 					</trans-unit>
 					<trans-unit id="blackbox_format_text">
-					  <source>Formatted text</source>
-					  <target>Formatert tekst</target>
+						<source>Formatted text</source>
+						<target>Formatert tekst</target>
 					</trans-unit>
 					<trans-unit id="blackbox_export">
-					  <source>Export...</source>
-					  <target>Eksport...</target>
+						<source>Export...</source>
+						<target>Eksport...</target>
 					</trans-unit>
 				</group>
 				<group id="packages">
 					<trans-unit id="title">
-					  <source>Package Management</source>
-					  <target>Pakkehåndtering</target>
+						<source>Package Management</source>
+						<target>Pakkehåndtering</target>
 					</trans-unit>
 					<trans-unit id="proceed">
-					  <source>Proceed...</source>
-					  <target>Fortsett...</target>
+						<source>Proceed...</source>
+						<target>Fortsett...</target>
 					</trans-unit>
 					<trans-unit id="proceed_anyway">
-					  <source>Proceed Anyway</source>
-					  <target>Fortsett uansett...</target>
+						<source>Proceed Anyway</source>
+						<target>Fortsett uansett...</target>
 					</trans-unit>
 					<trans-unit id="processing">
-					  <source>Processing, please wait...</source>
-					  <target>Prosesserer, vennligst vent...</target>
+						<source>Processing, please wait...</source>
+						<target>Prosesserer, vennligst vent...</target>
 					</trans-unit>
 					<trans-unit id="unknown_file">
-					  <source>Unknown File...</source>
-					  <target>Ukjent fil...</target>
+						<source>Unknown File...</source>
+						<target>Ukjent fil...</target>
 					</trans-unit>
 					<trans-unit id="shownlist">
-					  <source>These are shown in the list below:</source>
-					  <target>Disse er vist i listen under:</target>
+						<source>These are shown in the list below:</source>
+						<target>Disse er vist i listen under:</target>
 					</trans-unit>
 					<trans-unit id="selection_none">
-					  <source>No package selected.</source>
-					  <target>Ingen pakker er valgt.</target>
+						<source>No package selected.</source>
+						<target>Ingen pakker er valgt.</target>
 					</trans-unit>
 					<trans-unit id="selection_none_website">
-					  <source>No website provided.</source>
-					  <target>Ingen nettside er registrert.</target>
+						<source>No website provided.</source>
+						<target>Ingen nettside er registrert.</target>
 					</trans-unit>
 					<trans-unit id="list">
-					  <source>Installed Packages</source>
-					  <target>Installerte pakker</target>
+						<source>Installed Packages</source>
+						<target>Installerte pakker</target>
 					</trans-unit>
 					<trans-unit id="list_type">
-					  <source>Select the type of packages you wish to view:</source>
-					  <target>Velg type pakker du ønsker å se:</target>
+						<source>Select the type of packages you wish to view:</source>
+						<target>Velg type pakker du ønsker å se:</target>
 					</trans-unit>
 					<trans-unit id="list_name">
-					  <source>Name</source>
-					  <target>Navn</target>
+						<source>Name</source>
+						<target>Navn</target>
 					</trans-unit>
 					<trans-unit id="list_version">
-					  <source>Version</source>
-					  <target>Versjon</target>
+						<source>Version</source>
+						<target>Versjon</target>
 					</trans-unit>
 					<trans-unit id="list_minimum">
-					  <source>Minimum Version</source>
-					  <target>Minimums-versjon</target>
+						<source>Minimum Version</source>
+						<target>Minimums-versjon</target>
 					</trans-unit>
 					<trans-unit id="list_maximum">
-					  <source>Maximum Version</source>
-					  <target>Maksimums-versjon</target>
+						<source>Maximum Version</source>
+						<target>Maksimums-versjon</target>
 					</trans-unit>
 					<trans-unit id="list_author">
-					  <source>Author</source>
-					  <target>Forfatter</target>
+						<source>Author</source>
+						<target>Forfatter</target>
 					</trans-unit>
 					<trans-unit id="list_website">
-					  <source>Website</source>
-					  <target>Nettside</target>
+						<source>Website</source>
+						<target>Nettside</target>
 					</trans-unit>
 					<trans-unit id="list_packagetype">
-					  <source>Type</source>
-					  <target>Type</target>
+						<source>Type</source>
+						<target>Type</target>
 					</trans-unit>
 					<trans-unit id="install">
-					  <source>Install</source>
-					  <target>Installer</target>
+						<source>Install</source>
+						<target>Installer</target>
 					</trans-unit>
 					<trans-unit id="install_button">
-					  <source>Install Package</source>
-					  <target>Installer pakke</target>
+						<source>Install Package</source>
+						<target>Installer pakke</target>
 					</trans-unit>
 					<trans-unit id="install_header">
-					  <source>Install a Package</source>
-					  <target>Installer en pakke</target>
+						<source>Install a Package</source>
+						<target>Installer en pakke</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-					  <source>This file does not appear to be a valid openBVE package.</source>
-					  <target>Filen ser ikke ut til å være en valid openBVE pakke.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Filen ser ikke ut til å være en valid OpenBVE pakke.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
-					  <source>Package Version Error</source>
-					  <target>Pakkeversjonsfeil</target>
+						<source>Package Version Error</source>
+						<target>Pakkeversjonsfeil</target>
 					</trans-unit>
 					<trans-unit id="install_version_new">
-					  <source>The selected package is already installed, and is a newer version.</source>
-					  <target>Den valgte pakken er allerede installert og er en nyere versjon.</target>
+						<source>The selected package is already installed, and is a newer version.</source>
+						<target>Den valgte pakken er allerede installert og er en nyere versjon.</target>
 					</trans-unit>
 					<trans-unit id="install_version_old">
-					  <source>The selected package is already installed, and is an older version.</source>
-					  <target>Den valgte pakken er allerede installert og er en eldre versjon.</target>
+						<source>The selected package is already installed, and is an older version.</source>
+						<target>Den valgte pakken er allerede installert og er en eldre versjon.</target>
 					</trans-unit>
 					<trans-unit id="install_version_same">
-					  <source>The selected package is already installed, and is an identical version.</source>
-					  <target>Den valgte pakken er allerede installert og er en lik versjon.</target>
+						<source>The selected package is already installed, and is an identical version.</source>
+						<target>Den valgte pakken er allerede installert og er en lik versjon.</target>
 					</trans-unit>
 					<trans-unit id="install_success">
-					  <source>Package installation was successful.</source>
-					  <target>Pakkeinstallasjonen var velykket.</target>
+						<source>Package installation was successful.</source>
+						<target>Pakkeinstallasjonen var velykket.</target>
 					</trans-unit>
 					<trans-unit id="install_success_header">
-					  <source>Installation Successful</source>
-					  <target>Installasjon velykket</target>
+						<source>Installation Successful</source>
+						<target>Installasjon velykket</target>
 					</trans-unit>
 					<trans-unit id="install_success_files">
-					  <source>A list of files installed is shown below:</source>
-					  <target>En liste over filer installert vises under:</target>
+						<source>A list of files installed is shown below:</source>
+						<target>En liste over filer installert vises under:</target>
 					</trans-unit>
 					<trans-unit id="install_failure">
-					  <source>Unfortunately, package installation failed.</source>
-					  <target>Dessverre feilet pakkeinstallasjonen.</target>
+						<source>Unfortunately, package installation failed.</source>
+						<target>Dessverre feilet pakkeinstallasjonen.</target>
 					</trans-unit>
 					<trans-unit id="install_failure_header">
-					  <source>Package Installation Failed</source>
-					  <target>Pakkeinstallasjonen feilet</target>
+						<source>Package Installation Failed</source>
+						<target>Pakkeinstallasjonen feilet</target>
 					</trans-unit>
 					<trans-unit id="install_select">
-					  <source>Select Package......</source>
-					  <target>Velg en pakke......</target>
+						<source>Select Package......</source>
+						<target>Velg en pakke......</target>
 					</trans-unit>
 					<trans-unit id="install_dependancies_unmet">
-					  <source>The current package has unmet dependancies.</source>
-					  <target>Den valgte pakken har avhengigheter som ikke er oppfylt.</target>
+						<source>The current package has unmet dependancies.</source>
+						<target>Den valgte pakken har avhengigheter som ikke er oppfylt.</target>
 					</trans-unit>
 					<trans-unit id="install_dependancies_unmet_header">
-					  <source>Dependancy Error</source>
-					  <target>Avhengighetsfeil</target>
+						<source>Dependancy Error</source>
+						<target>Avhengighetsfeil</target>
 					</trans-unit>
 					<trans-unit id="install_dependancies_broken">
-					  <source>The following dependancies may be broken by this action:</source>
-					  <target>Følgende avhengigheter blir ødelagt av denne handlingen:</target>
+						<source>The following dependancies may be broken by this action:</source>
+						<target>Følgende avhengigheter blir ødelagt av denne handlingen:</target>
 					</trans-unit>
 					<trans-unit id="install_reccomends_unmet">
-					  <source>The following packages are recommended, but not installed:</source>
-					  <target>Følgende pakker er anbefalt men ikke installert:</target>
+						<source>The following packages are recommended, but not installed:</source>
+						<target>Følgende pakker er anbefalt men ikke installert:</target>
 					</trans-unit>
 					<trans-unit id="install_reccomends_unmet_header">
-					  <source>Recommended Packages</source>
-					  <target>Anbefalte pakker</target>
+						<source>Recommended Packages</source>
+						<target>Anbefalte pakker</target>
 					</trans-unit>
 					<trans-unit id="install_name">
-					  <source>Package Name:</source>
-					  <target>Pakkens navn:</target>
+						<source>Package Name:</source>
+						<target>Pakkens navn:</target>
 					</trans-unit>
 					<trans-unit id="install_author">
-					  <source>Package Author:</source>
-					  <target>Pakkens forfatter:</target>
+						<source>Package Author:</source>
+						<target>Pakkens forfatter:</target>
 					</trans-unit>
 					<trans-unit id="install_version">
-					  <source>Package Version:</source>
-					  <target>Pakkens versjon:</target>
+						<source>Package Version:</source>
+						<target>Pakkens versjon:</target>
 					</trans-unit>
 					<trans-unit id="install_website">
-					  <source>Package Website:</source>
-					  <target>Pakkens nettside:</target>
+						<source>Package Website:</source>
+						<target>Pakkens nettside:</target>
 					</trans-unit>
 					<trans-unit id="install_description">
-					  <source>Package Description:</source>
-					  <target>Pakkens beskrivelse:</target>
+						<source>Package Description:</source>
+						<target>Pakkens beskrivelse:</target>
 					</trans-unit>
 					<trans-unit id="creation_button">
-					  <source>Create Package</source>
-					  <target>Lag pakke</target>
+						<source>Create Package</source>
+						<target>Lag pakke</target>
 					</trans-unit>
 					<trans-unit id="creation_header">
-					  <source>Create a Package</source>
-					  <target>Lag en pakke</target>
-					  
+						<source>Create a Package</source>
+						<target>Lag en pakke</target>
 					</trans-unit>
 					<trans-unit id="creation_saveas_button">
-					  <source>Save As...</source>
-					  <target>Lagre som...</target>
+						<source>Save As...</source>
+						<target>Lagre som...</target>
 					</trans-unit>
 					<trans-unit id="creation_saveas_label">
-					  <source>Save package as:</source>
-					  <target>Lagre pakke som:</target>
+						<source>Save package as:</source>
+						<target>Lagre pakke som:</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies">
-					  <source>Select Dependancies</source>
-					  <target>Velg avhengigheter</target>
+						<source>Select Dependancies</source>
+						<target>Velg avhengigheter</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_add">
-					  <source>Add Dependancy</source>
-					  <target>Legg til avhengighet</target>
+						<source>Add Dependancy</source>
+						<target>Legg til avhengighet</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_remove">
-					  <source>Remove</source>
-					  <target>Fjern</target>
+						<source>Remove</source>
+						<target>Fjern</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
-					  <source>Package details and dependancies may be assigned in the following steps.</source>
-					  <target>Pakke detaljer og avhengigheter vil bli lagt til i følgende steg.</target>
+						<source>Package details and dependancies may be assigned in the following steps.</source>
+						<target>Pakke detaljer og avhengigheter vil bli lagt til i følgende steg.</target>
 					</trans-unit>
 					<trans-unit id="creation_reccommends_add">
-					  <source>Add Recommendation</source>
-					  <target>Legg til anbefaling</target>
+						<source>Add Recommendation</source>
+						<target>Legg til anbefaling</target>
 					</trans-unit>
 					<trans-unit id="creation_clearselection">
-					  <source>Clear Selection</source>
-					  <target>Fjern utvalgte</target>
+						<source>Clear Selection</source>
+						<target>Fjern utvalgte</target>
 					</trans-unit>
 					<trans-unit id="creation_additems">
-					  <source>Add Item(s)</source>
-					  <target>Legg til elementer</target>
+						<source>Add Item(s)</source>
+						<target>Legg til elementer</target>
 					</trans-unit>
 					<trans-unit id="creation_selecteditems">
-					  <source>The following files and folders will be packaged:</source>
-					  <target>Følgende filer og pakker vil bli pakket:</target>
+						<source>The following files and folders will be packaged:</source>
+						<target>Følgende filer og pakker vil bli pakket:</target>
 					</trans-unit>
 					<trans-unit id="creation_new_guid">
-					  <source>The new package has been assigned the following GUID:</source>
-					  <target>Den nye pakken har fått følgende GUID:</target>
+						<source>The new package has been assigned the following GUID:</source>
+						<target>Den nye pakken har fått følgende GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
-					  <source>Enter Package Details</source>
-					  <target>Legg inn pakkedetaljer</target>
+					<trans-unit id="enter_details_header">
+						<source>Enter Package Details</source>
+						<target>Legg inn pakkedetaljer</target>
 					</trans-unit>
 					<trans-unit id="creation_name">
-					  <source>Please enter a package name.</source>
-					  <target>Legg til navn på pakken.</target>
+						<source>Please enter a package name.</source>
+						<target>Legg til navn på pakken.</target>
 					</trans-unit>
 					<trans-unit id="creation_author">
-					  <source>Please enter a package author.</source>
-					  <target>Legg til pakkens forfatter.</target>
+						<source>Please enter a package author.</source>
+						<target>Legg til pakkens forfatter.</target>
 					</trans-unit>
 					<trans-unit id="creation_description">
-					  <source>Please enter a package description.</source>
-					  <target>Legg til beskrivelse på pakke.</target>
+						<source>Please enter a package description.</source>
+						<target>Legg til beskrivelse på pakke.</target>
 					</trans-unit>
 					<trans-unit id="creation_version">
-					  <source>Please enter a valid package version number in the following format: \r\n 1.0.0</source>
-					  <target>Legg til en gyldig pakkeversjonsnummer på følgende format: \r\n 1.0.0</target>
+						<source>Please enter a valid package version number in the following format: \r\n 1.0.0</source>
+						<target>Legg til en gyldig pakkeversjonsnummer på følgende format: \r\n 1.0.0</target>
 					</trans-unit>
 					<trans-unit id="creation_version_invalid">
-					  <source>You have entered an invalid version number. \r\n Please try again.</source>
-					  <target>Du har skrevet inn et ikke gyldig versjonsnummer. \r\n Prøv igjen.</target>
+						<source>You have entered an invalid version number. \r\n Please try again.</source>
+						<target>Du har skrevet inn et ikke gyldig versjonsnummer. \r\n Prøv igjen.</target>
 					</trans-unit>
 					<trans-unit id="creation_success">
-					  <source>Package creation was successful.</source>
-					  <target>Pakken ble velykket laget.</target>
+						<source>Package creation was successful.</source>
+						<target>Pakken ble velykket laget.</target>
 					</trans-unit>
 					<trans-unit id="creation_success_header">
-					  <source>Package Creation Successful</source>
-					  <target>Laging av pakken er vellykket.</target>
+						<source>Package Creation Successful</source>
+						<target>Laging av pakken er vellykket.</target>
 					</trans-unit>
 					<trans-unit id="creation_success_files">
-					  <source>The following files were added to your package:</source>
-					  <target>Følgende filer ble lagt til din pakke:</target>
+						<source>The following files were added to your package:</source>
+						<target>Følgende filer ble lagt til din pakke:</target>
 					</trans-unit>
 					<trans-unit id="creation_failure">
-					  <source>Unfortunately, creation of your package failed.</source>
-					  <target>Dessverre feilet opprettelsen av pakken din. </target>
+						<source>Unfortunately, creation of your package failed.</source>
+						<target>Dessverre feilet opprettelsen av pakken din. </target>
 					</trans-unit>
 					<trans-unit id="creation_failure_header">
-					  <source>Package Creation Failed</source>
-					  <target>Laging av pakken feilet</target>
+						<source>Package Creation Failed</source>
+						<target>Laging av pakken feilet</target>
 					</trans-unit>
 					<trans-unit id="creation_failure_error">
-					  <source>The following error was encountered:</source>
-					  <target>Følgende feil oppstod:</target>
+						<source>The following error was encountered:</source>
+						<target>Følgende feil oppstod:</target>
 					</trans-unit>
 					<trans-unit id="creation_proceed">
-					  <source>Proceed......</source>
-					  <target>Fortsett.....</target>
+						<source>Proceed......</source>
+						<target>Fortsett.....</target>
 					</trans-unit>
 					<trans-unit id="creation_invalid_nofiles">
-					  <source>No files were selected to package- Please retry.</source>
-					  <target>Ingen filer ble lagt til i pakken. Prøv igjen.</target>
+						<source>No files were selected to package- Please retry.</source>
+						<target>Ingen filer ble lagt til i pakken. Prøv igjen.</target>
 					</trans-unit>
 					<trans-unit id="creation_invalid_filename">
-					  <source>The selected filename is invalid- Please retry.</source>
-					  <target>Valgt filnavn er ikke gyldig. Prøv igjen.</target>
+						<source>The selected filename is invalid- Please retry.</source>
+						<target>Valgt filnavn er ikke gyldig. Prøv igjen.</target>
 					</trans-unit>
 					<trans-unit id="creation_new_id">
-					  <source>The new package has been assigned the following GUID:</source>
-					  <target>Pakken har blitt tildelt følgende GUID:</target>
+						<source>The new package has been assigned the following GUID:</source>
+						<target>Pakken har blitt tildelt følgende GUID:</target>
 					</trans-unit>
 					<trans-unit id="creation_replace_id">
-					  <source>Replacing the package with the following GUID:</source>
-					  <target>Bytter ut pakken med følgende GUID:</target>
+						<source>Replacing the package with the following GUID:</source>
+						<target>Bytter ut pakken med følgende GUID:</target>
 					</trans-unit>
 					<trans-unit id="creation_save">
-					  <source>Save Package</source>
-					  <target>Lagre pakke</target>
+						<source>Save Package</source>
+						<target>Lagre pakke</target>
 					</trans-unit>
 					<trans-unit id="creation_replace">
-					  <source>Is this to replace an existing package?</source>
-					  <target>Er dette en oppdatering av en eksisterende pakke?</target>
+						<source>Is this to replace an existing package?</source>
+						<target>Er dette en oppdatering av en eksisterende pakke?</target>
 					</trans-unit>
 					<trans-unit id="creation_yes">
-					  <source>Yes</source>
-					  <target>Ja</target>
+						<source>Yes</source>
+						<target>Ja</target>
 					</trans-unit>
 					<trans-unit id="creation_no">
-					  <source>No</source>
-					  <target>Nei</target>
+						<source>No</source>
+						<target>Nei</target>
 					</trans-unit>
 					<trans-unit id="replace_select">
-					  <source>Replace this Package</source>
-					  <target>Bytt ut denne pakken</target>
+						<source>Replace this Package</source>
+						<target>Bytt ut denne pakken</target>
 					</trans-unit>
 					<trans-unit id="replace_choose">
-					  <source>Please select the package you wish to replace:</source>
-					  <target>Velg pakken du ønsker å bytte ut:</target>
+						<source>Please select the package you wish to replace:</source>
+						<target>Velg pakken du ønsker å bytte ut:</target>
 					</trans-unit>
 					<trans-unit id="replace_noneavailable">
-					  <source>No packages are currently installed.</source>
-					  <target>Ingen pakker er foreløpig installert.</target>
+						<source>No packages are currently installed.</source>
+						<target>Ingen pakker er foreløpig installert.</target>
 					</trans-unit>
 					<trans-unit id="type_route">
-					  <source>Route</source>
-					  <target>Ruter</target>
+						<source>Route</source>
+						<target>Ruter</target>
 					</trans-unit>
 					<trans-unit id="type_train">
-					  <source>Train</source>
-					  <target>Tog</target>
+						<source>Train</source>
+						<target>Tog</target>
 					</trans-unit>
 					<trans-unit id="type_other">
-					  <source>Other</source>
-					  <target>Andre</target>
+						<source>Other</source>
+						<target>Andre</target>
 					</trans-unit>
 					<trans-unit id="type_select">
-					  <source>Please select the package type:</source>
-					  <target>Velg en pakketype:</target>
+						<source>Please select the package type:</source>
+						<target>Velg en pakketype:</target>
 					</trans-unit>
 					<trans-unit id="uninstall_failure">
-					  <source>Unfortunately, uninstallation of this package failed.</source>
-					  <target>Avinstallering av denne pakken feilet.</target>
+						<source>Unfortunately, uninstallation of this package failed.</source>
+						<target>Avinstallering av denne pakken feilet.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_failure_header">
-					  <source>Uninstallation Failed</source>
-					  <target>Avinstallering feilet</target>
+						<source>Uninstallation Failed</source>
+						<target>Avinstallering feilet</target>
 					</trans-unit>
 					<trans-unit id="uninstall_success">
-					  <source>Uninstallation of this package was successful.</source>
-					  <target>Avinstalleringen av denne pakken var vellykket.</target>
+						<source>Uninstallation of this package was successful.</source>
+						<target>Avinstalleringen av denne pakken var vellykket.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_success_header">
-					  <source>Uninstallation Successful</source>
-					  <target>Avinstallering vellykket</target>
+						<source>Uninstallation Successful</source>
+						<target>Avinstallering vellykket</target>
 					</trans-unit>
 					<trans-unit id="uninstall_log">
-					  <source>A log is shown below:</source>
-					  <target>Loggen vises nedenfor:</target>
+						<source>A log is shown below:</source>
+						<target>Loggen vises nedenfor:</target>
 					</trans-unit>
 					<trans-unit id="uninstall_button">
-					  <source>Uninstall Package</source>
-					  <target>Avinstaller pakker</target>
+						<source>Uninstall Package</source>
+						<target>Avinstaller pakker</target>
 					</trans-unit>
 					<trans-unit id="uninstall_broken">
-					  <source>Some existing packages may be broken by this action.</source>
-					  <target>Eksisterende pakker kan bli skadet av denne handlingen.</target>
+						<source>Some existing packages may be broken by this action.</source>
+						<target>Eksisterende pakker kan bli skadet av denne handlingen.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_missing_xml">
-					  <source>Unable to uninstall the selected package. \r\n XML file list missing.</source>
-					  <target>Ikke mulig å avinstallere den valgte pakken. \r\n XML listefil mangler.</target>
+						<source>Unable to uninstall the selected package. \r\n XML file list missing.</source>
+						<target>Ikke mulig å avinstallere den valgte pakken. \r\n XML listefil mangler.</target>
 					</trans-unit>
 					<trans-unit id="uninstall_database_remove">
-					  <source>Do you wish to remove this package from the database?</source>
-					  <target>Ønsker du å fjerne denne pakken helt fra databasen?</target>
+						<source>Do you wish to remove this package from the database?</source>
+						<target>Ønsker du å fjerne denne pakken helt fra databasen?</target>
 					</trans-unit>
 					<trans-unit id="database_save_error">
-					  <source>An error occured whilst saving the package database. \r\n Please check for write permissions.</source>
-					  <target>En feil oppstod mens pakken prøvde å lagres til databasen. \r\n Vennligst sjekk om du har skriverettigheter.</target>
+						<source>An error occured whilst saving the package database. \r\n Please check for write permissions.</source>
+						<target>En feil oppstod mens pakken prøvde å lagres til databasen. \r\n Vennligst sjekk om du har skriverettigheter.</target>
 					</trans-unit>
 					<trans-unit id="version_new">
-					  <source>New version:</source>
-					  <target>Ny versjon:</target>
+						<source>New version:</source>
+						<target>Ny versjon:</target>
 					</trans-unit>
 					<trans-unit id="version_current">
-					  <source>Current version:</source>
-					  <target>Nåværende versjon:</target>
+						<source>Current version:</source>
+						<target>Nåværende versjon:</target>
 					</trans-unit>
 					<trans-unit id="success">
-					  <source>Finished!</source>
-					  <target>Ferdig!</target>
+						<source>Finished!</source>
+						<target>Ferdig!</target>
 					</trans-unit>
 					<trans-unit id="selected">
-					  <source>Selected Packages</source>
-					  <target>Valgte pakker</target>
+						<source>Selected Packages</source>
+						<target>Valgte pakker</target>
 					</trans-unit>
 					<trans-unit id="dependancy">
-					  <source>Dependancy</source>
-					  <target>Avhengigheter</target>
+						<source>Dependancy</source>
+						<target>Avhengigheter</target>
 					</trans-unit>
 					<trans-unit id="recommendation">
-					  <source>Recommendation</source>
-					  <target>Anbefaling</target>
+						<source>Recommendation</source>
+						<target>Anbefaling</target>
 					</trans-unit>
 					<trans-unit id="error_action">
-					  <source>Please select the action you wish to take:</source>
-					  <target>Velg handlingen du ønsker å ta:</target>
+						<source>Please select the action you wish to take:</source>
+						<target>Velg handlingen du ønsker å ta:</target>
 					</trans-unit>
 					<trans-unit id="error_overwrite">
-					  <source>Overwrite</source>
-					  <target>Skriv over</target>
+						<source>Overwrite</source>
+						<target>Skriv over</target>
 					</trans-unit>
 					<trans-unit id="error_replace">
-					  <source>Replace</source>
-					  <target>Bytt ut</target>
+						<source>Replace</source>
+						<target>Bytt ut</target>
 					</trans-unit>
 					<trans-unit id="button_next">
-					  <source>Next &gt;</source>
-					  <target>Neste &gt;</target>
+						<source>Next &gt;</source>
+						<target>Neste &gt;</target>
 					</trans-unit>
 					<trans-unit id="button_back">
-					  <source>&lt; Back</source>
-					  <target>&lt; Tilbake</target>
+						<source>&lt; Back</source>
+						<target>&lt; Tilbake</target>
 					</trans-unit>
 					<trans-unit id="button_cancel">
-					  <source>Cancel</source>
-					  <target>Avbryt</target>
+						<source>Cancel</source>
+						<target>Avbryt</target>
 					</trans-unit>
 					<trans-unit id="button_ok">
-					  <source>OK</source>
-					  <target>OK</target>
+						<source>OK</source>
+						<target>OK</target>
 					</trans-unit>
 					<trans-unit id="button_install">
-					  <source>Install</source>
-					  <target>Installer</target>
+						<source>Install</source>
+						<target>Installer</target>
 					</trans-unit>
 					<trans-unit id="button_create">
-					  <source>Create</source>
-					  <target>Lag</target>
+						<source>Create</source>
+						<target>Lag</target>
 					</trans-unit>
 					<trans-unit id="button_ignore">
-					  <source>Ignore</source>
-					  <target>Ignorer</target>
+						<source>Ignore</source>
+						<target>Ignorer</target>
 					</trans-unit>
 					<trans-unit id="button_abort">
-					  <source>Abort</source>
-					  <target>Avbryt</target>
+						<source>Abort</source>
+						<target>Avbryt</target>
 					</trans-unit>
 					<trans-unit id="filename_empty">
-					  <source>Attempted to create a package with an empty filename.</source>
-					  <target>Prøvde å lage en pakke med tomt filnavn.</target>
+						<source>Attempted to create a package with an empty filename.</source>
+						<target>Prøvde å lage en pakke med tomt filnavn.</target>
 					</trans-unit>
 					<trans-unit id="directory_missing">
-					  <source>The directory in which you attempted to save the package file does not exist: \r \n</source>
-					  <target>Mappen hvor du prøvede å skrive pakken til fins ikke: \r \n</target>
+						<source>The directory in which you attempted to save the package file does not exist: \r \n</source>
+						<target>Mappen hvor du prøvede å skrive pakken til fins ikke: \r \n</target>
 					</trans-unit>
 					<trans-unit id="directory_nowrite">
-					  <source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
-					  <target>Det er ikke skrivetilgang i mappen hvor du prøver å lagre pakkefilen til: \r \n</target>
+						<source>No write access available in the directory in which you attempted to save the package file: \r \n</source>
+						<target>Det er ikke skrivetilgang i mappen hvor du prøver å lagre pakkefilen til: \r \n</target>
 					</trans-unit>
 					<trans-unit id="file_generic">
-					  <source>Failed to create the following file: \r \n</source>
-					  <target>Klarte ikke å lage følgende fil: \r \n</target>
+						<source>Failed to create the following file: \r \n</source>
+						<target>Klarte ikke å lage følgende fil: \r \n</target>
+					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
-					  <source>Customize controls</source>
-					  <target>Endre knapper / kontroller</target>
+						<source>Customize controls</source>
+						<target>Endre knapper / kontroller</target>
 					</trans-unit>
 					<trans-unit id="list_command">
-					  <source>Command</source>
-					  <target>Kommando</target>
+						<source>Command</source>
+						<target>Kommando</target>
 					</trans-unit>
 					<trans-unit id="list_type">
-					  <source>Type</source>
-					  <target>Type</target>
+						<source>Type</source>
+						<target>Type</target>
 					</trans-unit>
 					<trans-unit id="list_type_digital">
-					  <source>Digital</source>
-					  <target>Digital</target>
+						<source>Digital</source>
+						<target>Digital</target>
 					</trans-unit>
 					<trans-unit id="list_type_analoghalf">
-					  <source>Analog (half axis)</source>
-					  <target>Analog (halv akse)</target>
+						<source>Analog (half axis)</source>
+						<target>Analog (halv akse)</target>
 					</trans-unit>
 					<trans-unit id="list_type_analogfull">
-					  <source>Analog (full axis)</source>
-					  <target>Analog (full akse)</target>
+						<source>Analog (full axis)</source>
+						<target>Analog (full akse)</target>
 					</trans-unit>
 					<trans-unit id="list_description">
-					  <source>Description</source>
-					  <target>Beskrivelse</target>
+						<source>Description</source>
+						<target>Beskrivelse</target>
 					</trans-unit>
 					<trans-unit id="list_assignment">
-					  <source>Assignment</source>
-					  <target>Tilordning</target>
+						<source>Assignment</source>
+						<target>Tilordning</target>
 					</trans-unit>
 					<trans-unit id="list_option">
-					  <source>Command Option</source>
-					  <target>Kommandovalg</target>
+						<source>Command Option</source>
+						<target>Kommandovalg</target>
 					</trans-unit>
 					<trans-unit id="add">
-					  <source>Add control</source>
-					  <target>Legg til knapp</target>
+						<source>Add control</source>
+						<target>Legg til knapp</target>
 					</trans-unit>
 					<trans-unit id="remove">
-					  <source>Remove control</source>
-					  <target>Fjern knapp</target>
+						<source>Remove control</source>
+						<target>Fjern knapp</target>
 					</trans-unit>
 					<trans-unit id="import">
-					  <source>Import...</source>
-					  <target>Importer...</target>
+						<source>Import...</source>
+						<target>Importer...</target>
 					</trans-unit>
 					<trans-unit id="export">
-					  <source>Export...</source>
-					  <target>Eksporter...</target>
+						<source>Export...</source>
+						<target>Eksporter...</target>
 					</trans-unit>
 					<trans-unit id="reset_question">
 						<source>Reset the current control configuration to the defaults?</source>
 					</trans-unit>
 					<trans-unit id="reset">
-					  <source>Reset to defaults</source>
-					  <target>Tilbakestill</target>
+						<source>Reset to defaults</source>
+						<target>Tilbakestill</target>
 					</trans-unit>
 					<trans-unit id="up">
-					  <source>Move up</source>
-					  <target>Flytt opp</target>
+						<source>Move up</source>
+						<target>Flytt opp</target>
 					</trans-unit>
 					<trans-unit id="down">
-					  <source>Move down</source>
-					  <target>Flytt ned</target>
+						<source>Move down</source>
+						<target>Flytt ned</target>
 					</trans-unit>
 					<trans-unit id="selection">
-					  <source>Currently selected command</source>
-					  <target>Valgte kommando</target>
+						<source>Currently selected command</source>
+						<target>Valgte kommando</target>
 					</trans-unit>
 					<trans-unit id="selection_command">
-					  <source>Command:</source>
-					  <target>Kommando:</target>
+						<source>Command:</source>
+						<target>Kommando:</target>
 					</trans-unit>
 					<trans-unit id="selection_command_option">
-					  <source>Command Option:</source>
-					  <target>Kommandovalg:</target>
+						<source>Command Option:</source>
+						<target>Kommandovalg:</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard">
-					  <source>Keyboard:</source>
-					  <target>Tastatur:</target>
+						<source>Keyboard:</source>
+						<target>Tastatur:</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard_assignment_grab">
-					  <source>Click here to enable keyboard grab to automatically select the desired key.</source>
-					  <target>Trykk her for å velge ønsket knapp på tastaturet.</target>
+						<source>Click here to enable keyboard grab to automatically select the desired key.</source>
+						<target>Trykk her for å velge ønsket knapp på tastaturet.</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard_assignment_grabbing">
-					  <source>Please press any key...</source>
-					  <target>Trykk hvilken som helst knapp...</target>
+						<source>Please press any key...</source>
+						<target>Trykk hvilken som helst knapp...</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard_key">
-					  <source>Key:</source>
-					  <target>Knapp:</target>
+						<source>Key:</source>
+						<target>Knapp:</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard_modifiers">
-					  <source>Modifiers:</source>
-					  <target>Kombinasjonsknapp:</target>
+						<source>Modifiers:</source>
+						<target>Kombinasjonsknapp:</target>
 					</trans-unit>
 					<trans-unit id="selection_keyboard_modifiers_shift">
 						<source>Shift</source>
@@ -1105,28 +1121,28 @@
 						<source>Joystick:</source>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment">
-					  <source>Assignment:</source>
-					  <target>Tilordning:</target>
+						<source>Assignment:</source>
+						<target>Tilordning:</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab">
-					  <source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
-					  <target>Trykk her for å velge ønsket knapp på joysticken.</target>
+						<source>Click here to enable joystick grab to automatically select the desired axis, button or hat.</source>
+						<target>Trykk her for å velge ønsket knapp på joysticken.</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_normal">
-					  <source>Press a button or move an axis or hat into the desired direction...</source>
-					  <target>Trykk en knapp eller beveg en akse inn i ønsket retning...</target>
+						<source>Press a button or move an axis or hat into the desired direction...</source>
+						<target>Trykk en knapp eller beveg en akse inn i ønsket retning...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-					  <source>Move an axis into the direction of "increase" or "power"...</source>
-					  <target>Flytt en akse inn i ønsket retning "øke akselerasjon"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Flytt en akse inn i ønsket retning &quot;øke akselerasjon&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
-					  <source>Attached joysticks</source>
-					  <target>Tilkoblede joysticker</target>
+						<source>Attached joysticks</source>
+						<target>Tilkoblede joysticker</target>
 					</trans-unit>
 					<trans-unit id="assignment_keyboard">
-					  <source>Keyboard</source>
-					  <target>Tastatur</target>
+						<source>Keyboard</source>
+						<target>Tastatur</target>
 					</trans-unit>
 					<trans-unit id="assignment_keyboard_shift">
 						<source>Shift +\x20</source>
@@ -1144,63 +1160,63 @@
 						<source>axis [index]</source>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_axis_negative">
-					  <source>negative direction</source>
-					  <target>negativ retning</target>
+						<source>negative direction</source>
+						<target>negativ retning</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_axis_positive">
-					  <source>positive direction</source>
-					  <target>positiv retning</target>
+						<source>positive direction</source>
+						<target>positiv retning</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_axis_invalid">
-					  <source>invalid direction</source>
-					  <target>ugyldig retning</target>
+						<source>invalid direction</source>
+						<target>ugyldig retning</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_button">
-					  <source>button [index]</source>
-					  <target>knapp [index]</target>
+						<source>button [index]</source>
+						<target>knapp [index]</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat">
 						<source>hat [index]</source>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_left">
-					  <source>left</source>
-					  <target>venstre</target>
+						<source>left</source>
+						<target>venstre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_upleft">
-					  <source>up-left</source>
-					  <target>opp-venstre</target>
+						<source>up-left</source>
+						<target>opp-venstre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_up">
-					  <source>up</source>
-					  <target>opp</target>
+						<source>up</source>
+						<target>opp</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_upright">
-					  <source>up-right</source>
-					  <target>opp-høyre</target>
+						<source>up-right</source>
+						<target>opp-høyre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_right">
-					  <source>right</source>
-					  <target>høyre</target>
+						<source>right</source>
+						<target>høyre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_downright">
-					  <source>down-right</source>
-					  <target>ned-høyre</target>
+						<source>down-right</source>
+						<target>ned-høyre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_down">
-					  <source>down</source>
-					  <target>ned</target>
+						<source>down</source>
+						<target>ned</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_downleft">
-					  <source>down-left</source>
-					  <target>ned-venstre</target>
+						<source>down-left</source>
+						<target>ned-venstre</target>
 					</trans-unit>
 					<trans-unit id="assignment_joystick_hat_invalid">
-					  <source>invalid</source>
-					  <target>ugyldig</target>
+						<source>invalid</source>
+						<target>ugyldig</target>
 					</trans-unit>
 					<trans-unit id="assignment_invalid">
-					  <source>Not assigned</source>
-					  <target>Ikke tilordnet</target>
+						<source>Not assigned</source>
+						<target>Ikke tilordnet</target>
 					</trans-unit>
 					<trans-unit id="assignment_separator">
 						<source>,\x20</source>
@@ -1208,680 +1224,681 @@
 				</group>
 				<group id="raildriver">
 					<trans-unit id="speedunits">
-					  <source>LED Display speed units</source>
-					  <target>LED Display hastighetsenhet</target>
+						<source>LED Display speed units</source>
+						<target>LED Display hastighetsenhet</target>
 					</trans-unit>
 					<trans-unit id="milesperhour">
-					  <source>Miles per Hour (MPH)</source>
-					  <target>Engelsk mil i timen (MPH)</target>
+						<source>Miles per Hour (MPH)</source>
+						<target>Engelsk mil i timen (MPH)</target>
 					</trans-unit>
 					<trans-unit id="kilometersperhour">
-					  <source>Kilometers per Hour (KPH)</source>
-					  <target>Kilometer i timen (Km/H)</target>
+						<source>Kilometers per Hour (KPH)</source>
+						<target>Kilometer i timen (Km/H)</target>
 					</trans-unit>
 					<trans-unit id="setcalibration">
-					  <source>Set Calibration:</source>
-					  <target>Sett kalibrering</target>
+						<source>Set Calibration:</source>
+						<target>Sett kalibrering</target>
 					</trans-unit>
 					<trans-unit id="launch">
-					  <source>Launch</source>
-					  <!-- unshure of this-->
-					  <target>Start</target>
+						<source>Launch</source>
+						<target>Start</target>
 					</trans-unit>
 					<trans-unit id="notdetected">
-					  <source>No RailDriver controllers detected.</source>
-					  <target>Ingen RailDriver kontroller oppdaget.</target>
+						<source>No RailDriver controllers detected.</source>
+						<target>Ingen RailDriver kontroller oppdaget.</target>
 					</trans-unit>
 					<trans-unit id="config_error">
-					  <source>Error loading RailDriver calibration file.</source>
-					  <target>Feil ved lasting av RailDriver kalibreringsfil.</target>
+						<source>Error loading RailDriver calibration file.</source>
+						<target>Feil ved lasting av RailDriver kalibreringsfil.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-					  <source>Please press 'Next' to start calibration.</source>
-					  <target>Trykk 'Neste' for å starte kalibrering.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Trykk &apos;Neste&apos; for å starte kalibrering.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-					  <source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-					  <target>Dytt vendegir-spaken til fullstendig revers og trykk 'Neste'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Dytt vendegir-spaken til fullstendig revers og trykk &apos;Neste&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-					  <source>Move the reverser lever to the full forward position and press 'Next'.</source>
-					  <target>Dytt vendegir-spaken til fullstendig forover og trykk 'Neste'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Dytt vendegir-spaken til fullstendig forover og trykk &apos;Neste&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-					  <source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-					<target>Dytt kombinasjonsbremsen til full akselerasjon og trykk 'Neste'.</target>								</trans-unit>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Dytt kombinasjonsbremsen til full akselerasjon og trykk &apos;Neste&apos;.</target>
+					</trans-unit>
 					<trans-unit id="calibration_d">
-					  <source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-					<target>Dytt kombinasjonsbremsen til full brems og trykk 'Neste'.</target>										</trans-unit>
-				      
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Dytt kombinasjonsbremsen til full brems og trykk &apos;Neste&apos;.</target>
+					</trans-unit>
 					<trans-unit id="calibration_e">
-					  <source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-					  <target>Dytt den regenerative bremsen til fullstendig av og trykk 'Neste'</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Dytt den regenerative bremsen til fullstendig av og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-					  <source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-					  <target>Dytt den regenerative bremsen til nødbrems og trykk 'Neste'</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Dytt den regenerative bremsen til nødbrems og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-					  <source>Move the independant brake lever to the release position and press 'Next'.</source>
-					  <target>Dytt lokomotiv bremsen til fullstendig av og trykk 'Neste'</target>
-					  
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Dytt lokomotiv bremsen til fullstendig av og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-					  <source>Move the independant brake lever to the full position and press 'Next'.</source>
-					  <target>Dytt lokomotiv bremsen til fullstendig på og trykk 'Neste'</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Dytt lokomotiv bremsen til fullstendig på og trykk &apos;Neste&apos;</target>
 					</trans-unit>
-					<!-- unshure of this -->
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-					  <source>Move the wiper switch to OFF and press 'Next'.</source>
-					  <target>Flytt vindusvisker til AV og trykk 'Neste'</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Flytt vindusvisker til AV og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-					  <source>Move the wiper switch to FULL and press 'Next'.</source>
-					  <target>Flytt vindusvisker til FULL og trykk 'Neste'</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Flytt vindusvisker til FULL og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-					  <source>Move the lights switch to OFF and press 'Next'.</source>
-					  <target>Flytt lysbryteren til AV og trykk 'Neste'</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Flytt lysbryteren til AV og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-					  <source>Move the lights switch to FULL and press 'Next'.</source>
-					  <target>Flytt lysbryteren til FULL og trykk 'Neste'</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Flytt lysbryteren til FULL og trykk &apos;Neste&apos;</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
-					  <source>Calibration complete.</source>
-					  <target>Kalibrering ferdig.</target>
+						<source>Calibration complete.</source>
+						<target>Kalibrering ferdig.</target>
 					</trans-unit>
 				</group>
 				<group id="options">
-				  <trans-unit id="title">
-				    <source>Options</source>
-				    <target>Innstillinger</target>
+					<trans-unit id="title">
+						<source>Options</source>
+						<target>Innstillinger</target>
 					</trans-unit>
 					<trans-unit id="language">
-					  <source>Language</source>
-					  <target>Språk</target>
+						<source>Language</source>
+						<target>Språk</target>
 					</trans-unit>
 					<trans-unit id="display">
-					  <source>Display</source>
-					  <target>Skjerm</target>
+						<source>Display</source>
+						<target>Skjerm</target>
 					</trans-unit>
 					<trans-unit id="display_mode">
-					  <source>Display mode</source>
-					  <target>Skjermmodus</target>
+						<source>Display mode</source>
+						<target>Skjermmodus</target>
 					</trans-unit>
 					<trans-unit id="display_mode_window">
-					  <source>Window mode</source>
-					  <target>Vindusmodus</target>
+						<source>Window mode</source>
+						<target>Vindusmodus</target>
 					</trans-unit>
 					<trans-unit id="display_mode_fullscreen">
-					  <source>Fullscreen mode</source>
-					  <target>Fullskjermsmodus</target>
+						<source>Fullscreen mode</source>
+						<target>Fullskjermsmodus</target>
 					</trans-unit>
 					<trans-unit id="display_vsync">
-					  <source>Vertical synchronization:</source>
-					  <target>Vertikal synkronisering::</target>
+						<source>Vertical synchronization:</source>
+						<target>Vertikal synkronisering::</target>
 					</trans-unit>
 					<trans-unit id="display_vsync_off">
-					  <source>Disabled</source>
-					  <target>Avslått</target>
+						<source>Disabled</source>
+						<target>Avslått</target>
 					</trans-unit>
 					<trans-unit id="display_vsync_on">
-					  <source>Enabled</source>
-					  <target>Påslått</target>
+						<source>Enabled</source>
+						<target>Påslått</target>
 					</trans-unit>
 					<trans-unit id="display_window">
-					  <source>Window mode</source>
-					  <target>Vindusmodus</target>
+						<source>Window mode</source>
+						<target>Vindusmodus</target>
 					</trans-unit>
 					<trans-unit id="display_window_width">
-					  <source>Width:</source>
-					  <target>Bredde:</target>
+						<source>Width:</source>
+						<target>Bredde:</target>
 					</trans-unit>
 					<trans-unit id="display_window_height">
-					  <source>Height:</source>
-					  <target>Høyde:</target>
+						<source>Height:</source>
+						<target>Høyde:</target>
 					</trans-unit>
 					<trans-unit id="display_fullscreen">
-					  <source>Fullscreen</source>
-					  <target>Fullskjerm</target>
+						<source>Fullscreen</source>
+						<target>Fullskjerm</target>
 					</trans-unit>
 					<trans-unit id="display_fullscreen_width">
-					  <source>Width:</source>
-					  <target>Bredde:</target>
+						<source>Width:</source>
+						<target>Bredde:</target>
 					</trans-unit>
 					<trans-unit id="display_fullscreen_height">
-					  <source>Height:</source>
-					  <target>Høyde:</target>
+						<source>Height:</source>
+						<target>Høyde:</target>
 					</trans-unit>
 					<trans-unit id="display_fullscreen_bits">
-					  <source>Bits per pixel:</source>
-					  <target>Bits per piksel:</target>
+						<source>Bits per pixel:</source>
+						<target>Bits per piksel:</target>
 					</trans-unit>
 					<trans-unit id="quality">
-					  <source>Quality</source>
-					  <target>Kvalitet</target>
+						<source>Quality</source>
+						<target>Kvalitet</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation">
-					  <source>Interpolation</source>
-					  <target>Interpolasjon</target>
+						<source>Interpolation</source>
+						<target>Interpolasjon</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode">
-					  <source>Mode:</source>
-					  <target>Modus:</target>
+						<source>Mode:</source>
+						<target>Modus:</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_nearest">
-					  <source>Nearest neighbor</source>
-					  <target>Nærmeste nabo</target>
+						<source>Nearest neighbor</source>
+						<target>Nærmeste nabo</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_bilinear">
-					  <source>Bilinear</source>
-					  <target>Bilineær</target>
+						<source>Bilinear</source>
+						<target>Bilineær</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_nearestmipmap">
-					  <source>Nearest neighbor (mipmapping)</source>
-					  <target>Nærmeste nabo (mipmapping)</target>
+						<source>Nearest neighbor (mipmapping)</source>
+						<target>Nærmeste nabo (mipmapping)</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_bilinearmipmap">
-					  <source>Bilinear (mipmapping)</source>
-					  <target>Bilineær (mipmapping)</target>
+						<source>Bilinear (mipmapping)</source>
+						<target>Bilineær (mipmapping)</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_trilinearmipmap">
-					  <source>Trilinear (mipmapping)</source>
-					  <target>Trilineær (mipmapping)</target>
+						<source>Trilinear (mipmapping)</source>
+						<target>Trilineær (mipmapping)</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_anisotropic">
-					  <source>Anisotropic filtering</source>
-					  <target>Anisotropisk filtrering</target>
+						<source>Anisotropic filtering</source>
+						<target>Anisotropisk filtrering</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_anisotropic_level">
-					  <source>Level of anisotropic filtering:</source>
-					  <target>Nivå av anisotropisk filtrering:</target>
+						<source>Level of anisotropic filtering:</source>
+						<target>Nivå av anisotropisk filtrering:</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_antialiasing_level">
-					  <source>Level of anti-aliasing:</source>
-					  <target>Nivå av kantutjevning (anti-aliasing):</target>
+						<source>Level of anti-aliasing:</source>
+						<target>Nivå av kantutjevning (anti-aliasing):</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_transparency">
-					  <source>Transparency:</source>
-					  <target>Transparens</target>
+						<source>Transparency:</source>
+						<target>Transparens</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_transparency_sharp">
-					  <source>Sharp</source>
-					  <target>Skarp</target>
+						<source>Sharp</source>
+						<target>Skarp</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_transparency_smooth">
-					  <source>Smooth</source>
-					  <target>Myk</target>
+						<source>Smooth</source>
+						<target>Myk</target>
 					</trans-unit>
 					<trans-unit id="quality_distance">
-					  <source>Distance effects</source>
-					  <target>Avstandseffekter</target>
+						<source>Distance effects</source>
+						<target>Avstandseffekter</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_viewingdistance">
-					  <source>Viewing distance:</source>
-					  <target>Utsiktsavstand:</target>
+						<source>Viewing distance:</source>
+						<target>Utsiktsavstand:</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
-					  <source>Motion blur:</source>
-					  <target>Bevegelsesuskarphet:</target>
+						<source>Motion blur:</source>
+						<target>Bevegelsesuskarphet:</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur_none">
-					  <source>Disabled</source>
-					  <target>Avslått</target>
+						<source>Disabled</source>
+						<target>Avslått</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur_low">
-					  <source>Low</source>
-					  <target>Lav</target>
+						<source>Low</source>
+						<target>Lav</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur_medium">
-					  <source>Medium</source>
-					  <target>Medium</target>
+						<source>Medium</source>
+						<target>Medium</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur_high">
-					  <source>High</source>
-					  <target>Høy</target>
+						<source>High</source>
+						<target>Høy</target>
 					</trans-unit>
 					<trans-unit id="misc">
-					  <source>Miscellaneous</source>
-					  <target>Diverse</target>
+						<source>Miscellaneous</source>
+						<target>Diverse</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation">
-					  <source>Detail of simulation</source>
-					  <target>Simuleringsdetalj</target>
+						<source>Detail of simulation</source>
+						<target>Simuleringsdetalj</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation_toppling">
-					  <source>Toppling</source>
-					  <target>Velting</target>
+						<source>Toppling</source>
+						<target>Velting</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation_collisions">
-					  <source>Collisions</source>
-					  <target>Kolisjoner</target>
+						<source>Collisions</source>
+						<target>Kolisjoner</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation_derailments">
-					  <source>Derailments</source>
-					  <target>Avsporinger</target>
+						<source>Derailments</source>
+						<target>Avsporinger</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation_blackbox">
-					  <source>Enable black box</source>
-					  <target>Slå på blackbox</target>
+						<source>Enable black box</source>
+						<target>Slå på blackbox</target>
 					</trans-unit>
 					<trans-unit id="misc_simulation_loadingsway">
-					  <source>Enable loading sway</source>
-					  <target>Slå på laste svai</target>
+						<source>Enable loading sway</source>
+						<target>Slå på laste svai</target>
 					</trans-unit>
 					<trans-unit id="misc_controls">
-					  <source>Controls</source>
-					  <target>Kontroller</target>
+						<source>Controls</source>
+						<target>Kontroller</target>
 					</trans-unit>
 					<trans-unit id="misc_controls_joysticks">
-					  <source>Joysticks enabled</source>
-					  <target>Joysticker påslått</target>
+						<source>Joysticks enabled</source>
+						<target>Joysticker påslått</target>
 					</trans-unit>
 					<trans-unit id="misc_controls_threshold">
-					  <source>Joystick threshold:</source>
-					  <target>Joystick terskel:</target>
+						<source>Joystick threshold:</source>
+						<target>Joystick terskel:</target>
 					</trans-unit>
 					<trans-unit id="misc_controls_ebaxis">
-					  <source>Allow EB on brake axis</source>
+						<source>Allow EB on brake axis</source>
 					</trans-unit>
 					<trans-unit id="misc_sound">
-					  <source>Sound</source>
-					  <target>Lyd</target>
+						<source>Sound</source>
+						<target>Lyd</target>
 					</trans-unit>
 					<trans-unit id="misc_sound_range">
-					  <source>Effective range:</source>
-					  <target>Effektiv avstand:</target>
+						<source>Effective range:</source>
+						<target>Effektiv avstand:</target>
 					</trans-unit>
 					<trans-unit id="misc_sound_range_low">
-					  <source>Low</source>
-					  <target>Lav</target>
+						<source>Low</source>
+						<target>Lav</target>
 					</trans-unit>
 					<trans-unit id="misc_sound_range_medium">
-					  <source>Medium</source>
-					  <target>Medium</target>
+						<source>Medium</source>
+						<target>Medium</target>
 					</trans-unit>
 					<trans-unit id="misc_sound_range_high">
-					  <source>High</source>
-					  <target>Høy</target>
+						<source>High</source>
+						<target>Høy</target>
 					</trans-unit>
 					<trans-unit id="misc_sound_number">
-					  <source>Number of allowed sounds:</source>
-					  <target>Antall lyder som kan spilles på en gang:</target>
+						<source>Number of allowed sounds:</source>
+						<target>Antall lyder som kan spilles på en gang:</target>
 					</trans-unit>
 					<trans-unit id="verbosity">
-					  <source>Verbosity</source>
-					  <target>Detaljnivå</target>
+						<source>Verbosity</source>
+						<target>Detaljnivå</target>
 					</trans-unit>
 					<trans-unit id="verbosity_warningmessages">
-					  <source>Show warning messages</source>
-					  <target>Vis varselmeldinger</target>
+						<source>Show warning messages</source>
+						<target>Vis varselmeldinger</target>
 					</trans-unit>
 					<trans-unit id="verbosity_errormessages">
-					  <source>Show error messages</source>
-					  <target>Vis feilmeldinger</target>
+						<source>Show error messages</source>
+						<target>Vis feilmeldinger</target>
 					</trans-unit>
 					<trans-unit id="verbosity_accessibilityaids">
 						<source>Accessibility Aids</source>
 						<target>Accessibility Aids</target>
 					</trans-unit>
 					<trans-unit id="advanced">
-					  <source>Advanced Options</source>
-					  <target>Avanserte valg</target>
+						<source>Advanced Options</source>
+						<target>Avanserte valg</target>
 					</trans-unit>
 					<trans-unit id="advanced_load_advance">
-					  <source>Load in advance</source>
-					  <target>Last in råd</target>
+						<source>Load in advance</source>
+						<target>Last in råd</target>
 					</trans-unit>
 					<trans-unit id="advanced_is_use_new_renderer">
-					  <source>Enable the new renderer</source>
-					  <target>Slå på den nye rendereren</target>
+						<source>Enable the new renderer</source>
+						<target>Slå på den nye rendereren</target>
 					</trans-unit>
 					<trans-unit id="advanced_timefactor">
-					  <source>Accelerated Time Factor</source>
-					  <target>Akselerert tidsfaktor</target>
+						<source>Accelerated Time Factor</source>
+						<target>Akselerert tidsfaktor</target>
 					</trans-unit>
 					<trans-unit id="advanced_unload_textures">
-					  <source>Unload unused textures</source>
-					  <target>Last av ubrukte teksturer</target>
+						<source>Unload unused textures</source>
+						<target>Last av ubrukte teksturer</target>
 					</trans-unit>
 					<trans-unit id="advanced_cursor">
 						<source>Cursor</source>
 						<target>Cursor</target>
 					</trans-unit>
 					<trans-unit id="other">
-					  <source>Other</source>
-					  <target>Annet</target>
+						<source>Other</source>
+						<target>Annet</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode">
-					  <source>Timetable mode:</source>
-					  <target>Tidstabell modus:</target>
+						<source>Timetable mode:</source>
+						<target>Tidstabell modus:</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_none">
-					  <source>None</source>
-					  <target>Ingen</target>
+						<source>None</source>
+						<target>Ingen</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_default">
-					  <source>Default</source>
-					  <target>Forholdsvalgete</target>
+						<source>Default</source>
+						<target>Forholdsvalgete</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_autogenerated">
-					  <source>Auto-generated timetable</source>
-					  <target>Automatisk generert tidstabell</target>
+						<source>Auto-generated timetable</source>
+						<target>Automatisk generert tidstabell</target>
 					</trans-unit>
 					<trans-unit id="other_timetable_mode_prefercustom">
-					  <source>Prefer custom timetable</source>
-					  <target>Foretrekk egenlaget tidstabell</target>
+						<source>Prefer custom timetable</source>
+						<target>Foretrekk egenlaget tidstabell</target>
 					</trans-unit>
 					<trans-unit id="package_choose">
-					  <source>Choose...</source>
-					  <target>Velg...</target>
+						<source>Choose...</source>
+						<target>Velg...</target>
 					</trans-unit>
 					<trans-unit id="package_route_directory">
-					  <source>Route installation directory:</source>
-					  <target>Mappe for installasjon av ruter:</target>
+						<source>Route installation directory:</source>
+						<target>Mappe for installasjon av ruter:</target>
 					</trans-unit>
 					<trans-unit id="package_train_directory">
-					  <source>Train installation directory:</source>
-					  <target>Mappe for installasjon av tog:</target>
+						<source>Train installation directory:</source>
+						<target>Mappe for installasjon av tog:</target>
 					</trans-unit>
 					<trans-unit id="package_other_directory">
-					  <source>Other items installation directory:</source>
-					  <target>Mappe for installasjon av andre ting:</target>
+						<source>Other items installation directory:</source>
+						<target>Mappe for installasjon av andre ting:</target>
 					</trans-unit>
 					<trans-unit id="package_compression">
-					  <source>Package compression format:</source>
-					  <target>Pakke kompresjonsformat:</target>
+						<source>Package compression format:</source>
+						<target>Pakke kompresjonsformat:</target>
 					</trans-unit>
 					<trans-unit id="page_previous">
-					  <source>Previous Page...</source>
-					  <target>Forrige side...</target>
+						<source>Previous Page...</source>
+						<target>Forrige side...</target>
 					</trans-unit>
 					<trans-unit id="page_next">
-					  <source>Next Page...</source>
-					  <target>Neste side...</target>
+						<source>Next Page...</source>
+						<target>Neste side...</target>
 					</trans-unit>
 					<trans-unit id="kiosk_mode">
-					  <source>Kiosk Mode</source>
-					  <target>Kioskmodus</target>
+						<source>Kiosk Mode</source>
+						<target>Kioskmodus</target>
 					</trans-unit>
 					<trans-unit id="kiosk_mode_enable">
-					  <source>Enable Kiosk Mode</source>
-					  <target>Slå på kioskmodus</target>
+						<source>Enable Kiosk Mode</source>
+						<target>Slå på kioskmodus</target>
 					</trans-unit>
 					<trans-unit id="kiosk_mode_timer">
-					  <source>Control Timeout (s)</source>
-					  <target>Kontrolltimeout (s)</target>
+						<source>Control Timeout (s)</source>
+						<target>Kontrolltimeout (s)</target>
 					</trans-unit>
 					<trans-unit id="hud_size">
-					  <source>HUD Size</source>
-					  <target>HUD størrelse</target>
+						<source>HUD Size</source>
+						<target>HUD størrelse</target>
 					</trans-unit>
 					<trans-unit id="hud_size_small">
-					  <source>Small</source>
-					  <target>Liten</target>
+						<source>Small</source>
+						<target>Liten</target>
 					</trans-unit>
 					<trans-unit id="hud_size_normal">
-					  <source>Normal</source>
-					  <target>Normal</target>
+						<source>Normal</source>
+						<target>Normal</target>
 					</trans-unit>
 					<trans-unit id="hud_size_large">
-					  <source>Large</source>
-					  <target>Stor</target>
+						<source>Large</source>
+						<target>Stor</target>
 					</trans-unit>
 					<trans-unit id="font">
 						<source>Font:</source>
 						<target>Font:</target>
 					</trans-unit>
 					<trans-unit id="transparencyfix">
-					  <source>Attempt to fix transparency issues in older content.</source>
-					  <target>Prøver å fiske feil med gjennomsiktighet for gammelt innhold.</target>
+						<source>Attempt to fix transparency issues in older content.</source>
+						<target>Prøver å fiske feil med gjennomsiktighet for gammelt innhold.</target>
 					</trans-unit>
 					<trans-unit id="hacks_enable">
-					  <source>Enable hacks for buggy older content.</source>
-					  <target>Slå på "hacks" for buggy gammelt innhold.</target>
+						<source>Enable hacks for buggy older content.</source>
+						<target>Slå på &quot;hacks&quot; for buggy gammelt innhold.</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin">
-					  <source>Input Device Plugin</source>
-					  <target>Inndataenhetplugin</target>
+						<source>Input Device Plugin</source>
+						<target>Inndataenhetplugin</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_warning">
-					  <source>WARNING: If you enable Input Device Plugin(s), these may conflict with one or more controls.</source>
-					  <target>ADVARSEL: Hvis du slår på Inndataenhetplugin kan de skape konflikt med andre kontrollenheter.</target>
+						<source>WARNING: If you enable Input Device Plugin(s), these may conflict with one or more controls.</source>
+						<target>ADVARSEL: Hvis du slår på Inndataenhetplugin kan de skape konflikt med andre kontrollenheter.</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_name">
-					  <source>Name</source>
-					  <target>Navn</target>
+						<source>Name</source>
+						<target>Navn</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status">
-					  <source>Status</source>
-					  <target>Status</target>
+						<source>Status</source>
+						<target>Status</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_failure">
-					  <source>Failure</source>
-					  <target>Feil</target>
+						<source>Failure</source>
+						<target>Feil</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_disable">
-					  <source>Disable</source>
-					  <target>Slå av</target>
+						<source>Disable</source>
+						<target>Slå av</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_status_enable">
-					  <source>Enable</source>
-					  <target>Slå på</target>
+						<source>Enable</source>
+						<target>Slå på</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_version">
-					  <source>Version</source>
-					  <target>Versjon</target>
+						<source>Version</source>
+						<target>Versjon</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_provider">
-					  <source>Provider</source>
-					  <target>Leverandør</target>
+						<source>Provider</source>
+						<target>Leverandør</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_file_name">
-					  <source>File Name</source>
-					  <target>Filnavn</target>
+						<source>File Name</source>
+						<target>Filnavn</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_switch">
-					  <source>Enable this Input Device Plugin</source>
-					  <target>Slå på denne inndata plugin</target>
+						<source>Enable this Input Device Plugin</source>
+						<target>Slå på denne inndata plugin</target>
 					</trans-unit>
 					<trans-unit id="input_device_plugin_config">
-					  <source>Config</source>
-					  <target>Konfigurer</target>
+						<source>Config</source>
+						<target>Konfigurer</target>
 					</trans-unit>
 					<trans-unit id="panel2_extended">
-					  <source>Enable Panel2 Extended Mode</source>
-					  <target>Slå på panel2 utvidet modus</target>
+						<source>Enable Panel2 Extended Mode</source>
+						<target>Slå på panel2 utvidet modus</target>
 					</trans-unit>
 					<trans-unit id="object_parser">
 						<source>Object Parser</source>
 					</trans-unit>
 					<trans-unit id="xobject_parser">
-					  <source>X Object Parser</source>
-					  <target>X Objekt parser</target>
+						<source>X Object Parser</source>
+						<target>X Objekt parser</target>
 					</trans-unit>
 					<trans-unit id="objobject_parser">
-					  <source>OBJ Object Parser</source>
-					  <target>OBJ objekt parser</target>
+						<source>OBJ Object Parser</source>
+						<target>OBJ objekt parser</target>
 					</trans-unit>
 					<trans-unit id="compatibility_signals">
-					  <source>Default Signals:</source>
-					  <target>Forhåndsvalgte signaler (stillverk):</target>
+						<source>Default Signals:</source>
+						<target>Forhåndsvalgte signaler (stillverk):</target>
+					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
 					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
-					  <source>CSV files</source>
-					  <target>CSV filer</target>
+						<source>CSV files</source>
+						<target>CSV filer</target>
 					</trans-unit>
 					<trans-unit id="textfiles">
-					  <source>Text files</source>
-					  <target>Tekstfiler</target>
+						<source>Text files</source>
+						<target>Tekstfiler</target>
 					</trans-unit>
 					<trans-unit id="controlsfiles">
-					  <source>Controls</source>
-					  <target>Knappefiler</target>
+						<source>Controls</source>
+						<target>Knappefiler</target>
 					</trans-unit>
 					<trans-unit id="allfiles">
-					  <source>All files</source>
-					  <target>Alle filer</target>
+						<source>All files</source>
+						<target>Alle filer</target>
 					</trans-unit>
 				</group>
 				<group id="log">
 					<trans-unit id="time">
-					  <source>Time</source>
-					  <target>Tid</target>
+						<source>Time</source>
+						<target>Tid</target>
 					</trans-unit>
 					<trans-unit id="position">
-					  <source>Position (m)</source>
-					  <target>Posisjon (m)</target>
+						<source>Position (m)</source>
+						<target>Posisjon (m)</target>
 					</trans-unit>
 					<trans-unit id="value">
-					  <source>Value</source>
-					  <target>Verdi</target>
+						<source>Value</source>
+						<target>Verdi</target>
 					</trans-unit>
 					<trans-unit id="cumulative">
-					  <source>Cumulative</source>
-					  <target>Kumulativ</target>
+						<source>Cumulative</source>
+						<target>Kumulativ</target>
 					</trans-unit>
 					<trans-unit id="reason">
-					  <source>Reason</source>
-					  <target>Årsak</target>
+						<source>Reason</source>
+						<target>Årsak</target>
 					</trans-unit>
 					<trans-unit id="speed">
-					  <source>Speed (m/s)</source>
-					  <target>Fart (m/s)</target>
+						<source>Speed (m/s)</source>
+						<target>Fart (m/s)</target>
 					</trans-unit>
 					<trans-unit id="acceleration">
-					  <source>Acceleration (m/s²)</source>
-					  <target>Akselerasjon (m/s²)</target>
+						<source>Acceleration (m/s²)</source>
+						<target>Akselerasjon (m/s²)</target>
 					</trans-unit>
 					<trans-unit id="reverser">
-					  <source>Reverser</source>
-					  <target>Vendegir</target>
+						<source>Reverser</source>
+						<target>Vendegir</target>
 					</trans-unit>
 					<trans-unit id="power">
-					  <source>Power</source>
-					  <target>Kraft</target>
+						<source>Power</source>
+						<target>Kraft</target>
 					</trans-unit>
 					<trans-unit id="brake">
-					  <source>Brake</source>
-					  <target>Brems</target>
+						<source>Brake</source>
+						<target>Brems</target>
 					</trans-unit>
 					<trans-unit id="event">
-					  <source>Event</source>
-					  <target>Hendelse</target>
+						<source>Event</source>
+						<target>Hendelse</target>
 					</trans-unit>
 					<trans-unit id="route">
-					  <source>Route:</source>
-					  <target>Rute:</target>
+						<source>Route:</source>
+						<target>Rute:</target>
 					</trans-unit>
 					<trans-unit id="train">
-					  <source>Train:</source>
-					  <target>Tog:</target>
+						<source>Train:</source>
+						<target>Tog:</target>
 					</trans-unit>
 					<trans-unit id="date">
-					  <source>Date:</source>
-					  <target>Dato:</target>
+						<source>Date:</source>
+						<target>Dato:</target>
 					</trans-unit>
 					<trans-unit id="mode">
-					  <source>Mode:</source>
-					  <target>Modus:</target>
+						<source>Mode:</source>
+						<target>Modus:</target>
 					</trans-unit>
 					<trans-unit id="score">
-					  <source>Score:</source>
-					  <target>Poeng:</target>
+						<source>Score:</source>
+						<target>Poeng:</target>
 					</trans-unit>
 					<trans-unit id="rating">
-					  <source>Rating:</source>
-					  <target>Vurdering:</target>
+						<source>Rating:</source>
+						<target>Vurdering:</target>
 					</trans-unit>
 				</group>
 				<group id="loading">
 					<trans-unit id="loading">
-					  <source>Loading</source>
-					  <target>Laster</target>
+						<source>Loading</source>
+						<target>Laster</target>
 					</trans-unit>
 					<trans-unit id="loading_route">
-					  <source>Loading route...</source>
-					  <target>Laster rute...</target>
+						<source>Loading route...</source>
+						<target>Laster rute...</target>
 					</trans-unit>
 					<trans-unit id="loading_train">
-					  <source>Loading train...</source>
-					  <target>Laster tog...</target>
+						<source>Loading train...</source>
+						<target>Laster tog...</target>
 					</trans-unit>
 					<trans-unit id="almost">
-					  <source>Almost ready to start</source>
-					  <target>Nest klart til å starte</target>
+						<source>Almost ready to start</source>
+						<target>Nest klart til å starte</target>
 					</trans-unit>
 					<trans-unit id="almost_filesnotfound">
-					  <source>Files not found:</source>
-					  <target>Filer ikke funnet:</target>
+						<source>Files not found:</source>
+						<target>Filer ikke funnet:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
 					</trans-unit>
 					<trans-unit id="almost_show">
-					  <source>Show issues</source>
-					  <target>Vis problemer</target>
+						<source>Show issues</source>
+						<target>Vis problemer</target>
 					</trans-unit>
 					<trans-unit id="problems">
-					  <source>Problems</source>
-					  <target>Problemer</target>
+						<source>Problems</source>
+						<target>Problemer</target>
 					</trans-unit>
 					<trans-unit id="problems_type">
 						<source>Type</source>
 					</trans-unit>
 					<trans-unit id="problems_description">
-					  <source>Description</source>
-					  <target>Beskrivelse</target>
+						<source>Description</source>
+						<target>Beskrivelse</target>
 					</trans-unit>
 					<trans-unit id="save">
-					  <source>Save report...</source>
-					  <target>Lagre rapport...</target>
+						<source>Save report...</source>
+						<target>Lagre rapport...</target>
 					</trans-unit>
 					<trans-unit id="ignore">
-					  <source>Ignore</source>
-					  <target>Ignorer</target>
+						<source>Ignore</source>
+						<target>Ignorer</target>
 					</trans-unit>
 					<trans-unit id="cancel">
-					  <source>Cancel</source>
-					  <target>Avbryt</target>
+						<source>Cancel</source>
+						<target>Avbryt</target>
 					</trans-unit>
 				</group>
 				<group id="timetable">
 					<trans-unit id="highestspeed">
-					  <source>Max.\r\nspd.</source>
-					  <target>MAx.\r\nfart</target>
+						<source>Max.\r\nspd.</source>
+						<target>MAx.\r\nfart</target>
 					</trans-unit>
 					<trans-unit id="drivingtime">
-					  <source>Drv.\r\ntime</source>
-					  <target>Kjr.\r\ntid</target>
+						<source>Drv.\r\ntime</source>
+						<target>Kjr.\r\ntid</target>
 					</trans-unit>
 					<trans-unit id="stationname">
-					  <source>Station name</source>
-					  <target>Stasjonsnavn</target>
+						<source>Station name</source>
+						<target>Stasjonsnavn</target>
 					</trans-unit>
 					<trans-unit id="arrivaltime">
-					  <source>Arrival</source>
-					  <target>Ankomst</target>
+						<source>Arrival</source>
+						<target>Ankomst</target>
 					</trans-unit>
 					<trans-unit id="departuretime">
-					  <source>Departure</source>
-					  <target>Avgang</target>
+						<source>Departure</source>
+						<target>Avgang</target>
 					</trans-unit>
 				</group>
 				<group id="message">
@@ -1889,110 +1906,125 @@
 						<source>\x20</source>
 					</trans-unit>
 					<trans-unit id="signal_proceed">
-					  <source>You may proceed at [speed] [unit] with extreme caution.</source>
-					  <target>Du kan kjøre i [speed] [unit] med ekstrem forsiktighet.</target>
+						<source>You may proceed at [speed] [unit] with extreme caution.</source>
+						<target>Du kan kjøre i [speed] [unit] med ekstrem forsiktighet.</target>
 					</trans-unit>
 					<trans-unit id="signal_stop">
-					  <source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
-					  <target>Du har kjørt forbi et stop-signal. Vennligst slå på nødbrems umiddelbart og stopp toget.</target>
+						<source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
+						<target>Du har kjørt forbi et stop-signal. Vennligst slå på nødbrems umiddelbart og stopp toget.</target>
 					</trans-unit>
 					<trans-unit id="signal_overspeed">
-					  <source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
-					  <target>Signalet indikerer fartsgrense på [limit] [unit]. Du kjører nå i [speed] [unit]. Vennligst senk farten.</target>
+						<source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
+						<target>Signalet indikerer fartsgrense på [limit] [unit]. Du kjører nå i [speed] [unit]. Vennligst senk farten.</target>
 					</trans-unit>
 					<trans-unit id="route_overspeed">
-					  <source>The speed post indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
-					  <target>Fartsgrensen er på [limit] [unit]. Du kjører nå i [speed] [unit]. Vennligst senk farten.</target>
+						<source>The speed post indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
+						<target>Fartsgrensen er på [limit] [unit]. Du kjører nå i [speed] [unit]. Vennligst senk farten.</target>
 					</trans-unit>
 					<trans-unit id="station_arrival">
-					  <source>You have arrived at [name].</source>
-					  <target>Du har ankommet [name].</target>
+						<source>You have arrived at [name].</source>
+						<target>Du har ankommet [name].</target>
 					</trans-unit>
 					<trans-unit id="station_arrival_late">
-					  <source>You have arrived at [name] and are [time] late.</source>
-					  <target>Du har ankommet [name] og er [time] for sen.</target>
+						<source>You have arrived at [name] and are [time] late.</source>
+						<target>Du har ankommet [name] og er [time] for sen.</target>
 					</trans-unit>
 					<trans-unit id="station_arrival_early">
-					  <source>You have arrived at [name] and are [time] early.</source>
-					  <target>Du har ankommet [name] og er [time] for tidlig.</target>
+						<source>You have arrived at [name] and are [time] early.</source>
+						<target>Du har ankommet [name] og er [time] for tidlig.</target>
 					</trans-unit>
 					<trans-unit id="station_overrun">
-					  <source>Overrun: [difference] m.</source>
-					  <target>Du har stoppet [difference] m for sent.</target>
+						<source>Overrun: [difference] m.</source>
+						<target>Du har stoppet [difference] m for sent.</target>
 					</trans-unit>
 					<trans-unit id="station_underrun">
-					  <source>Underrun: [difference] m.</source>
-					  <target>Du har stoppet [difference] m for tidlig.</target>
+						<source>Underrun: [difference] m.</source>
+						<target>Du har stoppet [difference] m for tidlig.</target>
 					</trans-unit>
 					<trans-unit id="station_terminal">
-					  <source>This is the terminal station.</source>
-					  <target>Dette er siste stasjon.</target>
+						<source>This is the terminal station.</source>
+						<target>Dette er siste stasjon.</target>
 					</trans-unit>
 					<trans-unit id="station_deadline">
-					  <source>Departure is expected in [time].</source>
-					  <target>Avgang er forventet om [time].</target>
+						<source>Departure is expected in [time].</source>
+						<target>Avgang er forventet om [time].</target>
 					</trans-unit>
 					<trans-unit id="station_security">
-					  <source>Please activate [system].</source>
-					  <target>Vennligst aktivert [system].</target>
+						<source>Please activate [system].</source>
+						<target>Vennligst aktivert [system].</target>
 					</trans-unit>
 					<trans-unit id="station_correct">
-					  <source>Please correct your stop position.</source>
-					  <target>Vennligst stopp på rett plass.</target>
+						<source>Please correct your stop position.</source>
+						<target>Vennligst stopp på rett plass.</target>
 					</trans-unit>
 					<trans-unit id="station_depart_closedoors">
-					  <source>Boarding complete. You may close the doors now.</source>
-					  <target>Ombordstigning er ferdig. Du kan lukke dørene nå.</target>
+						<source>Boarding complete. You may close the doors now.</source>
+						<target>Ombordstigning er ferdig. Du kan lukke dørene nå.</target>
 					</trans-unit>
 					<trans-unit id="station_depart">
-					  <source>Boarding complete.</source>
-					  <target>Ombordstigning ferdig.</target>
+						<source>Boarding complete.</source>
+						<target>Ombordstigning ferdig.</target>
 					</trans-unit>
 					<trans-unit id="station_passed">
-					  <source>You have passed [name] where you should have stopped.</source>
-					  <target>Du har kjørt forbi [name] hvor du skulle ha stoppet.</target>
+						<source>You have passed [name] where you should have stopped.</source>
+						<target>Du har kjørt forbi [name] hvor du skulle ha stoppet.</target>
 					</trans-unit>
 					<trans-unit id="station_passed_boarding">
-					  <source>You have passed [name] while still boarding. Please come to a complete hold immediately.</source>
-					  <target>Du har passert [name] mens du fremdeles laster på. Stopp umiddelbart.</target>
+						<source>You have passed [name] while still boarding. Please come to a complete hold immediately.</source>
+						<target>Du har passert [name] mens du fremdeles laster på. Stopp umiddelbart.</target>
 					</trans-unit>
 					<trans-unit id="loading">
-					  <source>Loading. Please wait...</source>
-					  <target>Laster. Vennligst vent...</target>
+						<source>Loading. Please wait...</source>
+						<target>Laster. Vennligst vent...</target>
+					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
 					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
-					  <source>Interior camera</source>
-					  <target>Innendørs kamera</target>
+						<source>Interior camera</source>
+						<target>Innendørs kamera</target>
 					</trans-unit>
 					<trans-unit id="interior_lookahead">
-					  <source>Interior camera (look ahead)</source>
-					  <target>Innendørs camera (se frem)</target>
+						<source>Interior camera (look ahead)</source>
+						<target>Innendørs camera (se frem)</target>
 					</trans-unit>
 					<trans-unit id="exterior">
-					  <source>Exterior camera</source>
-					  <target>Utendørs kamera</target>
+						<source>Exterior camera</source>
+						<target>Utendørs kamera</target>
 					</trans-unit>
 					<trans-unit id="track">
-					  <source>Track camera</source>
-					  <target>Sporveikamera</target>
+						<source>Track camera</source>
+						<target>Sporveikamera</target>
 					</trans-unit>
 					<trans-unit id="flybynormal">
-					  <source>Fly-by camera (normal)</source>
-					  <target>Fly-by kamera (normal)</target>
+						<source>Fly-by camera (normal)</source>
+						<target>Fly-by kamera (normal)</target>
 					</trans-unit>
 					<trans-unit id="flybyzooming">
-					  <source>Fly-by camera (zooming)</source>
-					  <target>Fly-by kamera (med zoom)</target>
+						<source>Fly-by camera (zooming)</source>
+						<target>Fly-by kamera (med zoom)</target>
 					</trans-unit>
 					<trans-unit id="cpu_normal">
-					  <source>CPU: normal</source>
-					  <target>CPU: normal</target>
+						<source>CPU: normal</source>
+						<target>CPU: normal</target>
 					</trans-unit>
 					<trans-unit id="cpu_low">
-					  <source>CPU: low</source>
-					  <target>CPU: lav</target>
+						<source>CPU: low</source>
+						<target>CPU: lav</target>
 					</trans-unit>
 					<trans-unit id="backfaceculling_on">
 						<source>Backface culling: on</source>
@@ -2001,209 +2033,240 @@
 						<source>Backface culling: off</source>
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
-					  <source>This feature is not available in Expert mode.</source>
-					  <target>Denne funksjonen er ikke tilgjengelig i ekspert modus.</target>
+						<source>This feature is not available in Expert mode.</source>
+						<target>Denne funksjonen er ikke tilgjengelig i ekspert modus.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
-					  <source>The AI might be unable to fully operate this train.</source>
-					  <target>Den kunstige intelligensen klarer kanskje ikke å kjøre dette toget.</target>
+						<source>The AI might be unable to fully operate this train.</source>
+						<target>Den kunstige intelligensen klarer kanskje ikke å kjøre dette toget.</target>
 					</trans-unit>
 					<trans-unit id="camerarestriction_on">
-					  <source>Camera restriction: on</source>
-					  <target>Kamerabegrensning: på</target>
+						<source>Camera restriction: on</source>
+						<target>Kamerabegrensning: på</target>
 					</trans-unit>
 					<trans-unit id="camerarestriction_off">
-					  <source>Camera restriction: off</source>
-					  <target>Kamerabegrensning: av</target>
+						<source>Camera restriction: off</source>
+						<target>Kamerabegrensning: av</target>
 					</trans-unit>
 					<trans-unit id="mousegrab_on">
-					  <source>Mouse grab: on</source>
-					  <target>"Mouse grab": på</target>
+						<source>Mouse grab: on</source>
+						<target>&quot;Mouse grab&quot;: på</target>
 					</trans-unit>
 					<trans-unit id="mousegrab_off">
-					  <source>Mouse grab: off</source>
-					  <target>"Mouse grab": av</target>
+						<source>Mouse grab: off</source>
+						<target>&quot;Mouse grab&quot;: av</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
 					<trans-unit id="overspeed">
-					  <source>Overspeed</source>
-					  <target>Forfortkjøring</target>
+						<source>Overspeed</source>
+						<target>Forfortkjøring</target>
 					</trans-unit>
 					<trans-unit id="redsignal">
-					  <source>Passed red signal</source>
-					  <target>Forbikjørt rødt signal</target>
+						<source>Passed red signal</source>
+						<target>Forbikjørt rødt signal</target>
 					</trans-unit>
 					<trans-unit id="toppling">
-					  <source>Toppling</source>
-					  <target>Velting</target>
+						<source>Toppling</source>
+						<target>Velting</target>
 					</trans-unit>
 					<trans-unit id="derailed">
-					  <source>Derailed</source>
-					  <target>Avsporing</target>
+						<source>Derailed</source>
+						<target>Avsporing</target>
 					</trans-unit>
 					<trans-unit id="discomfort">
-					  <source>Passenger discomfort</source>
-					  <target>Ukomfortabelhet blant passasjerene</target>
+						<source>Passenger discomfort</source>
+						<target>Ukomfortabelhet blant passasjerene</target>
 					</trans-unit>
 					<trans-unit id="doors">
-					  <source>Doors opened</source>
-					  <target>Dørene åpnet</target>
+						<source>Doors opened</source>
+						<target>Dørene åpnet</target>
 					</trans-unit>
 					<trans-unit id="station_arrived">
-					  <source>Arrived at station</source>
-					  <target>Ankom på stasjon</target>
+						<source>Arrived at station</source>
+						<target>Ankom på stasjon</target>
 					</trans-unit>
 					<trans-unit id="station_perfecttime">
-					  <source>Perfect time bonus</source>
-					  <target>Perfekt på tiden bonus</target>
+						<source>Perfect time bonus</source>
+						<target>Perfekt på tiden bonus</target>
 					</trans-unit>
 					<trans-unit id="station_late">
-					  <source>Late</source>
-					  <target>For sen</target>
+						<source>Late</source>
+						<target>For sen</target>
 					</trans-unit>
 					<trans-unit id="station_perfectstop">
-					  <source>Perfect stop bonus</source>
-					  <target>Prefekt stopp bonus</target>
+						<source>Perfect stop bonus</source>
+						<target>Prefekt stopp bonus</target>
 					</trans-unit>
 					<trans-unit id="station_stop">
-					  <source>Stop</source>
-					  <target>Stop</target>
+						<source>Stop</source>
+						<target>Stop</target>
 					</trans-unit>
 					<trans-unit id="station_departure">
-					  <source>Premature departure</source>
-					  <target>For tidlig avgang</target>
+						<source>Premature departure</source>
+						<target>For tidlig avgang</target>
 					</trans-unit>
 					<trans-unit id="station_total">
-					  <source>Total</source>
-					  <target>Totalt</target>
+						<source>Total</source>
+						<target>Totalt</target>
 					</trans-unit>
 					<trans-unit id="rating">
-					  <source>Your rating:</source>
-					  <target>Din vurdering:</target>
+						<source>Your rating:</source>
+						<target>Din vurdering:</target>
 					</trans-unit>
 				</group>
 				<group id="rating">
 					<trans-unit id="0">
-					  <source>Abysmal</source>
-					  <target>Grusomt</target>
+						<source>Abysmal</source>
+						<target>Grusomt</target>
 					</trans-unit>
 					<trans-unit id="1">
-					  <source>Terrible</source>
-					  <target>Forferdelig</target>
+						<source>Terrible</source>
+						<target>Forferdelig</target>
 					</trans-unit>
 					<trans-unit id="2">
-					  <source>Bad</source>
-					  <target>Dårlig</target>
+						<source>Bad</source>
+						<target>Dårlig</target>
 					</trans-unit>
 					<trans-unit id="3">
-					  <source>Poor</source>
-					  <target>Stakkarslig</target>
+						<source>Poor</source>
+						<target>Stakkarslig</target>
 					</trans-unit>
 					<trans-unit id="4">
-					  <source>Fair</source>
-					  <target>Adekvat</target>
+						<source>Fair</source>
+						<target>Adekvat</target>
 					</trans-unit>
 					<trans-unit id="5">
-					  <source>Mediocre</source>
-					  <target>Gjennomsnittlig</target>
+						<source>Mediocre</source>
+						<target>Gjennomsnittlig</target>
 					</trans-unit>
 					<trans-unit id="6">
-					  <source>Good</source>
-					  <target>Bra</target>
+						<source>Good</source>
+						<target>Bra</target>
 					</trans-unit>
 					<trans-unit id="7">
-					  <source>Great</source>
-					  <target>Flott</target>
+						<source>Great</source>
+						<target>Flott</target>
 					</trans-unit>
 					<trans-unit id="8">
-					  <source>Superb</source>
-					  <target>Utmerket</target>
+						<source>Superb</source>
+						<target>Utmerket</target>
 					</trans-unit>
 					<trans-unit id="9">
-					  <source>Excellent</source>
-					  <target>Perfekt</target>
+						<source>Excellent</source>
+						<target>Perfekt</target>
 					</trans-unit>
 					<trans-unit id="unknown">
-					  <source>Unknown</source>
-					  <target>Uvisst</target>
+						<source>Unknown</source>
+						<target>Uvisst</target>
 					</trans-unit>
 				</group>
 				<group id="menu">
 					<trans-unit id="resume">
-					  <source>Resume simulation</source>
-					  <target>Fortsett simulartor</target>
+						<source>Resume simulation</source>
+						<target>Fortsett simulartor</target>
 					</trans-unit>
 					<trans-unit id="jump">
-					  <source>Jump to station</source>
-					  <target>Hopp til stasjon</target>
+						<source>Jump to station</source>
+						<target>Hopp til stasjon</target>
 					</trans-unit>
 					<trans-unit id="exit">
-					  <source>Exit to main menu</source>
-					  <target>Avslutt til menyen</target>
+						<source>Exit to main menu</source>
+						<target>Avslutt til menyen</target>
 					</trans-unit>
 					<trans-unit id="exit_question">
-					  <source>Do you really want to exit to the main menu?</source>
-					  <target>Er du sikker på at du vil avslutte til menyen?</target>
+						<source>Do you really want to exit to the main menu?</source>
+						<target>Er du sikker på at du vil avslutte til menyen?</target>
 					</trans-unit>
 					<trans-unit id="exit_no">
-					  <source>No</source>
-					  <target>Nei</target>
+						<source>No</source>
+						<target>Nei</target>
 					</trans-unit>
 					<trans-unit id="exit_yes">
-					  <source>Yes</source>
-					  <target>Ja</target>
+						<source>Yes</source>
+						<target>Ja</target>
 					</trans-unit>
 					<trans-unit id="quit">
-					  <source>Quit</source>
-					  <target>Avslutt</target>
+						<source>Quit</source>
+						<target>Avslutt</target>
 					</trans-unit>
 					<trans-unit id="quit_question">
-					  <source>Do you really want to quit?</source>
-					  <target>Er du sikker på at du vil avslutte?</target>
+						<source>Do you really want to quit?</source>
+						<target>Er du sikker på at du vil avslutte?</target>
 					</trans-unit>
 					<trans-unit id="quit_no">
-					  <source>No</source>
-					  <target>Nei</target>
+						<source>No</source>
+						<target>Nei</target>
 					</trans-unit>
 					<trans-unit id="quit_yes">
-					  <source>Yes</source>
-					  <target>Ja</target>
+						<source>Yes</source>
+						<target>Ja</target>
 					</trans-unit>
 					<trans-unit id="back">
-					  <source>← Back</source>
-					  <target>← Tilbake</target>
+						<source>← Back</source>
+						<target>← Tilbake</target>
 					</trans-unit>
 					<trans-unit id="customize_controls">
-					  <source>Customise controls</source>
-					  <target>Tilpass kontroller</target>
+						<source>Customise controls</source>
+						<target>Tilpass kontroller</target>
 					</trans-unit>
 					<trans-unit id="assign">
 						<source>Please press any key or move a joystick axis to set this control...</source>
 					</trans-unit>
 					<trans-unit id="keyboard">
-					  <source>Keyboard</source>
-					  <target>Tastatur</target>
+						<source>Keyboard</source>
+						<target>Tastatur</target>
 					</trans-unit>
 					<trans-unit id="joystick">
-					  <source>Joystick</source>
-					  <target>Joystick</target>
+						<source>Joystick</source>
+						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-					  <source>N/A</source>
-					  <target>-- ikke der --</target>
+						<source>Joystick (Not currently connected)</source>
+						<target>-- ikke der --</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
-					  <source>Positive</source>
-					  <target>Positiv</target>
+						<source>Positive</source>
+						<target>Positiv</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_negative">
-					  <source>Negative</source>
-					  <target>Negativ</target>
+						<source>Negative</source>
+						<target>Negativ</target>
 					</trans-unit>
 					<trans-unit id="assignment_current">
-					  <source>Current assignment:</source>
-					  <target>Nåværende oppdrag:</target>
+						<source>Current assignment:</source>
+						<target>Nåværende oppdrag:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Standard for rute</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2250,7 +2313,6 @@
 						<source>CONST SPEED</source>
 					</trans-unit>
 				</group>
-				<!-- I do not know if these needs translations -->
 				<group id="handles">
 					<trans-unit id="forward">
 						<source>F</source>
@@ -2294,10 +2356,10 @@
 				</group>
 				<group id="doors">
 					<trans-unit id="left">
-						<source>V</source>
+						<source>L</source>
 					</trans-unit>
 					<trans-unit id="right">
-						<source>H</source>
+						<source>R</source>
 					</trans-unit>
 				</group>
 				<group id="misc">
@@ -2306,121 +2368,121 @@
 					</trans-unit>
 				</group>
 				<group id="commands">
-				  <trans-unit id="power_increase">
-				    <source>Increases power by one notch for trains with two handles</source>
-				    <target>Øker turtallet med et hakk for tog med to håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="power_decrease">
-				    <source>Decreases power by one notch for trains with two handles</source>
-				    <target>Minster turtallet med et hakk for tog med to håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="power_halfaxis">
-				    <source>Controls power for trains with two handles on half of a joystick axis</source>
-				    <target>Kontrollerer turtallet for tog med to håndtak på en halv joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="power_fullaxis">
-				    <source>Controls power for trains with two handles on a full joystick axis</source>
-				    <target>Kontrollerer turtallet på tog med to håndtak på en full joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="brake_decrease">
-				    <source>Decreases brake by one notch for trains with two handles</source>
-				    <target>Slepp opp bremsen med et hakk for tog med to håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="brake_increase">
-				    <source>Increases brake by one notch for trains with two handles</source>
-				    <target>Øk bremsen med et hakk for tog med to håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="locobrake_decrease">
+					<trans-unit id="power_increase">
+						<source>Increases power by one notch for trains with two handles</source>
+						<target>Øker turtallet med et hakk for tog med to håndtak</target>
+					</trans-unit>
+					<trans-unit id="power_decrease">
+						<source>Decreases power by one notch for trains with two handles</source>
+						<target>Minster turtallet med et hakk for tog med to håndtak</target>
+					</trans-unit>
+					<trans-unit id="power_halfaxis">
+						<source>Controls power for trains with two handles on half of a joystick axis</source>
+						<target>Kontrollerer turtallet for tog med to håndtak på en halv joystick akse</target>
+					</trans-unit>
+					<trans-unit id="power_fullaxis">
+						<source>Controls power for trains with two handles on a full joystick axis</source>
+						<target>Kontrollerer turtallet på tog med to håndtak på en full joystick akse</target>
+					</trans-unit>
+					<trans-unit id="brake_decrease">
+						<source>Decreases brake by one notch for trains with two handles</source>
+						<target>Slepp opp bremsen med et hakk for tog med to håndtak</target>
+					</trans-unit>
+					<trans-unit id="brake_increase">
+						<source>Increases brake by one notch for trains with two handles</source>
+						<target>Øk bremsen med et hakk for tog med to håndtak</target>
+					</trans-unit>
+					<trans-unit id="locobrake_decrease">
 						<source>Decreases the locomotive brake by one notch</source>
 					</trans-unit>
 					<trans-unit id="locobrake_increase">
 						<source>Increases the locomotive brake by one notch</source>
 					</trans-unit>
-				  <trans-unit id="brake_halfaxis">
-				    <source>Controls brake for trains with two handles on half of a joystick axis</source>
-				    <target>Kontrollerer bremsen for tog med to håndtak på en halv joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="brake_fullaxis">
-				    <source>Controls brake for trains with two handles on a full joystick axis</source>
-				    <target>Kontrollerer bremsen for tog med to håndtak på en hel joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="brake_emergency">
-				    <source>Activates emergency brakes for trains with two handles</source>
-				    <target>Aktiverer nødbrems for tog med to håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="single_power">
-				    <source>Moves handle toward power by one notch for trains with one handle</source>
-				    <target>Dytter håndtaket et trinn mot høyere turtall for tog med et håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="single_neutral">
-				    <source>Moves handle toward neutral by one notch for trains with one handle</source>
-				    <target>Dytter håndtaket ett trinn mot nøytral stilling for tog med et håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="single_brake">
-				    <source>Moves handle toward brake by one notch for trains with one handle</source>
-				    <target>Dytter håndtaket ett trinn mot brems for tog med et håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="single_emergency">
-				    <source>Activates emergency brake for trains with one handle</source>
-				    <target>Aktiverer nødbrems for tog med et håndtak</target>
-				  </trans-unit>
-				  <trans-unit id="single_fullaxis">
-				    <source>Controls power and brake for trains with one handle on a full joystick axis</source>
-				    <target>Kontrollerer turtall og brems for tog med ett håndtak på en full joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="power_any_notch">
-				    <source>Adjusts the power notch directly from a command option value.</source>
-				    <target>Juster turtallet til en direkte posisjon via en gitt verdi</target>
-				  </trans-unit>
-				  <trans-unit id="brake_any_notch">
-				    <source>Adjusts the brake notch directly from a command option value.</source>
-				    <target>Juster bremsen til en direkte posisjon via en gitt verdi</target>
-				  </trans-unit>
-				  <trans-unit id="reverser_any_position">
-				    <source>Adjusts the reverser directly from a command option value.</source>
-				    <target>Juster vendegiret til en direkte posisjon via en gitt verdi</target>
-				  </trans-unit>
-				  <trans-unit id="hold_brake">
-				    <source>Hold Brake</source>
-				    <target>Parkeringsbrems</target>
-				  </trans-unit>
-				  <trans-unit id="reverser_forward">
-				    <source>Moves reverser forward by one notch</source>
-				    <target>Dytter vendegiret et hakk frem</target>
-				  </trans-unit>
-				  <trans-unit id="reverser_backward">
-				    <source>Moves reverser backward by one notch</source>
-				    <target>Dytter vendegiret et hakk bakover</target>
-				  </trans-unit>
-				  <trans-unit id="reverser_fullaxis">
-				    <source>Controls reverser on a full joystick axis</source>
-				    <target>Kontrollerer vendegiret på en full joystick akse</target>
-				  </trans-unit>
-				  <trans-unit id="doors_left">
-				    <source>Opens or closes the left doors</source>
-				    <target>Åpner og lukker venstre dør</target>
-				  </trans-unit>
-				  <trans-unit id="doors_right">
-				    <source>Opens or closes the right doors</source>
-				    <target>Åpner og lukker høyre dør</target>
-				  </trans-unit>
-				  <trans-unit id="horn_primary">
-				    <source>Plays the primary horn</source>
-				    <target>Tut med primærhornet</target>
-				  </trans-unit>
-				  <trans-unit id="horn_secondary">
-				    <source>Plays the secondary horn</source>
-				    <target>Tut med sekundærhornet</target>
-				  </trans-unit>
-				  <trans-unit id="horn_music">
-				    <source>Plays or stops the music horn</source>
-				    <target>Starter og stopper musikkhornet</target>
-				  </trans-unit>
-				  <trans-unit id="device_constspeed">
-				    <source>Activates or deactivates the constant speed device</source>
-				    <target>Aktiverer eller deaktiverer kruskontroll</target>
-				  </trans-unit>
-				  <trans-unit id="play_mic_sounds">
+					<trans-unit id="brake_halfaxis">
+						<source>Controls brake for trains with two handles on half of a joystick axis</source>
+						<target>Kontrollerer bremsen for tog med to håndtak på en halv joystick akse</target>
+					</trans-unit>
+					<trans-unit id="brake_fullaxis">
+						<source>Controls brake for trains with two handles on a full joystick axis</source>
+						<target>Kontrollerer bremsen for tog med to håndtak på en hel joystick akse</target>
+					</trans-unit>
+					<trans-unit id="brake_emergency">
+						<source>Activates emergency brakes for trains with two handles</source>
+						<target>Aktiverer nødbrems for tog med to håndtak</target>
+					</trans-unit>
+					<trans-unit id="single_power">
+						<source>Moves handle toward power by one notch for trains with one handle</source>
+						<target>Dytter håndtaket et trinn mot høyere turtall for tog med et håndtak</target>
+					</trans-unit>
+					<trans-unit id="single_neutral">
+						<source>Moves handle toward neutral by one notch for trains with one handle</source>
+						<target>Dytter håndtaket ett trinn mot nøytral stilling for tog med et håndtak</target>
+					</trans-unit>
+					<trans-unit id="single_brake">
+						<source>Moves handle toward brake by one notch for trains with one handle</source>
+						<target>Dytter håndtaket ett trinn mot brems for tog med et håndtak</target>
+					</trans-unit>
+					<trans-unit id="single_emergency">
+						<source>Activates emergency brake for trains with one handle</source>
+						<target>Aktiverer nødbrems for tog med et håndtak</target>
+					</trans-unit>
+					<trans-unit id="single_fullaxis">
+						<source>Controls power and brake for trains with one handle on a full joystick axis</source>
+						<target>Kontrollerer turtall og brems for tog med ett håndtak på en full joystick akse</target>
+					</trans-unit>
+					<trans-unit id="power_any_notch">
+						<source>Adjusts the power notch directly from a command option value.</source>
+						<target>Juster turtallet til en direkte posisjon via en gitt verdi</target>
+					</trans-unit>
+					<trans-unit id="brake_any_notch">
+						<source>Adjusts the brake notch directly from a command option value.</source>
+						<target>Juster bremsen til en direkte posisjon via en gitt verdi</target>
+					</trans-unit>
+					<trans-unit id="reverser_any_position">
+						<source>Adjusts the reverser directly from a command option value.</source>
+						<target>Juster vendegiret til en direkte posisjon via en gitt verdi</target>
+					</trans-unit>
+					<trans-unit id="hold_brake">
+						<source>Hold Brake</source>
+						<target>Parkeringsbrems</target>
+					</trans-unit>
+					<trans-unit id="reverser_forward">
+						<source>Moves reverser forward by one notch</source>
+						<target>Dytter vendegiret et hakk frem</target>
+					</trans-unit>
+					<trans-unit id="reverser_backward">
+						<source>Moves reverser backward by one notch</source>
+						<target>Dytter vendegiret et hakk bakover</target>
+					</trans-unit>
+					<trans-unit id="reverser_fullaxis">
+						<source>Controls reverser on a full joystick axis</source>
+						<target>Kontrollerer vendegiret på en full joystick akse</target>
+					</trans-unit>
+					<trans-unit id="doors_left">
+						<source>Opens or closes the left doors</source>
+						<target>Åpner og lukker venstre dør</target>
+					</trans-unit>
+					<trans-unit id="doors_right">
+						<source>Opens or closes the right doors</source>
+						<target>Åpner og lukker høyre dør</target>
+					</trans-unit>
+					<trans-unit id="horn_primary">
+						<source>Plays the primary horn</source>
+						<target>Tut med primærhornet</target>
+					</trans-unit>
+					<trans-unit id="horn_secondary">
+						<source>Plays the secondary horn</source>
+						<target>Tut med sekundærhornet</target>
+					</trans-unit>
+					<trans-unit id="horn_music">
+						<source>Plays or stops the music horn</source>
+						<target>Starter og stopper musikkhornet</target>
+					</trans-unit>
+					<trans-unit id="device_constspeed">
+						<source>Activates or deactivates the constant speed device</source>
+						<target>Aktiverer eller deaktiverer kruskontroll</target>
+					</trans-unit>
+					<trans-unit id="play_mic_sounds">
 						<source>Activates or deactivates the system microphone soundsource</source>
 						<target>Activates or deactivates the system microphone soundsource</target>
 					</trans-unit>
@@ -2428,368 +2490,386 @@
 						<source>Activates or deactivates the sanders</source>
 						<target>Activates or deactivates the sanders</target>
 					</trans-unit>
-				  <trans-unit id="security_power">
-				    <source>Activates or deactivates the security system on some trains</source>
-				    <target>Aktiverer eller deaktiverer sikkerhetssystemet på noen tog</target>
-				  </trans-unit>
-				  <trans-unit id="security_s">
-				    <source>The S function of the security system</source>
-				    <target>S funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_a1">
-				    <source>The A1 function of the security system</source>
-				    <target>A1 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_a2">
-				    <source>The A2 function of the security system</source>
-				    <target>A2 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_b1">
-				    <source>The B1 function of the security system</source>
-				    <target>B1 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_b2">
-				    <source>The B2 function of the security system</source>
-				    <target>B2 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_c1">
-				    <source>The C1 function of the security system</source>
-				    <target>C1 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_c2">
-				    <source>The C2 function of the security system</source>
-				    <target>C2 funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_d">
-				    <source>The D function of the security system</source>
-				    <target>D funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_e">
-				    <source>The E function of the security system</source>
-				    <target>E funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_f">
-				    <source>The F function of the security system</source>
-				    <target>F funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_g">
-				    <source>The G function of the security system</source>
-				    <target>G funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_h">
-				    <source>The H function of the security system</source>
-				    <target>H funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_i">
-				    <source>The I function of the security system</source>
-				    <target>I funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_j">
-				    <source>The J function of the security system</source>
-				    <target>J funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_k">
-				    <source>The K function of the security system</source>
-				    <target>K funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_l">
-				    <source>The L function of the security system</source>
-				    <target>L funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_m">
-				    <source>The M function of the security system</source>
-				    <target>M funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_n">
-				    <source>The N function of the security system</source>
-				    <target>N funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_o">
-				    <source>The O function of the security system</source>
-				    <target>O funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="security_p">
-				    <source>The P function of the security system</source>
-				    <target>P funksjonen på sikkerhetssystemet</target>
-				  </trans-unit>
-				  <trans-unit id="camera_interior">
-				    <source>Switches to the train's interior view</source>
-				    <target>Bytt til togets interiørvisning</target>
-				  </trans-unit>
-				  <trans-unit id="camera_interior_nopanel">
-				    <source>Switches to the train's interior view. However, the panel is not displayed.</source>
-				    <target>Bytt til togets interiørvisning. Panelt vises ikke.</target>					  
-				  </trans-unit>
-				  <trans-unit id="camera_exterior">
-				    <source>Switches to the train's exterior view</source>
-				    <target>Bytt til togets eksteriørvisning.</target>
-				  </trans-unit>
-				  <trans-unit id="camera_track">
-				    <source>Switches to the track view</source>
-				    <target>Bytt til skinnegangvisning</target>
-				  </trans-unit>
-				  <trans-unit id="camera_flyby">
-				    <source>Switches between different fly-by views</source>
-				    <target>Bytt mellom forskjellige fly-by visninger</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_forward">
-				    <source>Moves the camera forward</source>
-				    <target>Flytter kamera forover</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_backward">
-				    <source>Moves the camera backward</source>
-				    <target>Flytter kamera bakover</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_left">
-				    <source>Moves the camera left</source>
-				    <target>Flytter kamera venstre</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_right">
-				    <source>Moves the camera right</source>
-				    <target>Flytter kamera høyre</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_up">
-				    <source>Moves the camera up</source>
-				    <target>Flytter kamera opp</target>
-				  </trans-unit>
-				  <trans-unit id="camera_move_down">
-				    <source>Moves the camera down</source>
-				    <target>Flytter kamera ned</target>
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_left">
-				    <source>Rotates the camera left</source>
-				    <target>Roterer kamera venstre</target>
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_right">
-				    <source>Rotates the camera right</source>
-				    <target>Roterer kamera høyre</target>					  
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_up">
-				    <source>Rotates the camera up</source>
-				    <target>Roterer kamera oppover</target>					  			  
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_down">
-				    <source>Rotates the camera down</source>
-				    <target>Roterer kamera nedover</target>		  
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_ccw">
-				    <source>Rotates the camera counter-clockwise</source>
-				    <target>Roterer kamera mot klokken</target>	  
-				  </trans-unit>
-				  <trans-unit id="camera_rotate_cw">
-				    <source>Rotates the camera clockwise</source>
-				    <target>Roterer kamera med klokken</target>	  
-				  </trans-unit>
-				  <trans-unit id="camera_zoom_in">
-				    <source>Zooms the camera in</source>
-				    <target>Zoomer kamera inn</target>
-				  </trans-unit>
-				  <trans-unit id="camera_zoom_out">
-				    <source>Zooms the camera out</source>
-				    <target>Zoomer kamera ut</target>
-				  </trans-unit>
-				  <trans-unit id="camera_poi_previous">
-				    <source>Jumps to the previous point of interest in the route.</source>
-				    <target>Hopper til forrige punkt av interesse på denne ruten.</target>
-				  </trans-unit>
-				  <trans-unit id="camera_poi_next">
-				    <source>Jumps to the next point of interest in the route.</source>
-				    <target>Hopper til neste punkt av interesse på denne ruten.</target>				    
-				  </trans-unit>
-				  <trans-unit id="camera_reset">
-				    <source>Resets the camera view to default values</source>
-				    <target>Resetter kamera til forhåndsdefinerte innstillinger</target>
-				  </trans-unit>
-				  <trans-unit id="camera_restriction">
-				    <source>Activates or deactivates interior view camera restriction</source>
-				    <target>Aktiverer eller deaktiverer interiørvisningskamerarestriksjoner</target>
-				  </trans-unit>
-				  <trans-unit id="timetable_toggle">
-				    <source>Toggles through different timetable modes</source>
-				    <target>Bytter mellom forskjellige tidtabellsmoduser</target>
-				  </trans-unit>
-				  <trans-unit id="timetable_up">
-				    <source>Scrolls the timetable up</source>
-				    <target>Flytt tidtabell opp</target>
-				  </trans-unit>
-				  <trans-unit id="timetable_down">
-				    <source>Scrolls the timetable down</source>
-				    <target>Flytt tidtabell ned</target>
-				  </trans-unit>
-				  <trans-unit id="menu_activate">
-				    <source>Displays the in-game menu</source>
-				    <target>Viser menyen i spillet</target>
-				  </trans-unit>
-				  <trans-unit id="menu_up">
-				    <source>Moves the cursor up within the in-game menu</source>
-				    <target>Flytter markøren opp i spillmenyen</target>
-				  </trans-unit>
-				  <trans-unit id="menu_down">
-				    <source>Moves the cursor down within the in-game menu</source>
-				    <target>Flytter markøren ned i spillmenyen</target>
-				  </trans-unit>
-				  <trans-unit id="menu_enter">
-				    <source>Performs the selected command within the in-game menu</source>
-				    <target>Velger den valgte kommandoen i spillmenyen</target>
-				  </trans-unit>
-				  <trans-unit id="menu_back">
-				    <source>Goes back within the in-game menu</source>
-				    <target>Går tilbake inni spillmenyen</target>
-				  </trans-unit>
-				  <trans-unit id="misc_clock">
-				    <source>Shows or hides the clock</source>
-				    <target>Viser eller skjuler klokken</target>
-				  </trans-unit>
-				  <trans-unit id="misc_speed">
-				    <source>Toggles through different speed display modes</source>
-				    <target>Itererer gjennom forskjellige speedometermoduser</target>
-				  </trans-unit>
-				  <trans-unit id="misc_gradient">
-				    <source>Toggles through different gradient display modes</source>
-				    <target>Itererer gjennom forskjellige gradientvisningsmoduser</target>
-				  </trans-unit>
-				  <trans-unit id="misc_dist_next_station">
-				    <source>Toggles through different next station remain distance display modes</source>
-				    <target>Iterer gjennom forskjellige "av stand til neste stasjon" moduser</target>
-				  </trans-unit>
-				  <trans-unit id="misc_timefactor">
-				    <source>Toggles through different time acceleration factors</source>
-				    <target>Iterer gjennom forskjellige tidsakselerasjonsfaktorer</target>
-				  </trans-unit>
-				  <trans-unit id="misc_fps">
-				    <source>Shows or hides the frame rate display</source>
-				    <target>Viser eller skjuler bilde per sekund visningen</target>
-				  </trans-unit>
-				  <trans-unit id="misc_ai">
-				    <source>Activates or deactivates the virtual driver (AI)</source>
-				    <target>Aktiverer eller deaktiverer virtuell konduktør (AI)</target>
-				  </trans-unit>
-				  <trans-unit id="misc_pause">
-				    <source>Pauses or resumes the simulation</source>
-				    <target>Pause eller forsette simulatoren</target>
-				  </trans-unit>
-				  <trans-unit id="misc_fullscreen">
-				    <source>Toggles to or from fullscreen mode</source>
-				    <target>Setter av og på fullskjemsmodus</target>
-				  </trans-unit>
-				  <trans-unit id="misc_mute">
-				    <source>Mutes sound or resumes playing sounds</source>
-				    <target>Slår av og på lyd</target>
-				  </trans-unit>
-				  <trans-unit id="misc_quit">
-				    <source>Quits the simulation</source>
-				    <target>Avslutter simulatoren</target>
-				  </trans-unit>
-				  <trans-unit id="misc_interface">
-				    <source>Toggles through different interface modes</source>
-				    <target>Iterer gjennom forskjellige brukergrensesnitt</target>
-				  </trans-unit>
-				  <trans-unit id="misc_backface">
-				    <source>Activates or deactivates backface culling</source>
-				    <target>Aktiverer eller deaktiverer baksideavskjæring</target>
-				  </trans-unit>
-				  <trans-unit id="misc_cpumode">
-				    <source>Switches to or from reduced CPU mode</source>
-				    <target>Bytter til og fra redusert CPU modus</target>
-				  </trans-unit>
-				  <trans-unit id="debug_wireframe">
-				    <source>Activates or deactivates wireframe mode</source>
-				    <target>Aktiverer eller deaktiverer "wireframe" modus</target>
-				  </trans-unit>
-				  <trans-unit id="debug_normals">
-				    <source>Shows or hides vertex normals</source>
-				    <target>Vis eller skjul 3D hjelpe linjer</target>
-				  </trans-unit>
-				  <trans-unit id="debug_brake_systems">
-				    <source>Shows or hides brake system debug output</source>
-				    <target>Vis eller skjul utskrift fra bremsesystem</target>
-				  </trans-unit>
-				  <trans-unit id="debug_ats">
-				    <source>Shows or hides plugin debug output</source>
-				    <target>Vis eller skjul utskrift fra plugins</target>
-				  </trans-unit>
-				  <trans-unit id="debug_touch_mode">
-				    <source>Shows or hides the touch range</source>
-				    <target>Vis eller skjul avstand man kan nå / ta til</target>
-				  </trans-unit>
-				  <trans-unit id="route_information">
-				    <source>Shows or hides the route information window</source>
-				    <target>Vis eller skjul informasjon om ruten</target>
-				  </trans-unit>
-				  <trans-unit id="show_events">
-				    <source>Shows or hides event markers (For developers)</source>
-				    <target>Vis eller skjul hendelesmarkører (for utviklere)</target>
-				  </trans-unit>
-				  <trans-unit id="debug_renderer_mode">
-				    <source>Toggles the renderer</source>
-				    <target>Slå på "renderer-mode"</target>
-				  </trans-unit>
-				  <trans-unit id="wiper_speed_up">
-				    <source>Increases the speed of the windscreen wipers</source>
-				    <target>Øk hastigheten på store viskere</target>
-				  </trans-unit>
-				  <trans-unit id="wiper_speed_down">
-				    <source>Decreases the speed of the windscreen wipers</source>
-				    <target>Senk hastigheten på store viskere</target>
-				  </trans-unit>
-				  <trans-unit id="fill_fuel">
-				    <source>Fills fuel</source>
-				    <target>Fyller drivstoff</target>
-				  </trans-unit>
-				  <trans-unit id="headlights">
-				    <source>Toggles the train headlights</source>
-				    <target>Slå på storlysene</target>
-				  </trans-unit>
-				  <trans-unit id="live_steam_injector">
-				    <source>Activates or deactivates the live steam injector</source>
-				  </trans-unit>
-				  <trans-unit id="exhaust_steam_injector">
-				    <source>Activates or deactivates the exhaust steam injector</source>
-				  </trans-unit>
-				  <trans-unit id="increase_cutoff">
-				    <source>Increases the cutoff</source>
-				    <target>Øker momentum</target>
-				  </trans-unit>
-				  <trans-unit id="decrease_cutoff">
-				    <source>Decreases the cutoff</source>
-				    <target>Senker momentum</target>
-				  </trans-unit>
-				  <trans-unit id="blowers">
-				    <source>Activates or deactivates the blowers</source>
-				    <target>Aktiverer eller deaktiverer blåsere</target>
-				  </trans-unit>
-				  <trans-unit id="engine_start">
-				    <source>Starts the engine</source>
-				    <target>Starter motoren</target>
-				  </trans-unit>
-				  <trans-unit id="engine_stop">
-				    <source>Stops the engine</source>
-				    <target>Stopper motoren</target>
-				  </trans-unit>
-				  <trans-unit id="gear_up">
-				    <source>Shifts up a gear in a train fitted with a gearbox</source>
-				    <target>Skifter opp et gir i et tog utstyrt med girkasse</target>
-				  </trans-unit>
-				  <trans-unit id="gear_down">
-				    <source>Shifts down a gear in a train fitted with a gearbox</source>
-				    <target>Skifter ned et gir i et tog utstyrt med girkasse</target>
-				  </trans-unit>
-				  <trans-unit id="raise_pantograph">
-				    <source>Raises the pantograph</source>
-				    <target>Reiser pantografen</target>
-				  </trans-unit>
-				  <trans-unit id="lower_pantograph">
-				    <source>Lowers the pantograph</source>
-				    <target>Senker pantografen</target>
-				  </trans-unit>
-				  <trans-unit id="main_breaker">
-				    <source>Toggles the main breaker</source>
-				    <target>Slår på hovedbremsen</target>
-				  </trans-unit>
-				  <trans-unit id="raildriver_speed_units">
-				    <source>Toggles the RailDriver speed display units.</source>
-				    <target>Slår på RailDriver speedometerenheter</target>
-				  </trans-unit>
+					<trans-unit id="security_power">
+						<source>Activates or deactivates the security system on some trains</source>
+						<target>Aktiverer eller deaktiverer sikkerhetssystemet på noen tog</target>
+					</trans-unit>
+					<trans-unit id="security_s">
+						<source>The S function of the security system</source>
+						<target>S funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_a1">
+						<source>The A1 function of the security system</source>
+						<target>A1 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_a2">
+						<source>The A2 function of the security system</source>
+						<target>A2 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_b1">
+						<source>The B1 function of the security system</source>
+						<target>B1 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_b2">
+						<source>The B2 function of the security system</source>
+						<target>B2 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_c1">
+						<source>The C1 function of the security system</source>
+						<target>C1 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_c2">
+						<source>The C2 function of the security system</source>
+						<target>C2 funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_d">
+						<source>The D function of the security system</source>
+						<target>D funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_e">
+						<source>The E function of the security system</source>
+						<target>E funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_f">
+						<source>The F function of the security system</source>
+						<target>F funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_g">
+						<source>The G function of the security system</source>
+						<target>G funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_h">
+						<source>The H function of the security system</source>
+						<target>H funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_i">
+						<source>The I function of the security system</source>
+						<target>I funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_j">
+						<source>The J function of the security system</source>
+						<target>J funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_k">
+						<source>The K function of the security system</source>
+						<target>K funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_l">
+						<source>The L function of the security system</source>
+						<target>L funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_m">
+						<source>The M function of the security system</source>
+						<target>M funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_n">
+						<source>The N function of the security system</source>
+						<target>N funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_o">
+						<source>The O function of the security system</source>
+						<target>O funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="security_p">
+						<source>The P function of the security system</source>
+						<target>P funksjonen på sikkerhetssystemet</target>
+					</trans-unit>
+					<trans-unit id="camera_interior">
+						<source>Switches to the train&apos;s interior view</source>
+						<target>Bytt til togets interiørvisning</target>
+					</trans-unit>
+					<trans-unit id="camera_interior_nopanel">
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
+						<target>Bytt til togets interiørvisning. Panelt vises ikke.</target>
+					</trans-unit>
+					<trans-unit id="camera_exterior">
+						<source>Switches to the train&apos;s exterior view</source>
+						<target>Bytt til togets eksteriørvisning.</target>
+					</trans-unit>
+					<trans-unit id="camera_track">
+						<source>Switches to the track view</source>
+						<target>Bytt til skinnegangvisning</target>
+					</trans-unit>
+					<trans-unit id="camera_flyby">
+						<source>Switches between different fly-by views</source>
+						<target>Bytt mellom forskjellige fly-by visninger</target>
+					</trans-unit>
+					<trans-unit id="camera_move_forward">
+						<source>Moves the camera forward</source>
+						<target>Flytter kamera forover</target>
+					</trans-unit>
+					<trans-unit id="camera_move_backward">
+						<source>Moves the camera backward</source>
+						<target>Flytter kamera bakover</target>
+					</trans-unit>
+					<trans-unit id="camera_move_left">
+						<source>Moves the camera left</source>
+						<target>Flytter kamera venstre</target>
+					</trans-unit>
+					<trans-unit id="camera_move_right">
+						<source>Moves the camera right</source>
+						<target>Flytter kamera høyre</target>
+					</trans-unit>
+					<trans-unit id="camera_move_up">
+						<source>Moves the camera up</source>
+						<target>Flytter kamera opp</target>
+					</trans-unit>
+					<trans-unit id="camera_move_down">
+						<source>Moves the camera down</source>
+						<target>Flytter kamera ned</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_left">
+						<source>Rotates the camera left</source>
+						<target>Roterer kamera venstre</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_right">
+						<source>Rotates the camera right</source>
+						<target>Roterer kamera høyre</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_up">
+						<source>Rotates the camera up</source>
+						<target>Roterer kamera oppover</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_down">
+						<source>Rotates the camera down</source>
+						<target>Roterer kamera nedover</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_ccw">
+						<source>Rotates the camera counter-clockwise</source>
+						<target>Roterer kamera mot klokken</target>
+					</trans-unit>
+					<trans-unit id="camera_rotate_cw">
+						<source>Rotates the camera clockwise</source>
+						<target>Roterer kamera med klokken</target>
+					</trans-unit>
+					<trans-unit id="camera_zoom_in">
+						<source>Zooms the camera in</source>
+						<target>Zoomer kamera inn</target>
+					</trans-unit>
+					<trans-unit id="camera_zoom_out">
+						<source>Zooms the camera out</source>
+						<target>Zoomer kamera ut</target>
+					</trans-unit>
+					<trans-unit id="camera_poi_previous">
+						<source>Jumps to the previous point of interest in the route.</source>
+						<target>Hopper til forrige punkt av interesse på denne ruten.</target>
+					</trans-unit>
+					<trans-unit id="camera_poi_next">
+						<source>Jumps to the next point of interest in the route.</source>
+						<target>Hopper til neste punkt av interesse på denne ruten.</target>
+					</trans-unit>
+					<trans-unit id="camera_reset">
+						<source>Resets the camera view to default values</source>
+						<target>Resetter kamera til forhåndsdefinerte innstillinger</target>
+					</trans-unit>
+					<trans-unit id="camera_restriction">
+						<source>Activates or deactivates interior view camera restriction</source>
+						<target>Aktiverer eller deaktiverer interiørvisningskamerarestriksjoner</target>
+					</trans-unit>
+					<trans-unit id="timetable_toggle">
+						<source>Toggles through different timetable modes</source>
+						<target>Bytter mellom forskjellige tidtabellsmoduser</target>
+					</trans-unit>
+					<trans-unit id="timetable_up">
+						<source>Scrolls the timetable up</source>
+						<target>Flytt tidtabell opp</target>
+					</trans-unit>
+					<trans-unit id="timetable_down">
+						<source>Scrolls the timetable down</source>
+						<target>Flytt tidtabell ned</target>
+					</trans-unit>
+					<trans-unit id="menu_activate">
+						<source>Displays the in-game menu</source>
+						<target>Viser menyen i spillet</target>
+					</trans-unit>
+					<trans-unit id="menu_up">
+						<source>Moves the cursor up within the in-game menu</source>
+						<target>Flytter markøren opp i spillmenyen</target>
+					</trans-unit>
+					<trans-unit id="menu_down">
+						<source>Moves the cursor down within the in-game menu</source>
+						<target>Flytter markøren ned i spillmenyen</target>
+					</trans-unit>
+					<trans-unit id="menu_enter">
+						<source>Performs the selected command within the in-game menu</source>
+						<target>Velger den valgte kommandoen i spillmenyen</target>
+					</trans-unit>
+					<trans-unit id="menu_back">
+						<source>Goes back within the in-game menu</source>
+						<target>Går tilbake inni spillmenyen</target>
+					</trans-unit>
+					<trans-unit id="misc_clock">
+						<source>Shows or hides the clock</source>
+						<target>Viser eller skjuler klokken</target>
+					</trans-unit>
+					<trans-unit id="misc_speed">
+						<source>Toggles through different speed display modes</source>
+						<target>Itererer gjennom forskjellige speedometermoduser</target>
+					</trans-unit>
+					<trans-unit id="misc_gradient">
+						<source>Toggles through different gradient display modes</source>
+						<target>Itererer gjennom forskjellige gradientvisningsmoduser</target>
+					</trans-unit>
+					<trans-unit id="misc_dist_next_station">
+						<source>Toggles through different next station remain distance display modes</source>
+						<target>Iterer gjennom forskjellige &quot;av stand til neste stasjon&quot; moduser</target>
+					</trans-unit>
+					<trans-unit id="misc_timefactor">
+						<source>Toggles through different time acceleration factors</source>
+						<target>Iterer gjennom forskjellige tidsakselerasjonsfaktorer</target>
+					</trans-unit>
+					<trans-unit id="misc_fps">
+						<source>Shows or hides the frame rate display</source>
+						<target>Viser eller skjuler bilde per sekund visningen</target>
+					</trans-unit>
+					<trans-unit id="misc_ai">
+						<source>Activates or deactivates the virtual driver (AI)</source>
+						<target>Aktiverer eller deaktiverer virtuell konduktør (AI)</target>
+					</trans-unit>
+					<trans-unit id="misc_pause">
+						<source>Pauses or resumes the simulation</source>
+						<target>Pause eller forsette simulatoren</target>
+					</trans-unit>
+					<trans-unit id="misc_fullscreen">
+						<source>Toggles to or from fullscreen mode</source>
+						<target>Setter av og på fullskjemsmodus</target>
+					</trans-unit>
+					<trans-unit id="misc_mute">
+						<source>Mutes sound or resumes playing sounds</source>
+						<target>Slår av og på lyd</target>
+					</trans-unit>
+					<trans-unit id="misc_quit">
+						<source>Quits the simulation</source>
+						<target>Avslutter simulatoren</target>
+					</trans-unit>
+					<trans-unit id="misc_interface">
+						<source>Toggles through different interface modes</source>
+						<target>Iterer gjennom forskjellige brukergrensesnitt</target>
+					</trans-unit>
+					<trans-unit id="misc_backface">
+						<source>Activates or deactivates backface culling</source>
+						<target>Aktiverer eller deaktiverer baksideavskjæring</target>
+					</trans-unit>
+					<trans-unit id="misc_cpumode">
+						<source>Switches to or from reduced CPU mode</source>
+						<target>Bytter til og fra redusert CPU modus</target>
+					</trans-unit>
+					<trans-unit id="debug_wireframe">
+						<source>Activates or deactivates wireframe mode</source>
+						<target>Aktiverer eller deaktiverer &quot;wireframe&quot; modus</target>
+					</trans-unit>
+					<trans-unit id="debug_normals">
+						<source>Shows or hides vertex normals</source>
+						<target>Vis eller skjul 3D hjelpe linjer</target>
+					</trans-unit>
+					<trans-unit id="debug_brake_systems">
+						<source>Shows or hides brake system debug output</source>
+						<target>Vis eller skjul utskrift fra bremsesystem</target>
+					</trans-unit>
+					<trans-unit id="debug_ats">
+						<source>Shows or hides plugin debug output</source>
+						<target>Vis eller skjul utskrift fra plugins</target>
+					</trans-unit>
+					<trans-unit id="debug_touch_mode">
+						<source>Shows or hides the touch range</source>
+						<target>Vis eller skjul avstand man kan nå / ta til</target>
+					</trans-unit>
+					<trans-unit id="route_information">
+						<source>Shows or hides the route information window</source>
+						<target>Vis eller skjul informasjon om ruten</target>
+					</trans-unit>
+					<trans-unit id="show_events">
+						<source>Shows or hides event markers (For developers)</source>
+						<target>Vis eller skjul hendelesmarkører (for utviklere)</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+						<target>Slå på &quot;renderer-mode&quot;</target>
+					</trans-unit>
+					<trans-unit id="wiper_speed_up">
+						<source>Increases the speed of the windscreen wipers</source>
+						<target>Øk hastigheten på store viskere</target>
+					</trans-unit>
+					<trans-unit id="wiper_speed_down">
+						<source>Decreases the speed of the windscreen wipers</source>
+						<target>Senk hastigheten på store viskere</target>
+					</trans-unit>
+					<trans-unit id="fill_fuel">
+						<source>Fills fuel</source>
+						<target>Fyller drivstoff</target>
+					</trans-unit>
+					<trans-unit id="headlights">
+						<source>Toggles the train headlights</source>
+						<target>Slå på storlysene</target>
+					</trans-unit>
+					<trans-unit id="live_steam_injector">
+						<source>Activates or deactivates the live steam injector</source>
+					</trans-unit>
+					<trans-unit id="exhaust_steam_injector">
+						<source>Activates or deactivates the exhaust steam injector</source>
+					</trans-unit>
+					<trans-unit id="increase_cutoff">
+						<source>Increases the cutoff</source>
+						<target>Øker momentum</target>
+					</trans-unit>
+					<trans-unit id="decrease_cutoff">
+						<source>Decreases the cutoff</source>
+						<target>Senker momentum</target>
+					</trans-unit>
+					<trans-unit id="blowers">
+						<source>Activates or deactivates the blowers</source>
+						<target>Aktiverer eller deaktiverer blåsere</target>
+					</trans-unit>
+					<trans-unit id="engine_start">
+						<source>Starts the engine</source>
+						<target>Starter motoren</target>
+					</trans-unit>
+					<trans-unit id="engine_stop">
+						<source>Stops the engine</source>
+						<target>Stopper motoren</target>
+					</trans-unit>
+					<trans-unit id="gear_up">
+						<source>Shifts up a gear in a train fitted with a gearbox</source>
+						<target>Skifter opp et gir i et tog utstyrt med girkasse</target>
+					</trans-unit>
+					<trans-unit id="gear_down">
+						<source>Shifts down a gear in a train fitted with a gearbox</source>
+						<target>Skifter ned et gir i et tog utstyrt med girkasse</target>
+					</trans-unit>
+					<trans-unit id="raise_pantograph">
+						<source>Raises the pantograph</source>
+						<target>Reiser pantografen</target>
+					</trans-unit>
+					<trans-unit id="lower_pantograph">
+						<source>Lowers the pantograph</source>
+						<target>Senker pantografen</target>
+					</trans-unit>
+					<trans-unit id="main_breaker">
+						<source>Toggles the main breaker</source>
+						<target>Slår på hovedbremsen</target>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+						<target>Slår på RailDriver speedometerenheter</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
+					</trans-unit>
 				</group>
 				<group id="keys">
 					<trans-unit id="0">
@@ -3195,609 +3275,760 @@
 						<source>Z</source>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
 					<trans-unit id="new">
-					  <source>New</source>
-					  <target>Ny</target>
+						<source>New</source>
+						<target>Ny</target>
 					</trans-unit>
 					<trans-unit id="open">
-					  <source>Open...</source>
-					  <target>Åpne...</target>
+						<source>Open...</source>
+						<target>Åpne...</target>
 					</trans-unit>
 					<trans-unit id="save">
-					  <source>Save</source>
-					  <target>Lagre</target>
+						<source>Save</source>
+						<target>Lagre</target>
 					</trans-unit>
 					<trans-unit id="save_as">
-					  <source>Save as...</source>
-					  <target>Lagre som...</target>
+						<source>Save as...</source>
+						<target>Lagre som...</target>
 					</trans-unit>
 					<trans-unit id="close">
-					  <source>Close</source>
-					  <target>Lukk</target>
+						<source>Close</source>
+						<target>Lukk</target>
 					</trans-unit>
 					<trans-unit id="new_message">
-					  <source>Do you want to save data before creating a new train?</source>
-					  <target>Ønsker du å lagre før du lager et nytt tog?</target>
+						<source>Do you want to save data before creating a new train?</source>
+						<target>Ønsker du å lagre før du lager et nytt tog?</target>
 					</trans-unit>
 					<trans-unit id="open_message">
-					  <source>Do you want to save data before opening another train?</source>
-					  <target>Ønsker du å lagre data før åpne ett nytt tog?</target>
+						<source>Do you want to save data before opening another train?</source>
+						<target>Ønsker du å lagre data før åpne ett nytt tog?</target>
 					</trans-unit>
 					<trans-unit id="close_message">
-					  <source>Do you want to save data before closing?</source>
-					  <target>Ønsker du å lagre data før du lukker?</target>
+						<source>Do you want to save data before closing?</source>
+						<target>Ønsker du å lagre data før du lukker?</target>
 					</trans-unit>
 					<trans-unit id="properties_one">
-					  <source>Properties (1)</source>
-					  <target>Egenskaper (1)</target>
+						<source>Properties (1)</source>
+						<target>Egenskaper (1)</target>
 					</trans-unit>
 					<trans-unit id="properties_two">
-					  <source>Properties (2)</source>
-					  <target>Egenskaper (2)</target>
+						<source>Properties (2)</source>
+						<target>Egenskaper (2)</target>
 					</trans-unit>
 				</group>
 				<group id="performance">
 					<trans-unit id="performance">
-					  <source>Performance</source>
-					  <target>Ytelse</target>
+						<source>Performance</source>
+						<target>Ytelse</target>
 					</trans-unit>
 					<trans-unit id="deceleration">
-					  <source>Deceleration:</source>
-					  <target>Fartsreduksjon:</target>
+						<source>Deceleration:</source>
+						<target>Fartsreduksjon:</target>
 					</trans-unit>
 					<trans-unit id="static_friction">
-					  <source>CoefficientOfStaticFriction:</source>
-					  <target>Koeffisient for statisk friksjon</target>
+						<source>CoefficientOfStaticFriction:</source>
+						<target>Koeffisient for statisk friksjon</target>
 					</trans-unit>
 					<trans-unit id="rolling_resistance">
-					  <source>CoefficientOfRollingResistance:</source>
-					  <target>Koeffisient for rullemotstand</target>
+						<source>CoefficientOfRollingResistance:</source>
+						<target>Koeffisient for rullemotstand</target>
 					</trans-unit>
 					<trans-unit id="aerodynamic_drag">
-					  <source>AerodynamicDragCoefficient:</source>
-					  <target>Koeffisient for luftmotstand</target>
+						<source>AerodynamicDragCoefficient:</source>
+						<target>Koeffisient for luftmotstand</target>
 					</trans-unit>
 				</group>
 				<group id="delay">
 					<trans-unit id="delay">
-					  <source>Delay</source>
-					  <target>Forsinkelse</target>
+						<source>Delay</source>
+						<target>Forsinkelse</target>
 					</trans-unit>
 					<trans-unit id="power_up">
-					  <source>DelayPowerUp</source>
-					  <target>Forsinkelse turtall opp</target>
+						<source>DelayPowerUp</source>
+						<target>Forsinkelse turtall opp</target>
 					</trans-unit>
 					<trans-unit id="power_down">
-					  <source>DelayPowerDown</source>
-					  <target>Forsinkelse turtall ned</target>
+						<source>DelayPowerDown</source>
+						<target>Forsinkelse turtall ned</target>
 					</trans-unit>
 					<trans-unit id="brake_up">
-					  <source>DelayBrakeUp</source>
-					  <target>Forsinkelse bremse på</target>
+						<source>DelayBrakeUp</source>
+						<target>Forsinkelse bremse på</target>
 					</trans-unit>
 					<trans-unit id="brake_down">
-					  <source>DelayBrakeDown</source>
-					  <target>Forsinkelse bremse av</target>
+						<source>DelayBrakeDown</source>
+						<target>Forsinkelse bremse av</target>
 					</trans-unit>
 					<trans-unit id="set">
-					  <source>Set</source>
-					  <target>Set</target>
+						<source>Set</source>
+						<target>Set</target>
 					</trans-unit>
 					<trans-unit id="notch">
-					  <source>Notch</source>
-					  <target>Hakk</target>
+						<source>Notch</source>
+						<target>Hakk</target>
 					</trans-unit>
 					<trans-unit id="save">
-					  <source>Save</source>
-					  <target>Lagre</target>
+						<source>Save</source>
+						<target>Lagre</target>
 					</trans-unit>
 					<trans-unit id="cancel">
-					  <source>Cancel</source>
-					  <target>Avbryt</target>
+						<source>Cancel</source>
+						<target>Avbryt</target>
 					</trans-unit>
 				</group>
 				<group id="move">
 					<trans-unit id="move">
-					  <source>Move</source>
-					  <target>Bevegelse</target>
+						<source>Move</source>
+						<target>Bevegelse</target>
 					</trans-unit>
 					<trans-unit id="jerk_power_up">
-					  <source>JerkPowerUp:</source>
-					  <target>Dytt aksl. opp</target>
+						<source>JerkPowerUp:</source>
+						<target>Dytt aksl. opp</target>
 					</trans-unit>
 					<trans-unit id="jerk_power_down">
-					  <source>JerkPowerDown:</source>
-					  <target>Dytt aksl. ned</target>
+						<source>JerkPowerDown:</source>
+						<target>Dytt aksl. ned</target>
 					</trans-unit>
 					<trans-unit id="jerk_brake_up">
-					  <source>JerkBrakeUp:</source>
-					  <target>Dytt brems på</target>
+						<source>JerkBrakeUp:</source>
+						<target>Dytt brems på</target>
 					</trans-unit>
 					<trans-unit id="jerk_brake_down">
-					  <source>JerkBrakeDown:</source>
-					  <target>Dytt brems av</target>
+						<source>JerkBrakeDown:</source>
+						<target>Dytt brems av</target>
 					</trans-unit>
 					<trans-unit id="brake_cylinder_up">
-					  <source>BrakeCylinderUp:</source>
-					  <target>Bremsesylinder opp</target>
+						<source>BrakeCylinderUp:</source>
+						<target>Bremsesylinder opp</target>
 					</trans-unit>
 					<trans-unit id="brake_cylinder_down">
-					  <source>BrakeCylinderDown:</source>
-					  <target>Bremsesylinder ned</target>
+						<source>BrakeCylinderDown:</source>
+						<target>Bremsesylinder ned</target>
 					</trans-unit>
 				</group>
 				<group id="brake">
 					<trans-unit id="brake">
-					  <source>Brake</source>
-					  <target>Bremse</target>
+						<source>Brake</source>
+						<target>Bremse</target>
 					</trans-unit>
 					<trans-unit id="type">
-					  <source>BrakeType:</source>
-					  <target>Bremsesystem:</target>
+						<source>BrakeType:</source>
+						<target>Bremsesystem:</target>
 					</trans-unit>
 					<trans-unit id="control_system">
-					  <source>BrakeControlSystem:</source>
-					  <target>Bremsekontrollsystem:</target>
+						<source>BrakeControlSystem:</source>
+						<target>Bremsekontrollsystem:</target>
 					</trans-unit>
 					<trans-unit id="control_speed">
-					  <source>BrakeControlSpeed:</source>
-					  <target>Bremsekontrollfart</target>
+						<source>BrakeControlSpeed:</source>
+						<target>Bremsekontrollfart</target>
 					</trans-unit>
 					<trans-unit id="smee">
-					  <source>Electromagnetic straight air brake</source>
-					  <target>Elektromagnetisk rett luftbremse</target>
+						<source>Electromagnetic straight air brake</source>
+						<target>Elektromagnetisk rett luftbremse</target>
 					</trans-unit>
 					<trans-unit id="ecb">
-					  <source>Electro-pneumatic air brake without brake pipe</source>
-					  <target>Elektronisk pneumatisk luftbremse uten bremserør</target>
+						<source>Electro-pneumatic air brake without brake pipe</source>
+						<target>Elektronisk pneumatisk luftbremse uten bremserør</target>
 					</trans-unit>
 					<trans-unit id="cl">
-					  <source>Air brake with partial release feature</source>
-					  <target>Luftbrems med delvis utslipp</target>
+						<source>Air brake with partial release feature</source>
+						<target>Luftbrems med delvis utslipp</target>
 					</trans-unit>
 					<trans-unit id="control_system_none">
-					  <source>None</source>
-					  <target>Ingen</target>
+						<source>None</source>
+						<target>Ingen</target>
 					</trans-unit>
 					<trans-unit id="lock_out_valve">
-					  <source>Closing electromagnetic valve</source>
-					  <target>Lukket elektromagnetisk hvelv</target>
+						<source>Closing electromagnetic valve</source>
+						<target>Lukket elektromagnetisk hvelv</target>
 					</trans-unit>
 					<trans-unit id="delay_including_control">
-					  <source>Delay-including control</source>
-					  <target>Inkludert forsinkelses kontroll</target>
+						<source>Delay-including control</source>
+						<target>Inkludert forsinkelses kontroll</target>
 					</trans-unit>
 				</group>
 				<group id="pressure">
 					<trans-unit id="pressure">
-					  <source>Pressure</source>
-					  <target>Trykk</target>
+						<source>Pressure</source>
+						<target>Trykk</target>
 					</trans-unit>
 					<trans-unit id="brake_cylinder_service_max">
-					  <source>BrakeCylinderServiceMaximumPressure:</source>
-					  <target>Bremsesylinder maks operasjonelt trykk:</target>
+						<source>BrakeCylinderServiceMaximumPressure:</source>
+						<target>Bremsesylinder maks operasjonelt trykk:</target>
 					</trans-unit>
 					<trans-unit id="brake_cylinder_emergency_max">
-					  <source>BrakeCylinderEmergencyMaximumPressure:</source>
-					  <target>Bremsesylinder maks nødstopp trykk:</target>
-					  <target></target>
+						<source>BrakeCylinderEmergencyMaximumPressure:</source>
+						<target>Bremsesylinder maks nødstopp trykk:</target>
 					</trans-unit>
 					<trans-unit id="main_reservoir_min">
-					  <source>MainReservoirMinimumPressure:</source>
-					  <target>Hoved reservoar minimumstrykk:</target>
+						<source>MainReservoirMinimumPressure:</source>
+						<target>Hoved reservoar minimumstrykk:</target>
 					</trans-unit>
 					<trans-unit id="main_reservoir_max">
-					  <source>MainReservoirMaximumPressure:</source>
-					  <target>Hoved reservoar maksimumstrykk:</target>
+						<source>MainReservoirMaximumPressure:</source>
+						<target>Hoved reservoar maksimumstrykk:</target>
 					</trans-unit>
 					<trans-unit id="brake_pipe_normal">
-					  <source>BrakePipeNormalPressure:</source>
-					  <target>Bremserørets normale trykk:</target>
+						<source>BrakePipeNormalPressure:</source>
+						<target>Bremserørets normale trykk:</target>
 					</trans-unit>
 				</group>
 				<group id="handle">
 					<trans-unit id="handle">
-					  <source>Handle</source>
-					  <target>Spaker</target>
+						<source>Handle</source>
+						<target>Spaker</target>
 					</trans-unit>
 					<trans-unit id="type">
-					  <source>HandleType:</source>
-					  <target>Spak type:</target>
+						<source>HandleType:</source>
+						<target>Spak type:</target>
 					</trans-unit>
 					<trans-unit id="power_notches">
-					  <source>PowerNotches:</source>
-					  <target>Turtallhakk</target>
+						<source>PowerNotches:</source>
+						<target>Turtallhakk</target>
 					</trans-unit>
 					<trans-unit id="brake_notches">
-					  <source>BrakeNotches:</source>
-					  <target>Bremsehakk</target>
+						<source>BrakeNotches:</source>
+						<target>Bremsehakk</target>
 					</trans-unit>
 					<trans-unit id="driver_power_notches">
-					  <source>DriverPowerNotches:</source>
-					  <target>Fører turtall hakk:</target>
+						<source>DriverPowerNotches:</source>
+						<target>Fører turtall hakk:</target>
 					</trans-unit>
 					<trans-unit id="driver_brake_notches">
-					  <source>DriverBrakeNotches:</source>
-					  <target>Fører bremse hakk:</target>
+						<source>DriverBrakeNotches:</source>
+						<target>Fører bremse hakk:</target>
 					</trans-unit>
 					<trans-unit id="power_notch_reduce_steps">
-					  <source>PowerNotchReduceSteps:</source>
-					  <target>Fører reduserende hakk</target>
+						<source>PowerNotchReduceSteps:</source>
+						<target>Fører reduserende hakk</target>
 					</trans-unit>
 					<trans-unit id="separated">
-					  <source>Separated</source>
-					  <target>Separat</target>
+						<source>Separated</source>
+						<target>Separat</target>
 					</trans-unit>
 					<trans-unit id="combined">
-					  <source>Combined</source>
-					  <target>Kombinert</target>
+						<source>Combined</source>
+						<target>Kombinert</target>
 					</trans-unit>
 					<trans-unit id="brake_notches_error_message">
-					  <source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
-					  <target>Bremsehakk må være minst 1 hvis parkeringsbremsen er satt.</target>
+						<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						<target>Bremsehakk må være minst 1 hvis parkeringsbremsen er satt.</target>
 					</trans-unit>
 					<trans-unit id="driver_power_notches_error_message">
-					  <source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
-					  <target>Førerbremsen må være mindre eller lik turtallshakkene.</target>
+						<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						<target>Førerbremsen må være mindre eller lik turtallshakkene.</target>
 					</trans-unit>
 					<trans-unit id="driver_brake_notches_error_message">
-					  <source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
-					  <target>Førers bremsehakk må være mindre eller lik bremsehakkene</target>
+						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
+						<target>Førers bremsehakk må være mindre eller lik bremsehakkene</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
 					<trans-unit id="cab">
-					  <source>Cab</source>
-					  <target>Førerhytten</target>
+						<source>Cab</source>
+						<target>Førerhytten</target>
 					</trans-unit>
 					<trans-unit id="driver_car">
-					  <source>DriverCar:</source>
-					  <target>Førervogna:</target>
+						<source>DriverCar:</source>
+						<target>Førervogna:</target>
 					</trans-unit>
 					<trans-unit id="driver_car_error_message">
-					  <source>DriverCar must be less than NumberOfMotorCars + NumberOfTrailerCars.</source>
-
+						<source>DriverCar must be less than NumberOfMotorCars + NumberOfTrailerCars.</source>
 					</trans-unit>
 				</group>
 				<group id="car">
 					<trans-unit id="car">
-					  <source>Car</source>
-					  <target>Vogner</target>
+						<source>Car</source>
+						<target>Vogner</target>
 					</trans-unit>
 					<trans-unit id="motor_car_mass">
-					  <source>MotorCarMass:</source>
-					  <target>Motorvognmasse:</target>
+						<source>MotorCarMass:</source>
+						<target>Motorvognmasse:</target>
 					</trans-unit>
 					<trans-unit id="number_of_motor_cars">
-					  <source>NumberOfMotorCars:</source>
-					  <target>Antall motorvogner:</target>
+						<source>NumberOfMotorCars:</source>
+						<target>Antall motorvogner:</target>
 					</trans-unit>
 					<trans-unit id="trailer_car_mass">
-					  <source>TrailerCarMass:</source>
-					  <target>Trekkvognmasse:</target>
+						<source>TrailerCarMass:</source>
+						<target>Trekkvognmasse:</target>
 					</trans-unit>
 					<trans-unit id="number_of_trailer_cars">
-					  <source>NumberOfTrailerCars:</source>
-					  <target>Antall trekkvogner:</target>
+						<source>NumberOfTrailerCars:</source>
+						<target>Antall trekkvogner:</target>
 					</trans-unit>
 					<trans-unit id="length_of_a_car">
-					  <source>LengthOfACar:</source>
-					  <target>Lengde på vogn:</target>
+						<source>LengthOfACar:</source>
+						<target>Lengde på vogn:</target>
 					</trans-unit>
 					<trans-unit id="front_car_is_motor_car">
-					  <source>FrontCarIsMotorCar:</source>
-					  <target>Fremste vogn har motor:</target>
+						<source>FrontCarIsMotorCar:</source>
+						<target>Fremste vogn har motor:</target>
 					</trans-unit>
 					<trans-unit id="width_of_a_car">
-					  <source>WidthOfACar:</source>
-					  <target>Vognbredde:</target>
+						<source>WidthOfACar:</source>
+						<target>Vognbredde:</target>
 					</trans-unit>
 					<trans-unit id="height_of_a_car">
-					  <source>HeightOfACar:</source>
-					  <target>Vognhøyde</target>
+						<source>HeightOfACar:</source>
+						<target>Vognhøyde</target>
 					</trans-unit>
 					<trans-unit id="center_of_gravity_height">
-					  <source>CenterOfGravityHeight:</source>
-					  <target>Senter for gravitasjon høyde:</target>
+						<source>CenterOfGravityHeight:</source>
+						<target>Senter for gravitasjon høyde:</target>
 					</trans-unit>
 					<trans-unit id="exposed_frontal_area">
-					  <source>ExposedFrontalArea:</source>
-					  <target>Eksponert frontalområde</target>
+						<source>ExposedFrontalArea:</source>
+						<target>Eksponert frontalområde</target>
 					</trans-unit>
 					<trans-unit id="unexposed_frontal_area">
-					  <source>UnexposedFrontalArea:</source>
-					  <target>Ikke-eksponert frontalområde</target>
+						<source>UnexposedFrontalArea:</source>
+						<target>Ikke-eksponert frontalområde</target>
 					</trans-unit>
 					<trans-unit id="number_of_trailer_cars_error_message">
-					  <source>NumberOfTrailerCars must be at least 1 if FrontCarIsAMotorCar is not set.</source>
-					  <target>Antall trekkvogner må være minst 1 hvis første vogn ikke er satt til motorvogn.</target>
+						<source>NumberOfTrailerCars must be at least 1 if FrontCarIsAMotorCar is not set.</source>
+						<target>Antall trekkvogner må være minst 1 hvis første vogn ikke er satt til motorvogn.</target>
 					</trans-unit>
 				</group>
 				<group id="device">
 					<trans-unit id="device">
-					  <source>Device</source>
-					  <target>Enheter</target>
+						<source>Device</source>
+						<target>Enheter</target>
 					</trans-unit>
 					<trans-unit id="const_speed">
-					  <source>ConstSpeed:</source>
-					  <target>Kruskontroll:</target>
+						<source>ConstSpeed:</source>
+						<target>Kruskontroll:</target>
 					</trans-unit>
 					<trans-unit id="hold_brake">
-					  <source>HoldBrake:</source>
-					  <target>Parkeringsbrems:</target>
+						<source>HoldBrake:</source>
+						<target>Parkeringsbrems:</target>
 					</trans-unit>
 					<trans-unit id="readhesion_device">
-					  <source>ReAdhesionDevice:</source>
-					  <target>Re-adhesjonenhet:</target>
-					  <target></target>
+						<source>ReAdhesionDevice:</source>
+						<target>Re-adhesjonenhet:</target>
 					</trans-unit>
 					<trans-unit id="pass_alarm">
-					  <source>PassAlarm:</source>
-					  <target>Passeringsalarm:</target>
+						<source>PassAlarm:</source>
+						<target>Passeringsalarm:</target>
 					</trans-unit>
 					<trans-unit id="door_open_mode">
-					  <source>DoorOpenMode:</source>
-					  <target>Døråpningsmetode:</target>
+						<source>DoorOpenMode:</source>
+						<target>Døråpningsmetode:</target>
 					</trans-unit>
 					<trans-unit id="door_close_mode">
-					  <source>DoorCloseMode:</source>
-					  <target>Dørlukkingsmetode:</target>
+						<source>DoorCloseMode:</source>
+						<target>Dørlukkingsmetode:</target>
 					</trans-unit>
 					<trans-unit id="door_width">
-					  <source>DoorWidth:</source>
-					  <target>Dørbredde:</target>
+						<source>DoorWidth:</source>
+						<target>Dørbredde:</target>
 					</trans-unit>
 					<trans-unit id="door_max_tolerance">
-					  <source>DoorMaxTolerance:</source>
-					  <target>Dørens makstoleranse:</target>
+						<source>DoorMaxTolerance:</source>
+						<target>Dørens makstoleranse:</target>
 					</trans-unit>
 					<trans-unit id="none">
-					  <source>None</source>
-					  <target>Ingen</target>
+						<source>None</source>
+						<target>Ingen</target>
 					</trans-unit>
 					<trans-unit id="manual_switching">
-					  <source>Manual switching</source>
-					  <target>Manuell switching</target>
+						<source>Manual switching</source>
+						<target>Manuell switching</target>
 					</trans-unit>
 					<trans-unit id="automatic_switching">
-					  <source>Automatic switching</source>
-					  <target>Automatisk switching</target>
+						<source>Automatic switching</source>
+						<target>Automatisk switching</target>
 					</trans-unit>
 					<trans-unit id="type_a">
-					  <source>Type A (instant)</source>
-					  <target>Type A (umiddelbart)</target>
+						<source>Type A (instant)</source>
+						<target>Type A (umiddelbart)</target>
 					</trans-unit>
 					<trans-unit id="type_b">
-					  <source>Type B (slow)</source>
-					  <target>Type B (sein)</target>
+						<source>Type B (slow)</source>
+						<target>Type B (sein)</target>
 					</trans-unit>
 					<trans-unit id="type_c">
-					  <source>Type C (medium)</source>
-					  <target>Type C (medium)</target>
+						<source>Type C (medium)</source>
+						<target>Type C (medium)</target>
 					</trans-unit>
 					<trans-unit id="type_d">
-					  <source>Type D (fast)</source>
-					  <target>Type D (rask)</target>
+						<source>Type D (fast)</source>
+						<target>Type D (rask)</target>
 					</trans-unit>
 					<trans-unit id="single">
-					  <source>Single</source>
-					  <target>Enkel alarm</target>
+						<source>Single</source>
+						<target>Enkel alarm</target>
 					</trans-unit>
 					<trans-unit id="looping">
-					  <source>Looping</source>
-					  <target>Repeterende</target>
+						<source>Looping</source>
+						<target>Repeterende</target>
 					</trans-unit>
 					<trans-unit id="semi_automatic">
-					  <source>Semi-automatic</source>
-					  <target>Semi-automatisk</target>
+						<source>Semi-automatic</source>
+						<target>Semi-automatisk</target>
 					</trans-unit>
 					<trans-unit id="automatic">
-					  <source>Automatic</source>
-					  <target>Automatisk</target>
+						<source>Automatic</source>
+						<target>Automatisk</target>
 					</trans-unit>
 					<trans-unit id="manual">
-					  <source>Manual</source>
-					  <target>Manuell</target>
+						<source>Manual</source>
+						<target>Manuell</target>
 					</trans-unit>
 				</group>
 				<group id="acceleration">
 					<trans-unit id="acceleration">
-					  <source>Acceleration</source>
-					  <target>Akselerasjon</target>
+						<source>Acceleration</source>
+						<target>Akselerasjon</target>
 					</trans-unit>
 					<trans-unit id="notch">
-					  <source>Notch:</source>
-					  <target>Hakk / Trinn:</target>
+						<source>Notch:</source>
+						<target>Hakk / Trinn:</target>
 					</trans-unit>
 					<trans-unit id="data">
-					  <source>Data</source>
-					  <target>Data</target>
+						<source>Data</source>
+						<target>Data</target>
 					</trans-unit>
 					<trans-unit id="preview">
-					  <source>Preview</source>
-					  <target>Forhåndsvis</target>
+						<source>Preview</source>
+						<target>Forhåndsvis</target>
 					</trans-unit>
 					<trans-unit id="subtract_deceleration">
-					  <source>Subtract deceleration due to air and rolling resistance</source>
-					  <target>Trekk fra deselerasjon på grunn av luft- og rullemotstand</target>
+						<source>Subtract deceleration due to air and rolling resistance</source>
+						<target>Trekk fra deselerasjon på grunn av luft- og rullemotstand</target>
 					</trans-unit>
 					<trans-unit id="max_x">
-					  <source>Xmax:</source>
-					  <target>XMaks:</target>
+						<source>Xmax:</source>
+						<target>XMaks:</target>
 					</trans-unit>
 					<trans-unit id="max_y">
-					  <source>Ymax:</source>
-					  <target>YMax:</target>
+						<source>Ymax:</source>
+						<target>YMax:</target>
 					</trans-unit>
 				</group>
 				<group id="motor">
 					<trans-unit id="sound">
-					  <source>Motor Sound</source>
-					  <target>Motorlyd</target>
+						<source>Motor Sound</source>
+						<target>Motorlyd</target>
 					</trans-unit>
 					<trans-unit id="edit">
-					  <source>Edit mode</source>
-					  <target>Redigeringsmodus</target>
+						<source>Edit mode</source>
+						<target>Redigeringsmodus</target>
 					</trans-unit>
 					<trans-unit id="sound_index">
-					  <source>SoundIndex:</source>
-					  <target>Lydindeks:</target>
+						<source>SoundIndex:</source>
+						<target>Lydindeks:</target>
 					</trans-unit>
 					<trans-unit id="pitch">
-					  <source>Pitch</source>
-					  <target>Pitch</target>
+						<source>Pitch</source>
+						<target>Pitch</target>
 					</trans-unit>
 					<trans-unit id="volume">
-					  <source>Volume</source>
-					  <target>Nivå</target>
+						<source>Volume</source>
+						<target>Nivå</target>
 					</trans-unit>
 					<trans-unit id="sound_none">
-					  <source>None</source>
-					  <target>Ingen</target>
+						<source>None</source>
+						<target>Ingen</target>
 					</trans-unit>
 					<trans-unit id="preview">
-					  <source>Preview</source>
-					  <target>Forhåndsvis</target>
+						<source>Preview</source>
+						<target>Forhåndsvis</target>
 					</trans-unit>
 					<trans-unit id="y_pitch">
-					  <source>Ypitch</source>
-					  <target>Y-pitch</target>
+						<source>Ypitch</source>
+						<target>Y-pitch</target>
 					</trans-unit>
 					<trans-unit id="y_volume">
-					  <source>Yvolume</source>
-					  <target>Y-nivå</target>
+						<source>Yvolume</source>
+						<target>Y-nivå</target>
 					</trans-unit>
 					<trans-unit id="min_x">
-					  <source>Xmin:</source>
-					  <target>Xmin:</target>
+						<source>Xmin:</source>
+						<target>Xmin:</target>
 					</trans-unit>
 					<trans-unit id="max_x">
-					  <source>Xmax:</source>
-					  <target>Xmaks:</target>
+						<source>Xmax:</source>
+						<target>Xmaks:</target>
 					</trans-unit>
 					<trans-unit id="left">
-					  <source>Left</source>
-					  <target>Venstre</target>
+						<source>Left</source>
+						<target>Venstre</target>
 					</trans-unit>
 					<trans-unit id="right">
-					  <source>Right</source>
-					  <target>Høyre</target>
+						<source>Right</source>
+						<target>Høyre</target>
 					</trans-unit>
 					<trans-unit id="in">
-					  <source>In</source>
-					  <target>Inne</target>
+						<source>In</source>
+						<target>Inne</target>
 					</trans-unit>
 					<trans-unit id="out">
-					  <source>Out</source>
-					  <target>Ute</target>
+						<source>Out</source>
+						<target>Ute</target>
 					</trans-unit>
 					<trans-unit id="max_y_pitch">
-					  <source>YmaxPitch:</source>
-					  <target>Maks y pitch:</target>
+						<source>YmaxPitch:</source>
+						<target>Maks y pitch:</target>
 					</trans-unit>
 					<trans-unit id="max_y_volume">
-					  <source>YmaxVolume:</source>
-					  <target>Maks y nivå:</target>
+						<source>YmaxVolume:</source>
+						<target>Maks y nivå:</target>
 					</trans-unit>
 				</group>
 				<group id="extended">
 					<trans-unit id="features">
-					  <source>Extended Features</source>
-					  <target>Utvidede funksjoner</target>
+						<source>Extended Features</source>
+						<target>Utvidede funksjoner</target>
 					</trans-unit>
 					<trans-unit id="note">
-					  <source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-					  <target>Obs: Disse funksjonene krever minimum denne versjonen av openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Obs: Disse funksjonene krever minimum denne versjonen av OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
-					  <source>Locomotive Brake</source>
-					  <target>Lokomotivbremse</target>
+						<source>Locomotive Brake</source>
+						<target>Lokomotivbremse</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_system_type">
-					  <source>BrakeType:</source>
-					  <target>Bremsetype</target>
+						<source>BrakeType:</source>
+						<target>Bremsetype</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_notches">
-					  <source>Notches:</source>
-					  <target>Hakk:</target>
+						<source>Notches:</source>
+						<target>Hakk:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_delay_up">
-					  <source>DelayUp:</source>
-					  <target>Forsinkelse opp:</target>
+						<source>DelayUp:</source>
+						<target>Forsinkelse opp:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_delay_down">
-					  <source>DelayDown:</source>
-					  <target>Forsinkelse ned:</target>
+						<source>DelayDown:</source>
+						<target>Forsinkelse ned:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_type">
-					  <source>Type:</source>
-					  <target>Type:</target>
+						<source>Type:</source>
+						<target>Type:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_set">
 						<source>Set</source>
 					</trans-unit>
 					<trans-unit id="loco_brake_none">
-					  <source>Not fitted</source>
-					  <target>Ikke tilpasset</target>
+						<source>Not fitted</source>
+						<target>Ikke tilpasset</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_notched_air_brake">
-					  <source>Notched air brake</source>
-					  <target>Trinnvis luftbrems</target>
+						<source>Notched air brake</source>
+						<target>Trinnvis luftbrems</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_cl">
-					  <source>Air brake with partial release</source>
-					  <target>Luftbrems med delvis utslipp</target>
+						<source>Air brake with partial release</source>
+						<target>Luftbrems med delvis utslipp</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_combined">
-					  <source>Combined</source>
-					  <target>Kombinert</target>
+						<source>Combined</source>
+						<target>Kombinert</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_independant">
-					  <source>Independent</source>
-					  <target>Uavhengig</target>
+						<source>Independent</source>
+						<target>Uavhengig</target>
 					</trans-unit>
 					<trans-unit id="loco_brake_blocking">
-					  <source>Blocking</source>
-					  <target>Blokerende</target>
+						<source>Blocking</source>
+						<target>Blokerende</target>
 					</trans-unit>
 					<trans-unit id="delay_loco_brake_up">
-					  <source>DelayLocoBrakeUp</source>
-					  <target>Forsinkelse lokomotivbrems opp</target>
+						<source>DelayLocoBrakeUp</source>
+						<target>Forsinkelse lokomotivbrems opp</target>
 					</trans-unit>
 					<trans-unit id="delay_loco_brake_down">
-					  <source>DelayLocoBrakeDown</source>
-					  <target>Forsinkelse lokomotivbrems ned</target>
+						<source>DelayLocoBrakeDown</source>
+						<target>Forsinkelse lokomotivbrems ned</target>
 					</trans-unit>
 					<trans-unit id="misc">
-					  <source>Miscellaneous Features</source>
-					  <target>Diverse egenskaper</target>>
+						<source>Miscellaneous Features</source>
+						<target>Diverse egenskaper</target>
 					</trans-unit>
 					<trans-unit id="misc_eb">
-					  <source>Handle behaviour on EB:</source>
-					  <target>Spakoppførsel ved NB:</target>
+						<source>Handle behaviour on EB:</source>
+						<target>Spakoppførsel ved NB:</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_no">
-					  <source>No Action</source>
-					  <target>Ingen handling</target>					  
+						<source>No Action</source>
+						<target>Ingen handling</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_power">
-					  <source>Return Power to neutral</source>
-					  <target>Sett turtall i nøytral</target>
+						<source>Return Power to neutral</source>
+						<target>Sett turtall i nøytral</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_reverser">
-					  <source>Return Reverser to neutral</source>
-					  <target>Sett vendegir til nøytral</target>
+						<source>Return Reverser to neutral</source>
+						<target>Sett vendegir til nøytral</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_power_reverser">
-					  <source>Return Power and Reverser to neutral</source>
-					  <target>Sett turtall og vendegir til nøytral</target>
+						<source>Return Power and Reverser to neutral</source>
+						<target>Sett turtall og vendegir til nøytral</target>
 					</trans-unit>
 					<trans-unit id="language">
-					  <source>Language</source>
-					  <target>Språk</target>
+						<source>Language</source>
+						<target>Språk</target>
 					</trans-unit>
 				</group>
 			</group>
@@ -3805,202 +4036,213 @@
 				<group id="menu">
 					<group id="file">
 						<trans-unit id="name">
-						  <source>File</source>
-						  <target>Fil</target>
+							<source>File</source>
+							<target>Fil</target>
 						</trans-unit>
 						<trans-unit id="new">
-						  <source>New</source>
-						  <target>Ny</target>
+							<source>New</source>
+							<target>Ny</target>
 						</trans-unit>
 						<trans-unit id="open">
-						  <source>Open...</source>
-						  <target>Åpne...</target>
+							<source>Open...</source>
+							<target>Åpne...</target>
 						</trans-unit>
 						<trans-unit id="save">
-						  <source>Save</source>
-						  <target>Lagre</target>
+							<source>Save</source>
+							<target>Lagre</target>
 						</trans-unit>
 						<trans-unit id="save_as">
-						  <source>Save as...</source>
-						  <target>Lagre som...</target>
+							<source>Save as...</source>
+							<target>Lagre som...</target>
 						</trans-unit>
 						<trans-unit id="import">
-						  <source>Import...</source>
-						  <target>Importer...</target>
+							<source>Import...</source>
+							<target>Importer...</target>
 						</trans-unit>
 						<trans-unit id="export">
-						  <source>Export...</source>
-						  <target>Eksporter...</target>
+							<source>Export...</source>
+							<target>Eksporter...</target>
 						</trans-unit>
 						<trans-unit id="exit">
-						  <source>Exit</source>
-						  <target>Avslutt</target>
+							<source>Exit</source>
+							<target>Avslutt</target>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-						  <source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
-						  <target>Du har forsøkt å åpnet et tog \n\n Disse kan ikke åpnes direkte. \n\n Bruk importfunksjonen for å importere toget til TrainEditor2</target>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
+							<target>Du har forsøkt å åpnet et tog \n\n Disse kan ikke åpnes direkte. \n\n Bruk importfunksjonen for å importere toget til TrainEditor2</target>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="new">
+							<source>Do you want to save the current file before creating a new one?</source>
+							<target>Ønsker du å lagre den nåværende filen før du lager en ny en?</target>
+						</trans-unit>
+						<trans-unit id="open">
+							<source>Do you want to save the current file before opening another file?</source>
+							<target>Ønsker du å lagre den nåværende filen før du åpner en ny en?</target>
+						</trans-unit>
+						<trans-unit id="exit">
+							<source>Do you want to save the current file before closing?</source>
+							<target>Ønsker du å lagre den nåværende filen før du lukker?</target>
 						</trans-unit>
 					</group>
 					<trans-unit id="language">
-					  <source>Language</source>
-					  <target>Språk</target>
+						<source>Language</source>
+						<target>Språk</target>
 					</trans-unit>
-					<group id="message">
-						<trans-unit id="new">
-						  <source>Do you want to save the current file before creating a new one?</source>
-						  <target>Ønsker du å lagre den nåværende filen før du lager en ny en?</target>
-						</trans-unit>
-						<trans-unit id="open">
-						  <source>Do you want to save the current file before opening another file?</source>
-						  <target>Ønsker du å lagre den nåværende filen før du åpner en ny en?</target>
-						</trans-unit>
-						<trans-unit id="exit">
-						  <source>Do you want to save the current file before closing?</source>
-						  <target>Ønsker du å lagre den nåværende filen før du lukker?</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
-					  <source>Up</source>
-					  <target>Opp</target>
+						<source>Up</source>
+						<target>Opp</target>
 					</trans-unit>
 					<trans-unit id="down">
-					  <source>Down</source>
-					  <target>Ned</target>
+						<source>Down</source>
+						<target>Ned</target>
 					</trans-unit>
 					<trans-unit id="add">
-					  <source>Add</source>
-					  <target>Legg til</target>
+						<source>Add</source>
+						<target>Legg til</target>
 					</trans-unit>
 					<trans-unit id="remove">
-					  <source>Remove</source>
-					  <target>Fjern</target>
+						<source>Remove</source>
+						<target>Fjern</target>
 					</trans-unit>
 					<trans-unit id="copy">
-					  <source>Copy</source>
-					  <target>Kopier</target>
+						<source>Copy</source>
+						<target>Kopier</target>
 					</trans-unit>
 					<trans-unit id="set">
-					  <source>Set...</source>
-					  <target>Set...</target>
+						<source>Set...</source>
+						<target>Set...</target>
 					</trans-unit>
 					<trans-unit id="open">
-					  <source>Open...</source>
-					  <target>Åpne...</target>
+						<source>Open...</source>
+						<target>Åpne...</target>
 					</trans-unit>
 				</group>
 				<group id="tree_cars">
 					<trans-unit id="train">
-					  <source>Train</source>
-					  <target>Tog</target>
+						<source>Train</source>
+						<target>Tog</target>
 					</trans-unit>
 					<trans-unit id="general">
-					  <source>General</source>
-					  <target>Generelt</target>
+						<source>General</source>
+						<target>Generelt</target>
 					</trans-unit>
 					<trans-unit id="cars">
-					  <source>Cars</source>
-					  <target>Vogner</target>
+						<source>Cars</source>
+						<target>Vogner</target>
 					</trans-unit>
 					<trans-unit id="couplers">
-					  <source>Couplers</source>
-					  <target>Koblere</target>
+						<source>Couplers</source>
+						<target>Koblere</target>
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-					  <source>General settings</source>
-					  <target>Generelle settinger</target>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-						  <source>Handle</source>
-						  <target>Spaktype</target>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
-							  <source>HandleType</source>
-							  <target>Spaktype</target>
+								<source>HandleType</source>
+								<target>Spaktype</target>
 							</trans-unit>
 							<trans-unit id="separated">
-							  <source>Separated</source>
-							  <target>Separert</target>
+								<source>Separated</source>
+								<target>Separert</target>
 							</trans-unit>
 							<trans-unit id="combined">
-							  <source>Combined</source>
-							  <target>Kombinert</target>
+								<source>Combined</source>
+								<target>Kombinert</target>
+							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-						  <source>PowerNotches</source>
-						  <target>Turtallhakk</target>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-						  <source>BrakeNotches</source>
-						  <target>Bremsehakk</target>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-						  <source>PowerNotchReduceSteps</source>
-						  <target>Bremsehakk reduserende steg</target>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-						  <source>DriverPowerNotches</source>
-						  <target>Turtallhakk</target>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-						  <source>DriverBrakeNotches</source>
-						  <target>Bremsehakk</target>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
-							  <source>EbHandleBehaviour</source>
-							  <target>Nødbrems spak oppførsel</target>
+								<source>EbHandleBehaviour</source>
+								<target>Nødbrems spak oppførsel</target>
 							</trans-unit>
 							<trans-unit id="no">
-							  <source>No action</source>
-							  <target>Ingen handling</target>
+								<source>No action</source>
+								<target>Ingen handling</target>
 							</trans-unit>
 							<trans-unit id="power">
-							  <source>Return power to neutral</source>
-							  <target>Sett turtall i nøytral</target>
+								<source>Return power to neutral</source>
+								<target>Sett turtall i nøytral</target>
 							</trans-unit>
 							<trans-unit id="reverser">
-							  <source>Return reverser to neutral</source>
-							  <target>Sett vendegir til nøytral</target>
+								<source>Return reverser to neutral</source>
+								<target>Sett vendegir til nøytral</target>
 							</trans-unit>
 							<trans-unit id="power_reverser">
-							  <source>Return power and reverser to neutral</source>
-							  <target>Sett turtall og vendegir til nøytral</target>
+								<source>Return power and reverser to neutral</source>
+								<target>Sett turtall og vendegir til nøytral</target>
 							</trans-unit>
 						</group>
 						<group id="loco_brake_handle_type">
 							<trans-unit id="name">
-							  <source>LocoBrakeHandleType</source>
-							  <target>Lokomotivbrems type</target>
+								<source>LocoBrakeHandleType</source>
+								<target>Lokomotivbrems type</target>
 							</trans-unit>
 							<trans-unit id="combined">
-							  <source>Combined</source>
-							  <target>Kombinert</target>
+								<source>Combined</source>
+								<target>Kombinert</target>
 							</trans-unit>
 							<trans-unit id="independent">
-							  <source>Independent</source>
-							  <target>Uavhengig</target>
+								<source>Independent</source>
+								<target>Uavhengig</target>
 							</trans-unit>
 							<trans-unit id="blocking">
-							  <source>Blocking</source>
-							  <target>Blokkerende</target>
+								<source>Blocking</source>
+								<target>Blokkerende</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+							<target>Spaktype</target>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+							<target>Turtallhakk</target>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+							<target>Bremsehakk</target>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+							<target>Bremsehakk reduserende steg</target>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+							<target>Turtallhakk</target>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+							<target>Bremsehakk</target>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
-						  <source>LocoBrakeNotches</source>
-						  <target>Lokomotivbremshakk</target>
+							<source>LocoBrakeNotches</source>
+							<target>Lokomotivbremshakk</target>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
 						<trans-unit id="name">
-						  <source>Cab</source>
-						  <target>Førerhytte</target>
+							<source>Cab</source>
+							<target>Førerhytte</target>
 						</trans-unit>
 						<trans-unit id="x">
 							<source>X</source>
@@ -4012,15 +4254,11 @@
 							<source>Z</source>
 						</trans-unit>
 						<trans-unit id="driver_car">
-						  <source>DriverCar</source>
-						  <target>Førervogn</target>
+							<source>DriverCar</source>
+							<target>Førervogn</target>
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-						  <source>Device</source>
-						  <target>Enheter</target>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4043,182 +4281,188 @@
 								<source>None</source>
 							</trans-unit>
 							<trans-unit id="manual">
-							  <source>Manual switching</source>
-							  <target>Manuell switching</target>
+								<source>Manual switching</source>
+								<target>Manuell switching</target>
 							</trans-unit>
 							<trans-unit id="automatic">
-							  <source>Automatic switching</source>
-							  <target>Automatisk switching</target>
+								<source>Automatic switching</source>
+								<target>Automatisk switching</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-						  <source>Eb</source>
-						  <target>Nb</target>
-						</trans-unit>
-						<trans-unit id="const_speed">
-						  <source>ConstSpeed</source>
-						  <target>Cruise-kontroll</target>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-						  <source>HoldBrake</source>
-						  <target>Parkeringsbrems</target>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
-							  <source>ReAdhesionDevice</source>
-							  <target>Re-adhesjonenhet</target>
+								<source>ReAdhesionDevice</source>
+								<target>Re-adhesjonenhet</target>
 							</trans-unit>
 							<trans-unit id="none">
-							  <source>None</source>
-							  <target>Ingen</target>
+								<source>None</source>
+								<target>Ingen</target>
 							</trans-unit>
 							<trans-unit id="type_a">
-							  <source>Type A (instant)</source>
-							  <target>Type A (umiddelbart)</target>
+								<source>Type A (instant)</source>
+								<target>Type A (umiddelbart)</target>
 							</trans-unit>
 							<trans-unit id="type_b">
-							  <source>Type B (slow)</source>
-							  <target>Type B (sein)</target>
+								<source>Type B (slow)</source>
+								<target>Type B (sein)</target>
 							</trans-unit>
 							<trans-unit id="type_c">
-							  <source>Type C (medium)</source>
-							  <target>Type C (medium)</target>
+								<source>Type C (medium)</source>
+								<target>Type C (medium)</target>
 							</trans-unit>
 							<trans-unit id="type_d">
-							  <source>Type D (fast)</source>
-							  <target>Type D (rask)</target>
+								<source>Type D (fast)</source>
+								<target>Type D (rask)</target>
 							</trans-unit>
 						</group>
 						<group id="pass_alarm">
 							<trans-unit id="name">
-							  <source>PassAlarm</source>
-							  <target>Passeringsalarm</target>
+								<source>PassAlarm</source>
+								<target>Passeringsalarm</target>
 							</trans-unit>
 							<trans-unit id="none">
-							  <source>None</source>
-							  <target>Ingen</target>
+								<source>None</source>
+								<target>Ingen</target>
 							</trans-unit>
 							<trans-unit id="single">
-							  <source>Single</source>
-							  <target>Enkel</target>
+								<source>Single</source>
+								<target>Enkel</target>
 							</trans-unit>
 							<trans-unit id="looping">
-							  <source>Looping</source>
-							  <target>Repeterende</target>
+								<source>Looping</source>
+								<target>Repeterende</target>
 							</trans-unit>
 						</group>
 						<group id="door_mode">
 							<trans-unit id="open">
-							  <source>DoorOpenMode</source>
-							  <target>Døråpningsmetode:</target>
+								<source>DoorOpenMode</source>
+								<target>Døråpningsmetode:</target>
 							</trans-unit>
 							<trans-unit id="close">
-							  <source>DoorCloseMode</source>
-							  <target>Dørlukkingsmetode</target>
+								<source>DoorCloseMode</source>
+								<target>Dørlukkingsmetode</target>
 							</trans-unit>
 							<trans-unit id="semi_automatic">
-							  <source>Semi-automatic</source>
-							  <target>Semi-automatisk</target>
+								<source>Semi-automatic</source>
+								<target>Semi-automatisk</target>
 							</trans-unit>
 							<trans-unit id="automatic">
-							  <source>Automatic</source>
-							  <target>Automatisk</target>
+								<source>Automatic</source>
+								<target>Automatisk</target>
 							</trans-unit>
 							<trans-unit id="manual">
-							  <source>Manual</source>
-							  <target>Manuell</target>
+								<source>Manual</source>
+								<target>Manuell</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+							<target>Enheter</target>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+							<target>Nb</target>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+							<target>Cruise-kontroll</target>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+							<target>Parkeringsbrems</target>
+						</trans-unit>
 						<trans-unit id="door_width">
-						  <source>DoorWidth</source>
-						  <target>Dørbredde</target>
+							<source>DoorWidth</source>
+							<target>Dørbredde</target>
 						</trans-unit>
 						<trans-unit id="door_max_tolerance">
-						  <source>DoorMaxTolerance</source>
-						  <target>Dørens makstoleranse</target>
+							<source>DoorMaxTolerance</source>
+							<target>Dørens makstoleranse</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+						<target>Generelle settinger</target>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-					  <source>Car settings</source>
-					  <target>Vognegenskaper</target>
-					</trans-unit>
 					<group id="general">
-						<trans-unit id="name">
-						  <source>General</source>
-						  <target>Generelt</target>
-						</trans-unit>
-						<trans-unit id="is_motor_car">
-						  <source>IsMotorCar</source>
-						  <target>Er motorvogn</target>
-						</trans-unit>
-						<trans-unit id="mass">
-						  <source>Mass</source>
-						  <target>Masse</target>
-						</trans-unit>
-						<trans-unit id="length">
-						  <source>Length</source>
-						  <target>Lengde</target>
-						</trans-unit>
-						<trans-unit id="width">
-						  <source>Width</source>
-						  <target>Bredde</target>
-						</trans-unit>
-						<trans-unit id="height">
-						  <source>Height</source>
-						  <target>Høyde</target>
-						</trans-unit>
-						<trans-unit id="center_of_gravity_height">
-						  <source>CenterOfGravityHeight</source>
-						  <target>Senter for høyden på gravitasjon</target>
-						</trans-unit>
-						<trans-unit id="exposed_frontal_area">
-						  <source>ExposedFrontalArea</source>
-						  <target>Eksponert frontalområde</target>
-						</trans-unit>
-						<trans-unit id="unexposed_frontal_area">
-						  <source>UnexposedFrontalArea</source>
-						  <target>Ikke-eksponert frontalområde</target>
-						  
-						</trans-unit>
-						<trans-unit id="defined_axles">
-						  <source>DefinedAxles</source>
-						  <target>Definerte aksler</target>
-						</trans-unit>
 						<group id="axles">
 							<trans-unit id="name">
-							  <source>Axles</source>
-							  <target>Aksler</target>
+								<source>Axles</source>
+								<target>Aksler</target>
 							</trans-unit>
 							<trans-unit id="front">
-							  <source>FrontAxle</source>
-							  <target>Fram aksle</target>
+								<source>FrontAxle</source>
+								<target>Fram aksle</target>
 							</trans-unit>
 							<trans-unit id="rear">
-							  <source>RearAxle</source>
-							  <target>Bak aksle</target>
+								<source>RearAxle</source>
+								<target>Bak aksle</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>General</source>
+							<target>Generelt</target>
+						</trans-unit>
+						<trans-unit id="is_motor_car">
+							<source>IsMotorCar</source>
+							<target>Er motorvogn</target>
+						</trans-unit>
+						<trans-unit id="mass">
+							<source>Mass</source>
+							<target>Masse</target>
+						</trans-unit>
+						<trans-unit id="length">
+							<source>Length</source>
+							<target>Lengde</target>
+						</trans-unit>
+						<trans-unit id="width">
+							<source>Width</source>
+							<target>Bredde</target>
+						</trans-unit>
+						<trans-unit id="height">
+							<source>Height</source>
+							<target>Høyde</target>
+						</trans-unit>
+						<trans-unit id="center_of_gravity_height">
+							<source>CenterOfGravityHeight</source>
+							<target>Senter for høyden på gravitasjon</target>
+						</trans-unit>
+						<trans-unit id="exposed_frontal_area">
+							<source>ExposedFrontalArea</source>
+							<target>Eksponert frontalområde</target>
+						</trans-unit>
+						<trans-unit id="unexposed_frontal_area">
+							<source>UnexposedFrontalArea</source>
+							<target>Ikke-eksponert frontalområde</target>
+						</trans-unit>
+						<trans-unit id="defined_axles">
+							<source>DefinedAxles</source>
+							<target>Definerte aksler</target>
+						</trans-unit>
 						<trans-unit id="front_bogie">
-						  <source>FrontBogie</source>
-						  <target>Fremre bogie</target>
+							<source>FrontBogie</source>
+							<target>Fremre bogie</target>
 						</trans-unit>
 						<trans-unit id="rear_bogie">
-						  <source>RearBogie</source>
-						  <target>Bakre bogie</target>
+							<source>RearBogie</source>
+							<target>Bakre bogie</target>
 						</trans-unit>
 						<trans-unit id="loading_sway">
-						  <source>LoadingSway</source>
-						  <target>Laste svai</target>
+							<source>LoadingSway</source>
+							<target>Laste svai</target>
 						</trans-unit>
 						<trans-unit id="reversed">
-						  <source>Reversed</source>
-						  <target>Reversert</target>
+							<source>Reversed</source>
+							<target>Reversert</target>
 						</trans-unit>
 						<trans-unit id="object">
-						  <source>Object</source>
-						  <target>Objekt</target>
+							<source>Object</source>
+							<target>Objekt</target>
 						</trans-unit>
 					</group>
 					<group id="performance">
@@ -4240,165 +4484,174 @@
 					</group>
 					<group id="move">
 						<trans-unit id="name">
-						  <source>Move</source>
-						  <target>Bevegelse</target>
+							<source>Move</source>
+							<target>Bevegelse</target>
 						</trans-unit>
 						<trans-unit id="jerk_power_up">
-						  <source>JerkPowerUp</source>
-						  <target>Dytt aksl. opp</target>
+							<source>JerkPowerUp</source>
+							<target>Dytt aksl. opp</target>
 						</trans-unit>
 						<trans-unit id="jerk_power_down">
-						  <source>JerkPowerDown</source>
-						  <target>Dytt aksl. ned</target>
+							<source>JerkPowerDown</source>
+							<target>Dytt aksl. ned</target>
 						</trans-unit>
 						<trans-unit id="jerk_brake_up">
-						  <source>JerkBrakeUp</source>
-						  <target>Dytt brems på</target>
+							<source>JerkBrakeUp</source>
+							<target>Dytt brems på</target>
 						</trans-unit>
 						<trans-unit id="jerk_brake_down">
-						  <source>JerkBrakeDown</source>
-						  <target>Dytt brems av</target>
+							<source>JerkBrakeDown</source>
+							<target>Dytt brems av</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_up">
-						  <source>BrakeCylinderUp</source>
-						  <target>Bremsesylinder opp</target>
+							<source>BrakeCylinderUp</source>
+							<target>Bremsesylinder opp</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_down">
-						  <source>BrakeCylinderDown</source>
-						  <target>Bremsesylinder ned</target>
+							<source>BrakeCylinderDown</source>
+							<target>Bremsesylinder ned</target>
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-						  <source>Brake</source>
-						  <target>Brems</target>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
-							  <source>BrakeType</source>
-							  <target>Bremsesystem</target>
+								<source>BrakeType</source>
+								<target>Bremsesystem</target>
 							</trans-unit>
 							<trans-unit id="smee">
-							  <source>Electromagnetic straight air brake</source>
-							  <target>Elektromagnetisk rett luftbremse</target>
+								<source>Electromagnetic straight air brake</source>
+								<target>Elektromagnetisk rett luftbremse</target>
 							</trans-unit>
 							<trans-unit id="ecb">
-							  <source>Electro-pneumatic air brake without brake pipe</source>
-							  <target>Elektronisk pneumatisk luftbremse uten bremserør</target>
+								<source>Electro-pneumatic air brake without brake pipe</source>
+								<target>Elektronisk pneumatisk luftbremse uten bremserør</target>
 							</trans-unit>
 							<trans-unit id="cl">
-							  <source>Air brake with partial release feature</source>
-							  <target>Luftbrems med delvis utslipp</target>							  
+								<source>Air brake with partial release feature</source>
+								<target>Luftbrems med delvis utslipp</target>
 							</trans-unit>
 						</group>
 						<group id="loco_brake_type">
 							<trans-unit id="name">
-							  <source>LocoBrakeType</source>
-							  <target>Lokomotivets bremsesystem</target>
+								<source>LocoBrakeType</source>
+								<target>Lokomotivets bremsesystem</target>
 							</trans-unit>
 							<trans-unit id="none">
-							  <source>Not fitted</source>
-							  <target>Ikke tilpasset</target>
+								<source>Not fitted</source>
+								<target>Ikke tilpasset</target>
 							</trans-unit>
 							<trans-unit id="notched_air_brake">
-							  <source>Notched air brake</source>
-							  <target>Trinnvis luftbrems</target>
+								<source>Notched air brake</source>
+								<target>Trinnvis luftbrems</target>
 							</trans-unit>
 							<trans-unit id="cl">
-							  <source>Air brake with partial release</source>
-							  <target>Luftbrems med delvis utslipp</target>
+								<source>Air brake with partial release</source>
+								<target>Luftbrems med delvis utslipp</target>
 							</trans-unit>
 						</group>
 						<group id="brake_control_system">
 							<trans-unit id="name">
-							  <source>BrakeControlSystem</source>
-							  <target>Bremsekontrollsystem</target>o
+								<source>BrakeControlSystem</source>
+								<target>Bremsekontrollsystem</target>
 							</trans-unit>
 							<trans-unit id="none">
-							  <source>None</source>
-							  <target>Ingen</target>
+								<source>None</source>
+								<target>Ingen</target>
 							</trans-unit>
 							<trans-unit id="lock_out_valve">
-							  <source>Closing electromagnetic valve</source>
-							  <target>Lukket elektromagnetisk hvelv</target>							  
-							  <target></target>
+								<source>Closing electromagnetic valve</source>
+								<target>Lukket elektromagnetisk hvelv</target>
 							</trans-unit>
 							<trans-unit id="delay_including_control">
-							  <source>Delay-including control</source>
-							  <target>Inkludert forsinkelses kontroll</target>
+								<source>Delay-including control</source>
+								<target>Inkludert forsinkelses kontroll</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+							<target>Brems</target>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
-						  <source>BrakeControlSpeed</source>
-						  <target>Bremsekontrollhastighet</target>
+							<source>BrakeControlSpeed</source>
+							<target>Bremsekontrollhastighet</target>
 						</trans-unit>
 					</group>
 					<group id="pressure">
 						<trans-unit id="name">
-						  <source>Pressure</source>
-						  <target>Trykk</target>
+							<source>Pressure</source>
+							<target>Trykk</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_service_max">
-						  <source>BrakeCylinderServiceMaximumPressure</source>
-						  <target>Bremsesylinder maks operasjonelt trykk:</target>
+							<source>BrakeCylinderServiceMaximumPressure</source>
+							<target>Bremsesylinder maks operasjonelt trykk:</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_emergency_max">
-						  <source>BrakeCylinderEmergencyMaximumPressure</source>
-						  <target>Bremsesylinder maks nødstopp trykk:</target>
+							<source>BrakeCylinderEmergencyMaximumPressure</source>
+							<target>Bremsesylinder maks nødstopp trykk:</target>
 						</trans-unit>
 						<trans-unit id="main_reservoir_min">
-						  <source>MainReservoirMinimumPressure</source>
-						  <target>Hoved reservoar minimumstrykk:</target>
+							<source>MainReservoirMinimumPressure</source>
+							<target>Hoved reservoar minimumstrykk:</target>
 						</trans-unit>
 						<trans-unit id="main_reservoir_max">
-						  <source>MainReservoirMaximumPressure</source>
-						  <target>Hoved reservoar maksimumstrykk:</target>
+							<source>MainReservoirMaximumPressure</source>
+							<target>Hoved reservoar maksimumstrykk:</target>
 						</trans-unit>
 						<trans-unit id="brake_pipe_normal">
-						  <source>BrakePipeNormalPressure</source>
-						  <target>Bremserørets normale trykk:</target>
+							<source>BrakePipeNormalPressure</source>
+							<target>Bremserørets normale trykk:</target>
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
-						  <source>Delay</source>
-						  <target>Forsinkelse</target>
+							<source>Delay</source>
+							<target>Forsinkelse</target>
 						</trans-unit>
 						<trans-unit id="power">
-						  <source>Power</source>
-						  <target>Turtall</target>
+							<source>Power</source>
+							<target>Turtall</target>
 						</trans-unit>
 						<trans-unit id="brake">
-						  <source>Brake</source>
-						  <target>Brems</target>
+							<source>Brake</source>
+							<target>Brems</target>
 						</trans-unit>
 						<trans-unit id="loco_brake">
-						  <source>LocoBrake</source>
-						  <target>Lokomotiv brems</target>
+							<source>LocoBrake</source>
+							<target>Lokomotiv brems</target>
 						</trans-unit>
 						<trans-unit id="notch">
-						  <source>Notch</source>
-						  <target>Hakk</target>
+							<source>Notch</source>
+							<target>Hakk</target>
 						</trans-unit>
 						<trans-unit id="value">
-						  <source>Value</source>
-						  <target>Verdi</target>
+							<source>Value</source>
+							<target>Verdi</target>
+						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+						<target>Vognegenskaper</target>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-					  <source>Acceleration settings</source>
-					  <target>Akselerasjonsegenskaper</target>
-					</trans-unit>
-					<trans-unit id="notch">
-					  <source>Notch</source>
-					  <target>Hakk / Trinn</target>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
-						  <source>Parameter</source>
-						  <target>Parametere</target>
+							<source>Parameter</source>
+							<target>Parametere</target>
 						</trans-unit>
 						<trans-unit id="a0">
 							<source>a0</source>
@@ -4418,12 +4671,12 @@
 					</group>
 					<group id="preview">
 						<trans-unit id="name">
-						  <source>Preview</source>
-						  <target>Forhåndsvis</target>
+							<source>Preview</source>
+							<target>Forhåndsvis</target>
 						</trans-unit>
 						<trans-unit id="subtract_deceleration">
-						  <source>Subtract deceleration due to air and rolling resistance</source>
-						  <target>Trekk fra deselerasjon på grunn av luft- og rullemotstand</target>
+							<source>Subtract deceleration due to air and rolling resistance</source>
+							<target>Trekk fra deselerasjon på grunn av luft- og rullemotstand</target>
 						</trans-unit>
 						<trans-unit id="x">
 							<source>X</source>
@@ -4453,114 +4706,117 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+						<target>Akselerasjonsegenskaper</target>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+						<target>Hakk / Trinn</target>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-					  <source>Motor sound settings</source>
-					  <target>Motorlydegenskaper</target>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
-							  <source>Edit</source>
-							  <target>Endre</target>
+								<source>Edit</source>
+								<target>Endre</target>
 							</trans-unit>
 							<trans-unit id="undo">
-							  <source>Undo</source>
-							  <target>Undo</target>
+								<source>Undo</source>
+								<target>Undo</target>
 							</trans-unit>
 							<trans-unit id="redo">
-							  <source>Redo</source>
-							  <target>Redo</target>
+								<source>Redo</source>
+								<target>Redo</target>
 							</trans-unit>
 							<trans-unit id="cut">
-							  <source>Cut</source>
-							  <target>Kutt</target>
+								<source>Cut</source>
+								<target>Kutt</target>
 							</trans-unit>
 							<trans-unit id="copy">
-							  <source>Copy</source>
-							  <target>Kopier</target>
+								<source>Copy</source>
+								<target>Kopier</target>
 							</trans-unit>
 							<trans-unit id="paste">
-							  <source>Paste</source>
-							  <target>Lim-inn</target>
+								<source>Paste</source>
+								<target>Lim-inn</target>
 							</trans-unit>
 							<trans-unit id="cleanup">
-							  <source>Cleanup</source>
-							  <target>Rensk</target>
+								<source>Cleanup</source>
+								<target>Rensk</target>
 							</trans-unit>
 							<trans-unit id="delete">
-							  <source>Delete</source>
-							  <target>Slett</target>
+								<source>Delete</source>
+								<target>Slett</target>
 							</trans-unit>
 						</group>
 						<group id="view">
 							<trans-unit id="name">
-							  <source>View</source>
-							  <target>Vis</target>
+								<source>View</source>
+								<target>Vis</target>
 							</trans-unit>
 							<trans-unit id="power">
-							  <source>Power</source>
-							  <target>Turtall</target>
+								<source>Power</source>
+								<target>Turtall</target>
 							</trans-unit>
 							<trans-unit id="brake">
-							  <source>Brake</source>
-							  <target>Brems</target>
+								<source>Brake</source>
+								<target>Brems</target>
 							</trans-unit>
 							<trans-unit id="track">
-							  <source>Track</source>
-							  <target>Skinnegang</target>
+								<source>Track</source>
+								<target>Skinnegang</target>
 							</trans-unit>
 						</group>
 						<group id="input">
 							<trans-unit id="name">
-							  <source>Input</source>
-							  <target>Innputt</target>
+								<source>Input</source>
+								<target>Innputt</target>
 							</trans-unit>
 							<trans-unit id="pitch">
-							  <source>Pitch</source>
-
+								<source>Pitch</source>
 							</trans-unit>
 							<trans-unit id="volume">
-							  <source>Volume</source>
-							  <target>Nivå</target>
+								<source>Volume</source>
+								<target>Nivå</target>
 							</trans-unit>
 							<trans-unit id="sound_index">
-							  <source>Sound source index</source>
-							  <target>Lydindeks</target>
+								<source>Sound source index</source>
+								<target>Lydindeks</target>
 							</trans-unit>
 							<trans-unit id="sound_index_none">
-							  <source>None</source>
-							  <target>Ingen</target>
+								<source>None</source>
+								<target>Ingen</target>
 							</trans-unit>
 						</group>
 						<group id="tool">
 							<trans-unit id="name">
-							  <source>Tool</source>
-							  <target>Verktøy</target>
+								<source>Tool</source>
+								<target>Verktøy</target>
 							</trans-unit>
 							<trans-unit id="select">
-							  <source>Select</source>
-							  <target>Velg</target>
+								<source>Select</source>
+								<target>Velg</target>
 							</trans-unit>
 							<trans-unit id="move">
-							  <source>Move</source>
-							  <target>Flytt</target>
+								<source>Move</source>
+								<target>Flytt</target>
 							</trans-unit>
 							<trans-unit id="dot">
-							  <source>Dot</source>
-							  <target>Dott</target>
+								<source>Dot</source>
+								<target>Dott</target>
 							</trans-unit>
 							<trans-unit id="line">
-							  <source>Line</source>
-							  <target>Linje</target>
+								<source>Line</source>
+								<target>Linje</target>
 							</trans-unit>
 						</group>
 					</group>
 					<group id="view_setting">
 						<trans-unit id="name">
-						  <source>View setting</source>
-						  <target>Visningsvalg</target>
+							<source>View setting</source>
+							<target>Visningsvalg</target>
 						</trans-unit>
 						<trans-unit id="min_velocity">
 							<source>x-min(Velocity)</source>
@@ -4575,89 +4831,89 @@
 							<source>y-max(Pitch)</source>
 						</trans-unit>
 						<trans-unit id="min_volume">
-						  <source>y-min(Volume)</source>
-						  <target>y-min(Nivå)</target>
+							<source>y-min(Volume)</source>
+							<target>y-min(Nivå)</target>
 						</trans-unit>
 						<trans-unit id="max_volume">
-						  <source>y-max(Volume)</source>
-						  <target>y-max(Nivå)</target>
+							<source>y-max(Volume)</source>
+							<target>y-max(Nivå)</target>
 						</trans-unit>
 						<trans-unit id="zoom_in">
-						  <source>Zoom In</source>
-						  <target>Zoom inn</target>
+							<source>Zoom In</source>
+							<target>Zoom inn</target>
 						</trans-unit>
 						<trans-unit id="zoom_out">
-						  <source>Zoom Out</source>
-						  <target>Zoom ut</target>
+							<source>Zoom Out</source>
+							<target>Zoom ut</target>
 						</trans-unit>
 						<trans-unit id="reset">
-						  <source>Reset</source>
+							<source>Reset</source>
 						</trans-unit>
 					</group>
 					<group id="direct_input">
 						<trans-unit id="name">
-						  <source>Direct input</source>
-						  <target>Direkte innputt</target>
+							<source>Direct input</source>
+							<target>Direkte innputt</target>
 						</trans-unit>
 						<trans-unit id="x">
-						  <source>x coordinate</source>
-						  <target>x koordinat</target>
+							<source>x coordinate</source>
+							<target>x koordinat</target>
 						</trans-unit>
 						<trans-unit id="y">
-						  <source>y coordinate</source>
-						  <target>y koordinat</target>
+							<source>y coordinate</source>
+							<target>y koordinat</target>
 						</trans-unit>
 						<trans-unit id="dot">
 							<source>Dot</source>
 						</trans-unit>
 						<trans-unit id="move">
-						  <source>Move</source>
-						  <target>Flytt</target>
+							<source>Move</source>
+							<target>Flytt</target>
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-						  <source>Playback setting</source>
-						  <target>Avspillingsvalg</target>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
-							  <source>Sound source setting</source>
-							  <target>Lydkildevalg</target>
+								<source>Sound source setting</source>
+								<target>Lydkildevalg</target>
 							</trans-unit>
 							<trans-unit id="run">
-							  <source>Running sound</source>
-							  <target>Trillelyd</target>
+								<source>Running sound</source>
+								<target>Trillelyd</target>
 							</trans-unit>
 							<trans-unit id="track">
-							  <source>Track</source>
-							  <target>Skinne</target>
+								<source>Track</source>
+								<target>Skinne</target>
 							</trans-unit>
 						</group>
 						<group id="area">
 							<trans-unit id="name">
-							  <source>Area setting</source>
+								<source>Area setting</source>
 							</trans-unit>
 							<trans-unit id="loop">
-							  <source>Loop playback</source>
-							  <target>Løkke avspilling</target>
+								<source>Loop playback</source>
+								<target>Løkke avspilling</target>
 							</trans-unit>
 							<trans-unit id="constant">
-							  <source>Constant speed</source>
-							  <target>Konstant fart</target>
+								<source>Constant speed</source>
+								<target>Konstant fart</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-							  <source>Acceleration:</source>
-							  <target>Akselerasjon:</target>
+								<source>Acceleration</source>
+								<target>Akselerasjon:</target>
 							</trans-unit>
 							<trans-unit id="swap">
-							  <source>Swap</source>
-							  <target>Swap</target>
+								<source>Swap</source>
+								<target>Swap</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+							<target>Avspillingsvalg</target>
+						</trans-unit>
 						<trans-unit id="play">
-						  <source>Playback</source>
-						  <target>Avspilling</target>
+							<source>Playback</source>
+							<target>Avspilling</target>
 						</trans-unit>
 						<trans-unit id="pause">
 							<source>Pause</source>
@@ -4668,8 +4924,8 @@
 					</group>
 					<group id="vertex_info">
 						<trans-unit id="name">
-						  <source>Vertex information</source>
-						  <target>Vertex informasjon</target>
+							<source>Vertex information</source>
+							<target>Vertex informasjon</target>
 						</trans-unit>
 						<trans-unit id="velocity">
 							<source>Velocity</source>
@@ -4678,12 +4934,12 @@
 							<source>Pitch</source>
 						</trans-unit>
 						<trans-unit id="volume">
-						  <source>Volume</source>
-						  <target>Nivå</target>
+							<source>Volume</source>
+							<target>Nivå</target>
 						</trans-unit>
 						<trans-unit id="sound_index">
-						  <source>Sound source index</source>
-						  <target>Lydkildeindeks</target>
+							<source>Sound source index</source>
+							<target>Lydkildeindeks</target>
 						</trans-unit>
 					</group>
 					<group id="status">
@@ -4692,24 +4948,24 @@
 								<source>Type</source>
 							</trans-unit>
 							<trans-unit id="power">
-							  <source>Power</source>
-							  <target>Turtall</target>
+								<source>Power</source>
+								<target>Turtall</target>
 							</trans-unit>
 							<trans-unit id="brake">
-							  <source>Brake</source>
-							  <target>Bremse</target>
+								<source>Brake</source>
+								<target>Bremse</target>
 							</trans-unit>
 						</group>
 						<group id="track">
 							<trans-unit id="name">
-							  <source>Track</source>
-							  <target>Skinne</target>
+								<source>Track</source>
+								<target>Skinne</target>
 							</trans-unit>
 						</group>
 						<group id="mode">
 							<trans-unit id="name">
-							  <source>Mode</source>
-							  <target>Modus</target>
+								<source>Mode</source>
+								<target>Modus</target>
 							</trans-unit>
 							<trans-unit id="pitch">
 								<source>Pitch</source>
@@ -4718,29 +4974,29 @@
 								<source>Volume</source>
 							</trans-unit>
 							<trans-unit id="sound_index">
-							  <source>Sound source index</source>
-							  <target>Lydkildekindeks</target>
+								<source>Sound source index</source>
+								<target>Lydkildekindeks</target>
 							</trans-unit>
 						</group>
 						<group id="tool">
 							<trans-unit id="name">
-							  <source>Tool</source>
-							  <target>Verktøy</target>
+								<source>Tool</source>
+								<target>Verktøy</target>
 							</trans-unit>
 							<trans-unit id="select">
-							  <source>Select</source>
-							  <target>Velg</target>
+								<source>Select</source>
+								<target>Velg</target>
 							</trans-unit>
 							<trans-unit id="move">
-							  <source>Move</source>
-							  <target>Flytt</target>
+								<source>Move</source>
+								<target>Flytt</target>
 							</trans-unit>
 							<trans-unit id="dot">
 								<source>Dot</source>
 							</trans-unit>
 							<trans-unit id="line">
-							  <source>Line</source>
-							  <target>Linje</target>
+								<source>Line</source>
+								<target>Linje</target>
 							</trans-unit>
 						</group>
 						<group id="xy">
@@ -4757,77 +5013,41 @@
 					</group>
 					<group id="message">
 						<trans-unit id="vertex_exist">
-						  <source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
-						  <target>Et punkt eksisterer allerede i samme x koordinat, ønsker du å skrive over?</target>
+							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
+							<target>Et punkt eksisterer allerede i samme x koordinat, ønsker du å skrive over?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+						<target>Motorlydegenskaper</target>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-					  <source>Coupler settings</source>
-					  <target>Kobleegenskaper</target>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
-						  <source>General</source>
-						  <target>Generelt</target>
+							<source>General</source>
+							<target>Generelt</target>
 						</trans-unit>
 						<trans-unit id="min">
-						  <source>Min</source>
-						  <target>Min</target>
+							<source>Min</source>
+							<target>Min</target>
 						</trans-unit>
 						<trans-unit id="max">
-						  <source>Max</source>
-						  <target>Maks</target>
+							<source>Max</source>
+							<target>Maks</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+						<target>Kobleegenskaper</target>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-					  <source>Panel settings</source>
-					  <target>Panel egenskaper</target>
-					</trans-unit>
 					<group id="this">
-						<trans-unit id="name">
-						  <source>This</source>
-						  <target>Denne</target>
-						</trans-unit>
-						<trans-unit id="resolution">
-						  <source>Resolution</source>
-						  <target>Oppløsning</target>
-						</trans-unit>
-						<trans-unit id="left">
-						  <source>Left</source>
-						  <target>Venstre</target>
-						</trans-unit>
-						<trans-unit id="right">
-						  <source>Right</source>
-						  <target>Høyre</target>
-						</trans-unit>
-						<trans-unit id="top">
-						  <source>Top</source>
-						  <target>Topp</target>
-						</trans-unit>
-						<trans-unit id="bottom">
-						  <source>Bottom</source>
-						  <target>Bunn</target>
-						</trans-unit>
-						<trans-unit id="daytime_image">
-						  <source>DaytimeImage</source>
-						  <target>Dagbilde</target>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-						  <source>NighttimeImage</source>
-						  <target>Nattbilde</target>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
-						</trans-unit>
 						<group id="center">
 							<trans-unit id="name">
-							  <source>Center</source>
-							  <target>Senter</target>
+								<source>Center origin</source>
+								<target>Senter</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4838,8 +5058,8 @@
 						</group>
 						<group id="origin">
 							<trans-unit id="name">
-							  <source>Origin</source>
-							  <target>Opprinnelsespunkt</target>
+								<source>Track origin</source>
+								<target>Opprinnelsespunkt</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4848,34 +5068,62 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>This</source>
+							<target>Denne</target>
+						</trans-unit>
+						<trans-unit id="resolution">
+							<source>Resolution</source>
+							<target>Oppløsning</target>
+						</trans-unit>
+						<trans-unit id="left">
+							<source>Left</source>
+							<target>Venstre</target>
+						</trans-unit>
+						<trans-unit id="right">
+							<source>Right</source>
+							<target>Høyre</target>
+						</trans-unit>
+						<trans-unit id="top">
+							<source>Top</source>
+							<target>Topp</target>
+						</trans-unit>
+						<trans-unit id="bottom">
+							<source>Bottom</source>
+							<target>Bunn</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+							<target>Dagbilde</target>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+							<target>Nattbilde</target>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
+						</trans-unit>
 					</group>
 					<group id="screen">
 						<trans-unit id="name">
-						  <source>Screen</source>
-						  <target>Skjerm</target>
+							<source>Screen</source>
+							<target>Skjerm</target>
 						</trans-unit>
 						<trans-unit id="number">
-						  <source>Number</source>
-						  <target>Tall</target>
+							<source>Number</source>
+							<target>Tall</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="pilot_lamp">
-						<trans-unit id="name">
-						  <source>PilotLamp</source>
-						  <target>Pilotlampe</target>
-						</trans-unit>
-						<trans-unit id="subject">
-						  <source>Subject</source>
-						  <target>Subjekt</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
+								<source>Location</source>
+								<target>Lokasjon</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4884,140 +5132,141 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+							<target>Pilotlampe</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Subjekt</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
-						  <source>DaytimeImage</source>
-						  <target>Dagbilde</target>
+							<source>DaytimeImage</source>
+							<target>Dagbilde</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
-						  <source>NighttimeImage</source>
-						  <target>Nattbilde</target>
+							<source>NighttimeImage</source>
+							<target>Nattbilde</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Lokasjon</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Origin</source>
+								<target>Origo</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
-						  <source>Needle</source>
-						  <target>Nål</target>
+							<source>Needle</source>
+							<target>Nål</target>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
-						  <source>DefinedRadius</source>
-						  <target>Definert radius</target>
+							<source>DefinedRadius</source>
+							<target>Definert radius</target>
 						</trans-unit>
 						<trans-unit id="radius">
-						  <source>Radius</source>
-						  <target>Radius</target>
+							<source>Radius</source>
+							<target>Radius</target>
 						</trans-unit>
 						<trans-unit id="daytime_image">
-						  <source>DaytimeImage</source>
-						  <target>Dagbilde</target>
+							<source>DaytimeImage</source>
+							<target>Dagbilde</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
-						  <source>NighttimeImage</source>
-						  <target>Nattbilde</target>
+							<source>NighttimeImage</source>
+							<target>Nattbilde</target>
 						</trans-unit>
 						<trans-unit id="color">
-						  <source>Color</source>
-						  <target>Farge</target>
+							<source>Color</source>
+							<target>Farge</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
 						</trans-unit>
 						<trans-unit id="defined_origin">
-						  <source>DefinedOrigin</source>
-						  <target>Definert origo</target>
+							<source>DefinedOrigin</source>
+							<target>Definert origo</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-							  <source>Origin</source>
-							  <target>Origo</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
-						  <source>InitialAngle</source>
-						  <target>Initiell vinkel</target>
+							<source>InitialAngle</source>
+							<target>Initiell vinkel</target>
 						</trans-unit>
 						<trans-unit id="last_angle">
-						  <source>LastAngle</source>
-						  <target>Siste vinkel</target>
+							<source>LastAngle</source>
+							<target>Siste vinkel</target>
 						</trans-unit>
 						<trans-unit id="minimum">
-						  <source>Minimum</source>
-						  <target>Minimum</target>
+							<source>Minimum</source>
+							<target>Minimum</target>
 						</trans-unit>
 						<trans-unit id="maximum">
-						  <source>Maximum</source>
-						  <target>Maksimum</target>
+							<source>Maximum</source>
+							<target>Maksimum</target>
 						</trans-unit>
 						<trans-unit id="defined_natural_freq">
-						  <source>DefinedNaturalFreq</source>
-						  <target>Definert nøytral frekvens</target>
+							<source>DefinedNaturalFreq</source>
+							<target>Definert nøytral frekvens</target>
 						</trans-unit>
 						<trans-unit id="natural_freq">
-						  <source>NaturalFreq</source>
-						  <target>Nøytral frekvens</target>
+							<source>NaturalFreq</source>
+							<target>Nøytral frekvens</target>
 						</trans-unit>
 						<trans-unit id="defined_damping_ratio">
-						  <source>DefiedDampingRatio</source>
-						  <target>Definert dempingsforhold</target>
+							<source>DefiedDampingRatio</source>
+							<target>Definert dempingsforhold</target>
 						</trans-unit>
 						<trans-unit id="damping_ratio">
-						  <source>DampingRatio</source>
-						  <target>Dempingsforhold</target>
+							<source>DampingRatio</source>
+							<target>Dempingsforhold</target>
 						</trans-unit>
 						<trans-unit id="backstop">
-						  <source>Backstop</source>
-						  <target>Bakstopp</target>
+							<source>Backstop</source>
+							<target>Bakstopp</target>
 						</trans-unit>
 						<trans-unit id="smoothed">
-						  <source>smoothed</source>
-						  <target>utgjenvet</target>
+							<source>smoothed</source>
+							<target>utgjenvet</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-						  <source>DigitalNumber</source>
-						  <target>Digitalt nummer</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
+								<source>Location</source>
+								<target>Lokasjon</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5026,39 +5275,39 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+							<target>Digitalt nummer</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
-						  <source>DaytimeImage</source>
-						  <target>Dagbilde</target>
+							<source>DaytimeImage</source>
+							<target>Dagbilde</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
-						  <source>NighttimeImage</source>
-						  <target>Nattbilde</target>
+							<source>NighttimeImage</source>
+							<target>Nattbilde</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 						<trans-unit id="interval">
-						  <source>Interval</source>
-						  <target>Intervall</target>
+							<source>Interval</source>
+							<target>Intervall</target>
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-						  <source>DigitalGauge</source>
-						  <target>Digital måleenhet</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
+								<source>Location</source>
+								<target>Lokasjon</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5067,109 +5316,112 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+							<target>Digital måleenhet</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
-						  <source>Radius</source>
-						  <target>Radius</target>
+							<source>Radius</source>
+							<target>Radius</target>
 						</trans-unit>
 						<trans-unit id="color">
-						  <source>Color</source>
-						  <target>Farge</target>
+							<source>Color</source>
+							<target>Farge</target>
 						</trans-unit>
 						<trans-unit id="initial_angle">
-						  <source>InitialAngle</source>
-						  <target>Initiell vinkel</target>
+							<source>InitialAngle</source>
+							<target>Initiell vinkel</target>
 						</trans-unit>
 						<trans-unit id="last_angle">
-						  <source>LastAngle</source>
-						  <target>Siste vinkel</target>
+							<source>LastAngle</source>
+							<target>Siste vinkel</target>
 						</trans-unit>
 						<trans-unit id="minimum">
-						  <source>Minimum</source>
-						  <target>Minimum</target>
+							<source>Minimum</source>
+							<target>Minimum</target>
 						</trans-unit>
 						<trans-unit id="maximum">
-						  <source>Maximum</source>
-						  <target>Maksimum</target>
+							<source>Maximum</source>
+							<target>Maksimum</target>
 						</trans-unit>
 						<trans-unit id="step">
-						  <source>Step</source>
-						  <target>Steg</target>
+							<source>Step</source>
+							<target>Steg</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Lokasjon</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+								<target>Retning</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
-						  <source>LinearGauge</source>
-						  <target>Lineær måleenhet</target>
+							<source>LinearGauge</source>
+							<target>Lineær måleenhet</target>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="daytime_image">
-						  <source>DaytimeImage</source>
-						  <target>Dagbilde</target>
+							<source>DaytimeImage</source>
+							<target>Dagbilde</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
-						  <source>NighttimeImage</source>
-						  <target>Nattbilde</target>
+							<source>NighttimeImage</source>
+							<target>Nattbilde</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
 						</trans-unit>
 						<trans-unit id="minimum">
-						  <source>Minimum</source>
-						  <target>Minimum</target>
+							<source>Minimum</source>
+							<target>Minimum</target>
 						</trans-unit>
 						<trans-unit id="maximum">
-						  <source>Maximum</source>
-						  <target>Maksimum</target>
+							<source>Maximum</source>
+							<target>Maksimum</target>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-							  <source>Direction</source>
-							  <target>Retning</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
-						  <source>Width</source>
-						  <target>Bredde</target>
+							<source>Width</source>
+							<target>Bredde</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-						  <source>Timetable</source>
-						  <target>Tidstabell</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
-							  <source>Location</source>
-							  <target>Lokasjon</target>
+								<source>Location</source>
+								<target>Lokasjon</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5178,27 +5430,28 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+							<target>Tidstabell</target>
+						</trans-unit>
 						<trans-unit id="height">
-						  <source>Height</source>
-						  <target>Høyde</target>
+							<source>Height</source>
+							<target>Høyde</target>
 						</trans-unit>
 						<trans-unit id="width">
-						  <source>Width</source>
-						  <target>Bredde</target>
+							<source>Width</source>
+							<target>Bredde</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
-						  <source>TransparentColor</source>
-						  <target>Transparent farge</target>
+							<source>TransparentColor</source>
+							<target>Transparent farge</target>
 						</trans-unit>
 						<trans-unit id="layer">
-						  <source>Layer</source>
-						  <target>Lag</target>
+							<source>Layer</source>
+							<target>Lag</target>
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5221,6 +5474,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5233,157 +5489,299 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+						<target>Panel egenskaper</target>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
-					<trans-unit id="name">
-					  <source>Sound settings</source>
-					  <target>Lydegenskaper</target>
-					</trans-unit>
-					<trans-unit id="key">
-					  <source>Key</source>
-					  <target>Knapp</target>
-					</trans-unit>
-					<trans-unit id="filename">
-					  <source>Filename</source>
-					  <target>Filnavn</target>
-					</trans-unit>
-					<trans-unit id="position">
-					  <source>Position</source>
-					  <target>Posisjon</target>
-					</trans-unit>
-					<trans-unit id="radius">
-						<source>Radius</source>
-					</trans-unit>
 					<group id="edit_entry">
-						<trans-unit id="name">
-						  <source>Edit entry</source>
-						  <target>Endre valgt</target>
-						</trans-unit>
 						<group id="section">
 							<trans-unit id="name">
-							  <source>Section select</source>
-							  <target>Velg seksjon</target>
+								<source>Section select</source>
+								<target>Velg seksjon</target>
 							</trans-unit>
 						</group>
 						<group id="key">
 							<trans-unit id="name">
-							  <source>Key type select</source>
-							  <target>Knappetypevalg</target>
+								<source>Key type select</source>
+								<target>Knappetypevalg</target>
 							</trans-unit>
 						</group>
 						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+									<target>Posisjon</target>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+									<target>x koordinat</target>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+									<target>y koordinat</target>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+									<target>z koordinat</target>
+								</trans-unit>
+							</group>
 							<trans-unit id="name">
-							  <source>Input value</source>
-							  <target>Innputtverdi</target>
+								<source>Input value</source>
+								<target>Innputtverdi</target>
 							</trans-unit>
 							<trans-unit id="filename">
-							  <source>Filename</source>
-							  <target>Filnavn</target>
+								<source>Filename</source>
+								<target>Filnavn</target>
 							</trans-unit>
 							<trans-unit id="radius">
 								<source>Radius</source>
 							</trans-unit>
 							<trans-unit id="position">
-							  <source>Position setting</source>
-							  <target>Posisjonsvalg</target>
+								<source>Position setting</source>
+								<target>Posisjonsvalg</target>
 							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-								  <source>Position</source>
-								  <target>Posisjon</target>
-								</trans-unit>
-								<trans-unit id="x">
-								  <source>x coordinate</source>
-								  <target>x koordinat</target>
-								</trans-unit>
-								
-								<trans-unit id="y">
-								  <source>y coordinate</source>
-								  <target>y koordinat</target>
-								</trans-unit>
-								<trans-unit id="z">
-								  <source>z coordinate</source>
-								  <target>z koordinat</target>
-								</trans-unit>
-							</group>
 						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+							<target>Endre valgt</target>
+						</trans-unit>
 					</group>
 					<group id="message">
 						<trans-unit id="empty_filename">
-						  <source>File name has not been entered.</source>
-						  <target>Filnavn har ikke blitt skrevet inn.</target>
+							<source>File name has not been entered.</source>
+							<target>Filnavn har ikke blitt skrevet inn.</target>
 						</trans-unit>
 						<trans-unit id="key_exist">
-						  <source>The specified key is already set.</source>
-						  <target>Knappen er allerede satt til noe.</target>
+							<source>The specified key is already set.</source>
+							<target>Knappen er allerede satt til noe.</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Sound settings</source>
+						<target>Lydegenskaper</target>
+					</trans-unit>
+					<trans-unit id="key">
+						<source>Key</source>
+						<target>Knapp</target>
+					</trans-unit>
+					<trans-unit id="filename">
+						<source>Filename</source>
+						<target>Filnavn</target>
+					</trans-unit>
+					<trans-unit id="position">
+						<source>Position</source>
+						<target>Posisjon</target>
+					</trans-unit>
+					<trans-unit id="radius">
+						<source>Radius</source>
+					</trans-unit>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-					  <source>Status</source>
-					  <target>Status</target>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
-						  <source>Error</source>
-						  <target>Feil</target>
+							<source>Error</source>
+							<target>Feil</target>
 						</trans-unit>
 						<trans-unit id="warning">
-						  <source>Warning</source>
-						  <target>Advarsel</target>
+							<source>Warning</source>
+							<target>Advarsel</target>
 						</trans-unit>
 						<trans-unit id="info">
-						  <source>Information</source>
-						  <target>Informasjon</target>
+							<source>Information</source>
+							<target>Informasjon</target>
 						</trans-unit>
 						<trans-unit id="clear">
-						  <source>Clear</source>
-						  <target>Vask bort</target>
+							<source>Clear</source>
+							<target>Vask bort</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+						<target>Status</target>
+					</trans-unit>
 					<trans-unit id="level">
-					  <source>Level</source>
-					  <target>Nivå</target>
+						<source>Level</source>
+						<target>Nivå</target>
 					</trans-unit>
 					<trans-unit id="description">
-					  <source>Description</source>
-					  <target>Beskrivelse</target>
+						<source>Description</source>
+						<target>Beskrivelse</target>
 					</trans-unit>
 				</group>
 				<group id="message">
 					<trans-unit id="error">
-					  <source>Error</source>
-					  <target>Feil</target>
+						<source>Error</source>
+						<target>Feil</target>
 					</trans-unit>
 					<trans-unit id="warning">
-					  <source>Warning</source>
-					  <target>Advarsel</target>
+						<source>Warning</source>
+						<target>Advarsel</target>
 					</trans-unit>
 					<trans-unit id="info">
-					  <source>Information</source>
-					  <target>Informasjon</target>
+						<source>Information</source>
+						<target>Informasjon</target>
 					</trans-unit>
 					<trans-unit id="positive">
-					  <source>positive</source>
-					  <target>positiv</target>
+						<source>positive</source>
+						<target>positiv</target>
 					</trans-unit>
 					<trans-unit id="non_negative">
-					  <source>non-negative</source>
-					  <target>ikke-negativ</target>
+						<source>non-negative</source>
+						<target>ikke-negativ</target>
 					</trans-unit>
 					<trans-unit id="non_zero">
-					  <source>non-zero</source>
-					  <target>ikke-null</target>
+						<source>non-zero</source>
+						<target>ikke-null</target>
 					</trans-unit>
 					<trans-unit id="invalid_float">
-					  <source>This value must be a {0}floating-point number.</source>
-					  <target>Denne verdien må være en {0}flyttallsnummer.</target>
+						<source>This value must be a {0}floating-point number.</source>
+						<target>Denne verdien må være en {0}flyttallsnummer.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-					  <source>invalid_color</source>
-					  <target>invalid farge</target>
+						<source>Invalid HEX color</source>
+						<target>invalid farge</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/nl-NL.xlf
+++ b/assets/Languages/nl-NL.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="nl-NL">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2011-12-23</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,10 +371,6 @@
 						<source>Recently used</source>
 						<target>Onlangs gebruikt</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Standaard voor route</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Gebruik de trein die standaard wordt aanbevolen</target>
@@ -397,7 +399,7 @@
 						<target>Voorbeeld:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>De trein die bij de route hoort kon niet worden gevonden:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -415,6 +417,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -520,7 +531,7 @@
 					</trans-unit>
 					<trans-unit id="blackbox_format_csv">
 						<source>Comma-separated value</source>
-						<target>Door komma's gescheiden waarden (csv)</target>
+						<target>Door komma&apos;s gescheiden waarden (csv)</target>
 					</trans-unit>
 					<trans-unit id="blackbox_format_text">
 						<source>Formatted text</source>
@@ -613,8 +624,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +736,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +763,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +999,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,7 +1138,7 @@
 						<target>Druk op een knop naar keuze of beweeg een as in de gewenste richting...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Beweeg een as naar keuze in de positieve- of tractierichting...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1244,64 +1264,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1727,6 +1747,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1838,12 +1861,12 @@
 						<target>Bestanden niet gevonden:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Er zijn enkele fouten opgetreden bij het laden van de route en de trein.\r\n\r\nAangezien er enkele bestanden niet konden worden gevonden, is het mogelijk dat de route of trein er niet zo uitziet als de bedoeling is. Probeer de route en trein opnieuw te downloaden om er zeker van te zijn dat je alle nodige bestanden hebt.\r\n\r\nKlik op "Laat fouten zien" voor een lijst van de fouten, deze kan voor route-ontwikkelaars aanvullende informatie geven. Je kunt, als gewoon gebruiker ook de route starten door hieronder op "Negeren" te klikken.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Er zijn enkele fouten opgetreden bij het laden van de route en de trein.\r\n\r\nAangezien er enkele bestanden niet konden worden gevonden, is het mogelijk dat de route of trein er niet zo uitziet als de bedoeling is. Probeer de route en trein opnieuw te downloaden om er zeker van te zijn dat je alle nodige bestanden hebt.\r\n\r\nKlik op &quot;Laat fouten zien&quot; voor een lijst van de fouten, deze kan voor route-ontwikkelaars aanvullende informatie geven. Je kunt, als gewoon gebruiker ook de route starten door hieronder op &quot;Negeren&quot; te klikken.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Er zijn enkele fouten opgetreden bij het laden van de route en de trein. Als je de ontwikkelaar bent van de route of trein, kan het de moeite waard zijn de volgende lijst met fouten te bekijken.\r\n\r\nAls je een gewone gebruiker bent, kun je gewoon op "Negeren" klikken om het spel te starten.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Er zijn enkele fouten opgetreden bij het laden van de route en de trein. Als je de ontwikkelaar bent van de route of trein, kan het de moeite waard zijn de volgende lijst met fouten te bekijken.\r\n\r\nAls je een gewone gebruiker bent, kun je gewoon op &quot;Negeren&quot; klikken om het spel te starten.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1973,6 +1996,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Laden, even geduld...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2017,7 +2055,7 @@
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
 						<source>This feature is not available in Expert mode.</source>
-						<target>In de moeilijkheidsgraad "Expert" is deze functie niet beschikbaar.</target>
+						<target>In de moeilijkheidsgraad &quot;Expert&quot; is deze functie niet beschikbaar.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
 						<source>The AI might be unable to fully operate this train.</source>
@@ -2038,6 +2076,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Gezichtsveldregeling met muis: uit</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2206,7 +2259,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2220,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Standaard voor route</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2558,14 +2627,14 @@
 						<target>De P-functie van het beveiligingssysteem</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Schakelt naar het binnenaanzicht van de trein</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Schakelt naar het buitenaanzicht van de trein</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2574,7 +2643,7 @@
 					</trans-unit>
 					<trans-unit id="camera_flyby">
 						<source>Switches between different fly-by views</source>
-						<target>Schakelt naar en tussen de fly-bycamera's</target>
+						<target>Schakelt naar en tussen de fly-bycamera&apos;s</target>
 					</trans-unit>
 					<trans-unit id="camera_move_forward">
 						<source>Moves the camera forward</source>
@@ -2826,6 +2895,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3366,6 +3459,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3616,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3878,8 +4125,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3999,12 +4246,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4016,6 +4260,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4055,13 +4302,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4072,22 +4313,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4119,8 +4351,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4141,9 +4400,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4172,15 +4428,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4232,6 +4479,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4239,12 +4498,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4275,17 +4548,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4343,9 +4605,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4388,6 +4647,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4413,6 +4675,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4431,15 +4704,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4495,11 +4768,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4626,9 +4902,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4651,12 +4924,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4749,11 +5025,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4765,12 +5041,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4798,9 +5096,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4820,67 +5162,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4902,17 +5189,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4948,12 +5224,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4965,6 +5235,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4982,12 +5258,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4999,6 +5269,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5025,12 +5301,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5042,6 +5312,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5057,17 +5344,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5076,9 +5352,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5090,6 +5363,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5104,9 +5380,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5129,6 +5402,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5141,9 +5417,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5159,62 +5552,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5229,6 +5568,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5259,7 +5601,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/pl-PL.xlf
+++ b/assets/Languages/pl-PL.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pl-PL">
 		<body>
 			<group id="language">
@@ -234,9 +235,6 @@
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
 						<target>Wybrana trasa jest uszkodzona: \r\n Nie można zlokalizować wszystkich zdefiniowanych obiektów.</target>
 					</trans-unit>
-					<trans-unit id="route_corrupt_missingobjects">
-						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
 						<target>Wtyczka pociągu [plugin] nie załadowała się.</target>
@@ -268,6 +266,9 @@
 					<trans-unit id="security_badlocation">
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
 						<target>Jeśli próbujesz zainstalować dodatki w folderach Program Files lub ProgramData, może wymagać to uprawnień administratora. \r\n\r\n Nie jest to zalecane ze względów bezpieczeństwa.</target>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -334,18 +335,6 @@
 						<source>Choose Train...</source>
 						<target>Wybierz Skład...</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-						<target>Czy chcesz użyć domyślnego składu?</target>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-						<target>Nie</target>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
-						<target>Tak</target>
-					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
 						<target>Wybór pociągu</target>
@@ -411,6 +400,9 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -607,8 +599,8 @@
 						<target>Instaluj pakiet</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>Ten plik nie wygląda na plik pakietu openBVE</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Ten plik nie wygląda na plik pakietu OpenBVE</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -719,8 +711,8 @@
 						<target>Usuń</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -746,7 +738,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Do nowego pakietu przypisano następujący identyfikator GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -1246,64 +1238,64 @@
 						<target>Błąd wczytywania pliku kalibracji RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Wciśnij 'Dalej' aby rozpocząć kalibrację.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Wciśnij &apos;Dalej&apos; aby rozpocząć kalibrację.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Przesuń dźwignię nawrotnika na wsteczny kierunek i naciśnij 'Dalej'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię nawrotnika na wsteczny kierunek i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Przesuń dźwignię nawrotnika na kierunek do przodu i naciśnij 'Dalej'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię nawrotnika na kierunek do przodu i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Przesuń wspólną dźwignię hamulca / nastawnika na pełną moc i naciśnij 'Dalej'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Przesuń wspólną dźwignię hamulca / nastawnika na pełną moc i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Przesuń wspólną dźwignię hamulca / nastawnika na pełne hamowanie i naciśnij 'Dalej'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Przesuń wspólną dźwignię hamulca / nastawnika na pełne hamowanie i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Przesuń dźwignię hamulca dynamicznego na odhamowany i naciśnij 'Dalej'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię hamulca dynamicznego na odhamowany i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Przesuń dźwignię hamulca dynamicznego na hamowanie nagłe i naciśnij 'Dalej'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię hamulca dynamicznego na hamowanie nagłe i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Przesuń dźwignię hamulca niezależnego na odhamowany i naciśnij 'Dalej'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię hamulca niezależnego na odhamowany i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Przesuń dźwignię hamulca niezależnego na zahamowany i naciśnij 'Dalej'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię hamulca niezależnego na zahamowany i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Przesuń dźwignię bail-off do pozycji zwolnienia i naciśnij 'Dalej'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Przesuń dźwignię bail-off do pozycji zwolnienia i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Przesuń i przytrzymaj dźwignię bail-off do pozycji pełny i naciśnij 'Dalej'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Przesuń i przytrzymaj dźwignię bail-off do pozycji pełny i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Przełącz wycieraczki w pozycję OFF  i naciśnij 'Dalej'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Przełącz wycieraczki w pozycję OFF  i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Przełącz wycieraczki w pozycję FULL  i naciśnij 'Dalej'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Przełącz wycieraczki w pozycję FULL  i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Przełącz światła w pozycję OFF  i naciśnij 'Dalej'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Przełącz światła w pozycję OFF  i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Przełącz światła w pozycję FULL  i naciśnij 'Dalej'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Przełącz światła w pozycję FULL  i naciśnij &apos;Dalej&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1986,7 +1978,7 @@
 						<target>Ruszyłeś ze stacji [name] gdy ludzie wsiadali. Proszę zatrzymać pociąg.</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>Aktualna prędkość składu to [speed]</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2057,6 +2049,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Przechwycenie myszy: Wył</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2230,7 +2237,7 @@
 						<target>Kontroler</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2244,6 +2251,18 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Aktualne przypisanie:</target>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Czy chcesz użyć domyślnego składu?</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+						<target>Nie</target>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+						<target>Tak</target>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2577,15 +2596,15 @@
 						<target>Funkcja P w systemie bezpieczeństwa</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Przełącza do wewnętrznego widoku pociągu</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>Przełącza na widok wnętrza pociągu. Jednak panel nie jest wyświetlany.</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Przełącza do zewnętrznego widoku pociągu</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2855,6 +2874,24 @@
 					<trans-unit id="raildriver_speed_units">
 						<source>Toggles the RailDriver speed display units.</source>
 						<target>Przełącza jednostki wyświetlania prędkości RailDriver.</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3501,11 +3538,7 @@
 						<target>Linux</target>
 					</trans-unit>
 					<trans-unit id="help_controller1_textbox">
-						<source>If your non-USB controller is not providing correct input:
-
-1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller
-to separate buttons to avoid compatibility issues.
-2. Calibrate the controller from the configuration window, if necessary.</source>
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
 						<target>Jeśli kontroler inny niż USB nie działa prawidłowo:
 
 1. Upewnij się, że adapter USB działa. Adapter powinien mapować przyciski kierunkowe ze standardowego kontrolera
@@ -3517,19 +3550,14 @@ na oddzielne przyciski, aby uniknąć problemów ze zgodnością.
 						<target>Jeśli kontrolera PS2 nie ma na liście, wykonaj następujące kroki:</target>
 					</trans-unit>
 					<trans-unit id="help_windows_textbox">
-						<source>1. Extract the Windows drivers.
-2. Download and run Zadig.
-3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).
-4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
 						<target>1. Rozpakuj sterowniki dla Windowsa.
 2. Pobierz i uruchom Zadig.
 3. Wczytaj odpowiedni plik CFG dla twojego urządzenia (&quot;Device &gt; Load Preset Device&quot;&quot;)
 4. Naciśnij &quot;Install Driver&quot; i poczekaj na zakończenie instalacji.</target>
 					</trans-unit>
 					<trans-unit id="help_linux_textbox">
-						<source>1. Extract the Linux udev file.
-2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).
-3. Reboot or reload udev rules manually.</source>
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
 						<target>1. Wypakuj Linuxowy plik udev.
 2. Skopiuj ten plik do &quot;/etc/udev/rules.d/&quot; (wymagane uprawnienia roota).
 3. Uruchom ponownie lub przeładuj udev.</target>
@@ -3551,14 +3579,7 @@ na oddzielne przyciski, aby uniknąć problemów ze zgodnością.
 						<target>OK</target>
 					</trans-unit>
 					<trans-unit id="help_libusb_symlink">
-						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.
-Please follow the following instructions:
-
-1. Check that the &quot;libusb-1.0&quot; package is installed.
-2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;
-3. Open the directory in the terminal.
-4. Check this location to see if &quot;libusb-1.0.so&quot; exists.
-5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
 						<target>Wygląda na to, że brakuje LibUsb, albo nie zostało poprawnie połączone. Postępuj zgodnie z poniższymi instrukcjami:
 
 1. Sprawdź, czy zainstalowano pakiet „libusb-1.0”.
@@ -3566,6 +3587,35 @@ Please follow the following instructions:
 3. Otwórz katalog w konsoli.
 4. Sprawdź tę lokalizację, aby zobaczyć, czy istnieje &quot;libusb-1.0.so&quot;.
 5. Jeśli plik nie istnieje, musimy utworzyć odpowiedni symlink, wykonując następujące polecenie z konsoli: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</target>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -4074,8 +4124,8 @@ Please follow the following instructions:
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4193,13 +4243,10 @@ Please follow the following instructions:
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 							<target>Próbowałeś otworzyć skład. \n\n Nie można ich otworzyć bezpośrednio- \n\n Użyj funkcji importu, aby zaimportować ten skład do TrainEditor2.</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4211,6 +4258,9 @@ Please follow the following instructions:
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4254,13 +4304,7 @@ Please follow the following instructions:
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4278,21 +4322,6 @@ Please follow the following instructions:
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4328,8 +4357,35 @@ Please follow the following instructions:
 								<target>Blocking</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4350,9 +4406,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4383,15 +4436,6 @@ Please follow the following instructions:
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4443,6 +4487,18 @@ Please follow the following instructions:
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4450,12 +4506,28 @@ Please follow the following instructions:
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>FrontAxle</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>RearAxle</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4492,19 +4564,6 @@ Please follow the following instructions:
 							<source>DefinedAxles</source>
 							<target>DefinedAxles</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>FrontAxle</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>RearAxle</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>FrontBogie</target>
@@ -4567,9 +4626,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4613,6 +4669,9 @@ Please follow the following instructions:
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>BrakeControlSpeed</target>
@@ -4639,6 +4698,17 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4657,15 +4727,15 @@ Please follow the following instructions:
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4731,11 +4801,14 @@ Please follow the following instructions:
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4877,9 +4950,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4905,13 +4975,16 @@ Please follow the following instructions:
 								<target>Stała prędkość</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 								<target>Swap</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>Playback</target>
@@ -5008,11 +5081,11 @@ Please follow the following instructions:
 							<target>Punkt już istnieje na tej samej współrzędnej x, czy chcesz go zastąpić?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5026,12 +5099,34 @@ Please follow the following instructions:
 							<target>Max</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5064,9 +5159,56 @@ Please follow the following instructions:
 							<source>TransparentColor</source>
 							<target>TransparentColor</target>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+							<target>Number</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Warstwa</target>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Temat</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5086,70 +5228,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-							<target>Number</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target>Warstwa</target>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>Temat</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>DefinedRadius</target>
@@ -5175,17 +5259,6 @@ Please follow the following instructions:
 							<source>DefinedOrigin</source>
 							<target>DefinedOrigin</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>InitialAngle</target>
@@ -5231,12 +5304,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5248,6 +5315,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5266,12 +5339,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5283,6 +5350,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5310,12 +5383,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5327,6 +5394,23 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5342,17 +5426,6 @@ Please follow the following instructions:
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5361,9 +5434,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5375,6 +5445,9 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5389,9 +5462,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5414,6 +5484,9 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>JumpScreen</target>
@@ -5429,9 +5502,128 @@ Please follow the following instructions:
 							<source>CommandOption</source>
 							<target>CommandOption</target>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>Nie podano nazwy pliku.</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>Wybrany przycisk jest już przypisany.</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5449,64 +5641,8 @@ Please follow the following instructions:
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>Nie podano nazwy pliku.</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>Wybrany przycisk jest już przypisany.</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5523,6 +5659,9 @@ Please follow the following instructions:
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>Poziom</target>
@@ -5558,8 +5697,84 @@ Please follow the following instructions:
 						<target>This value must be a {0}floating-point number.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>invalid_color</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/pt-BR.xlf
+++ b/assets/Languages/pt-BR.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pt-BR">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>Chico (oBom), ALP (Ducatista)</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2009-03-26</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Utilizado recentemente</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Pré-definido</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Utiliza o trem pré-definido na linha</target>
@@ -398,7 +400,7 @@
 						<target>Pré-visualização:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>O trem associado à linha não foi encontrado:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Iniciar</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,8 +1139,8 @@
 						<target>Carregue em qualquer tecla ou desloque o eixo na direção desejada...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Desloque um eixo qualquer na direção de "aumentar" ou "força"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Desloque um eixo qualquer na direção de &quot;aumentar&quot; ou &quot;força&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="objobject_parser">
 						<source>OBJ Object Parser</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,12 +1862,12 @@
 						<target>Arquivos não encontrados:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Alguns problemas foram encontrados ao carregar a linha e o trem.\r\n\r\nComo alguns arquivos não foram encontrados, a linha e/ou trem podem não aparecer corretamente. Tente obter novamente a linha e/ou o trem para garantir que dispõe do pacote completo.\r\n\r\nA seguinte lista de problemas pode fornecer informações adicionais. Você pode, ainda assim, iniciar a simulação selecionando "Ignorar" na tecla abaixo.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Alguns problemas foram encontrados ao carregar a linha e o trem.\r\n\r\nComo alguns arquivos não foram encontrados, a linha e/ou trem podem não aparecer corretamente. Tente obter novamente a linha e/ou o trem para garantir que dispõe do pacote completo.\r\n\r\nA seguinte lista de problemas pode fornecer informações adicionais. Você pode, ainda assim, iniciar a simulação selecionando &quot;Ignorar&quot; na tecla abaixo.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Alguns problemas foram encontrados ao carregar a linha e o trem. Caso seja o autor da linha ou do trem, talvez valha a pena verificar à seguinte lista de problemas.\r\n\r\nComo utilizador pode selecionar "Ignorar" para poder iniciar a simulação.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Alguns problemas foram encontrados ao carregar a linha e o trem. Caso seja o autor da linha ou do trem, talvez valha a pena verificar à seguinte lista de problemas.\r\n\r\nComo utilizador pode selecionar &quot;Ignorar&quot; para poder iniciar a simulação.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Carregando. Por favor aguarde...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Mouse grab: off</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Pré-definido</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>Função P do sistema de segurança</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Muda para a vista interior do trem</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Muda para a vista exterior do trem</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2739,11 +2808,11 @@
 					</trans-unit>
 					<trans-unit id="debug_wireframe">
 						<source>Activates or deactivates wireframe mode</source>
-						<target>Ativa ou desativa o modo "wireframe"</target>
+						<target>Ativa ou desativa o modo &quot;wireframe&quot;</target>
 					</trans-unit>
 					<trans-unit id="debug_normals">
 						<source>Shows or hides vertex normals</source>
-						<target>Mostra ou esconde a posição dos "vertex"</target>
+						<target>Mostra ou esconde a posição dos &quot;vertex&quot;</target>
 					</trans-unit>
 					<trans-unit id="debug_brake_systems">
 						<source>Shows or hides brake system debug output</source>
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3367,6 +3460,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/pt-PT.xlf
+++ b/assets/Languages/pt-PT.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pt-PT">
 		<body>
 			<group id="language">
@@ -17,8 +17,8 @@
 					<note from="translator">Esta tradução não segue o ilegal e estúpido Acordo Ortográfico de 1990 e respeita a Convenção Ortográfica de 1945 (Decreto 35228 de 08-12-1945).</note>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2019-06-04</source>
-					<target state="translated">2023-12-27</target>
+					<source>2019-06-29</source>
+					<target>2023-12-27</target>
 				</trans-unit>
 			</group>
 			<group id="openbve">
@@ -31,69 +31,69 @@
 				<group id="about">
 					<trans-unit id="title">
 						<source>About</source>
-						<target state="translated">Acerca de</target>
+						<target>Acerca de</target>
 					</trans-unit>
 					<trans-unit id="description">
 						<source>OpenBVE is a free and open-source multi-platform train simulator, featuring support for 2D and 3D cabs and scenery.\r\n\r\nThis program was initially developed by Michelle, and is released into the public domain where legally possible.</source>
-						<target state="translated">O OpenBVE é um simulador grátis de código aberto e multiplataforma de condução de comboios, que incorpora suporte para cenários e cabinas 2D e 3D.\r\n\r\nEste programa foi inicialmente desenvolvido por Michelle e está disponível ao público onde legalmente possível.</target>
+						<target>O OpenBVE é um simulador grátis de código aberto e multiplataforma de condução de comboios, que incorpora suporte para cenários e cabinas 2D e 3D.\r\n\r\nEste programa foi inicialmente desenvolvido por Michelle e está disponível ao público onde legalmente possível.</target>
 					</trans-unit>
 					<trans-unit id="open_source_licenses">
 						<source>Open Source Licenses</source>
-						<target state="translated">Licença de Código Aberto</target>
+						<target>Licença de Código Aberto</target>
 					</trans-unit>
 					<trans-unit id="open_source_licenses_header">
 						<source>OpenBVE makes use of several open-source libraries, whose licenses are reproduced below:</source>
-						<target state="translated">O OpenBVE utiliza várias bibliotecas de código aberto, cujas licenças são reproduzidas abaixo:</target>
+						<target>O OpenBVE utiliza várias bibliotecas de código aberto, cujas licenças são reproduzidas abaixo:</target>
 					</trans-unit>
 					<trans-unit id="close">
 						<source>Close</source>
-						<target state="translated">Fechar</target>
+						<target>Fechar</target>
 					</trans-unit>
 				</group>
 				<group id="bug_report">
 					<trans-unit id="title">
 						<source>Report Problem</source>
-						<target state="translated">Reportar Problema</target>
+						<target>Reportar Problema</target>
 					</trans-unit>
 					<trans-unit id="description">
 						<source>This function will create a zip archive on your Desktop, containing the previous Simulation log and Crash log (If any), along with a text file containing the brief description of the problem entered below.\r\n\r\nPlease post this on the discussion board, or create a new issue on Github.</source>
-						<target state="translated">Esta função vai criar um arquivo ZIP na sua Área de Trabalho, contendo os anteriores relatórios da Simulação e das Avarias (se existentes), juntamente com um ficheiro de texto contendo uma breve descrição do problema indicado abaixo.\r\n\r\nPor favor publique isto na área de discussão, ou crie uma nova entrada no Github.</target>
+						<target>Esta função vai criar um arquivo ZIP na sua Área de Trabalho, contendo os anteriores relatórios da Simulação e das Avarias (se existentes), juntamente com um ficheiro de texto contendo uma breve descrição do problema indicado abaixo.\r\n\r\nPor favor publique isto na área de discussão, ou crie uma nova entrada no Github.</target>
 					</trans-unit>
 					<trans-unit id="view_log_button">
 						<source>View...</source>
-						<target state="translated">Ver...</target>
+						<target>Ver...</target>
 					</trans-unit>
 					<trans-unit id="view_log">
 						<source>View the previous log:</source>
-						<target state="translated">Ver o registo anterior:</target>
+						<target>Ver o registo anterior:</target>
 					</trans-unit>
 					<trans-unit id="view_crash_log">
 						<source>View the previous crash log:</source>
-						<target state="translated">Ver o registo anterior de avaria:</target>
+						<target>Ver o registo anterior de avaria:</target>
 					</trans-unit>
 					<trans-unit id="enter_description">
 						<source>Please enter a brief description of the problem:</source>
-						<target state="translated">Por favor descreva brevemente o problema:</target>
+						<target>Por favor descreva brevemente o problema:</target>
 					</trans-unit>
 					<trans-unit id="no_log">
 						<source>No simulation logs were found.</source>
-						<target state="translated">Não foram encontrados registos da simulação.</target>
+						<target>Não foram encontrados registos da simulação.</target>
 					</trans-unit>
 					<trans-unit id="no_crash_log">
 						<source>No crash logs were found.</source>
-						<target state="translated">Não foram encontrados registos de avarias.</target>
+						<target>Não foram encontrados registos de avarias.</target>
 					</trans-unit>
 					<trans-unit id="save">
 						<source>Save Bug Report</source>
-						<target state="translated">Guardar Relatório do Erro</target>
+						<target>Guardar Relatório do Erro</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target state="translated">O relatório foi guardado como "[filename]" na sua Área de Trabalho. \r\n\r\nAgora pode submeter um relatório de erro na área de discussão, ou colocando uma questão no GitHub com este ficheiro ZIP anexado.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>O relatório foi guardado como &quot;[filename]&quot; na sua Área de Trabalho. \r\n\r\nAgora pode submeter um relatório de erro na área de discussão, ou colocando uma questão no GitHub com este ficheiro ZIP anexado.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target state="translated">Impossível criar o relatório de erro! \r\n\r\nPode aceder ao Registo e Registo de Avaria directamente clicando no botão "Ver..." , submetendo depois estes registos à área de discussão ou colocando uma questão no GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Impossível criar o relatório de erro! \r\n\r\nPode aceder ao Registo e Registo de Avaria directamente clicando no botão &quot;Ver...&quot; , submetendo depois estes registos à área de discussão ou colocando uma questão no GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -139,7 +139,7 @@
 					</trans-unit>
 					<trans-unit id="updates_daily">
 						<source>The most recent nightly build from [date] is available for download.</source>
-						<target state="translated">A versão nocturna mais recente de [date] está disponível para baixar.</target>
+						<target>A versão nocturna mais recente de [date] está disponível para baixar.</target>
 					</trans-unit>
 					<trans-unit id="close">
 						<source>Close</source>
@@ -247,7 +247,7 @@
 					</trans-unit>
 					<trans-unit id="route_corrupt_missingobjects">
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-						<target state="translated">A linha seleccionada está corrompida: \r\n Não é possível localizar todos os objectos definidos.</target>
+						<target>A linha seleccionada está corrompida: \r\n Não é possível localizar todos os objectos definidos.</target>
 					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
@@ -283,15 +283,21 @@
 					</trans-unit>
 					<trans-unit id="database_newer_expected">
 						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
-						<target state="translated">A versão da base de dados do pacote parece ser mais recente que a suportada por esta edição do OpenBVE.</target>
+						<target>A versão da base de dados do pacote parece ser mais recente que a suportada por esta edição do OpenBVE.</target>
 					</trans-unit>
 					<trans-unit id="database_invalid_xml">
 						<source>The package database XML was invalid, and has been re-created.</source>
-						<target state="translated">A base de dados XML do pacote é inválida e foi recreada.</target>
+						<target>A base de dados XML do pacote é inválida e foi recreada.</target>
 					</trans-unit>
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
-						<target state="translated">Actualmente ocupado a trabalhar no pacote. Por favor aguarde um momento e tente de novo.</target>
+						<target>Actualmente ocupado a trabalhar no pacote. Por favor aguarde um momento e tente de novo.</target>
+					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -371,10 +377,6 @@
 						<source>Recently used</source>
 						<target>Utilizado recentemente</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Pré-definido</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Utiliza o comboio pré-definido na linha</target>
@@ -397,14 +399,14 @@
 					</trans-unit>
 					<trans-unit id="train_settings_reverseconsist">
 						<source>Reverse Consist:</source>
-						<target state="translated">Inverter composição:</target>
+						<target>Inverter composição:</target>
 					</trans-unit>
 					<trans-unit id="train_settings_encoding_preview">
 						<source>Preview:</source>
 						<target>Pré-visualização:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>O comboio associado à linha não foi encontrado:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -422,6 +424,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Iniciar</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -620,8 +631,8 @@
 						<target>Instala um pacote</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target state="translated">Este ficheiro não parece ser um pacote válido do openBVE.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>Este ficheiro não parece ser um pacote válido do OpenBVE.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -732,8 +743,8 @@
 						<target>Remover</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target state="translated">Se o seu pacote não assenta noutras dependências pode prosseguir clicando no botão "Criar".</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>Se o seu pacote não assenta noutras dependências pode prosseguir clicando no botão &quot;Criar&quot;.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -759,7 +770,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>Foi atribuído o seguinte GUID ao novo pacote:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Criar um pacote</target>
 					</trans-unit>
@@ -995,6 +1006,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Falhou a criação do seguinte ficheiro: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1051,7 +1071,7 @@
 					</trans-unit>
 					<trans-unit id="reset_question">
 						<source>Reset the current control configuration to the defaults?</source>
-						<target state="translated">Recolocar as actuais configurações de controle na predefinição?</target>
+						<target>Recolocar as actuais configurações de controle na predefinição?</target>
 					</trans-unit>
 					<trans-unit id="reset">
 						<source>Reset to defaults</source>
@@ -1126,8 +1146,8 @@
 						<target>Carregue em qualquer tecla ou desloque o eixo na direcção desejada...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Desloque um eixo qualquer na direcção de "aumentar" ou "força"...</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Desloque um eixo qualquer na direcção de &quot;aumentar&quot; ou &quot;força&quot;...</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,71 +1265,71 @@
 					</trans-unit>
 					<trans-unit id="notdetected">
 						<source>No RailDriver controllers detected.</source>
-						<target>Não foram encontrados controladores do "RailDriver".</target>
+						<target>Não foram encontrados controladores do &quot;RailDriver&quot;.</target>
 					</trans-unit>
 					<trans-unit id="config_error">
 						<source>Error loading RailDriver calibration file.</source>
 						<target>Erro ao carregar o ficheiro de calibragem do RailDriver.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Carregue em 'Seguinte' para iniciar a calibragem.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Carregue em &apos;Seguinte&apos; para iniciar a calibragem.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Mova o inversor para marcha-atrás e carregue em 'Seguinte'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Mova o inversor para marcha-atrás e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Mova o inversor para marcha-à-frente e carregue em 'Seguinte'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Mova o inversor para marcha-à-frente e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Mova o combinador para a potência máxima e carregue em 'Seguinte'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Mova o combinador para a potência máxima e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Mova o combinador para a travagem máxima e carregue em 'Seguinte'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Mova o combinador para a travagem máxima e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Mova o travão dinâmico para neutro e carregue em 'Seguinte'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Mova o travão dinâmico para neutro e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Mova o travão dinâmico para emergência e carregue em 'Seguinte'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Mova o travão dinâmico para emergência e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Mova o travão independente para neutro e carregue em 'Seguinte'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Mova o travão independente para neutro e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Mova o travão independente para a máxima travagem e carregue em 'Seguinte'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Mova o travão independente para a máxima travagem e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Mova a manete do travão do comboio para neutro e carregue em 'Seguinte'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Mova a manete do travão do comboio para neutro e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Mova a manete do travão do comboio para máximo e carregue em 'Seguinte'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Mova a manete do travão do comboio para máximo e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target state="translated">Desligue o limpa-pára-brisas e carregue em 'Seguinte'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Desligue o limpa-pára-brisas e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Ligue o limpa-pára-brisas e carregue em 'Seguinte'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Ligue o limpa-pára-brisas e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Desligue os faróis e carregue em 'Seguinte'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Desligue os faróis e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Ligue os faróis e carregue em 'Seguinte'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Ligue os faróis e carregue em &apos;Seguinte&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1379,7 +1399,7 @@
 					</trans-unit>
 					<trans-unit id="display_fullscreen_bits">
 						<source>Bits per pixel:</source>
-						<target state="translated">Bites por pixel:</target>
+						<target>Bites por pixel:</target>
 					</trans-unit>
 					<trans-unit id="quality">
 						<source>Quality</source>
@@ -1551,7 +1571,7 @@
 					</trans-unit>
 					<trans-unit id="verbosity_accessibilityaids">
 						<source>Accessibility Aids</source>
-						<target state="translated">Ajudas de acessibilidade</target>
+						<target>Ajudas de acessibilidade</target>
 					</trans-unit>
 					<trans-unit id="advanced">
 						<source>Advanced Options</source>
@@ -1563,7 +1583,7 @@
 					</trans-unit>
 					<trans-unit id="advanced_is_use_new_renderer">
 						<source>Enable the new renderer</source>
-					<target>Activar o novo renderizador</target>
+						<target>Activar o novo renderizador</target>
 					</trans-unit>
 					<trans-unit id="advanced_disable_displaylists">
 						<source>Disable OpenGL display lists</source>
@@ -1723,23 +1743,26 @@
 					</trans-unit>
 					<trans-unit id="panel2_extended">
 						<source>Enable Panel2 Extended Mode</source>
-						<target state="translated">Activar o modo extendido do Panel2</target>
+						<target>Activar o modo extendido do Panel2</target>
 					</trans-unit>
 					<trans-unit id="object_parser">
 						<source>Object Parser</source>
-						<target state="translated">Analisador de Objectos</target>
+						<target>Analisador de Objectos</target>
 					</trans-unit>
 					<trans-unit id="xobject_parser">
 						<source>X Object Parser</source>
-						<target state="translated">Objecto X</target>
+						<target>Objecto X</target>
 					</trans-unit>
 					<trans-unit id="objobject_parser">
 						<source>OBJ Object Parser</source>
-						<target state="translated">Objecto OBJ</target>
+						<target>Objecto OBJ</target>
 					</trans-unit>
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
-						<target state="translated">Sinais pré-definidos:</target>
+						<target>Sinais pré-definidos:</target>
+					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
 					</trans-unit>
 				</group>
 				<group id="dialog">
@@ -1852,12 +1875,12 @@
 						<target>Ficheiros não encontrados:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target state="translated">Foram encontrados alguns problemas ao carregar a linha e o comboio.\r\n\r\nComo alguns ficheiros não foram encontrados, a linha e/ou comboio podem não aparecer correctamente. Tente obter novamente a linha e/ou o comboio para garantir que dispõe do pacote completo.\r\n\r\nA seguinte lista de problemas pode fornecer informações adicionais. Pode, ainda assim, iniciar a simulação seleccionando "Ignorar" no botão abaixo.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Foram encontrados alguns problemas ao carregar a linha e o comboio.\r\n\r\nComo alguns ficheiros não foram encontrados, a linha e/ou comboio podem não aparecer correctamente. Tente obter novamente a linha e/ou o comboio para garantir que dispõe do pacote completo.\r\n\r\nA seguinte lista de problemas pode fornecer informações adicionais. Pode, ainda assim, iniciar a simulação seleccionando &quot;Ignorar&quot; no botão abaixo.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target state="translated">Foram encontrados alguns problemas ao carregar a linha e o comboio. Caso seja o autor da linha ou do comboio, talvez valha a pena dar uma olhadela à seguinte lista de problemas.\r\n\r\nComo utilizador pode seleccionar "Ignorar" para poder iniciar a simulação.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Foram encontrados alguns problemas ao carregar a linha e o comboio. Caso seja o autor da linha ou do comboio, talvez valha a pena dar uma olhadela à seguinte lista de problemas.\r\n\r\nComo utilizador pode seleccionar &quot;Ignorar&quot; para poder iniciar a simulação.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1921,7 +1944,7 @@
 					</trans-unit>
 					<trans-unit id="signal_stop">
 						<source>You have passed a stop signal. Please apply the emergency brakes immediately and come to a complete hold.</source>
-						<target state="translated">Passou um sinal de paragem. Por favor accione imediatamente os travões de emergência e pare.</target>
+						<target>Passou um sinal de paragem. Por favor accione imediatamente os travões de emergência e pare.</target>
 					</trans-unit>
 					<trans-unit id="signal_overspeed">
 						<source>The signal indicates a speed limit of [limit] [unit]. You are currently traveling at [speed] [unit]. Please slow down.</source>
@@ -1986,6 +2009,21 @@
 					<trans-unit id="loading">
 						<source>Loading. Please wait...</source>
 						<target>A carregar. Por favor aguarde...</target>
+					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
 					</trans-unit>
 				</group>
 				<group id="notification">
@@ -2052,6 +2090,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Agarrar com o rato: Desligado</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2220,7 +2273,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>Indisponível</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2235,6 +2288,22 @@
 						<source>Current assignment:</source>
 						<target>Actual atribuição:</target>
 					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Pré-definido</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+					</trans-unit>
 				</group>
 				<group id="lamps">
 					<trans-unit id="ats">
@@ -2247,7 +2316,7 @@
 					</trans-unit>
 					<trans-unit id="atsppower">
 						<source>P POWER</source>
-						<target state="translated">P - FORÇA</target>
+						<target>P - FORÇA</target>
 					</trans-unit>
 					<trans-unit id="atsppattern">
 						<source>PTN APPROACH</source>
@@ -2275,7 +2344,7 @@
 					</trans-unit>
 					<trans-unit id="atcpower">
 						<source>ATC POWER</source>
-						<target state="translated">ATC - FORÇA</target>
+						<target>ATC - FORÇA</target>
 					</trans-unit>
 					<trans-unit id="atcuse">
 						<source>ATC SRV</source>
@@ -2287,7 +2356,7 @@
 					</trans-unit>
 					<trans-unit id="eb">
 						<source>EB</source>
-						<target state="translated">HOMEM-MORTO</target>
+						<target>HOMEM-MORTO</target>
 					</trans-unit>
 					<trans-unit id="constspeed">
 						<source>CONST SPEED</source>
@@ -2391,11 +2460,11 @@
 					</trans-unit>
 					<trans-unit id="locobrake_decrease">
 						<source>Decreases the locomotive brake by one notch</source>
-						<target state="translated">Diminui um ponto à travagem da locomotiva</target>
+						<target>Diminui um ponto à travagem da locomotiva</target>
 					</trans-unit>
 					<trans-unit id="locobrake_increase">
 						<source>Increases the locomotive brake by one notch</source>
-						<target state="translated">Aumenta um ponto à travagem da locomotiva</target>
+						<target>Aumenta um ponto à travagem da locomotiva</target>
 					</trans-unit>
 					<trans-unit id="brake_halfaxis">
 						<source>Controls brake for trains with two handles on half of a joystick axis</source>
@@ -2574,15 +2643,15 @@
 						<target>Função P do sistema de segurança</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Muda para a vista interior do comboio</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>Muda para a vista interior do comboio. No entanto, o painel não é mostrado.</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Muda para a vista exterior do comboio</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2755,11 +2824,11 @@
 					</trans-unit>
 					<trans-unit id="debug_wireframe">
 						<source>Activates or deactivates wireframe mode</source>
-						<target>Activa ou desactiva o modo "vêr grelha"</target>
+						<target>Activa ou desactiva o modo &quot;vêr grelha&quot;</target>
 					</trans-unit>
 					<trans-unit id="debug_normals">
 						<source>Shows or hides vertex normals</source>
-						<target>Mostra ou esconde a posição dos "vértices"</target>
+						<target>Mostra ou esconde a posição dos &quot;vértices&quot;</target>
 					</trans-unit>
 					<trans-unit id="debug_brake_systems">
 						<source>Shows or hides brake system debug output</source>
@@ -2843,7 +2912,31 @@
 					</trans-unit>
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
-						<target state="translated">Disjuntor principal</target>
+						<target>Disjuntor principal</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3384,6 +3477,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3511,11 +3752,11 @@
 					</trans-unit>
 					<trans-unit id="brake_cylinder_up">
 						<source>BrakeCylinderUp:</source>
-						<target state="translated">Máximo cil. dos travões:</target>
+						<target>Máximo cil. dos travões:</target>
 					</trans-unit>
 					<trans-unit id="brake_cylinder_down">
 						<source>BrakeCylinderDown:</source>
-						<target state="translated">Mínimo cil. dos travões:</target>
+						<target>Mínimo cil. dos travões:</target>
 					</trans-unit>
 				</group>
 				<group id="brake">
@@ -3537,11 +3778,11 @@
 					</trans-unit>
 					<trans-unit id="smee">
 						<source>Electromagnetic straight air brake</source>
-						<target state="translated">Electromagnético de ar directo</target>
+						<target>Electromagnético de ar directo</target>
 					</trans-unit>
 					<trans-unit id="ecb">
 						<source>Electro-pneumatic air brake without brake pipe</source>
-						<target state="translated">Electropneumático sem conduta</target>
+						<target>Electropneumático sem conduta</target>
 					</trans-unit>
 					<trans-unit id="cl">
 						<source>Air brake with partial release feature</source>
@@ -3553,7 +3794,7 @@
 					</trans-unit>
 					<trans-unit id="lock_out_valve">
 						<source>Closing electromagnetic valve</source>
-						<target state="translated">Válvula electromagnética de fecho</target>
+						<target>Válvula electromagnética de fecho</target>
 					</trans-unit>
 					<trans-unit id="delay_including_control">
 						<source>Delay-including control</source>
@@ -3605,11 +3846,11 @@
 					</trans-unit>
 					<trans-unit id="driver_power_notches">
 						<source>DriverPowerNotches:</source>
-						<target state="translated">Pontos de força do maquinista:</target>
+						<target>Pontos de força do maquinista:</target>
 					</trans-unit>
 					<trans-unit id="driver_brake_notches">
 						<source>DriverBrakeNotches:</source>
-						<target state="translated">Pts travagem do maquinista:</target>
+						<target>Pts travagem do maquinista:</target>
 					</trans-unit>
 					<trans-unit id="power_notch_reduce_steps">
 						<source>PowerNotchReduceSteps:</source>
@@ -3634,6 +3875,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>Os Pontos de travagem do maquinista devem ser menores ou iguais aos Pontos de travagem.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3701,7 +3948,7 @@
 					</trans-unit>
 					<trans-unit id="number_of_trailer_cars_error_message">
 						<source>NumberOfTrailerCars must be at least 1 if FrontCarIsAMotorCar is not set.</source>
-						<target>Nº de reboques deve ser pelo menos 1, se não está definido "Carruagem da frente é Motora".</target>
+						<target>Nº de reboques deve ser pelo menos 1, se não está definido &quot;Carruagem da frente é Motora&quot;.</target>
 					</trans-unit>
 				</group>
 				<group id="device">
@@ -3719,7 +3966,7 @@
 					</trans-unit>
 					<trans-unit id="readhesion_device">
 						<source>ReAdhesionDevice:</source>
-						<target state="translated">Dispositivo de readerência:</target>
+						<target>Dispositivo de readerência:</target>
 					</trans-unit>
 					<trans-unit id="pass_alarm">
 						<source>PassAlarm:</source>
@@ -3809,7 +4056,7 @@
 					</trans-unit>
 					<trans-unit id="subtract_deceleration">
 						<source>Subtract deceleration due to air and rolling resistance</source>
-						<target state="translated">Resistência ao ar e à deslocação</target>
+						<target>Resistência ao ar e à deslocação</target>
 					</trans-unit>
 					<trans-unit id="max_x">
 						<source>Xmax:</source>
@@ -3896,8 +4143,8 @@
 						<target>Outras funcionalidades</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Nota: As funcionalidades desta página podem requerer a seguinte versão mínima do openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Nota: As funcionalidades desta página podem requerer a seguinte versão mínima do OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3965,7 +4212,7 @@
 					</trans-unit>
 					<trans-unit id="misc_eb">
 						<source>Handle behaviour on EB:</source>
-						<target state="translated">Homem-morto:</target>
+						<target>Homem-morto:</target>
 					</trans-unit>
 					<trans-unit id="misc_eb_no">
 						<source>No Action</source>
@@ -3994,1664 +4241,1835 @@
 					<group id="file">
 						<trans-unit id="name">
 							<source>File</source>
-							<target state="translated">Ficheiro</target>
+							<target>Ficheiro</target>
 						</trans-unit>
 						<trans-unit id="new">
 							<source>New</source>
-							<target state="translated">Novo</target>
+							<target>Novo</target>
 						</trans-unit>
 						<trans-unit id="open">
 							<source>Open...</source>
-							<target state="translated">Abrir...</target>
+							<target>Abrir...</target>
 						</trans-unit>
 						<trans-unit id="save">
 							<source>Save</source>
-							<target state="translated">Guardar</target>
+							<target>Guardar</target>
 						</trans-unit>
 						<trans-unit id="save_as">
 							<source>Save as...</source>
-							<target state="translated">Guardar como...</target>
+							<target>Guardar como...</target>
 						</trans-unit>
 						<trans-unit id="import">
 							<source>Import...</source>
-							<target state="translated">Importar...</target>
+							<target>Importar...</target>
 						</trans-unit>
 						<trans-unit id="export">
 							<source>Export...</source>
-							<target state="translated">Exportar...</target>
+							<target>Exportar...</target>
 						</trans-unit>
 						<trans-unit id="exit">
 							<source>Exit</source>
-							<target state="translated">Sair</target>
+							<target>Sair</target>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
-							<target state="translated">Tentou abrir um comboio. \n\n Estes não podem ser abertos directamente-\n\n Por favor utilize a função de importação para importar este comboio para o TrainEditor2.</target>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
+							<target>Tentou abrir um comboio. \n\n Estes não podem ser abertos directamente-\n\n Por favor utilize a função de importação para importar este comboio para o TrainEditor2.</target>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="new">
+							<source>Do you want to save the current file before creating a new one?</source>
+							<target>Pretende guardar o actual ficheiro antes de criar outro?</target>
+						</trans-unit>
+						<trans-unit id="open">
+							<source>Do you want to save the current file before opening another file?</source>
+							<target>Pretende guardar o actual ficheiro antes de abrir outro?</target>
+						</trans-unit>
+						<trans-unit id="exit">
+							<source>Do you want to save the current file before closing?</source>
+							<target>Pretende guardar o actual ficheiro antes de fechar?</target>
 						</trans-unit>
 					</group>
 					<trans-unit id="language">
 						<source>Language</source>
-						<target state="translated">Idioma</target>
+						<target>Idioma</target>
 					</trans-unit>
-					<group id="message">
-						<trans-unit id="new">
-							<source>Do you want to save the current file before creating a new one?</source>
-							<target state="translated">Pretende guardar o actual ficheiro antes de criar outro?</target>
-						</trans-unit>
-						<trans-unit id="open">
-							<source>Do you want to save the current file before opening another file?</source>
-							<target state="translated">Pretende guardar o actual ficheiro antes de abrir outro?</target>
-						</trans-unit>
-						<trans-unit id="exit">
-							<source>Do you want to save the current file before closing?</source>
-							<target state="translated">Pretende guardar o actual ficheiro antes de fechar?</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
 						<source>Up</source>
-						<target state="translated">Cima</target>
+						<target>Cima</target>
 					</trans-unit>
 					<trans-unit id="down">
 						<source>Down</source>
-						<target state="translated">Baixo</target>
+						<target>Baixo</target>
 					</trans-unit>
 					<trans-unit id="add">
 						<source>Add</source>
-						<target state="translated">Adicionar</target>
+						<target>Adicionar</target>
 					</trans-unit>
 					<trans-unit id="remove">
 						<source>Remove</source>
-						<target state="translated">Remover</target>
+						<target>Remover</target>
 					</trans-unit>
 					<trans-unit id="copy">
 						<source>Copy</source>
-						<target state="translated">Copiar</target>
+						<target>Copiar</target>
 					</trans-unit>
 					<trans-unit id="set">
 						<source>Set...</source>
-						<target state="translated">Definir...</target>
+						<target>Definir...</target>
 					</trans-unit>
 					<trans-unit id="open">
 						<source>Open...</source>
-						<target state="translated">Abrir...</target>
+						<target>Abrir...</target>
 					</trans-unit>
 				</group>
 				<group id="tree_cars">
 					<trans-unit id="train">
 						<source>Train</source>
-						<target state="translated">Comboio</target>
+						<target>Comboio</target>
 					</trans-unit>
 					<trans-unit id="general">
 						<source>General</source>
-						<target state="translated">Geral</target>
+						<target>Geral</target>
 					</trans-unit>
 					<trans-unit id="cars">
 						<source>Cars</source>
-						<target state="translated">Carruagens</target>
+						<target>Carruagens</target>
 					</trans-unit>
 					<trans-unit id="couplers">
 						<source>Couplers</source>
-						<target state="translated">Engates</target>
+						<target>Engates</target>
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-						<target state="translated">Definições gerais</target>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-							<target state="translated">Manípulo</target>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
-								<target state="translated">Tipo de manípulo</target>
+								<target>Tipo de manípulo</target>
 							</trans-unit>
 							<trans-unit id="separated">
 								<source>Separated</source>
-								<target state="translated">Separados</target>
+								<target>Separados</target>
 							</trans-unit>
 							<trans-unit id="combined">
 								<source>Combined</source>
-								<target state="translated">Combinados</target>
+								<target>Combinados</target>
+							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-							<target state="translated">Pontos de força</target>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-							<target state="translated">Pontos de travagem</target>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-							<target state="translated">Redução de pontos de força</target>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-							<target state="translated">Pontos de força do maquinista</target>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-							<target state="translated">Pontos de travagem</target>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
-								<target state="translated">Comportamento do Homem-morto</target>
+								<target>Comportamento do Homem-morto</target>
 							</trans-unit>
 							<trans-unit id="no">
 								<source>No action</source>
-								<target state="translated">Sem acção</target>
+								<target>Sem acção</target>
 							</trans-unit>
 							<trans-unit id="power">
 								<source>Return power to neutral</source>
-								<target state="translated">Retornar a força a zero</target>
+								<target>Retornar a força a zero</target>
 							</trans-unit>
 							<trans-unit id="reverser">
 								<source>Return reverser to neutral</source>
-								<target state="translated">Retornar o inversor a zero</target>
+								<target>Retornar o inversor a zero</target>
 							</trans-unit>
 							<trans-unit id="power_reverser">
 								<source>Return power and reverser to neutral</source>
-								<target state="translated">Retornar a força e o inversor a zero</target>
+								<target>Retornar a força e o inversor a zero</target>
 							</trans-unit>
 						</group>
 						<group id="loco_brake_handle_type">
 							<trans-unit id="name">
 								<source>LocoBrakeHandleType</source>
-								<target state="translated">Manípulo do travão da locomotiva</target>
+								<target>Manípulo do travão da locomotiva</target>
 							</trans-unit>
 							<trans-unit id="combined">
 								<source>Combined</source>
-								<target state="translated">Combinado</target>
+								<target>Combinado</target>
 							</trans-unit>
 							<trans-unit id="independent">
 								<source>Independent</source>
-								<target state="translated">Independente</target>
+								<target>Independente</target>
 							</trans-unit>
 							<trans-unit id="blocking">
 								<source>Blocking</source>
-								<target state="translated">Bloqueador</target>
+								<target>Bloqueador</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+							<target>Manípulo</target>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+							<target>Pontos de força</target>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+							<target>Pontos de travagem</target>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+							<target>Redução de pontos de força</target>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+							<target>Pontos de força do maquinista</target>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+							<target>Pontos de travagem</target>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
-							<target state="translated">Pontos de travagem da locomotiva</target>
+							<target>Pontos de travagem da locomotiva</target>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
 						<trans-unit id="name">
 							<source>Cab</source>
-							<target state="translated">Cabina</target>
+							<target>Cabina</target>
 						</trans-unit>
 						<trans-unit id="x">
 							<source>X</source>
-							<target state="translated">X</target>
+							<target>X</target>
 						</trans-unit>
 						<trans-unit id="y">
 							<source>Y</source>
-							<target state="translated">Y</target>
+							<target>Y</target>
 						</trans-unit>
 						<trans-unit id="z">
 							<source>Z</source>
-							<target state="translated">Z</target>
+							<target>Z</target>
 						</trans-unit>
 						<trans-unit id="driver_car">
 							<source>DriverCar</source>
-							<target state="translated">Veículo-piloto</target>
+							<target>Veículo-piloto</target>
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-							<target state="translated">Dispositivo</target>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
-								<target state="translated">Ats</target>
+								<target>Ats</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 							<trans-unit id="ats_sn">
 								<source>ATS-SN</source>
-								<target state="translated">ATS-SN</target>
+								<target>ATS-SN</target>
 							</trans-unit>
 							<trans-unit id="ats_sn_ats_p">
 								<source>ATS-SN / ATS-P</source>
-								<target state="translated">ATS-SN / ATS-P</target>
+								<target>ATS-SN / ATS-P</target>
 							</trans-unit>
 						</group>
 						<group id="atc">
 							<trans-unit id="name">
 								<source>Atc</source>
-								<target state="translated">Atc</target>
+								<target>Atc</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 							<trans-unit id="manual">
 								<source>Manual switching</source>
-								<target state="translated">Comutação manual</target>
+								<target>Comutação manual</target>
 							</trans-unit>
 							<trans-unit id="automatic">
 								<source>Automatic switching</source>
-								<target state="translated">Comutação automática</target>
+								<target>Comutação automática</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-							<target state="translated">Homem-morto</target>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-							<target state="translated">Velocidade constante</target>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-							<target state="translated">Mantém o travão</target>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
-								<target state="translated">Readerência</target>
+								<target>Readerência</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 							<trans-unit id="type_a">
 								<source>Type A (instant)</source>
-								<target state="translated">Tipo A (momentâneo)</target>
+								<target>Tipo A (momentâneo)</target>
 							</trans-unit>
 							<trans-unit id="type_b">
 								<source>Type B (slow)</source>
-								<target state="translated">Tipo B (lento)</target>
+								<target>Tipo B (lento)</target>
 							</trans-unit>
 							<trans-unit id="type_c">
 								<source>Type C (medium)</source>
-								<target state="translated">Tipo C (médio)</target>
+								<target>Tipo C (médio)</target>
 							</trans-unit>
 							<trans-unit id="type_d">
 								<source>Type D (fast)</source>
-								<target state="translated">Tipo D (rápido)</target>
+								<target>Tipo D (rápido)</target>
 							</trans-unit>
 						</group>
 						<group id="pass_alarm">
 							<trans-unit id="name">
 								<source>PassAlarm</source>
-								<target state="translated">Alarme de passagem</target>
+								<target>Alarme de passagem</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 							<trans-unit id="single">
 								<source>Single</source>
-								<target state="translated">Único</target>
+								<target>Único</target>
 							</trans-unit>
 							<trans-unit id="looping">
 								<source>Looping</source>
-								<target state="translated">Contínuo</target>
+								<target>Contínuo</target>
 							</trans-unit>
 						</group>
 						<group id="door_mode">
 							<trans-unit id="open">
 								<source>DoorOpenMode</source>
-								<target state="translated">Abertura de portas</target>
+								<target>Abertura de portas</target>
 							</trans-unit>
 							<trans-unit id="close">
 								<source>DoorCloseMode</source>
-								<target state="translated">Fecho de portas</target>
+								<target>Fecho de portas</target>
 							</trans-unit>
 							<trans-unit id="semi_automatic">
 								<source>Semi-automatic</source>
-								<target state="translated">Semi-automático</target>
+								<target>Semi-automático</target>
 							</trans-unit>
 							<trans-unit id="automatic">
 								<source>Automatic</source>
-								<target state="translated">Automático</target>
+								<target>Automático</target>
 							</trans-unit>
 							<trans-unit id="manual">
 								<source>Manual</source>
-								<target state="translated">Manual</target>
+								<target>Manual</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+							<target>Dispositivo</target>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+							<target>Homem-morto</target>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+							<target>Velocidade constante</target>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+							<target>Mantém o travão</target>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
-							<target state="translated">Largura de porta</target>
+							<target>Largura de porta</target>
 						</trans-unit>
 						<trans-unit id="door_max_tolerance">
 							<source>DoorMaxTolerance</source>
-							<target state="translated">Máxima tolerância</target>
+							<target>Máxima tolerância</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+						<target>Definições gerais</target>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-						<target state="translated">Definições do veículo</target>
-					</trans-unit>
 					<group id="general">
-						<trans-unit id="name">
-							<source>General</source>
-							<target state="translated">Geral</target>
-						</trans-unit>
-						<trans-unit id="is_motor_car">
-							<source>IsMotorCar</source>
-							<target state="translated">É motora</target>
-						</trans-unit>
-						<trans-unit id="mass">
-							<source>Mass</source>
-							<target state="translated">Massa</target>
-						</trans-unit>
-						<trans-unit id="length">
-							<source>Length</source>
-							<target state="translated">Comprimento</target>
-						</trans-unit>
-						<trans-unit id="width">
-							<source>Width</source>
-							<target state="translated">Largura</target>
-						</trans-unit>
-						<trans-unit id="height">
-							<source>Height</source>
-							<target state="translated">Altura</target>
-						</trans-unit>
-						<trans-unit id="center_of_gravity_height">
-							<source>CenterOfGravityHeight</source>
-							<target state="translated">Alt. centro gravidade</target>
-						</trans-unit>
-						<trans-unit id="exposed_frontal_area">
-							<source>ExposedFrontalArea</source>
-							<target state="translated">Área frontal exposta</target>
-						</trans-unit>
-						<trans-unit id="unexposed_frontal_area">
-							<source>UnexposedFrontalArea</source>
-							<target state="translated">Área frontal não exposta</target>
-						</trans-unit>
-						<trans-unit id="defined_axles">
-							<source>DefinedAxles</source>
-							<target state="translated">Eixos definidos</target>
-						</trans-unit>
 						<group id="axles">
 							<trans-unit id="name">
 								<source>Axles</source>
-								<target state="translated">Eixos</target>
+								<target>Eixos</target>
 							</trans-unit>
 							<trans-unit id="front">
 								<source>FrontAxle</source>
-								<target state="translated">Eixo dianteiro</target>
+								<target>Eixo dianteiro</target>
 							</trans-unit>
 							<trans-unit id="rear">
 								<source>RearAxle</source>
-								<target state="translated">Eixo traseiro</target>
+								<target>Eixo traseiro</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>General</source>
+							<target>Geral</target>
+						</trans-unit>
+						<trans-unit id="is_motor_car">
+							<source>IsMotorCar</source>
+							<target>É motora</target>
+						</trans-unit>
+						<trans-unit id="mass">
+							<source>Mass</source>
+							<target>Massa</target>
+						</trans-unit>
+						<trans-unit id="length">
+							<source>Length</source>
+							<target>Comprimento</target>
+						</trans-unit>
+						<trans-unit id="width">
+							<source>Width</source>
+							<target>Largura</target>
+						</trans-unit>
+						<trans-unit id="height">
+							<source>Height</source>
+							<target>Altura</target>
+						</trans-unit>
+						<trans-unit id="center_of_gravity_height">
+							<source>CenterOfGravityHeight</source>
+							<target>Alt. centro gravidade</target>
+						</trans-unit>
+						<trans-unit id="exposed_frontal_area">
+							<source>ExposedFrontalArea</source>
+							<target>Área frontal exposta</target>
+						</trans-unit>
+						<trans-unit id="unexposed_frontal_area">
+							<source>UnexposedFrontalArea</source>
+							<target>Área frontal não exposta</target>
+						</trans-unit>
+						<trans-unit id="defined_axles">
+							<source>DefinedAxles</source>
+							<target>Eixos definidos</target>
+						</trans-unit>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
-							<target state="translated">Bogie dianteiro</target>
+							<target>Bogie dianteiro</target>
 						</trans-unit>
 						<trans-unit id="rear_bogie">
 							<source>RearBogie</source>
-							<target state="translated">Bogie traseiro</target>
+							<target>Bogie traseiro</target>
 						</trans-unit>
 						<trans-unit id="loading_sway">
 							<source>LoadingSway</source>
-							<target state="translated">Balanceamento ao carregar</target>
+							<target>Balanceamento ao carregar</target>
 						</trans-unit>
 						<trans-unit id="reversed">
 							<source>Reversed</source>
-							<target state="translated">Invertido</target>
+							<target>Invertido</target>
 						</trans-unit>
 						<trans-unit id="object">
 							<source>Object</source>
-							<target state="translated">Objecto</target>
+							<target>Objecto</target>
 						</trans-unit>
 					</group>
 					<group id="performance">
 						<trans-unit id="name">
 							<source>Performance</source>
-							<target state="translated">Desempenho</target>
+							<target>Desempenho</target>
 						</trans-unit>
 						<trans-unit id="deceleration">
 							<source>Deceleration</source>
-							<target state="translated">Desaceleração</target>
+							<target>Desaceleração</target>
 						</trans-unit>
 						<trans-unit id="static_friction">
 							<source>CoefficientOfStaticFriction</source>
-							<target state="translated">Coef. fricção estática</target>
+							<target>Coef. fricção estática</target>
 						</trans-unit>
 						<trans-unit id="rolling_resistance">
 							<source>CoefficientOfRollingResistance</source>
-							<target state="translated">Coef. resistência à deslocação</target>
+							<target>Coef. resistência à deslocação</target>
 						</trans-unit>
 						<trans-unit id="aerodynamic_drag">
 							<source>AerodynamicDragCoefficient</source>
-							<target state="translated">Coef. arrastamento aerodinâmico</target>
+							<target>Coef. arrastamento aerodinâmico</target>
 						</trans-unit>
 					</group>
 					<group id="move">
 						<trans-unit id="name">
 							<source>Move</source>
-							<target state="translated">Mover</target>
+							<target>Mover</target>
 						</trans-unit>
 						<trans-unit id="jerk_power_up">
 							<source>JerkPowerUp</source>
-							<target state="translated">Impulso à aceleração</target>
+							<target>Impulso à aceleração</target>
 						</trans-unit>
 						<trans-unit id="jerk_power_down">
 							<source>JerkPowerDown</source>
-							<target state="translated">Impulso à desaceleração</target>
+							<target>Impulso à desaceleração</target>
 						</trans-unit>
 						<trans-unit id="jerk_brake_up">
 							<source>JerkBrakeUp</source>
-							<target state="translated">Impulso à travagem</target>
+							<target>Impulso à travagem</target>
 						</trans-unit>
 						<trans-unit id="jerk_brake_down">
 							<source>JerkBrakeDown</source>
-							<target state="translated">Impulso à destravagem</target>
+							<target>Impulso à destravagem</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_up">
 							<source>BrakeCylinderUp</source>
-							<target state="translated">Máx. cilindro dos travões</target>
+							<target>Máx. cilindro dos travões</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_down">
 							<source>BrakeCylinderDown</source>
-							<target state="translated">Mín. cilindro dos travões</target>
+							<target>Mín. cilindro dos travões</target>
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-							<target state="translated">Travão</target>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
-								<target state="translated">Tipo de travão</target>
+								<target>Tipo de travão</target>
 							</trans-unit>
 							<trans-unit id="smee">
 								<source>Electromagnetic straight air brake</source>
-								<target state="translated">Electromagnético de ar directo</target>
+								<target>Electromagnético de ar directo</target>
 							</trans-unit>
 							<trans-unit id="ecb">
 								<source>Electro-pneumatic air brake without brake pipe</source>
-								<target state="translated">Electropneumático sem conduta</target>
+								<target>Electropneumático sem conduta</target>
 							</trans-unit>
 							<trans-unit id="cl">
 								<source>Air brake with partial release feature</source>
-								<target state="translated">Pneumático com dispositivo de relaxamento parcial</target>
+								<target>Pneumático com dispositivo de relaxamento parcial</target>
 							</trans-unit>
 						</group>
 						<group id="loco_brake_type">
 							<trans-unit id="name">
 								<source>LocoBrakeType</source>
-								<target state="translated">Locomotiva</target>
+								<target>Locomotiva</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>Not fitted</source>
-								<target state="translated">Não equipado</target>
+								<target>Não equipado</target>
 							</trans-unit>
 							<trans-unit id="notched_air_brake">
 								<source>Notched air brake</source>
-								<target state="translated">Travão a ar por pontos</target>
+								<target>Travão a ar por pontos</target>
 							</trans-unit>
 							<trans-unit id="cl">
 								<source>Air brake with partial release</source>
-								<target state="translated">Travão a ar com relaxamento parcial</target>
+								<target>Travão a ar com relaxamento parcial</target>
 							</trans-unit>
 						</group>
 						<group id="brake_control_system">
 							<trans-unit id="name">
 								<source>BrakeControlSystem</source>
-								<target state="translated">Controlo de travagem</target>
+								<target>Controlo de travagem</target>
 							</trans-unit>
 							<trans-unit id="none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 							<trans-unit id="lock_out_valve">
 								<source>Closing electromagnetic valve</source>
-								<target state="translated">Válvula electromagnética de fecho</target>
+								<target>Válvula electromagnética de fecho</target>
 							</trans-unit>
 							<trans-unit id="delay_including_control">
 								<source>Delay-including control</source>
-								<target state="translated">Controlo de inclusão de atraso</target>
+								<target>Controlo de inclusão de atraso</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+							<target>Travão</target>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
-							<target state="translated">Controlo da velocidade de travagem</target>
+							<target>Controlo da velocidade de travagem</target>
 						</trans-unit>
 					</group>
 					<group id="pressure">
 						<trans-unit id="name">
 							<source>Pressure</source>
-							<target state="translated">Pressão</target>
+							<target>Pressão</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_service_max">
 							<source>BrakeCylinderServiceMaximumPressure</source>
-							<target state="translated">Pressão máx. de serviço do cilindro</target>
+							<target>Pressão máx. de serviço do cilindro</target>
 						</trans-unit>
 						<trans-unit id="brake_cylinder_emergency_max">
 							<source>BrakeCylinderEmergencyMaximumPressure</source>
-							<target state="translated">Pressão máx. de emergência do cilindro</target>
+							<target>Pressão máx. de emergência do cilindro</target>
 						</trans-unit>
 						<trans-unit id="main_reservoir_min">
 							<source>MainReservoirMinimumPressure</source>
-							<target state="translated">Pressão mínima do tanque principal</target>
+							<target>Pressão mínima do tanque principal</target>
 						</trans-unit>
 						<trans-unit id="main_reservoir_max">
 							<source>MainReservoirMaximumPressure</source>
-							<target state="translated">Pressão máxima do tanque principal</target>
+							<target>Pressão máxima do tanque principal</target>
 						</trans-unit>
 						<trans-unit id="brake_pipe_normal">
 							<source>BrakePipeNormalPressure</source>
-							<target state="translated">Pressão normal da conduta</target>
+							<target>Pressão normal da conduta</target>
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
-							<target state="translated">Atraso</target>
+							<target>Atraso</target>
 						</trans-unit>
 						<trans-unit id="power">
 							<source>Power</source>
-							<target state="translated">Acelerador</target>
+							<target>Acelerador</target>
 						</trans-unit>
 						<trans-unit id="brake">
 							<source>Brake</source>
-							<target state="translated">Travão</target>
+							<target>Travão</target>
 						</trans-unit>
 						<trans-unit id="loco_brake">
 							<source>LocoBrake</source>
-							<target state="translated">Travão da locomotiva</target>
+							<target>Travão da locomotiva</target>
 						</trans-unit>
 						<trans-unit id="notch">
 							<source>Notch</source>
-							<target state="translated">Ponto</target>
+							<target>Ponto</target>
 						</trans-unit>
 						<trans-unit id="value">
 							<source>Value</source>
-							<target state="translated">Valor</target>
+							<target>Valor</target>
+						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+						<target>Definições do veículo</target>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-						<target state="translated">Definições de aceleração</target>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-						<target state="translated">Ponto</target>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
-							<target state="translated">Parâmetro</target>
+							<target>Parâmetro</target>
 						</trans-unit>
 						<trans-unit id="a0">
 							<source>a0</source>
-							<target state="translated">a0</target>
+							<target>a0</target>
 						</trans-unit>
 						<trans-unit id="a1">
 							<source>a1</source>
-							<target state="translated">a1</target>
+							<target>a1</target>
 						</trans-unit>
 						<trans-unit id="v1">
 							<source>v1</source>
-							<target state="translated">v1</target>
+							<target>v1</target>
 						</trans-unit>
 						<trans-unit id="v2">
 							<source>v2</source>
-							<target state="translated">v2</target>
+							<target>v2</target>
 						</trans-unit>
 						<trans-unit id="e">
 							<source>e (2.0)</source>
-							<target state="translated">e(2.0)</target>
+							<target>e(2.0)</target>
 						</trans-unit>
 					</group>
 					<group id="preview">
 						<trans-unit id="name">
 							<source>Preview</source>
-							<target state="translated">Pré-visualização</target>
+							<target>Pré-visualização</target>
 						</trans-unit>
 						<trans-unit id="subtract_deceleration">
 							<source>Subtract deceleration due to air and rolling resistance</source>
-							<target state="translated">Subtrair desaceleração devido à resistência ao ar e à deslocação</target>
+							<target>Subtrair desaceleração devido à resistência ao ar e à deslocação</target>
 						</trans-unit>
 						<trans-unit id="x">
 							<source>X</source>
-							<target state="translated">X</target>
+							<target>X</target>
 						</trans-unit>
 						<trans-unit id="y">
 							<source>Y</source>
-							<target state="translated">Y</target>
+							<target>Y</target>
 						</trans-unit>
 						<trans-unit id="x_min">
 							<source>x-min</source>
-							<target state="translated">x-mín</target>
+							<target>x-mín</target>
 						</trans-unit>
 						<trans-unit id="x_max">
 							<source>x-max</source>
-							<target state="translated">x-máx</target>
+							<target>x-máx</target>
 						</trans-unit>
 						<trans-unit id="y_min">
 							<source>y-min</source>
-							<target state="translated">y-mín</target>
+							<target>y-mín</target>
 						</trans-unit>
 						<trans-unit id="y_max">
 							<source>y-max</source>
-							<target state="translated">y-máx</target>
+							<target>y-máx</target>
 						</trans-unit>
 						<trans-unit id="zoom_in">
 							<source>Zoom In</source>
-							<target state="translated">Aproximar</target>
+							<target>Aproximar</target>
 						</trans-unit>
 						<trans-unit id="zoom_out">
 							<source>Zoom Out</source>
-							<target state="translated">Afastar</target>
+							<target>Afastar</target>
 						</trans-unit>
 						<trans-unit id="reset">
 							<source>Reset</source>
-							<target state="translated">Redefinir</target>
+							<target>Redefinir</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+						<target>Definições de aceleração</target>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+						<target>Ponto</target>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-						<target state="translated">Definições do som do motor</target>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
 								<source>Edit</source>
-								<target state="translated">Editar</target>
+								<target>Editar</target>
 							</trans-unit>
 							<trans-unit id="undo">
 								<source>Undo</source>
-								<target state="translated">Desfazer</target>
+								<target>Desfazer</target>
 							</trans-unit>
 							<trans-unit id="redo">
 								<source>Redo</source>
-								<target state="translated">Refazer</target>
+								<target>Refazer</target>
 							</trans-unit>
 							<trans-unit id="cut">
 								<source>Cut</source>
-								<target state="translated">Cortar</target>
+								<target>Cortar</target>
 							</trans-unit>
 							<trans-unit id="copy">
 								<source>Copy</source>
-								<target state="translated">Copiar</target>
+								<target>Copiar</target>
 							</trans-unit>
 							<trans-unit id="paste">
 								<source>Paste</source>
-								<target state="translated">Colar</target>
+								<target>Colar</target>
 							</trans-unit>
 							<trans-unit id="cleanup">
 								<source>Cleanup</source>
-								<target state="translated">Limpar</target>
+								<target>Limpar</target>
 							</trans-unit>
 							<trans-unit id="delete">
 								<source>Delete</source>
-								<target state="translated">Apagar</target>
+								<target>Apagar</target>
 							</trans-unit>
 						</group>
 						<group id="view">
 							<trans-unit id="name">
 								<source>View</source>
-								<target state="translated">Ver</target>
+								<target>Ver</target>
 							</trans-unit>
 							<trans-unit id="power">
 								<source>Power</source>
-								<target state="translated">Acelerador</target>
+								<target>Acelerador</target>
 							</trans-unit>
 							<trans-unit id="brake">
 								<source>Brake</source>
-								<target state="translated">Travão</target>
+								<target>Travão</target>
 							</trans-unit>
 							<trans-unit id="track">
 								<source>Track</source>
-								<target state="translated">Faixa</target>
+								<target>Faixa</target>
 							</trans-unit>
 						</group>
 						<group id="input">
 							<trans-unit id="name">
 								<source>Input</source>
-								<target state="translated">Entrada</target>
+								<target>Entrada</target>
 							</trans-unit>
 							<trans-unit id="pitch">
 								<source>Pitch</source>
-								<target state="translated">Timbre</target>
+								<target>Timbre</target>
 							</trans-unit>
 							<trans-unit id="volume">
 								<source>Volume</source>
-								<target state="translated">Volume</target>
+								<target>Volume</target>
 							</trans-unit>
 							<trans-unit id="sound_index">
 								<source>Sound source index</source>
-								<target state="translated">Índice da fonte sonora</target>
+								<target>Índice da fonte sonora</target>
 							</trans-unit>
 							<trans-unit id="sound_index_none">
 								<source>None</source>
-								<target state="translated">Nenhum</target>
+								<target>Nenhum</target>
 							</trans-unit>
 						</group>
 						<group id="tool">
 							<trans-unit id="name">
 								<source>Tool</source>
-								<target state="translated">Ferramenta</target>
+								<target>Ferramenta</target>
 							</trans-unit>
 							<trans-unit id="select">
 								<source>Select</source>
-								<target state="translated">Seleccionar</target>
+								<target>Seleccionar</target>
 							</trans-unit>
 							<trans-unit id="move">
 								<source>Move</source>
-								<target state="translated">Mover</target>
+								<target>Mover</target>
 							</trans-unit>
 							<trans-unit id="dot">
 								<source>Dot</source>
-								<target state="translated">Ponto</target>
+								<target>Ponto</target>
 							</trans-unit>
 							<trans-unit id="line">
 								<source>Line</source>
-								<target state="translated">Linha</target>
+								<target>Linha</target>
 							</trans-unit>
 						</group>
 					</group>
 					<group id="view_setting">
 						<trans-unit id="name">
 							<source>View setting</source>
-							<target state="translated">Definição de visualização</target>
+							<target>Definição de visualização</target>
 						</trans-unit>
 						<trans-unit id="min_velocity">
 							<source>x-min(Velocity)</source>
-							<target state="translated">x-mín. (Velocidade)</target>
+							<target>x-mín. (Velocidade)</target>
 						</trans-unit>
 						<trans-unit id="max_velocity">
 							<source>x-max(Velocity)</source>
-							<target state="translated">x-máx. (Velocidade)</target>
+							<target>x-máx. (Velocidade)</target>
 						</trans-unit>
 						<trans-unit id="min_pitch">
 							<source>y-min(Pitch)</source>
-							<target state="translated">y-mín. (Timbre)</target>
+							<target>y-mín. (Timbre)</target>
 						</trans-unit>
 						<trans-unit id="max_pitch">
 							<source>y-max(Pitch)</source>
-							<target state="translated">y-máx. (Timbre)</target>
+							<target>y-máx. (Timbre)</target>
 						</trans-unit>
 						<trans-unit id="min_volume">
 							<source>y-min(Volume)</source>
-							<target state="translated">y-mín. (Volume)</target>
+							<target>y-mín. (Volume)</target>
 						</trans-unit>
 						<trans-unit id="max_volume">
 							<source>y-max(Volume)</source>
-							<target state="translated">y-máx. (Volume)</target>
+							<target>y-máx. (Volume)</target>
 						</trans-unit>
 						<trans-unit id="zoom_in">
 							<source>Zoom In</source>
-							<target state="translated">Aproximar</target>
+							<target>Aproximar</target>
 						</trans-unit>
 						<trans-unit id="zoom_out">
 							<source>Zoom Out</source>
-							<target state="translated">Afastar</target>
+							<target>Afastar</target>
 						</trans-unit>
 						<trans-unit id="reset">
 							<source>Reset</source>
-							<target state="translated">Redefinir</target>
+							<target>Redefinir</target>
 						</trans-unit>
 					</group>
 					<group id="direct_input">
 						<trans-unit id="name">
 							<source>Direct input</source>
-							<target state="translated">Entrada directa</target>
+							<target>Entrada directa</target>
 						</trans-unit>
 						<trans-unit id="x">
 							<source>x coordinate</source>
-							<target state="translated">coordenada x</target>
+							<target>coordenada x</target>
 						</trans-unit>
 						<trans-unit id="y">
 							<source>y coordinate</source>
-							<target state="translated">coordenada y</target>
+							<target>coordenada y</target>
 						</trans-unit>
 						<trans-unit id="dot">
 							<source>Dot</source>
-							<target state="translated">Ponto</target>
+							<target>Ponto</target>
 						</trans-unit>
 						<trans-unit id="move">
 							<source>Move</source>
-							<target state="translated">Mover</target>
+							<target>Mover</target>
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-							<target state="translated">Definição de reprodução</target>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
-								<target state="translated">Definição da fonte sonora</target>
+								<target>Definição da fonte sonora</target>
 							</trans-unit>
 							<trans-unit id="run">
 								<source>Running sound</source>
-								<target state="translated">Som actual</target>
+								<target>Som actual</target>
 							</trans-unit>
 							<trans-unit id="track">
 								<source>Track</source>
-								<target state="translated">Faixa</target>
+								<target>Faixa</target>
 							</trans-unit>
 						</group>
 						<group id="area">
 							<trans-unit id="name">
 								<source>Area setting</source>
-								<target state="translated">Definição de área</target>
+								<target>Definição de área</target>
 							</trans-unit>
 							<trans-unit id="loop">
 								<source>Loop playback</source>
-								<target state="translated">Reprodução contínua</target>
+								<target>Reprodução contínua</target>
 							</trans-unit>
 							<trans-unit id="constant">
 								<source>Constant speed</source>
-								<target state="translated">Velocidade constante</target>
+								<target>Velocidade constante</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
-								<target state="translated">Aceleração:</target>
+								<source>Acceleration</source>
+								<target>Aceleração:</target>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
-								<target state="translated">Troca</target>
+								<target>Troca</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+							<target>Definição de reprodução</target>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
-							<target state="translated">Reprodução</target>
+							<target>Reprodução</target>
 						</trans-unit>
 						<trans-unit id="pause">
 							<source>Pause</source>
-							<target state="translated">Pausa</target>
+							<target>Pausa</target>
 						</trans-unit>
 						<trans-unit id="stop">
 							<source>Stop</source>
-							<target state="translated">Parar</target>
+							<target>Parar</target>
 						</trans-unit>
 					</group>
 					<group id="vertex_info">
 						<trans-unit id="name">
 							<source>Vertex information</source>
-							<target state="translated">Informação do vértice</target>
+							<target>Informação do vértice</target>
 						</trans-unit>
 						<trans-unit id="velocity">
 							<source>Velocity</source>
-							<target state="translated">Velocidade</target>
+							<target>Velocidade</target>
 						</trans-unit>
 						<trans-unit id="pitch">
 							<source>Pitch</source>
-							<target state="translated">Timbre</target>
+							<target>Timbre</target>
 						</trans-unit>
 						<trans-unit id="volume">
 							<source>Volume</source>
-							<target state="translated">Volume</target>
+							<target>Volume</target>
 						</trans-unit>
 						<trans-unit id="sound_index">
 							<source>Sound source index</source>
-							<target state="translated">Índice da fonte sonora</target>
+							<target>Índice da fonte sonora</target>
 						</trans-unit>
 					</group>
 					<group id="status">
 						<group id="type">
 							<trans-unit id="name">
 								<source>Type</source>
-								<target state="translated">Tipo</target>
+								<target>Tipo</target>
 							</trans-unit>
 							<trans-unit id="power">
 								<source>Power</source>
-								<target state="translated">Acelerador</target>
+								<target>Acelerador</target>
 							</trans-unit>
 							<trans-unit id="brake">
 								<source>Brake</source>
-								<target state="translated">Travão</target>
+								<target>Travão</target>
 							</trans-unit>
 						</group>
 						<group id="track">
 							<trans-unit id="name">
 								<source>Track</source>
-								<target state="translated">Faixa</target>
+								<target>Faixa</target>
 							</trans-unit>
 						</group>
 						<group id="mode">
 							<trans-unit id="name">
 								<source>Mode</source>
-								<target state="translated">Modo</target>
+								<target>Modo</target>
 							</trans-unit>
 							<trans-unit id="pitch">
 								<source>Pitch</source>
-								<target state="translated">Timbre</target>
+								<target>Timbre</target>
 							</trans-unit>
 							<trans-unit id="volume">
 								<source>Volume</source>
-								<target state="translated">Volume</target>
+								<target>Volume</target>
 							</trans-unit>
 							<trans-unit id="sound_index">
 								<source>Sound source index</source>
-								<target state="translated">Índice da fonte sonora</target>
+								<target>Índice da fonte sonora</target>
 							</trans-unit>
 						</group>
 						<group id="tool">
 							<trans-unit id="name">
 								<source>Tool</source>
-								<target state="translated">Ferramenta</target>
+								<target>Ferramenta</target>
 							</trans-unit>
 							<trans-unit id="select">
 								<source>Select</source>
-								<target state="translated">Seleccionar</target>
+								<target>Seleccionar</target>
 							</trans-unit>
 							<trans-unit id="move">
 								<source>Move</source>
-								<target state="translated">Mover</target>
+								<target>Mover</target>
 							</trans-unit>
 							<trans-unit id="dot">
 								<source>Dot</source>
-								<target state="translated">Ponto</target>
+								<target>Ponto</target>
 							</trans-unit>
 							<trans-unit id="line">
 								<source>Line</source>
-								<target state="translated">Linha</target>
+								<target>Linha</target>
 							</trans-unit>
 						</group>
 						<group id="xy">
 							<trans-unit id="velocity">
 								<source>Velocity</source>
-								<target state="translated">Velocidade</target>
+								<target>Velocidade</target>
 							</trans-unit>
 							<trans-unit id="pitch">
 								<source>Pitch</source>
-								<target state="translated">Timbre</target>
+								<target>Timbre</target>
 							</trans-unit>
 							<trans-unit id="volume">
 								<source>Volume</source>
-								<target state="translated">Volume</target>
+								<target>Volume</target>
 							</trans-unit>
 						</group>
 					</group>
 					<group id="message">
 						<trans-unit id="vertex_exist">
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
-							<target state="translated">Já existe um ponto com a mesma coordenada x. Pretende reescrever?</target>
+							<target>Já existe um ponto com a mesma coordenada x. Pretende reescrever?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+						<target>Definições do som do motor</target>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-						<target state="translated">Definições de engate</target>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
-							<target state="translated">Geral</target>
+							<target>Geral</target>
 						</trans-unit>
 						<trans-unit id="min">
 							<source>Min</source>
-							<target state="translated">Mínimo</target>
+							<target>Mínimo</target>
 						</trans-unit>
 						<trans-unit id="max">
 							<source>Max</source>
-							<target state="translated">Máximo</target>
+							<target>Máximo</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+						<target>Definições de engate</target>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-						<target state="translated">Definições do painel</target>
-					</trans-unit>
 					<group id="this">
-						<trans-unit id="name">
-							<source>This</source>
-							<target state="translated">Este</target>
-						</trans-unit>
-						<trans-unit id="resolution">
-							<source>Resolution</source>
-							<target state="translated">Resolução</target>
-						</trans-unit>
-						<trans-unit id="left">
-							<source>Left</source>
-							<target state="translated">Esquerda</target>
-						</trans-unit>
-						<trans-unit id="right">
-							<source>Right</source>
-							<target state="translated">Direita</target>
-						</trans-unit>
-						<trans-unit id="top">
-							<source>Top</source>
-							<target state="translated">Topo</target>
-						</trans-unit>
-						<trans-unit id="bottom">
-							<source>Bottom</source>
-							<target state="translated">Base</target>
-						</trans-unit>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-							<target state="translated">Imagem Diurna</target>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-							<target state="translated">Imagem nocturna</target>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
-						</trans-unit>
 						<group id="center">
 							<trans-unit id="name">
-								<source>Center</source>
-								<target state="translated">Centro</target>
+								<source>Center origin</source>
+								<target>Centro</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
 						<group id="origin">
 							<trans-unit id="name">
-								<source>Origin</source>
-								<target state="translated">Origem</target>
+								<source>Track origin</source>
+								<target>Origem</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>This</source>
+							<target>Este</target>
+						</trans-unit>
+						<trans-unit id="resolution">
+							<source>Resolution</source>
+							<target>Resolução</target>
+						</trans-unit>
+						<trans-unit id="left">
+							<source>Left</source>
+							<target>Esquerda</target>
+						</trans-unit>
+						<trans-unit id="right">
+							<source>Right</source>
+							<target>Direita</target>
+						</trans-unit>
+						<trans-unit id="top">
+							<source>Top</source>
+							<target>Topo</target>
+						</trans-unit>
+						<trans-unit id="bottom">
+							<source>Bottom</source>
+							<target>Base</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+							<target>Imagem Diurna</target>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+							<target>Imagem nocturna</target>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+							<target>Cor transparente</target>
+						</trans-unit>
 					</group>
 					<group id="screen">
 						<trans-unit id="name">
 							<source>Screen</source>
-							<target state="translated">Tela</target>
+							<target>Tela</target>
 						</trans-unit>
 						<trans-unit id="number">
 							<source>Number</source>
-							<target state="translated">Número</target>
+							<target>Número</target>
 						</trans-unit>
 						<trans-unit id="layer">
 							<source>Layer</source>
-							<target state="translated">Camada</target>
+							<target>Camada</target>
 						</trans-unit>
 					</group>
 					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-							<target state="translated">Luz-piloto</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target state="translated">Assunto</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
-								<target state="translated">Localização</target>
+								<target>Localização</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+							<target>Luz-piloto</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Assunto</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
-							<target state="translated">Imagem diurna</target>
+							<target>Imagem diurna</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
 							<source>NighttimeImage</source>
-							<target state="translated">Imagem nocturna</target>
+							<target>Imagem nocturna</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
+							<target>Cor transparente</target>
 						</trans-unit>
 						<trans-unit id="layer">
 							<source>Layer</source>
-							<target state="translated">Camada</target>
+							<target>Camada</target>
 						</trans-unit>
 					</group>
 					<group id="needle">
-						<trans-unit id="name">
-							<source>Needle</source>
-							<target state="translated">Ponteiro</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target state="translated">Assunto</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
-								<target state="translated">Localização</target>
+								<target>Localização</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="defined_radius">
-							<source>DefinedRadius</source>
-							<target state="translated">Raio definido</target>
-						</trans-unit>
-						<trans-unit id="radius">
-							<source>Radius</source>
-							<target state="translated">Raio</target>
-						</trans-unit>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-							<target state="translated">Imagem diurna</target>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-							<target state="translated">Imagem nocturna</target>
-						</trans-unit>
-						<trans-unit id="color">
-							<source>Color</source>
-							<target state="translated">Cor</target>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
-						</trans-unit>
-						<trans-unit id="defined_origin">
-							<source>DefinedOrigin</source>
-							<target state="translated">Origem definida</target>
-						</trans-unit>
 						<group id="origin">
 							<trans-unit id="name">
 								<source>Origin</source>
-								<target state="translated">Origem</target>
+								<target>Origem</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="initial_angle">
-							<source>InitialAngle</source>
-							<target state="translated">Ângulo inicial</target>
-						</trans-unit>
-						<trans-unit id="last_angle">
-							<source>LastAngle</source>
-							<target state="translated">Ângulo final</target>
-						</trans-unit>
-						<trans-unit id="minimum">
-							<source>Minimum</source>
-							<target state="translated">Mínimo</target>
-						</trans-unit>
-						<trans-unit id="maximum">
-							<source>Maximum</source>
-							<target state="translated">Máximo</target>
-						</trans-unit>
-						<trans-unit id="defined_natural_freq">
-							<source>DefinedNaturalFreq</source>
-							<target state="translated">Frequência natural definida</target>
-						</trans-unit>
-						<trans-unit id="natural_freq">
-							<source>NaturalFreq</source>
-							<target state="translated">Frequência natural</target>
-						</trans-unit>
-						<trans-unit id="defined_damping_ratio">
-							<source>DefiedDampingRatio</source>
-							<target state="translated">Relação definida de amortecimento</target>
-						</trans-unit>
-						<trans-unit id="damping_ratio">
-							<source>DampingRatio</source>
-							<target state="translated">Relação de amortecimento</target>
-						</trans-unit>
-						<trans-unit id="backstop">
-							<source>Backstop</source>
-							<target state="translated">Espera</target>
-						</trans-unit>
-						<trans-unit id="smoothed">
-							<source>smoothed</source>
-							<target state="translated">esbatido</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target state="translated">Camada</target>
-						</trans-unit>
-					</group>
-					<group id="digital_number">
 						<trans-unit id="name">
-							<source>DigitalNumber</source>
-							<target state="translated">Número digital</target>
+							<source>Needle</source>
+							<target>Ponteiro</target>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
-							<target state="translated">Assunto</target>
+							<target>Assunto</target>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-								<target state="translated">Localização</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-								<target state="translated">X</target>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-								<target state="translated">Y</target>
-							</trans-unit>
-						</group>
+						<trans-unit id="defined_radius">
+							<source>DefinedRadius</source>
+							<target>Raio definido</target>
+						</trans-unit>
+						<trans-unit id="radius">
+							<source>Radius</source>
+							<target>Raio</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
-							<target state="translated">Imagem diurna</target>
+							<target>Imagem diurna</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
 							<source>NighttimeImage</source>
-							<target state="translated">Imagem nocturna</target>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target state="translated">Camada</target>
-						</trans-unit>
-						<trans-unit id="interval">
-							<source>Interval</source>
-							<target state="translated">Inervalo</target>
-						</trans-unit>
-					</group>
-					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-							<target state="translated">Mostrador digital</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target state="translated">Assunto</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-								<target state="translated">Localização</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-								<target state="translated">X</target>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-								<target state="translated">Y</target>
-							</trans-unit>
-						</group>
-						<trans-unit id="radius">
-							<source>Radius</source>
-							<target state="translated">Raio</target>
+							<target>Imagem nocturna</target>
 						</trans-unit>
 						<trans-unit id="color">
 							<source>Color</source>
-							<target state="translated">Cor</target>
+							<target>Cor</target>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+							<target>Cor transparente</target>
+						</trans-unit>
+						<trans-unit id="defined_origin">
+							<source>DefinedOrigin</source>
+							<target>Origem definida</target>
 						</trans-unit>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
-							<target state="translated">Ângulo inicial</target>
+							<target>Ângulo inicial</target>
 						</trans-unit>
 						<trans-unit id="last_angle">
 							<source>LastAngle</source>
-							<target state="translated">Ângulo final</target>
+							<target>Ângulo final</target>
 						</trans-unit>
 						<trans-unit id="minimum">
 							<source>Minimum</source>
-							<target state="translated">Mínimo</target>
+							<target>Mínimo</target>
 						</trans-unit>
 						<trans-unit id="maximum">
 							<source>Maximum</source>
-							<target state="translated">Máximo</target>
+							<target>Máximo</target>
 						</trans-unit>
-						<trans-unit id="step">
-							<source>Step</source>
-							<target state="translated">Passo</target>
+						<trans-unit id="defined_natural_freq">
+							<source>DefinedNaturalFreq</source>
+							<target>Frequência natural definida</target>
+						</trans-unit>
+						<trans-unit id="natural_freq">
+							<source>NaturalFreq</source>
+							<target>Frequência natural</target>
+						</trans-unit>
+						<trans-unit id="defined_damping_ratio">
+							<source>DefiedDampingRatio</source>
+							<target>Relação definida de amortecimento</target>
+						</trans-unit>
+						<trans-unit id="damping_ratio">
+							<source>DampingRatio</source>
+							<target>Relação de amortecimento</target>
+						</trans-unit>
+						<trans-unit id="backstop">
+							<source>Backstop</source>
+							<target>Espera</target>
+						</trans-unit>
+						<trans-unit id="smoothed">
+							<source>smoothed</source>
+							<target>esbatido</target>
 						</trans-unit>
 						<trans-unit id="layer">
 							<source>Layer</source>
-							<target state="translated">Camada</target>
+							<target>Camada</target>
 						</trans-unit>
 					</group>
-					<group id="linear_gauge">
+					<group id="digital_number">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Localização</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+								<target>X</target>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+								<target>Y</target>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
-							<source>LinearGauge</source>
-							<target state="translated">Mostrador linear</target>
+							<source>DigitalNumber</source>
+							<target>Número digital</target>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
-							<target state="translated">Assunto</target>
+							<target>Assunto</target>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-								<target state="translated">Localização</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-								<target state="translated">X</target>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-								<target state="translated">Y</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
-							<target state="translated">Imagem diurna</target>
+							<target>Imagem diurna</target>
 						</trans-unit>
 						<trans-unit id="nighttime_image">
 							<source>NighttimeImage</source>
-							<target state="translated">Imagem nocturna</target>
+							<target>Imagem nocturna</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
+							<target>Cor transparente</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Camada</target>
+						</trans-unit>
+						<trans-unit id="interval">
+							<source>Interval</source>
+							<target>Inervalo</target>
+						</trans-unit>
+					</group>
+					<group id="digital_gauge">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Localização</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+								<target>X</target>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+								<target>Y</target>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+							<target>Mostrador digital</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Assunto</target>
+						</trans-unit>
+						<trans-unit id="radius">
+							<source>Radius</source>
+							<target>Raio</target>
+						</trans-unit>
+						<trans-unit id="color">
+							<source>Color</source>
+							<target>Cor</target>
+						</trans-unit>
+						<trans-unit id="initial_angle">
+							<source>InitialAngle</source>
+							<target>Ângulo inicial</target>
+						</trans-unit>
+						<trans-unit id="last_angle">
+							<source>LastAngle</source>
+							<target>Ângulo final</target>
 						</trans-unit>
 						<trans-unit id="minimum">
 							<source>Minimum</source>
-							<target state="translated">Mínimo</target>
+							<target>Mínimo</target>
 						</trans-unit>
 						<trans-unit id="maximum">
 							<source>Maximum</source>
-							<target state="translated">Máximo</target>
+							<target>Máximo</target>
 						</trans-unit>
+						<trans-unit id="step">
+							<source>Step</source>
+							<target>Passo</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Camada</target>
+						</trans-unit>
+					</group>
+					<group id="linear_gauge">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Localização</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+								<target>X</target>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+								<target>Y</target>
+							</trans-unit>
+						</group>
 						<group id="direction">
 							<trans-unit id="name">
 								<source>Direction</source>
-								<target state="translated">Direcção</target>
+								<target>Direcção</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="width">
-							<source>Width</source>
-							<target state="translated">Largura</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target state="translated">Camada</target>
-						</trans-unit>
-					</group>
-					<group id="timetable">
 						<trans-unit id="name">
-							<source>Timetable</source>
-							<target state="translated">Horário</target>
+							<source>LinearGauge</source>
+							<target>Mostrador linear</target>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-								<target state="translated">Localização</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-								<target state="translated">X</target>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-								<target state="translated">Y</target>
-							</trans-unit>
-						</group>
-						<trans-unit id="height">
-							<source>Height</source>
-							<target state="translated">Altura</target>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Assunto</target>
 						</trans-unit>
-						<trans-unit id="width">
-							<source>Width</source>
-							<target state="translated">Largura</target>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+							<target>Imagem diurna</target>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+							<target>Imagem nocturna</target>
 						</trans-unit>
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
-							<target state="translated">Cor transparente</target>
+							<target>Cor transparente</target>
+						</trans-unit>
+						<trans-unit id="minimum">
+							<source>Minimum</source>
+							<target>Mínimo</target>
+						</trans-unit>
+						<trans-unit id="maximum">
+							<source>Maximum</source>
+							<target>Máximo</target>
+						</trans-unit>
+						<trans-unit id="width">
+							<source>Width</source>
+							<target>Largura</target>
 						</trans-unit>
 						<trans-unit id="layer">
 							<source>Layer</source>
-							<target state="translated">Camada</target>
+							<target>Camada</target>
 						</trans-unit>
 					</group>
-					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-							<target state="translated">Toque</target>
-						</trans-unit>
+					<group id="timetable">
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
-								<target state="translated">Localização</target>
+								<target>Localização</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+							<target>Horário</target>
+						</trans-unit>
+						<trans-unit id="height">
+							<source>Height</source>
+							<target>Altura</target>
+						</trans-unit>
+						<trans-unit id="width">
+							<source>Width</source>
+							<target>Largura</target>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+							<target>Cor transparente</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>Camada</target>
+						</trans-unit>
+					</group>
+					<group id="touch">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
+								<target>Localização</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+								<target>X</target>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+								<target>Y</target>
 							</trans-unit>
 						</group>
 						<group id="size">
 							<trans-unit id="name">
 								<source>Size</source>
-								<target state="translated">Tamanho</target>
+								<target>Tamanho</target>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
-								<target state="translated">X</target>
+								<target>X</target>
 							</trans-unit>
 							<trans-unit id="y">
 								<source>Y</source>
-								<target state="translated">Y</target>
+								<target>Y</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+							<target>Toque</target>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
-							<target state="translated">Tela de salto</target>
+							<target>Tela de salto</target>
 						</trans-unit>
 						<trans-unit id="sound_index">
 							<source>SoundIndex</source>
-							<target state="translated">Índice do som</target>
+							<target>Índice do som</target>
 						</trans-unit>
 						<trans-unit id="command">
 							<source>Command</source>
-							<target state="translated">Comando</target>
+							<target>Comando</target>
 						</trans-unit>
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
-							<target state="translated">Opção de comando</target>
+							<target>Opção de comando</target>
+						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
 						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+						<target>Definições do painel</target>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
-					<trans-unit id="name">
-						<source>Sound settings</source>
-						<target state="translated">Definições de som</target>
-					</trans-unit>
-					<trans-unit id="key">
-						<source>Key</source>
-						<target state="translated">Tecla</target>
-					</trans-unit>
-					<trans-unit id="filename">
-						<source>Filename</source>
-						<target state="translated">Nome do ficheiro</target>
-					</trans-unit>
-					<trans-unit id="position">
-						<source>Position</source>
-						<target state="translated">Posição</target>
-					</trans-unit>
-					<trans-unit id="radius">
-						<source>Radius</source>
-						<target state="translated">Raio</target>
-					</trans-unit>
 					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-							<target state="translated">Editar a entrada</target>
-						</trans-unit>
 						<group id="section">
 							<trans-unit id="name">
 								<source>Section select</source>
-								<target state="translated">Seleccionar a secção</target>
+								<target>Seleccionar a secção</target>
 							</trans-unit>
 						</group>
 						<group id="key">
 							<trans-unit id="name">
 								<source>Key type select</source>
-								<target state="translated">Seleccionar o tipo de tecla</target>
+								<target>Seleccionar o tipo de tecla</target>
 							</trans-unit>
 						</group>
 						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-								<target state="translated">Valor da entrada</target>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-								<target state="translated">Nome do ficheiro</target>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-								<target state="translated">Raio</target>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-								<target state="translated">Definição da posição</target>
-							</trans-unit>
 							<group id="position">
 								<trans-unit id="name">
 									<source>Position</source>
-									<target state="translated">Posição</target>
+									<target>Posição</target>
 								</trans-unit>
 								<trans-unit id="x">
-									<source>x coordinate</source>
-									<target state="translated">coordenada x</target>
+									<source>X</source>
+									<target>coordenada x</target>
 								</trans-unit>
 								<trans-unit id="y">
-									<source>y coordinate</source>
-									<target state="translated">coordenada y</target>
+									<source>Y</source>
+									<target>coordenada y</target>
 								</trans-unit>
 								<trans-unit id="z">
-									<source>z coordinate</source>
-									<target state="translated">coordenada z</target>
+									<source>Z</source>
+									<target>coordenada z</target>
 								</trans-unit>
 							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+								<target>Valor da entrada</target>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+								<target>Nome do ficheiro</target>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+								<target>Raio</target>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+								<target>Definição da posição</target>
+							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+							<target>Editar a entrada</target>
+						</trans-unit>
 					</group>
 					<group id="message">
 						<trans-unit id="empty_filename">
 							<source>File name has not been entered.</source>
-							<target state="translated">O nome do ficheiro não deu entrada.</target>
+							<target>O nome do ficheiro não deu entrada.</target>
 						</trans-unit>
 						<trans-unit id="key_exist">
 							<source>The specified key is already set.</source>
-							<target state="translated">A tecla especificada já está definida.</target>
+							<target>A tecla especificada já está definida.</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Sound settings</source>
+						<target>Definições de som</target>
+					</trans-unit>
+					<trans-unit id="key">
+						<source>Key</source>
+						<target>Tecla</target>
+					</trans-unit>
+					<trans-unit id="filename">
+						<source>Filename</source>
+						<target>Nome do ficheiro</target>
+					</trans-unit>
+					<trans-unit id="position">
+						<source>Position</source>
+						<target>Posição</target>
+					</trans-unit>
+					<trans-unit id="radius">
+						<source>Radius</source>
+						<target>Raio</target>
+					</trans-unit>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-						<target state="translated">Estado</target>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
-							<target state="translated">Erro</target>
+							<target>Erro</target>
 						</trans-unit>
 						<trans-unit id="warning">
 							<source>Warning</source>
-							<target state="translated">Aviso</target>
+							<target>Aviso</target>
 						</trans-unit>
 						<trans-unit id="info">
 							<source>Information</source>
-							<target state="translated">Informação</target>
+							<target>Informação</target>
 						</trans-unit>
 						<trans-unit id="clear">
 							<source>Clear</source>
-							<target state="translated">Limpar</target>
+							<target>Limpar</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+						<target>Estado</target>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
-						<target state="translated">Nível</target>
+						<target>Nível</target>
 					</trans-unit>
 					<trans-unit id="description">
 						<source>Description</source>
-						<target state="translated">Descrição</target>
+						<target>Descrição</target>
 					</trans-unit>
 				</group>
 				<group id="message">
 					<trans-unit id="error">
 						<source>Error</source>
-						<target state="translated">Erro</target>
+						<target>Erro</target>
 					</trans-unit>
 					<trans-unit id="warning">
 						<source>Warning</source>
-						<target state="translated">Aviso</target>
+						<target>Aviso</target>
 					</trans-unit>
 					<trans-unit id="info">
 						<source>Information</source>
-						<target state="translated">Informação</target>
+						<target>Informação</target>
 					</trans-unit>
 					<trans-unit id="positive">
 						<source>positive</source>
-						<target state="translated">positivo</target>
+						<target>positivo</target>
 					</trans-unit>
 					<trans-unit id="non_negative">
 						<source>non-negative</source>
-						<target state="translated">não negativo</target>
+						<target>não negativo</target>
 					</trans-unit>
 					<trans-unit id="non_zero">
 						<source>non-zero</source>
-						<target state="translated">diferente de zero</target>
+						<target>diferente de zero</target>
 					</trans-unit>
 					<trans-unit id="invalid_float">
 						<source>This value must be a {0}floating-point number.</source>
-						<target state="translated">Este valor deve ser um {0} número decimal.</target>
+						<target>Este valor deve ser um {0} número decimal.</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
-						<target state="translated">cor inválida</target>
+						<source>Invalid HEX color</source>
+						<target>cor inválida</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/ro-RO.xlf
+++ b/assets/Languages/ro-RO.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ro-RO">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>cool2010</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2011-12-24</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>Ultimul folosit</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Prevăzut de rută</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Utilizaţi tren pe care ruta îl sugerează</target>
@@ -398,7 +400,7 @@
 						<target>Previzualizare:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Trenul care este asociat cu ruta nu a putut fi găsit:\n\n</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Start</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,8 +1139,8 @@
 						<target>Apăsaţi un buton sau mutaţi o axa sau pălăria  în  direcţia dorită...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
-						<target>Mută o axă în direcţia de "crestere" sau "putere"</target>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
+						<target>Mută o axă în direcţia de &quot;crestere&quot; sau &quot;putere&quot;</target>
 					</trans-unit>
 					<trans-unit id="attached">
 						<source>Attached joysticks</source>
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1728,6 +1748,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1839,11 +1862,11 @@
 						<target>Fişiere negăsite:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
 						<target>Câteva erori au apărut în timp ce se încărca ruta şi trenul.\r\n\r\nDin moment ce nu s-au  în cărcat perfect, ruta sau trenul nu se pot vizualiza cum era de aşteptat. Încearcă să redescarci ruta sau trenul şi ăncearcă din nou.\r\n\r\nUrmătoarea listă cu erori t+ar putea pune  în  temă cu erorile prezente. Poţi totuşi să rulezi ruta apăsând butonul Ignoră.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
 						<target>Câteva erori au apărut în timp ce se încărca ruta şi trenul. Dacă eşti creatorul rutei sau al trenului,nu ar strica să te uiţi în următoarea istă cu erori.\r\n\r\nCa un utilizator normal, poţi apăsa Ignoră pentru a începe jocul.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
@@ -1974,6 +1997,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Se încarcă. Vă rugăm să aşteptaţi...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2039,6 +2077,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Navigare Mouse: Dezactivat</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2207,7 +2260,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2221,6 +2274,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Prevăzut de rută</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2559,14 +2628,14 @@
 						<target>Functia P al sistemului de securitate</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Schimbă camera pentru a vizualiza interiorul trenului.</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Schimbă camera pentru a vizualiza exteriorul trenului.</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2827,6 +2896,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3188,11 +3281,11 @@
 					</trans-unit>
 					<trans-unit id="quote">
 						<source>Quote</source>
-						<target>Citat (')</target>
+						<target>Citat (&apos;)</target>
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>Dublu Citat ('')</target>
+						<target>Dublu Citat (&apos;&apos;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3365,6 +3458,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3617,6 +3858,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3879,8 +4126,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4000,12 +4247,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4017,6 +4261,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4056,13 +4303,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4073,22 +4314,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4120,8 +4352,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4142,9 +4401,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4173,15 +4429,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4233,6 +4480,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4240,12 +4499,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4276,17 +4549,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4344,9 +4606,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4389,6 +4648,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4414,6 +4676,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4432,15 +4705,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4496,11 +4769,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4627,9 +4903,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4652,12 +4925,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4750,11 +5026,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4766,12 +5042,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4799,9 +5097,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4821,67 +5163,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4903,17 +5190,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4949,12 +5225,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4966,6 +5236,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4983,12 +5259,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5000,6 +5270,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5026,12 +5302,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5043,6 +5313,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5058,17 +5345,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5077,9 +5353,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5091,6 +5364,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5105,9 +5381,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5130,6 +5403,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5142,9 +5418,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5160,62 +5553,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5230,6 +5569,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5260,7 +5602,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/ru-RU.xlf
+++ b/assets/Languages/ru-RU.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ru-RU">
 		<body>
 			<group id="language">
@@ -15,7 +15,7 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2016-02-24</target>
 				</trans-unit>
 			</group>
@@ -86,12 +86,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -287,6 +287,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -365,10 +371,6 @@
 						<source>Recently used</source>
 						<target>Недавние</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>По умолчанию</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Использовать состав прописанный в маршруте</target>
@@ -397,7 +399,7 @@
 						<target>Предпросмотр:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Состав указанный в маршруте не найден:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -415,6 +417,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Начать игру</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -613,8 +624,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -725,8 +736,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -752,7 +763,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -988,6 +999,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1118,7 +1138,7 @@
 						<target>Нажмите выбранную кнопку или сдвиньте рычаг выбранном направлении...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Сдвиньте рычаг в выбранном направлении для увеличения мощности...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1244,64 +1264,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1387,7 +1407,7 @@
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_nearest">
 						<source>Nearest neighbor</source>
-						<target>"Ближн. сосед"</target>
+						<target>&quot;Ближн. сосед&quot;</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_bilinear">
 						<source>Bilinear</source>
@@ -1395,7 +1415,7 @@
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_nearestmipmap">
 						<source>Nearest neighbor (mipmapping)</source>
-						<target>"Ближн. сосед" (MM)</target>
+						<target>&quot;Ближн. сосед&quot; (MM)</target>
 					</trans-unit>
 					<trans-unit id="quality_interpolation_mode_bilinearmipmap">
 						<source>Bilinear (mipmapping)</source>
@@ -1727,6 +1747,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1838,12 +1861,12 @@
 						<target>Файлы не найдены:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Во время загрузки маршрута обнаружены ошибки.\r\n\r\nТак как некоторые файлы не были найдены, маршрут может вести себя не корректным образом. Проверьте целостность установки маршрута и составов.\r\n\r\nНижеследующий список ошибок может дать дополнительную информацию. Вы можете начать игру нажав кнопку "Игнорировать".</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Во время загрузки маршрута обнаружены ошибки.\r\n\r\nТак как некоторые файлы не были найдены, маршрут может вести себя не корректным образом. Проверьте целостность установки маршрута и составов.\r\n\r\nНижеследующий список ошибок может дать дополнительную информацию. Вы можете начать игру нажав кнопку &quot;Игнорировать&quot;.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Во время загрузки маршрута обнаружены ошибки. Если вы являетесь разработчиком маршрута, вам может помочь список ошибок, для вывода списка нажмите "Показать ошибки".\r\n\r\nОбычный пользователь может нажать кнопку "Игнорировать" для запуска игры.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Во время загрузки маршрута обнаружены ошибки. Если вы являетесь разработчиком маршрута, вам может помочь список ошибок, для вывода списка нажмите &quot;Показать ошибки&quot;.\r\n\r\nОбычный пользователь может нажать кнопку &quot;Игнорировать&quot; для запуска игры.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1973,6 +1996,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Загрузка. Пожалуйста ждите...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2017,7 +2055,7 @@
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
 						<source>This feature is not available in Expert mode.</source>
-						<target>Эта функция недоступна в режиме "Экспертный".</target>
+						<target>Эта функция недоступна в режиме &quot;Экспертный&quot;.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
 						<source>The AI might be unable to fully operate this train.</source>
@@ -2038,6 +2076,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Выключить захват мыши</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2206,7 +2259,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2220,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>По умолчанию</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2459,7 +2528,7 @@
 					</trans-unit>
 					<trans-unit id="horn_music">
 						<source>Plays or stops the music horn</source>
-						<target>Включить/выключить "Звонок" (Зацикленный свисток)</target>
+						<target>Включить/выключить &quot;Звонок&quot; (Зацикленный свисток)</target>
 					</trans-unit>
 					<trans-unit id="device_constspeed">
 						<source>Activates or deactivates the constant speed device</source>
@@ -2558,14 +2627,14 @@
 						<target>Функция P системы безопасности</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Переключить на вид из кабины</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Переключить на вид снаружи</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2827,6 +2896,30 @@
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
 					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
+					</trans-unit>
 				</group>
 				<group id="keys">
 					<trans-unit id="0">
@@ -2879,7 +2972,7 @@
 					</trans-unit>
 					<trans-unit id="at">
 						<source>At</source>
-						<target>"Собака" (@)</target>
+						<target>&quot;Собака&quot; (@)</target>
 					</trans-unit>
 					<trans-unit id="backquote">
 						<source>Backquote</source>
@@ -2887,19 +2980,19 @@
 					</trans-unit>
 					<trans-unit id="backslash">
 						<source>Backslash</source>
-						<target>Обратная косая черта "\"</target>
+						<target>Обратная косая черта &quot;\&quot;</target>
 					</trans-unit>
 					<trans-unit id="backspace">
 						<source>Backspace</source>
-						<target>Клавиша "Backspace"</target>
+						<target>Клавиша &quot;Backspace&quot;</target>
 					</trans-unit>
 					<trans-unit id="break">
 						<source>Break</source>
-						<target>Клавиша "Break"</target>
+						<target>Клавиша &quot;Break&quot;</target>
 					</trans-unit>
 					<trans-unit id="capslock">
 						<source>Capslock</source>
-						<target>Клавиша "Caps Lock"</target>
+						<target>Клавиша &quot;Caps Lock&quot;</target>
 					</trans-unit>
 					<trans-unit id="caret">
 						<source>Caret</source>
@@ -2907,7 +3000,7 @@
 					</trans-unit>
 					<trans-unit id="clear">
 						<source>Clear</source>
-						<target>Клавиша "Clear"</target>
+						<target>Клавиша &quot;Clear&quot;</target>
 					</trans-unit>
 					<trans-unit id="colon">
 						<source>Colon</source>
@@ -2919,7 +3012,7 @@
 					</trans-unit>
 					<trans-unit id="delete">
 						<source>Delete</source>
-						<target>Клавиша "Delete"</target>
+						<target>Клавиша &quot;Delete&quot;</target>
 					</trans-unit>
 					<trans-unit id="dollar">
 						<source>Dollar</source>
@@ -2931,7 +3024,7 @@
 					</trans-unit>
 					<trans-unit id="end">
 						<source>End</source>
-						<target>Клавиша "End"</target>
+						<target>Клавиша &quot;End&quot;</target>
 					</trans-unit>
 					<trans-unit id="enter">
 						<source>Enter</source>
@@ -2943,7 +3036,7 @@
 					</trans-unit>
 					<trans-unit id="escape">
 						<source>Escape</source>
-						<target>Клавиша "Escape"</target>
+						<target>Клавиша &quot;Escape&quot;</target>
 					</trans-unit>
 					<trans-unit id="euro">
 						<source>Euro</source>
@@ -3023,15 +3116,15 @@
 					</trans-unit>
 					<trans-unit id="help">
 						<source>Help</source>
-						<target>Клавиша "Help"</target>
+						<target>Клавиша &quot;Help&quot;</target>
 					</trans-unit>
 					<trans-unit id="home">
 						<source>Home</source>
-						<target>Клавиша "Home"</target>
+						<target>Клавиша &quot;Home&quot;</target>
 					</trans-unit>
 					<trans-unit id="insert">
 						<source>Insert</source>
-						<target>Клавиша "Insert"</target>
+						<target>Клавиша &quot;Insert&quot;</target>
 					</trans-unit>
 					<trans-unit id="kp0">
 						<source>Keypad 0</source>
@@ -3119,7 +3212,7 @@
 					</trans-unit>
 					<trans-unit id="leftparen">
 						<source>Left parenthesis</source>
-						<target>Левая круглая скобка "("</target>
+						<target>Левая круглая скобка &quot;(&quot;</target>
 					</trans-unit>
 					<trans-unit id="less">
 						<source>Less</source>
@@ -3127,7 +3220,7 @@
 					</trans-unit>
 					<trans-unit id="lmeta">
 						<source>Left Meta</source>
-						<target>Левая клавиша "Meta"</target>
+						<target>Левая клавиша &quot;Meta&quot;</target>
 					</trans-unit>
 					<trans-unit id="lshift">
 						<source>Left Shift</source>
@@ -3135,11 +3228,11 @@
 					</trans-unit>
 					<trans-unit id="lsuper">
 						<source>Left Application</source>
-						<target>Левая клавиша "Super"</target>
+						<target>Левая клавиша &quot;Super&quot;</target>
 					</trans-unit>
 					<trans-unit id="menu">
 						<source>Menu</source>
-						<target>Клавиша "Меню"</target>
+						<target>Клавиша &quot;Меню&quot;</target>
 					</trans-unit>
 					<trans-unit id="minus">
 						<source>Minus</source>
@@ -3147,23 +3240,23 @@
 					</trans-unit>
 					<trans-unit id="mode">
 						<source>Alt Gr</source>
-						<target>Клавиша "Alt Gr"</target>
+						<target>Клавиша &quot;Alt Gr&quot;</target>
 					</trans-unit>
 					<trans-unit id="numlock">
 						<source>Numlock</source>
-						<target>Клавиша "Numlock"</target>
+						<target>Клавиша &quot;Numlock&quot;</target>
 					</trans-unit>
 					<trans-unit id="pagedown">
 						<source>Page down</source>
-						<target>Клавиша "Page down"</target>
+						<target>Клавиша &quot;Page down&quot;</target>
 					</trans-unit>
 					<trans-unit id="pageup">
 						<source>Page up</source>
-						<target>Клавиша "Page up"</target>
+						<target>Клавиша &quot;Page up&quot;</target>
 					</trans-unit>
 					<trans-unit id="pause">
 						<source>Pause</source>
-						<target>Клавиша "Pause"</target>
+						<target>Клавиша &quot;Pause&quot;</target>
 					</trans-unit>
 					<trans-unit id="period">
 						<source>Period</source>
@@ -3175,11 +3268,11 @@
 					</trans-unit>
 					<trans-unit id="power">
 						<source>Power</source>
-						<target>Клавиша "Power"</target>
+						<target>Клавиша &quot;Power&quot;</target>
 					</trans-unit>
 					<trans-unit id="print">
 						<source>Print</source>
-						<target>Клавиша "Print"</target>
+						<target>Клавиша &quot;Print&quot;</target>
 					</trans-unit>
 					<trans-unit id="question">
 						<source>Question</source>
@@ -3187,11 +3280,11 @@
 					</trans-unit>
 					<trans-unit id="quote">
 						<source>Quote</source>
-						<target>Одинарная кавычка (')</target>
+						<target>Одинарная кавычка (&apos;)</target>
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>Двойная кавычка (")</target>
+						<target>Двойная кавычка (&quot;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3215,11 +3308,11 @@
 					</trans-unit>
 					<trans-unit id="rightparen">
 						<source>Right parenthesis</source>
-						<target>Правая круглая скобка ")"</target>
+						<target>Правая круглая скобка &quot;)&quot;</target>
 					</trans-unit>
 					<trans-unit id="rmeta">
 						<source>Right Meta</source>
-						<target>Правая клавиша "Meta"</target>
+						<target>Правая клавиша &quot;Meta&quot;</target>
 					</trans-unit>
 					<trans-unit id="rshift">
 						<source>Right Shift</source>
@@ -3227,11 +3320,11 @@
 					</trans-unit>
 					<trans-unit id="rsuper">
 						<source>Right Application</source>
-						<target>Правая клавиша "Super"</target>
+						<target>Правая клавиша &quot;Super&quot;</target>
 					</trans-unit>
 					<trans-unit id="scrolllock">
 						<source>Scrolllock</source>
-						<target>Клавиша "ScrollLock"</target>
+						<target>Клавиша &quot;ScrollLock&quot;</target>
 					</trans-unit>
 					<trans-unit id="semicolon">
 						<source>Semicolon</source>
@@ -3247,7 +3340,7 @@
 					</trans-unit>
 					<trans-unit id="sysreq">
 						<source>SysRq</source>
-						<target>Клавиша "SysRq"</target>
+						<target>Клавиша &quot;SysRq&quot;</target>
 					</trans-unit>
 					<trans-unit id="tab">
 						<source>Tab</source>
@@ -3364,6 +3457,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3616,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3878,8 +4125,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3999,12 +4246,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4016,6 +4260,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4055,13 +4302,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4072,22 +4313,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4119,8 +4351,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4141,9 +4400,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4172,15 +4428,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4232,6 +4479,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4239,12 +4498,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4275,17 +4548,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4343,9 +4605,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4388,6 +4647,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4413,6 +4675,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4431,15 +4704,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4495,11 +4768,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4626,9 +4902,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4651,12 +4924,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4749,11 +5025,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4765,12 +5041,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4798,9 +5096,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4820,67 +5162,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4902,17 +5189,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4948,12 +5224,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4965,6 +5235,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4982,12 +5258,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4999,6 +5269,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5025,12 +5301,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5042,6 +5312,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5057,17 +5344,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5076,9 +5352,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5090,6 +5363,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5104,9 +5380,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5129,6 +5402,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5141,9 +5417,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5159,62 +5552,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5229,6 +5568,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5259,7 +5601,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/sk-SK.xlf
+++ b/assets/Languages/sk-SK.xlf
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<xliff version="1.2" NS0:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd"
-	xmlns="urn:oasis:names:tc:xliff:document:1.2"
-	xmlns:NS0="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="sk-SK">
 		<body>
 			<group id="language">
@@ -17,15 +15,15 @@
 					<source>Unknown</source>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2023-09-24</target>
 				</trans-unit>
 			</group>
 			<group id="openbve">
 				<group id="program">
 					<trans-unit id="title">
-						<source>openBVE</source>
-						<target>openBVE</target>
+						<source>OpenBVE</source>
+						<target>OpenBVE</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -84,6 +82,9 @@
 					<trans-unit id="about">
 						<source>About</source>
 						<target>O hre</target>
+					</trans-unit>
+					<trans-unit id="updates_daily">
+						<source>The most recent nightly build from [date] is available for download.</source>
 					</trans-unit>
 				</group>
 				<group id="mode">
@@ -214,6 +215,12 @@
 					<trans-unit id="database_invalid_xml">
 						<source>The package database XML was invalid, and has been re-created.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -292,10 +299,6 @@
 						<source>Recently used</source>
 						<target>Naposledy použité</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Východzie</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Použiť pridružený vlak k trati</target>
@@ -324,7 +327,7 @@
 						<target>Náhľad:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Vlak pridružený k trati nenájdený.</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -342,6 +345,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Spustiť</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -540,8 +552,8 @@
 						<target>Inštalovať Balík</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -675,7 +687,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -911,6 +923,18 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="creation_dependancies_skip_if_none">
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1041,7 +1065,7 @@
 						<target>Stlačte tlačidlo podľa vašej voľby alebo pohnite pákou v požadovanom smere...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Pohněte pákou v požadovanom smeru pre sníženie aleboo zvýšenie výkonu...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1147,7 +1171,7 @@
 						<target>Míle za Hodinu (MPH)</target>
 					</trans-unit>
 					<trans-unit id="kilometersperhour">
-						<source>Kilometre za Hodinu (KPH)</source>
+						<source>Kilometers per Hour (KPH)</source>
 						<target>Kilometers per Hour (KPH)</target>
 					</trans-unit>
 					<trans-unit id="setcalibration">
@@ -1159,7 +1183,7 @@
 						<target>Launch</target>
 					</trans-unit>
 					<trans-unit id="notdetected">
-						<source>No RailDriver conrollers detected.</source>
+						<source>No RailDriver controllers detected.</source>
 						<target>No RailDriver conrollers detected.</target>
 					</trans-unit>
 					<trans-unit id="config_error">
@@ -1167,64 +1191,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1635,6 +1659,21 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
+					<trans-unit id="verbosity_accessibilityaids">
+						<source>Accessibility Aids</source>
+					</trans-unit>
+					<trans-unit id="advanced_cursor">
+						<source>Cursor</source>
+					</trans-unit>
+					<trans-unit id="font">
+						<source>Font:</source>
+					</trans-unit>
+					<trans-unit id="object_parser">
+						<source>Object Parser</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1746,12 +1785,12 @@
 						<target>Súbory nenájdené:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Pri načítání trate a vlaku bolo nájdených niekoľko chýb.\r\n\r\nNiektoré súbory obsiahnuté v trati a vlaku neboli nájdené, preto se ujistite, či máte stiahnuté všetky súčasti simulácie.\r\n\r\nNásledujúcí zoznam chýb vám môže poskytnúť viac informácií. Kliknutím na tlačidlo "Ignorovať" môžete pokračovat v spustení simulácie.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Pri načítání trate a vlaku bolo nájdených niekoľko chýb.\r\n\r\nNiektoré súbory obsiahnuté v trati a vlaku neboli nájdené, preto se ujistite, či máte stiahnuté všetky súčasti simulácie.\r\n\r\nNásledujúcí zoznam chýb vám môže poskytnúť viac informácií. Kliknutím na tlačidlo &quot;Ignorovať&quot; môžete pokračovat v spustení simulácie.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Pri načítaní trate a vlaku bolo nájdených niekoľko chýb. Ak ste vývojárom tratí a vlakov, môže vám nasledujúci zoznam chýb poskytnúť viac informácií. Ako bežný užívateľ môžete kliknutím na tlačidlo "Ignorovať" pokračovať v spustení simulácie.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Pri načítaní trate a vlaku bolo nájdených niekoľko chýb. Ak ste vývojárom tratí a vlakov, môže vám nasledujúci zoznam chýb poskytnúť viac informácií. Ako bežný užívateľ môžete kliknutím na tlačidlo &quot;Ignorovať&quot; pokračovať v spustení simulácie.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1881,6 +1920,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Načítavanie. Prosím čakajte...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -1925,7 +1979,7 @@
 					</trans-unit>
 					<trans-unit id="notavailableexpert">
 						<source>This feature is not available in Expert mode.</source>
-						<target>Táto funkcia nie je v obtiažnosti "profesionál" k dispozícii.</target>
+						<target>Táto funkcia nie je v obtiažnosti &quot;profesionál&quot; k dispozícii.</target>
 					</trans-unit>
 					<trans-unit id="aiunable">
 						<source>The AI might be unable to fully operate this train.</source>
@@ -1946,6 +2000,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Ovládanie pomocou myši: VYP</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2083,7 +2152,7 @@
 					</trans-unit>
 					<trans-unit id="quit_question">
 						<source>Do you really want to quit?</source>
-						<target>Ukončiť openBVE?</target>
+						<target>Ukončiť OpenBVE?</target>
 					</trans-unit>
 					<trans-unit id="quit_no">
 						<source>No</source>
@@ -2114,7 +2183,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2128,6 +2197,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Východzie</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2458,14 +2543,14 @@
 						<target>P funkcia zabezpečovacieho systému</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Pohľad z kabíny</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Pohľad z vonku, nasleduje vlak</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2550,7 +2635,7 @@
 					</trans-unit>
 					<trans-unit id="timetable_toggle">
 						<source>Toggles through different timetable modes</source>
-						<target>Zobrazenie cestovného poriadku bve4/openBVE/VYP (bve4 pokiaľ je obsiahnutý)</target>
+						<target>Zobrazenie cestovného poriadku bve4/OpenBVE/VYP (bve4 pokiaľ je obsiahnutý)</target>
 					</trans-unit>
 					<trans-unit id="timetable_up">
 						<source>Scrolls the timetable up</source>
@@ -2726,6 +2811,36 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="play_mic_sounds">
+						<source>Activates or deactivates the system microphone soundsource</source>
+					</trans-unit>
+					<trans-unit id="sanders">
+						<source>Activates or deactivates the sanders</source>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3266,6 +3381,206 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="about">
+					<trans-unit id="title">
+						<source>About</source>
+					</trans-unit>
+					<trans-unit id="description">
+						<source>OpenBVE is a free and open-source multi-platform train simulator, featuring support for 2D and 3D cabs and scenery.\r\n\r\nThis program was initially developed by Michelle, and is released into the public domain where legally possible.</source>
+					</trans-unit>
+					<trans-unit id="open_source_licenses">
+						<source>Open Source Licenses</source>
+					</trans-unit>
+					<trans-unit id="open_source_licenses_header">
+						<source>OpenBVE makes use of several open-source libraries, whose licenses are reproduced below:</source>
+					</trans-unit>
+					<trans-unit id="close">
+						<source>Close</source>
+					</trans-unit>
+				</group>
+				<group id="bug_report">
+					<trans-unit id="title">
+						<source>Report Problem</source>
+					</trans-unit>
+					<trans-unit id="description">
+						<source>This function will create a zip archive on your Desktop, containing the previous Simulation log and Crash log (If any), along with a text file containing the brief description of the problem entered below.\r\n\r\nPlease post this on the discussion board, or create a new issue on Github.</source>
+					</trans-unit>
+					<trans-unit id="view_log_button">
+						<source>View...</source>
+					</trans-unit>
+					<trans-unit id="view_log">
+						<source>View the previous log:</source>
+					</trans-unit>
+					<trans-unit id="view_crash_log">
+						<source>View the previous crash log:</source>
+					</trans-unit>
+					<trans-unit id="enter_description">
+						<source>Please enter a brief description of the problem:</source>
+					</trans-unit>
+					<trans-unit id="no_log">
+						<source>No simulation logs were found.</source>
+					</trans-unit>
+					<trans-unit id="no_crash_log">
+						<source>No crash logs were found.</source>
+					</trans-unit>
+					<trans-unit id="save">
+						<source>Save Bug Report</source>
+					</trans-unit>
+					<trans-unit id="saved">
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+					</trans-unit>
+					<trans-unit id="save_failed">
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3516,6 +3831,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3778,8 +4099,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3899,12 +4220,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -3916,6 +4234,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -3955,13 +4276,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -3972,22 +4287,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4019,8 +4325,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4041,9 +4374,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4072,15 +4402,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4132,6 +4453,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4139,12 +4472,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4175,17 +4522,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4243,9 +4579,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4288,6 +4621,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4313,6 +4649,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4331,15 +4678,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4395,11 +4742,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4526,9 +4876,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4551,12 +4898,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4649,11 +4999,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4665,12 +5015,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4698,9 +5070,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4720,67 +5136,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4802,17 +5163,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4848,12 +5198,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4865,6 +5209,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4882,12 +5232,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4899,6 +5243,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -4925,12 +5275,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4942,6 +5286,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4957,17 +5318,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -4976,9 +5326,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4990,6 +5337,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5004,9 +5354,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5029,6 +5376,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5041,9 +5391,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5059,62 +5526,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5129,6 +5542,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5159,7 +5575,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/uk-UA.xlf
+++ b/assets/Languages/uk-UA.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="uk-UA">
 		<body>
 			<group id="language">
@@ -17,7 +17,7 @@
 					<note from="translator">З питаннями звертатися на deemuss@mail.ua</note>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2012-04-08</target>
 				</trans-unit>
 			</group>
@@ -88,12 +88,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -289,6 +289,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -367,10 +373,6 @@
 						<source>Recently used</source>
 						<target>Останній вжитий</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>Стандартний для маршруту</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>Вжити стандартний поїзд для обраного маршруту</target>
@@ -399,7 +401,7 @@
 						<target>Попередній перегляд:</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>Поїзд для цього машруту не знайдено:\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -417,6 +419,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>Старт</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -615,8 +626,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -727,8 +738,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -754,7 +765,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -990,6 +1001,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1120,7 +1140,7 @@
 						<target>Натисніть брану кнопку lub przesuń gałke w wybranym kierunku...</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>Przesuń gałkę w wybranym kierunku...</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1246,64 +1266,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1729,6 +1749,9 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1840,12 +1863,12 @@
 						<target>Файли не знайдено:</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
-						<target>Під час завантаження сталися помилки.\r\n\r\nКілька Файлів не знайдено, маршрут або поїзд може невірно працювати. Спробуйте знову скачати файл поїзда.\r\n\r\nСписок показує додаткову інформацію. Клацніть "Ігнорувати" аби продовжити.</target>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
+						<target>Під час завантаження сталися помилки.\r\n\r\nКілька Файлів не знайдено, маршрут або поїзд може невірно працювати. Спробуйте знову скачати файл поїзда.\r\n\r\nСписок показує додаткову інформацію. Клацніть &quot;Ігнорувати&quot; аби продовжити.</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
-						<target>Сталися проблеми під час завантаження маршруту. Якщо ви розробник цього маршруту, можете подивитися список проблем.\r\n\r\nЯкщо Ви гравець, клацніть "Ігнорувати" аби продовжити.</target>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
+						<target>Сталися проблеми під час завантаження маршруту. Якщо ви розробник цього маршруту, можете подивитися список проблем.\r\n\r\nЯкщо Ви гравець, клацніть &quot;Ігнорувати&quot; аби продовжити.</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
 						<source>Show issues</source>
@@ -1975,6 +1998,21 @@
 						<source>Loading. Please wait...</source>
 						<target>Завантаження. Зачекайте, будь ласка...</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2040,6 +2078,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>Захоплення миші: Вимк</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2208,7 +2261,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2222,6 +2275,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>Стандартний для маршруту</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2560,14 +2629,14 @@
 						<target>Функція P в системі безпеки</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>Переключення до внутрішнього вигляду поїзда</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>Переключення до зовнішнього вигляду поїзда</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2828,6 +2897,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3368,6 +3461,154 @@
 						<target>Z</target>
 					</trans-unit>
 				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
+					</trans-unit>
+				</group>
 			</group>
 			<group id="train_editor">
 				<group id="general">
@@ -3618,6 +3859,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3880,8 +4127,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4001,12 +4248,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4018,6 +4262,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4057,13 +4304,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4074,22 +4315,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4121,8 +4353,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4143,9 +4402,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4174,15 +4430,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4234,6 +4481,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4241,12 +4500,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4277,17 +4550,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4345,9 +4607,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4390,6 +4649,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4415,6 +4677,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4433,15 +4706,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4497,11 +4770,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4628,9 +4904,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4653,12 +4926,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4751,11 +5027,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4767,12 +5043,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4800,9 +5098,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4822,67 +5164,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4904,17 +5191,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4950,12 +5226,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4967,6 +5237,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4984,12 +5260,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5001,6 +5271,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5027,12 +5303,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5044,6 +5314,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5059,17 +5346,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5078,9 +5354,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5092,6 +5365,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5106,9 +5382,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5131,6 +5404,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5143,9 +5419,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5161,62 +5554,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5231,6 +5570,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5261,7 +5603,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/zh-CN.xlf
+++ b/assets/Languages/zh-CN.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-CN">
 		<body>
 			<group id="language">
@@ -280,6 +281,9 @@
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
 						<target>如果您要将扩展包安装在 Program Files 或 ProgramData 文件夹内，您需要选择以管理员身份运行本程序。\r\n\r\n 此配置并不安全，建议您在设置中修改。</target>
 					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -344,15 +348,6 @@
 					</trans-unit>
 					<trans-unit id="train_choose">
 						<source>Choose Train...</source>
-					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
 					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
@@ -421,6 +416,9 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>启动模拟</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -619,8 +617,8 @@
 						<target>安装一个扩展包</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>这个文件显然不是一个openBVE扩展包。</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>这个文件显然不是一个OpenBVE扩展包。</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -758,7 +756,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>这个新扩展包将拥有这一个GUID(标识号): </target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -1262,63 +1260,63 @@
 						<target>在加载RailDriver校准配置时出现错误。</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
 						<target>按‘继续’开始校准。</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
 						<target>将换向器移动至完全向后, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
 						<target>将换向器移动至完全向前, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
 						<target>将联控手柄移动到最大牵引, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
 						<target>将联控手柄移动到最大制动, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>将动力制动手柄移动到缓解, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
 						<target>将动力制动手柄移动到紧急制动, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>将独立制动手柄移动到缓解, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
 						<target>将独立制动手柄移动到最大制动, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
 						<target>将释放手柄移动到缓解, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
 						<target>将释放手柄移动到最大, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
 						<target>将雨刮器开关移动到关闭, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
 						<target>将雨刮器开关移动到最大, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
 						<target>将灯光开关移动到关闭, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
 						<target>将灯光开关移动到最大, 然后点击‘继续’。</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
@@ -2010,7 +2008,7 @@
 						<target>乘客还在 [name] 上下车, 请立刻停车。</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>列车当前速度[speed]。</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2292,6 +2290,15 @@
 						<source>Current assignment:</source>
 						<target>目前分配: </target>
 					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+					</trans-unit>
 				</group>
 				<group id="switchmenu">
 					<trans-unit id="title">
@@ -2309,6 +2316,12 @@
 					<trans-unit id="distance">
 						<source>Distance from Player: </source>
 						<target>距离玩家: </target>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2644,15 +2657,15 @@
 						<target>信号系统 P 键</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>进入车内视点</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>进入车内视点(无司机室)</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>进入车外视点</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -3586,6 +3599,15 @@
 						<source>OK</source>
 						<target>确定</target>
 					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
 				</group>
 			</group>
 			<group id="train_editor">
@@ -4105,8 +4127,8 @@
 						<target>扩展特性</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>请注意: 本页特性需要openBVE的至少以下版本: </target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>请注意: 本页特性需要OpenBVE的至少以下版本: </target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -4238,10 +4260,6 @@
 							<target>您在试图打开一个列车文件。\r\n然而 TrainEditor2 不直接处理这些列车文件。\r\n请将列车导入 TrainEditor2 。</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-						<target>语言</target>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4256,6 +4274,10 @@
 							<target>在退出前保存对当前工程的更改？</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+						<target>语言</target>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4324,15 +4346,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-						<target>常规属性</target>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-							<target>手柄</target>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4355,26 +4369,6 @@
 								<target>分离 (换向器联锁)</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-							<target>牵引手柄级位数</target>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-							<target>制动手柄级位数</target>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-							<target>牵引手柄动作分段</target>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-							<target>司机可用牵引级位数</target>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-							<target>司机可用制动级位数</target>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4415,6 +4409,30 @@
 								<target>阻塞</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+							<target>手柄</target>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+							<target>牵引手柄级位数</target>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+							<target>制动手柄级位数</target>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+							<target>牵引手柄动作分段</target>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+							<target>司机可用牵引级位数</target>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+							<target>司机可用制动级位数</target>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
 							<target>机车制动级位数</target>
@@ -4452,10 +4470,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-							<target>车载设备</target>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4490,18 +4504,6 @@
 								<target>自动切换</target>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-							<target>无人警惕</target>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-							<target>定速设备</target>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-							<target>抑速设备</target>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4568,6 +4570,22 @@
 								<target>手动</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+							<target>车载设备</target>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+							<target>无人警惕</target>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+							<target>定速设备</target>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+							<target>抑速设备</target>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 							<target>车门宽度</target>
@@ -4577,13 +4595,31 @@
 							<target>车门最大允许偏差</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+						<target>常规属性</target>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-						<target>车辆属性</target>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+								<target>轴</target>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>前轴</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>后轴</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+								<target>后轴距离必须小于前轴距离。</target>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 							<target>车辆</target>
@@ -4624,24 +4660,6 @@
 							<source>DefinedAxles</source>
 							<target>应用轴</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-								<target>轴</target>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>前轴</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>后轴</target>
-							</trans-unit>
-							<trans-unit id="mustbe_less">
-								<source>RearAxle must be less than FrontAxle.</source>
-								<target>后轴距离必须小于前轴距离。</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>前转向架</target>
@@ -4716,10 +4734,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-							<target>制动</target>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4774,6 +4788,10 @@
 								<target>延迟补偿控制</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+							<target>制动</target>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>电制动控制速度</target>
@@ -4806,6 +4824,20 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+								<target>编辑条目</target>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+								<target>加档</target>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+								<target>减档</target>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 							<target>延迟</target>
@@ -4834,31 +4866,13 @@
 							<source>Value</source>
 							<target>值</target>
 						</trans-unit>
-						<group id="edit_entry">
-							<trans-unit id="name">
-								<source>Edit entry</source>
-								<target>编辑条目</target>
-							</trans-unit>
-							<trans-unit id="up">
-								<source>Up</source>
-								<target>加档</target>
-							</trans-unit>
-							<trans-unit id="down">
-								<source>Down</source>
-								<target>减档</target>
-							</trans-unit>
-						</group>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+						<target>车辆属性</target>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-						<target>编辑加速度</target>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-						<target>级位</target>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4929,12 +4943,16 @@
 							<target>重置</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+						<target>编辑加速度</target>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+						<target>级位</target>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-						<target>编辑电机音</target>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -5098,10 +5116,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-							<target>电机音演示</target>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -5138,6 +5152,10 @@
 								<target>交换</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+							<target>电机音演示</target>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>播放</target>
@@ -5255,12 +5273,12 @@
 							<target>这个X轴位置上已经有一个顶点，是否覆盖？</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+						<target>编辑电机音</target>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-						<target>车钩属性</target>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5275,12 +5293,12 @@
 							<target>最大</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+						<target>车钩属性</target>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-						<target>编辑2D驾驶室</target>
-					</trans-unit>
 					<group id="subject">
 						<trans-unit id="name">
 							<source>Subject</source>
@@ -5304,6 +5322,30 @@
 						</trans-unit>
 					</group>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+								<target>中心点</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+								<target>轨道交点</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 							<target>背景面</target>
@@ -5340,30 +5382,6 @@
 							<source>TransparentColor</source>
 							<target>无背景色</target>
 						</trans-unit>
-						<group id="center">
-							<trans-unit id="name">
-								<source>Center point</source>
-								<target>中心点</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Track origin</source>
-								<target>轨道交点</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 					</group>
 					<group id="screen">
 						<trans-unit id="name">
@@ -5380,14 +5398,6 @@
 						</trans-unit>
 					</group>
 					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-							<target>指示灯对象</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>变量</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5400,6 +5410,14 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+							<target>指示灯对象</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>变量</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 							<target>日间图片</target>
@@ -5418,14 +5436,6 @@
 						</trans-unit>
 					</group>
 					<group id="needle">
-						<trans-unit id="name">
-							<source>Needle</source>
-							<target>旋转对象</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>变量</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5438,6 +5448,26 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Origin</source>
+								<target>原点</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Needle</source>
+							<target>旋转对象</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>变量</target>
+						</trans-unit>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>应用半径</target>
@@ -5466,18 +5496,6 @@
 							<source>DefinedOrigin</source>
 							<target>应用原点</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							<target>原点</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>起始角度</target>
@@ -5524,14 +5542,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-							<target>胶片帧对象</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>变量</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5544,6 +5554,14 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+							<target>胶片帧对象</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>变量</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 							<target>日间图片</target>
@@ -5566,14 +5584,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-							<target>动态裁切矩形</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>变量</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5586,6 +5596,14 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+							<target>动态裁切矩形</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>变量</target>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 							<target>半径</target>
@@ -5620,14 +5638,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-							<target>滑移对象</target>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>变量</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5640,6 +5650,26 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+								<target>方向</target>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+							<target>滑移对象</target>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>变量</target>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 							<target>日间图片</target>
@@ -5660,18 +5690,6 @@
 							<source>Maximum</source>
 							<target>最大值</target>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-								<target>方向</target>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 							<target>宽度</target>
@@ -5682,10 +5700,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-							<target>时刻表</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5698,6 +5712,10 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+							<target>时刻表</target>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 							<target>高度</target>
@@ -5716,10 +5734,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-							<target>交互</target>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5744,6 +5758,10 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+							<target>交互</target>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>跳转屏幕</target>
@@ -5758,10 +5776,6 @@
 						</trans-unit>
 					</group>
 					<group id="sound_command">
-						<trans-unit id="name">
-							<source>Sound and command</source>
-							<target>声音与指令</target>
-						</trans-unit>
 						<group id="tree">
 							<trans-unit id="touch_element">
 								<source>Touch element</source>
@@ -5777,24 +5791,12 @@
 							</trans-unit>
 						</group>
 						<group id="edit_entry">
-							<trans-unit id="name">
-								<source>Edit entry</source>
-								<target>编辑条目</target>
-							</trans-unit>
-							<trans-unit id="sound">
-								<source>Sound</source>
-								<target>声音</target>
-							</trans-unit>
 							<group id="sound">
 								<trans-unit id="index">
 									<source>Index</source>
 									<target>索引</target>
 								</trans-unit>
 							</group>
-							<trans-unit id="command">
-								<source>Command</source>
-								<target>命令</target>
-							</trans-unit>
 							<group id="command">
 								<trans-unit id="name">
 									<source>Key</source>
@@ -5805,10 +5807,80 @@
 									<target>属性</target>
 								</trans-unit>
 							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+								<target>编辑条目</target>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+								<target>声音</target>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+								<target>命令</target>
+							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+							<target>声音与指令</target>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+						<target>编辑2D驾驶室</target>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+								<target>键值类型</target>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+									<target>位置</target>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+								<target>参数</target>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+								<target>文件路径</target>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+								<target>半径</target>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+								<target>自定义位置</target>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+							<target>编辑条目</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 						<target>声音设置</target>
@@ -5829,66 +5901,8 @@
 						<source>Radius</source>
 						<target>半径</target>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-							<target>编辑条目</target>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-								<target>键值类型</target>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-								<target>参数</target>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-								<target>文件路径</target>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-								<target>半径</target>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-								<target>自定义位置</target>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-									<target>位置</target>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>X</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>Y</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>Z</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
 				</group>
 				<group id="import_export">
-					<trans-unit id="import_name">
-						<source>Import</source>
-						<target>导入</target>
-					</trans-unit>
-					<trans-unit id="export_name">
-						<source>Export</source>
-						<target>导出</target>
-					</trans-unit>
 					<group id="train">
 						<trans-unit id="name">
 							<source>Train setting file</source>
@@ -5933,6 +5947,14 @@
 							<source>Sound.xml</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+						<target>导入</target>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+						<target>导出</target>
+					</trans-unit>
 					<trans-unit id="folder">
 						<source>Folder</source>
 						<target>文件夹</target>
@@ -5943,10 +5965,6 @@
 					</trans-unit>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-						<target>报告</target>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5965,6 +5983,10 @@
 							<target>清理</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+						<target>报告</target>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>级别</target>
@@ -6006,14 +6028,6 @@
 						<source>Invalid HEX color</source>
 						<target>无效的HEX颜色</target>
 					</trans-unit>
-					<!--trans-unit id="empty_filename">
-						<source>File name has not been entered.</source>
-						<target>未输入文件名。</target>
-					</trans-unit>
-					<trans-unit id="key_exist">
-						<source>The specified key is already set.</source>
-						<target>指定的键值已被使用。</target>
-					</trans-unit-->
 					<trans-unit id="number_exist">
 						<source>The specified number is already set.</source>
 						<target>指定的索引已被使用。</target>

--- a/assets/Languages/zh-HK.xlf
+++ b/assets/Languages/zh-HK.xlf
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-HK">
 		<body>
 			<group id="language">
@@ -247,9 +248,6 @@
 						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
 						<target>未能讀取路線: \r\n 未能找到所有已定義的物件。</target>
 					</trans-unit>
-					<trans-unit id="route_corrupt_missingobjects">
-						<source>The selected route is corrupt: \r\n Unable to locate all defined objects.</source>
-					</trans-unit>
 					<trans-unit id="plugin_failure1">
 						<source>The train plugin [plugin] failed to load.</source>
 						<target>未能加載列車插件: [plugin]</target>
@@ -281,6 +279,9 @@
 					<trans-unit id="security_badlocation">
 						<source>If you are attempting to install addons in the Program Files or ProgramData folders, this may require administrator permission. \r\n\r\n This is not recommended for security reasons.</source>
 						<target>如果您要在&quot;Program Files&quot; 或 &quot;ProgramData&quot; 文件夾中安裝內容，則可能需要管理員權限. \r\n\r\n 但因安全考慮，一般不建議這樣做</target>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
 					</trans-unit>
 				</group>
 				<group id="start">
@@ -347,18 +348,6 @@
 						<source>Choose Train...</source>
 						<target>選擇列車</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Do you wish to use the default train?</source>
-						<target>你想使用預設列車嗎?</target>
-					</trans-unit>
-					<trans-unit id="train_default_no">
-						<source>No</source>
-						<target>否</target>
-					</trans-unit>
-					<trans-unit id="train_default_yes">
-						<source>Yes</source>
-						<target>是</target>
-					</trans-unit>
 					<trans-unit id="train_selection">
 						<source>Selection</source>
 						<target>選擇</target>
@@ -424,6 +413,9 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>開始</target>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -620,7 +612,7 @@
 						<target>安裝擴展包</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
 						<target>此檔案不是有效的OpenBVE擴展包。</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
@@ -759,7 +751,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>新擴展包已分配了以下GUID：</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 					</trans-unit>
 					<trans-unit id="creation_name">
@@ -1260,63 +1252,63 @@
 						<target>加載RailDriver校准文件時出錯</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
 						<target>請按“下一步”開始校準</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
 						<target>將倒檔桿移至完全倒檔位置，然後按“下一步”</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
 						<target>將倒檔桿移至最大前進位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
 						<target>將組合的製動/油門桿移至最大功率位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
 						<target>將組合的製動/油門桿移至全制動位置，然後按“下一步”</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>將動態制動桿移至釋放位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
 						<target>將動態制動桿移至緊急位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
 						<target>將獨立制動桿移至釋放位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
 						<target>將獨立制動桿移至最大位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
 						<target>將釋放桿移至釋放位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
 						<target>移動並保持釋放桿到最大位置，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
 						<target>將水撥開關移至“關閉”，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
 						<target>將水撥開關移至&quot;滿&quot;（FULL），然後按下一步。</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
 						<target>將燈光開關移至“關閉”，然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
 						<target>將燈光開關移至&quot;滿&quot;（FULL），然後按“下一步”。</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
@@ -2003,7 +1995,7 @@
 						<target>你未有在 [name] 讓乘客上落車，請立刻駛回車站。</target>
 					</trans-unit>
 					<trans-unit id="train_currentspeed">
-						<source>The train's current speed is [speed]</source>
+						<source>The train&apos;s current speed is [speed]</source>
 						<target>現時車速為 [speed]</target>
 					</trans-unit>
 					<trans-unit id="loading">
@@ -2074,6 +2066,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>滑鼠抓動：關閉</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2247,7 +2254,7 @@
 						<target>控制桿</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2261,6 +2268,18 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>目前分配:</target>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>你想使用預設列車嗎?</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+						<target>否</target>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
+						<target>是</target>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2596,15 +2615,15 @@
 						<target>保安系統的 P 功能鍵</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>切換至車內視覺</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 						<target>切換至車內視覺 (沒有面板)</target>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>切換至車外視覺</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2874,6 +2893,24 @@
 					<trans-unit id="raildriver_speed_units">
 						<source>Toggles the RailDriver speed display units.</source>
 						<target>切換 RailDriver 速度單位</target>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3221,11 +3258,11 @@
 					</trans-unit>
 					<trans-unit id="quote">
 						<source>Quote</source>
-						<target>Quote (')</target>
+						<target>Quote (&apos;)</target>
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>Quote double ('')</target>
+						<target>Quote double (&apos;&apos;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3520,11 +3557,7 @@
 						<target>Linux</target>
 					</trans-unit>
 					<trans-unit id="help_controller1_textbox">
-						<source>If your non-USB controller is not providing correct input:
-
-1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller
-to separate buttons to avoid compatibility issues.
-2. Calibrate the controller from the configuration window, if necessary.</source>
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
 						<target>如果您的非USB控制器未提供正確的輸入，請執行以下操作：
 
 1.確保USB適配器正常工作。 正常情況下，適配器應將標準控制器的方向按鈕映射到單獨的按鈕，以避免兼容性問題。 
@@ -3535,19 +3568,14 @@ to separate buttons to avoid compatibility issues.
 						<target>如果您的PS2控制器未出現在列表中，請按照下列步驟操作:</target>
 					</trans-unit>
 					<trans-unit id="help_windows_textbox">
-						<source>1. Extract the Windows drivers.
-2. Download and run Zadig.
-3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).
-4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
 						<target>1.解壓縮Windows驅動程序。
 2.下載並運行Zadig。
 3.加載適合您設備的cfg文件(&quot;設備 &gt; 加載預設設備&quot;)。
 4.按“安裝驅動程序”，然後等待安裝完成。</target>
 					</trans-unit>
 					<trans-unit id="help_linux_textbox">
-						<source>1. Extract the Linux udev file.
-2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).
-3. Reboot or reload udev rules manually.</source>
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
 						<target>1.解壓縮Linux udev文件。
 2.將文件複製到 &quot;/etc/udev/rules.d/&quot; (需root權限)。
 3.重啟電腦或重新加載udev規則。</target>
@@ -3569,14 +3597,7 @@ to separate buttons to avoid compatibility issues.
 						<target>確定</target>
 					</trans-unit>
 					<trans-unit id="help_libusb_symlink">
-						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.
-Please follow the following instructions:
-
-1. Check that the &quot;libusb-1.0&quot; package is installed.
-2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;
-3. Open the directory in the terminal.
-4. Check this location to see if &quot;libusb-1.0.so&quot; exists.
-5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
 						<target>未能找到LibUsb，或者運行時沒有加載正確符號鏈接。
 請跟隨以下說明：
 
@@ -3585,6 +3606,35 @@ Please follow the following instructions:
 3. 在Terminal打開目錄。
 4. 檢查 &quot;libusb-1.0.so&quot; 是否存在該目錄。
 5. 如果文件不存在，我們必須通過從該Terminal執行以下命令來創建適當的符號鏈接: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</target>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -4093,7 +4143,7 @@ Please follow the following instructions:
 						<target>擴展功能</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
 						<target>注意: 本頁看到的功能至少需要以下的OpenBVE版本:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
@@ -4212,13 +4262,10 @@ Please follow the following instructions:
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 							<target>您嘗試打開列車數據。 \n\n  但TrainEditor2不能直接讀取列車資料。 \n\n  請使用導入(Import)功能將列車資料導入到TrainEditor2格式。</target>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4230,6 +4277,9 @@ Please follow the following instructions:
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4273,13 +4323,7 @@ Please follow the following instructions:
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4297,21 +4341,6 @@ Please follow the following instructions:
 								<source>Separated (Reverser Interlocked)</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4347,8 +4376,35 @@ Please follow the following instructions:
 								<target>阻塞</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4369,9 +4425,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4402,15 +4455,6 @@ Please follow the following instructions:
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4462,6 +4506,18 @@ Please follow the following instructions:
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4469,12 +4525,28 @@ Please follow the following instructions:
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+								<target>FrontAxle</target>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+								<target>RearAxle</target>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4511,19 +4583,6 @@ Please follow the following instructions:
 							<source>DefinedAxles</source>
 							<target>DefinedAxles</target>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-								<target>FrontAxle</target>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-								<target>RearAxle</target>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 							<target>FrontBogie</target>
@@ -4586,9 +4645,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4632,6 +4688,9 @@ Please follow the following instructions:
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 							<target>BrakeControlSpeed</target>
@@ -4658,6 +4717,17 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4676,15 +4746,15 @@ Please follow the following instructions:
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4750,11 +4820,14 @@ Please follow the following instructions:
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4896,9 +4969,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4924,13 +4994,16 @@ Please follow the following instructions:
 								<target>恆定速度</target>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 								<target>交換</target>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 							<target>播放</target>
@@ -5027,11 +5100,11 @@ Please follow the following instructions:
 							<target>在相同的x坐標處已經存在一個點，是否要覆蓋?</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -5045,12 +5118,34 @@ Please follow the following instructions:
 							<target>最高</target>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -5083,9 +5178,56 @@ Please follow the following instructions:
 							<source>TransparentColor</source>
 							<target>TransparentColor</target>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+							<target>數字</target>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+							<target>層</target>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+							<target>Subject</target>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -5105,70 +5247,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-							<target>數字</target>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-							<target>層</target>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-							<target>Subject</target>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 							<target>DefinedRadius</target>
@@ -5194,17 +5278,6 @@ Please follow the following instructions:
 							<source>DefinedOrigin</source>
 							<target>DefinedOrigin</target>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 							<target>InitialAngle</target>
@@ -5250,12 +5323,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5267,6 +5334,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5285,12 +5358,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5302,6 +5369,12 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5329,12 +5402,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5346,6 +5413,23 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5361,17 +5445,6 @@ Please follow the following instructions:
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5380,9 +5453,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5394,6 +5464,9 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5408,9 +5481,6 @@ Please follow the following instructions:
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5433,6 +5503,9 @@ Please follow the following instructions:
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 							<target>JumpScreen</target>
@@ -5448,9 +5521,128 @@ Please follow the following instructions:
 							<source>CommandOption</source>
 							<target>CommandOption</target>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+							<target>尚未輸入檔案名。</target>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+							<target>指定的鍵已被設定。</target>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5468,64 +5660,8 @@ Please follow the following instructions:
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-							<target>尚未輸入檔案名。</target>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-							<target>指定的鍵已被設定。</target>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5542,6 +5678,9 @@ Please follow the following instructions:
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 						<target>水平</target>
@@ -5577,8 +5716,84 @@ Please follow the following instructions:
 						<target>數值一定要是 {0}浮點數</target>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
 						<target>invalid_color</target>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/assets/Languages/zh-TW.xlf
+++ b/assets/Languages/zh-TW.xlf
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-TW">
 		<body>
 			<group id="language">
@@ -16,7 +16,7 @@
 					<target>I-Circle BVE (http://bve.i-circle.net)</target>
 				</trans-unit>
 				<trans-unit id="last_updated">
-					<source>2016-02-21</source>
+					<source>2019-06-29</source>
 					<target>2009-07-30</target>
 				</trans-unit>
 			</group>
@@ -87,12 +87,12 @@
 						<target>Save Bug Report</target>
 					</trans-unit>
 					<trans-unit id="saved">
-						<source>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
-						<target>The report has been saved as "[filename]" on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
+						<source>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</source>
+						<target>The report has been saved as &quot;[filename]&quot; on your desktop. \r\n\r\nYou may now submit a bug report to the discussion board, or open an issue on GitHub with this zip file attached.</target>
 					</trans-unit>
 					<trans-unit id="save_failed">
-						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</source>
-						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the "View..." button, then submit these logs to the discussion board or open an issue on GitHub.</target>
+						<source>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</source>
+						<target>Cannot create bug report! \r\n\r\nYou may access the Log and Crash Log directly by clicking the &quot;View...&quot; button, then submit these logs to the discussion board or open an issue on GitHub.</target>
 					</trans-unit>
 				</group>
 				<group id="panel">
@@ -288,6 +288,12 @@
 					<trans-unit id="error_busy_thread">
 						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
 					</trans-unit>
+					<trans-unit id="route_please_select">
+						<source>Please first select a route file to begin.</source>
+					</trans-unit>
+					<trans-unit id="route_switch_turn">
+						<source>The .Turn command and the .Switch command may not be used in the same route.</source>
+					</trans-unit>
 				</group>
 				<group id="start">
 					<trans-unit id="title">
@@ -366,10 +372,6 @@
 						<source>Recently used</source>
 						<target>最近選用</target>
 					</trans-unit>
-					<trans-unit id="train_default">
-						<source>Route default</source>
-						<target>預設列車</target>
-					</trans-unit>
 					<trans-unit id="train_usedefault">
 						<source>Use the train suggested by the route</source>
 						<target>使用路線所建議的預設列車</target>
@@ -398,7 +400,7 @@
 						<target>預覽：</target>
 					</trans-unit>
 					<trans-unit id="train_notfound">
-						<source>The default train could not be found:\n\n</source>
+						<source>The default train could not be found:\r\n\r\n</source>
 						<target>找不到與路線聯繫的列車：\x20</target>
 					</trans-unit>
 					<trans-unit id="train_pluginnotsupported">
@@ -416,6 +418,15 @@
 					<trans-unit id="start_start">
 						<source>Start</source>
 						<target>開始</target>
+					</trans-unit>
+					<trans-unit id="train_choose">
+						<source>Choose Train...</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Route default</source>
+					</trans-unit>
+					<trans-unit id="train_notfound_download">
+						<source>The default train is not currently installed:\r\n\r\n [train]\r\n\r\n It may be downloaded at:\r\n\r\n</source>
 					</trans-unit>
 				</group>
 				<group id="review">
@@ -614,8 +625,8 @@
 						<target>Install a Package</target>
 					</trans-unit>
 					<trans-unit id="install_invalid">
-						<source>This file does not appear to be a valid openBVE package.</source>
-						<target>This file does not appear to be a valid openBVE package.</target>
+						<source>This file does not appear to be a valid OpenBVE package.</source>
+						<target>This file does not appear to be a valid OpenBVE package.</target>
 					</trans-unit>
 					<trans-unit id="install_version_error">
 						<source>Package Version Error</source>
@@ -726,8 +737,8 @@
 						<target>Remove</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_skip_if_none">
-						<source>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</source>
-						<target>If your package does not rely on other dependencies, you may continue by clicking the "Create" button.</target>
+						<source>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</source>
+						<target>If your package does not rely on other dependencies, you may continue by clicking the &quot;Create&quot; button.</target>
 					</trans-unit>
 					<trans-unit id="creation_dependancies_nextstep">
 						<source>Package details and dependancies may be assigned in the following steps.</source>
@@ -753,7 +764,7 @@
 						<source>The new package has been assigned the following GUID:</source>
 						<target>The new package has been assigned the following GUID:</target>
 					</trans-unit>
-					<trans-unit id="creation_header">
+					<trans-unit id="enter_details_header">
 						<source>Enter Package Details</source>
 						<target>Create a Package</target>
 					</trans-unit>
@@ -989,6 +1000,15 @@
 						<source>Failed to create the following file: \r \n</source>
 						<target>Failed to create the following file: \r \n</target>
 					</trans-unit>
+					<trans-unit id="database_newer_expected">
+						<source>The package database version appears to be a newer version than supported by this copy of OpenBVE.</source>
+					</trans-unit>
+					<trans-unit id="database_invalid_xml">
+						<source>The package database XML was invalid, and has been re-created.</source>
+					</trans-unit>
+					<trans-unit id="error_busy_thread">
+						<source>The package worker thread is currently busy. Please wait a moment and try again.</source>
+					</trans-unit>
 				</group>
 				<group id="controls">
 					<trans-unit id="title">
@@ -1119,7 +1139,7 @@
 						<target>按下你選擇使用的按鈕或將操縱桿移向所選的方向……</target>
 					</trans-unit>
 					<trans-unit id="selection_joystick_assignment_grab_fullaxis">
-						<source>Move an axis into the direction of "increase" or "power"...</source>
+						<source>Move an axis into the direction of &quot;increase&quot; or &quot;power&quot;...</source>
 						<target>移到操縱桿到選擇用作「增加」或「動力」的方向……</target>
 					</trans-unit>
 					<trans-unit id="attached">
@@ -1245,64 +1265,64 @@
 						<target>Error loading RailDriver calibration file.</target>
 					</trans-unit>
 					<trans-unit id="calibration_start">
-						<source>Please press 'Next' to start calibration.</source>
-						<target>Please press 'Next' to start calibration.</target>
+						<source>Please press &apos;Next&apos; to start calibration.</source>
+						<target>Please press &apos;Next&apos; to start calibration.</target>
 					</trans-unit>
 					<trans-unit id="calibration_a">
-						<source>Move the reverser lever to the full reverse position and press 'Next'.</source>
-						<target>Move the reverser lever to the full reverse position and press 'Next'.</target>
+						<source>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full reverse position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_b">
-						<source>Move the reverser lever to the full forward position and press 'Next'.</source>
-						<target>Move the reverser lever to the full forward position and press 'Next'.</target>
+						<source>Move the reverser lever to the full forward position and press &apos;Next&apos;.</source>
+						<target>Move the reverser lever to the full forward position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_c">
-						<source>Move the combined brake / throttle lever to the full power position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full power position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full power position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_d">
-						<source>Move the combined brake / throttle lever to the full brake position and press 'Next'.</source>
-						<target>Move the combined brake / throttle lever to the full brake position and press 'Next'.</target>
+						<source>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</source>
+						<target>Move the combined brake / throttle lever to the full brake position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_e">
-						<source>Move the dynamic brake lever to the release position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the release position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_f">
-						<source>Move the dynamic brake lever to the emergency position and press 'Next'.</source>
-						<target>Move the dynamic brake lever to the emergency position and press 'Next'.</target>
+						<source>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</source>
+						<target>Move the dynamic brake lever to the emergency position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_g">
-						<source>Move the independant brake lever to the release position and press 'Next'.</source>
-						<target>Move the independant brake lever to the release position and press 'Next'.</target>
+						<source>Move the independant brake lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_h">
-						<source>Move the independant brake lever to the full position and press 'Next'.</source>
-						<target>Move the independant brake lever to the full position and press 'Next'.</target>
+						<source>Move the independant brake lever to the full position and press &apos;Next&apos;.</source>
+						<target>Move the independant brake lever to the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_i">
-						<source>Move the bail-off lever to the release position and press 'Next'.</source>
-						<target>Move the bail-off lever to the release position and press 'Next'.</target>
+						<source>Move the bail-off lever to the release position and press &apos;Next&apos;.</source>
+						<target>Move the bail-off lever to the release position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_j">
-						<source>Move and hold the bail-off lever into the full position and press 'Next'.</source>
-						<target>Move and hold the bail-off lever into the full position and press 'Next'.</target>
+						<source>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</source>
+						<target>Move and hold the bail-off lever into the full position and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_k">
-						<source>Move the wiper switch to OFF and press 'Next'.</source>
-						<target>Move the wiper switch to OFF and press 'Next'.</target>
+						<source>Move the wiper switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_l">
-						<source>Move the wiper switch to FULL and press 'Next'.</source>
-						<target>Move the wiper switch to FULL and press 'Next'.</target>
+						<source>Move the wiper switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the wiper switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_m">
-						<source>Move the lights switch to OFF and press 'Next'.</source>
-						<target>Move the lights switch to OFF and press 'Next'.</target>
+						<source>Move the lights switch to OFF and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to OFF and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_n">
-						<source>Move the lights switch to FULL and press 'Next'.</source>
-						<target>Move the lights switch to FULL and press 'Next'.</target>
+						<source>Move the lights switch to FULL and press &apos;Next&apos;.</source>
+						<target>Move the lights switch to FULL and press &apos;Next&apos;.</target>
 					</trans-unit>
 					<trans-unit id="calibration_o">
 						<source>Calibration complete.</source>
@@ -1724,6 +1744,12 @@
 					<trans-unit id="compatibility_signals">
 						<source>Default Signals:</source>
 					</trans-unit>
+					<trans-unit id="resolution">
+						<source>Resolution:</source>
+					</trans-unit>
+					<trans-unit id="font">
+						<source>Font:</source>
+					</trans-unit>
 				</group>
 				<group id="dialog">
 					<trans-unit id="csvfiles">
@@ -1835,11 +1861,11 @@
 						<target>找不到檔案：</target>
 					</trans-unit>
 					<trans-unit id="almost_help_filesnotfound">
-						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting "Ignore" from below.</source>
+						<source>Some issues were encountered while loading the route and train.\r\n\r\nAs some files could not be found, the route or train might not appear as intended. Try to redownload the route and train packages in order to ensure that you have a complete distribution.\r\n\r\nThe following list of issues might give additional information. You can still start the route by selecting &quot;Ignore&quot; from below.</source>
 						<target>在載入路線和列車時遇到一些問題。\r\n\r\n因為找不到部分檔案，路線或列車可能未能按預期顯示。你可以嘗試重新下載該路線及列車檔案，以確保你取得完整的檔案。\r\n\r\n以下的問題清單可能提供額外的資料。你仍可以選擇「略過」來開始遊戲。</target>
 					</trans-unit>
 					<trans-unit id="almost_help_general">
-						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select "Ignore" at this point to start the game.</source>
+						<source>Some issues were encountered while loading the route and train. If you are the route or train developer, it might be worth taking a look at the following list of issues.\r\n\r\nAs a regular user, you can select &quot;Ignore&quot; at this point to start the game.</source>
 						<target>在載入路線和列車檔案時遇到一些問題。如果你是路線或列車案製作者，以下的問題清單可能值得一看。\r\n\r\n作為一名普通的玩家，你仍可以選擇「略過」來開始遊戲。</target>
 					</trans-unit>
 					<trans-unit id="almost_show">
@@ -1970,6 +1996,21 @@
 						<source>Loading. Please wait...</source>
 						<target>載入中，請稍候……</target>
 					</trans-unit>
+					<trans-unit id="route_newlimit">
+						<source>New speed limit: [limit] [unit].</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection">
+						<source>Next signal in [distance]</source>
+					</trans-unit>
+					<trans-unit id="route_nextsection_aspect">
+						<source>Next signal in [distance], with aspect [aspect]</source>
+					</trans-unit>
+					<trans-unit id="route_nextstation">
+						<source>Next station is [name] in [distance]</source>
+					</trans-unit>
+					<trans-unit id="train_currentspeed">
+						<source>The train&apos;s current speed is [speed]</source>
+					</trans-unit>
 				</group>
 				<group id="notification">
 					<trans-unit id="interior">
@@ -2035,6 +2076,21 @@
 					<trans-unit id="mousegrab_off">
 						<source>Mouse grab: off</source>
 						<target>滑鼠抓動：關閉</target>
+					</trans-unit>
+					<trans-unit id="switchexterior_uncouple">
+						<source>Please switch to exterior view to uncouple.</source>
+					</trans-unit>
+					<trans-unit id="unable_uncouple">
+						<source>Unable to uncouple this car.</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplerear">
+						<source>Uncoupling the rear of car number</source>
+					</trans-unit>
+					<trans-unit id="exterior_uncouplefront">
+						<source>Uncoupling the front of car number</source>
+					</trans-unit>
+					<trans-unit id="fixed_uncouple">
+						<source>This coupler is fixed, and cannot uncouple.</source>
 					</trans-unit>
 				</group>
 				<group id="score">
@@ -2203,7 +2259,7 @@
 						<target>Joystick</target>
 					</trans-unit>
 					<trans-unit id="joystick_notavailable">
-						<source>N/A</source>
+						<source>Joystick (Not currently connected)</source>
 						<target>N/A</target>
 					</trans-unit>
 					<trans-unit id="joystickdirection_positive">
@@ -2217,6 +2273,22 @@
 					<trans-unit id="assignment_current">
 						<source>Current assignment:</source>
 						<target>Current assignment:</target>
+					</trans-unit>
+					<trans-unit id="title">
+						<source>In-Game Menu</source>
+					</trans-unit>
+					<trans-unit id="pause_title">
+						<source>PAUSE</source>
+					</trans-unit>
+					<trans-unit id="train_default">
+						<source>Do you wish to use the default train?</source>
+						<target>預設列車</target>
+					</trans-unit>
+					<trans-unit id="train_default_no">
+						<source>No</source>
+					</trans-unit>
+					<trans-unit id="train_default_yes">
+						<source>Yes</source>
 					</trans-unit>
 				</group>
 				<group id="lamps">
@@ -2555,14 +2627,14 @@
 						<target>保安系統的 P 功能鍵</target>
 					</trans-unit>
 					<trans-unit id="camera_interior">
-						<source>Switches to the train's interior view</source>
+						<source>Switches to the train&apos;s interior view</source>
 						<target>切換至車內視點</target>
 					</trans-unit>
 					<trans-unit id="camera_interior_nopanel">
-						<source>Switches to the train's interior view. However, the panel is not displayed.</source>
+						<source>Switches to the train&apos;s interior view. However, the panel is not displayed.</source>
 					</trans-unit>
 					<trans-unit id="camera_exterior">
-						<source>Switches to the train's exterior view</source>
+						<source>Switches to the train&apos;s exterior view</source>
 						<target>切換至車外視點</target>
 					</trans-unit>
 					<trans-unit id="camera_track">
@@ -2823,6 +2895,30 @@
 					<trans-unit id="main_breaker">
 						<source>Toggles the main breaker</source>
 						<target>Toggles the main breaker</target>
+					</trans-unit>
+					<trans-unit id="debug_renderer_mode">
+						<source>Toggles the renderer</source>
+					</trans-unit>
+					<trans-unit id="raildriver_speed_units">
+						<source>Toggles the RailDriver speed display units.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_current_speed">
+						<source>Accessibility: Audibly announces the current speed.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_signal">
+						<source>Accessibility: Audibly announces the next signal distance and aspect.</source>
+					</trans-unit>
+					<trans-unit id="accessibility_next_station">
+						<source>Accessibility: Audibly announces the the next station name and distance.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_front">
+						<source>Uncouples the front coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="uncouple_rear">
+						<source>Uncouples the rear coupler for the selected car.</source>
+					</trans-unit>
+					<trans-unit id="switch_menu">
+						<source>Shows the change switch menu</source>
 					</trans-unit>
 				</group>
 				<group id="keys">
@@ -3184,11 +3280,11 @@
 					</trans-unit>
 					<trans-unit id="quote">
 						<source>Quote</source>
-						<target>Quote (')</target>
+						<target>Quote (&apos;)</target>
 					</trans-unit>
 					<trans-unit id="quotedbl">
 						<source>Quote double</source>
-						<target>Quote double ('')</target>
+						<target>Quote double (&apos;&apos;)</target>
 					</trans-unit>
 					<trans-unit id="ralt">
 						<source>Right Alt</source>
@@ -3361,6 +3457,154 @@
 					<trans-unit id="z">
 						<source>Z</source>
 						<target>Z</target>
+					</trans-unit>
+				</group>
+				<group id="switchmenu">
+					<trans-unit id="title">
+						<source>Select a Switch To Change: </source>
+					</trans-unit>
+					<trans-unit id="selected">
+						<source>Selected Switch: </source>
+					</trans-unit>
+					<trans-unit id="current">
+						<source>Current Setting: </source>
+					</trans-unit>
+					<trans-unit id="distance">
+						<source>Distance from Player: </source>
+					</trans-unit>
+					<trans-unit id="zoom_in">
+						<source>Zoom In</source>
+					</trans-unit>
+					<trans-unit id="zoom_out">
+						<source>Zoom Out</source>
+					</trans-unit>
+				</group>
+				<group id="denshadego">
+					<trans-unit id="config_title">
+						<source>Densha de GO! controller configuration</source>
+					</trans-unit>
+					<trans-unit id="input_section">
+						<source>Device input</source>
+					</trans-unit>
+					<trans-unit id="label_brake">
+						<source>Brake: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_power">
+						<source>Power: [notch]</source>
+					</trans-unit>
+					<trans-unit id="label_reverser">
+						<source>Reverser: [notch]</source>
+					</trans-unit>
+					<trans-unit id="calibration_button">
+						<source>Start calibration</source>
+					</trans-unit>
+					<trans-unit id="device">
+						<source>Device:</source>
+					</trans-unit>
+					<trans-unit id="button_section">
+						<source>Button mapping</source>
+					</trans-unit>
+					<trans-unit id="command_none">
+						<source>None</source>
+					</trans-unit>
+					<trans-unit id="handle_section">
+						<source>Handle mapping</source>
+					</trans-unit>
+					<trans-unit id="option_convert">
+						<source>Convert notches</source>
+					</trans-unit>
+					<trans-unit id="option_keep_minmax">
+						<source>Keep minimum and maximum</source>
+					</trans-unit>
+					<trans-unit id="option_holdbrake">
+						<source>Map hold brake to B1</source>
+					</trans-unit>
+					<trans-unit id="save_button">
+						<source>Save</source>
+					</trans-unit>
+					<trans-unit id="cancel_button">
+						<source>Cancel</source>
+					</trans-unit>
+					<trans-unit id="calibrate_button">
+						<source>Hold the [button] button in the controller and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_brake">
+						<source>Move the brake handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="calibrate_power">
+						<source>Move the power handle to [notch] and press OK.</source>
+					</trans-unit>
+					<trans-unit id="label_up">
+						<source>UP</source>
+					</trans-unit>
+					<trans-unit id="label_down">
+						<source>DOWN</source>
+					</trans-unit>
+					<trans-unit id="label_left">
+						<source>LEFT</source>
+					</trans-unit>
+					<trans-unit id="label_right">
+						<source>RIGHT</source>
+					</trans-unit>
+					<trans-unit id="label_pedal">
+						<source>PEDAL</source>
+					</trans-unit>
+					<trans-unit id="label_ldoor">
+						<source>L DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_rdoor">
+						<source>R DOOR</source>
+					</trans-unit>
+					<trans-unit id="label_a2">
+						<source>A2</source>
+					</trans-unit>
+					<trans-unit id="label_ats">
+						<source>ATS</source>
+					</trans-unit>
+					<trans-unit id="linkLabel_driver">
+						<source>My controller is not detected or does not work properly</source>
+					</trans-unit>
+					<trans-unit id="help_title">
+						<source>Help</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_label">
+						<source>My controller is not working correctly</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_label">
+						<source>My PS2 controller is not detected</source>
+					</trans-unit>
+					<trans-unit id="help_windows_label">
+						<source>Windows</source>
+					</trans-unit>
+					<trans-unit id="help_linux_label">
+						<source>Linux</source>
+					</trans-unit>
+					<trans-unit id="help_controller1_textbox">
+						<source>If your non-USB controller is not providing correct input:\r\n\r\n1. Ensure the USB adapter is working. Ideally, the adapter should map the direction buttons from a standard controller to separate buttons to avoid compatibility issues.\r\n2. Calibrate the controller from the configuration window, if necessary.</source>
+					</trans-unit>
+					<trans-unit id="help_controller2_textbox">
+						<source>If your PS2 controller does not appear in the list, follow these steps:</source>
+					</trans-unit>
+					<trans-unit id="help_windows_textbox">
+						<source>1. Extract the Windows drivers.\r\n2. Download and run Zadig.\r\n3. Load the appropriate CFG file for your device (&quot;Device &gt; Load Preset Device&quot;).\r\n4. Press &quot;Install Driver&quot; and wait for installation to complete.</source>
+					</trans-unit>
+					<trans-unit id="help_libusb_symlink">
+						<source>LibUsb appears to be either missing, or has not been correctly symlinked for runtime loading.\r\nPlease follow the following instructions:\r\n\r\n1. Check that the &quot;libusb-1.0&quot; package is installed.\r\n2. Find the location of &quot;libusb-1.0.so.0&quot; - On recent Ubuntu and Debian versions, this is likely to be &quot;/lib/x86_64-linux-gnu/&quot;\r\n3. Open the directory in the terminal.\r\n4. Check this location to see if &quot;libusb-1.0.so&quot; exists.\r\n5. If the file does not exist, we must create the appropriate symlink by executing the following command from this terminal: &quot;sudo ln -s libusb-1.0.so.0 libusb-1.0.so&quot;</source>
+					</trans-unit>
+					<trans-unit id="help_linux_textbox">
+						<source>1. Extract the Linux udev file.\r\n2. Copy the file to &quot;/etc/udev/rules.d/&quot; (root permissions required).\r\n3. Reboot or reload udev rules manually.</source>
+					</trans-unit>
+					<trans-unit id="help_zadig_button">
+						<source>Get Zadig</source>
+					</trans-unit>
+					<trans-unit id="help_windows_button">
+						<source>Extract files (Windows)</source>
+					</trans-unit>
+					<trans-unit id="help_linux_button">
+						<source>Extract files (Linux)</source>
+					</trans-unit>
+					<trans-unit id="help_ok_button">
+						<source>OK</source>
 					</trans-unit>
 				</group>
 			</group>
@@ -3613,6 +3857,12 @@
 					<trans-unit id="driver_brake_notches_error_message">
 						<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						<target>DriverBrakeNotches must be less than or equal to BrakeNotches.</target>
+					</trans-unit>
+					<trans-unit id="separated_interlocked">
+						<source>Separated (Interlocked)</source>
+					</trans-unit>
+					<trans-unit id="separated_interlocked_reverser">
+						<source>Separated (Reverser Interlocked)</source>
 					</trans-unit>
 				</group>
 				<group id="cab">
@@ -3875,8 +4125,8 @@
 						<target>Extended Features</target>
 					</trans-unit>
 					<trans-unit id="note">
-						<source>Please note: Features found on this page may require the following minimum version of openBVE:</source>
-						<target>Please note: Features found on this page may require the following minimum version of openBVE:</target>
+						<source>Please note: Features found on this page may require the following minimum version of OpenBVE:</source>
+						<target>Please note: Features found on this page may require the following minimum version of OpenBVE:</target>
 					</trans-unit>
 					<trans-unit id="loco_brake">
 						<source>Locomotive Brake</source>
@@ -3996,12 +4246,9 @@
 							<source>Exit</source>
 						</trans-unit>
 						<trans-unit id="wrongtype">
-							<source>You have attempted to open a train. \n\n  These cannot be opened directly- \n\n Please use the import function to import this train into TrainEditor2.</source>
+							<source>You have attempted to open a train.\r\nThese cannot be opened directly-\r\nPlease use the import function to import this train into TrainEditor2.</source>
 						</trans-unit>
 					</group>
-					<trans-unit id="language">
-						<source>Language</source>
-					</trans-unit>
 					<group id="message">
 						<trans-unit id="new">
 							<source>Do you want to save the current file before creating a new one?</source>
@@ -4013,6 +4260,9 @@
 							<source>Do you want to save the current file before closing?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="language">
+						<source>Language</source>
+					</trans-unit>
 				</group>
 				<group id="navigation">
 					<trans-unit id="up">
@@ -4052,13 +4302,7 @@
 					</trans-unit>
 				</group>
 				<group id="general_settings">
-					<trans-unit id="name">
-						<source>General settings</source>
-					</trans-unit>
 					<group id="handle">
-						<trans-unit id="name">
-							<source>Handle</source>
-						</trans-unit>
 						<group id="handle_type">
 							<trans-unit id="name">
 								<source>HandleType</source>
@@ -4069,22 +4313,13 @@
 							<trans-unit id="combined">
 								<source>Combined</source>
 							</trans-unit>
+							<trans-unit id="separated_interlocked">
+								<source>Separated (Interlocked)</source>
+							</trans-unit>
+							<trans-unit id="separated_interlocked_reverser">
+								<source>Separated (Reverser Interlocked)</source>
+							</trans-unit>
 						</group>
-						<trans-unit id="power_notches">
-							<source>PowerNotches</source>
-						</trans-unit>
-						<trans-unit id="brake_notches">
-							<source>BrakeNotches</source>
-						</trans-unit>
-						<trans-unit id="power_notch_reduce_steps">
-							<source>PowerNotchReduceSteps</source>
-						</trans-unit>
-						<trans-unit id="driver_power_notches">
-							<source>DriverPowerNotches</source>
-						</trans-unit>
-						<trans-unit id="driver_brake_notches">
-							<source>DriverBrakeNotches</source>
-						</trans-unit>
 						<group id="eb_handle_behaviour">
 							<trans-unit id="name">
 								<source>EbHandleBehaviour</source>
@@ -4116,8 +4351,35 @@
 								<source>Blocking</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Handle</source>
+						</trans-unit>
+						<trans-unit id="power_notches">
+							<source>PowerNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches">
+							<source>BrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="power_notch_reduce_steps">
+							<source>PowerNotchReduceSteps</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches">
+							<source>DriverPowerNotches</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches">
+							<source>DriverBrakeNotches</source>
+						</trans-unit>
 						<trans-unit id="loco_brake_notches">
 							<source>LocoBrakeNotches</source>
+						</trans-unit>
+						<trans-unit id="brake_notches_error_message">
+							<source>BrakeNotches must be at least 1 if HoldBrake is set.</source>
+						</trans-unit>
+						<trans-unit id="driver_power_notches_error_message">
+							<source>DriverPowerNotches must be less than or equal to PowerNotches.</source>
+						</trans-unit>
+						<trans-unit id="driver_brake_notches_error_message">
+							<source>DriverBrakeNotches must be less than or equal to BrakeNotches.</source>
 						</trans-unit>
 					</group>
 					<group id="cab">
@@ -4138,9 +4400,6 @@
 						</trans-unit>
 					</group>
 					<group id="device">
-						<trans-unit id="name">
-							<source>Device</source>
-						</trans-unit>
 						<group id="ats">
 							<trans-unit id="name">
 								<source>Ats</source>
@@ -4169,15 +4428,6 @@
 								<source>Automatic switching</source>
 							</trans-unit>
 						</group>
-						<trans-unit id="eb">
-							<source>Eb</source>
-						</trans-unit>
-						<trans-unit id="const_speed">
-							<source>ConstSpeed</source>
-						</trans-unit>
-						<trans-unit id="hold_brake">
-							<source>HoldBrake</source>
-						</trans-unit>
 						<group id="re_adhesion_device">
 							<trans-unit id="name">
 								<source>ReAdhesionDevice</source>
@@ -4229,6 +4479,18 @@
 								<source>Manual</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Device</source>
+						</trans-unit>
+						<trans-unit id="eb">
+							<source>Eb</source>
+						</trans-unit>
+						<trans-unit id="const_speed">
+							<source>ConstSpeed</source>
+						</trans-unit>
+						<trans-unit id="hold_brake">
+							<source>HoldBrake</source>
+						</trans-unit>
 						<trans-unit id="door_width">
 							<source>DoorWidth</source>
 						</trans-unit>
@@ -4236,12 +4498,26 @@
 							<source>DoorMaxTolerance</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>General settings</source>
+					</trans-unit>
 				</group>
 				<group id="car_settings">
-					<trans-unit id="name">
-						<source>Car settings</source>
-					</trans-unit>
 					<group id="general">
+						<group id="axles">
+							<trans-unit id="name">
+								<source>Axles</source>
+							</trans-unit>
+							<trans-unit id="front">
+								<source>FrontAxle</source>
+							</trans-unit>
+							<trans-unit id="rear">
+								<source>RearAxle</source>
+							</trans-unit>
+							<trans-unit id="mustbe_less">
+								<source>RearAxle must be less than FrontAxle.</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>General</source>
 						</trans-unit>
@@ -4272,17 +4548,6 @@
 						<trans-unit id="defined_axles">
 							<source>DefinedAxles</source>
 						</trans-unit>
-						<group id="axles">
-							<trans-unit id="name">
-								<source>Axles</source>
-							</trans-unit>
-							<trans-unit id="front">
-								<source>FrontAxle</source>
-							</trans-unit>
-							<trans-unit id="rear">
-								<source>RearAxle</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="front_bogie">
 							<source>FrontBogie</source>
 						</trans-unit>
@@ -4340,9 +4605,6 @@
 						</trans-unit>
 					</group>
 					<group id="brake">
-						<trans-unit id="name">
-							<source>Brake</source>
-						</trans-unit>
 						<group id="brake_type">
 							<trans-unit id="name">
 								<source>BrakeType</source>
@@ -4385,6 +4647,9 @@
 								<source>Delay-including control</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Brake</source>
+						</trans-unit>
 						<trans-unit id="brake_control_speed">
 							<source>BrakeControlSpeed</source>
 						</trans-unit>
@@ -4410,6 +4675,17 @@
 						</trans-unit>
 					</group>
 					<group id="delay">
+						<group id="edit_entry">
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="up">
+								<source>Up</source>
+							</trans-unit>
+							<trans-unit id="down">
+								<source>Down</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>Delay</source>
 						</trans-unit>
@@ -4428,15 +4704,15 @@
 						<trans-unit id="value">
 							<source>Value</source>
 						</trans-unit>
+						<trans-unit id="electric_brake">
+							<source>ElectricBrake</source>
+						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Car settings</source>
+					</trans-unit>
 				</group>
 				<group id="acceleration_settings">
-					<trans-unit id="name">
-						<source>Acceleration settings</source>
-					</trans-unit>
-					<trans-unit id="notch">
-						<source>Notch</source>
-					</trans-unit>
 					<group id="parameter">
 						<trans-unit id="name">
 							<source>Parameter</source>
@@ -4492,11 +4768,14 @@
 							<source>Reset</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Acceleration settings</source>
+					</trans-unit>
+					<trans-unit id="notch">
+						<source>Notch</source>
+					</trans-unit>
 				</group>
 				<group id="motor_sound_settings">
-					<trans-unit id="name">
-						<source>Motor sound settings</source>
-					</trans-unit>
 					<group id="menu">
 						<group id="edit">
 							<trans-unit id="name">
@@ -4623,9 +4902,6 @@
 						</trans-unit>
 					</group>
 					<group id="play_setting">
-						<trans-unit id="name">
-							<source>Playback setting</source>
-						</trans-unit>
 						<group id="source">
 							<trans-unit id="name">
 								<source>Sound source setting</source>
@@ -4648,12 +4924,15 @@
 								<source>Constant speed</source>
 							</trans-unit>
 							<trans-unit id="acceleration">
-								<source>Acceleration:</source>
+								<source>Acceleration</source>
 							</trans-unit>
 							<trans-unit id="swap">
 								<source>Swap</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Playback setting</source>
+						</trans-unit>
 						<trans-unit id="play">
 							<source>Playback</source>
 						</trans-unit>
@@ -4746,11 +5025,11 @@
 							<source>A point already exists at the same x coordinate, do you want to overwrite it?</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Motor sound settings</source>
+					</trans-unit>
 				</group>
 				<group id="coupler_settings">
-					<trans-unit id="name">
-						<source>Coupler settings</source>
-					</trans-unit>
 					<group id="general">
 						<trans-unit id="name">
 							<source>General</source>
@@ -4762,12 +5041,34 @@
 							<source>Max</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Coupler settings</source>
+					</trans-unit>
 				</group>
 				<group id="panel_settings">
-					<trans-unit id="name">
-						<source>Panel settings</source>
-					</trans-unit>
 					<group id="this">
+						<group id="center">
+							<trans-unit id="name">
+								<source>Center origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<group id="origin">
+							<trans-unit id="name">
+								<source>Track origin</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
 						<trans-unit id="name">
 							<source>This</source>
 						</trans-unit>
@@ -4795,9 +5096,53 @@
 						<trans-unit id="transparent_color">
 							<source>TransparentColor</source>
 						</trans-unit>
-						<group id="center">
+					</group>
+					<group id="screen">
+						<trans-unit id="name">
+							<source>Screen</source>
+						</trans-unit>
+						<trans-unit id="number">
+							<source>Number</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="pilot_lamp">
+						<group id="location">
 							<trans-unit id="name">
-								<source>Center</source>
+								<source>Location</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>PilotLamp</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="daytime_image">
+							<source>DaytimeImage</source>
+						</trans-unit>
+						<trans-unit id="nighttime_image">
+							<source>NighttimeImage</source>
+						</trans-unit>
+						<trans-unit id="transparent_color">
+							<source>TransparentColor</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
+					</group>
+					<group id="needle">
+						<group id="location">
+							<trans-unit id="name">
+								<source>Location</source>
 							</trans-unit>
 							<trans-unit id="x">
 								<source>X</source>
@@ -4817,67 +5162,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
-					</group>
-					<group id="screen">
-						<trans-unit id="name">
-							<source>Screen</source>
-						</trans-unit>
-						<trans-unit id="number">
-							<source>Number</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="pilot_lamp">
-						<trans-unit id="name">
-							<source>PilotLamp</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
-						<trans-unit id="daytime_image">
-							<source>DaytimeImage</source>
-						</trans-unit>
-						<trans-unit id="nighttime_image">
-							<source>NighttimeImage</source>
-						</trans-unit>
-						<trans-unit id="transparent_color">
-							<source>TransparentColor</source>
-						</trans-unit>
-						<trans-unit id="layer">
-							<source>Layer</source>
-						</trans-unit>
-					</group>
-					<group id="needle">
 						<trans-unit id="name">
 							<source>Needle</source>
 						</trans-unit>
 						<trans-unit id="subject">
 							<source>Subject</source>
 						</trans-unit>
-						<group id="location">
-							<trans-unit id="name">
-								<source>Location</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="defined_radius">
 							<source>DefinedRadius</source>
 						</trans-unit>
@@ -4899,17 +5189,6 @@
 						<trans-unit id="defined_origin">
 							<source>DefinedOrigin</source>
 						</trans-unit>
-						<group id="origin">
-							<trans-unit id="name">
-								<source>Origin</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="initial_angle">
 							<source>InitialAngle</source>
 						</trans-unit>
@@ -4945,12 +5224,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_number">
-						<trans-unit id="name">
-							<source>DigitalNumber</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4962,6 +5235,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalNumber</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -4979,12 +5258,6 @@
 						</trans-unit>
 					</group>
 					<group id="digital_gauge">
-						<trans-unit id="name">
-							<source>DigitalGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -4996,6 +5269,12 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>DigitalGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="radius">
 							<source>Radius</source>
 						</trans-unit>
@@ -5022,12 +5301,6 @@
 						</trans-unit>
 					</group>
 					<group id="linear_gauge">
-						<trans-unit id="name">
-							<source>LinearGauge</source>
-						</trans-unit>
-						<trans-unit id="subject">
-							<source>Subject</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5039,6 +5312,23 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<group id="direction">
+							<trans-unit id="name">
+								<source>Direction</source>
+							</trans-unit>
+							<trans-unit id="x">
+								<source>X</source>
+							</trans-unit>
+							<trans-unit id="y">
+								<source>Y</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>LinearGauge</source>
+						</trans-unit>
+						<trans-unit id="subject">
+							<source>Subject</source>
+						</trans-unit>
 						<trans-unit id="daytime_image">
 							<source>DaytimeImage</source>
 						</trans-unit>
@@ -5054,17 +5344,6 @@
 						<trans-unit id="maximum">
 							<source>Maximum</source>
 						</trans-unit>
-						<group id="direction">
-							<trans-unit id="name">
-								<source>Direction</source>
-							</trans-unit>
-							<trans-unit id="x">
-								<source>X</source>
-							</trans-unit>
-							<trans-unit id="y">
-								<source>Y</source>
-							</trans-unit>
-						</group>
 						<trans-unit id="width">
 							<source>Width</source>
 						</trans-unit>
@@ -5073,9 +5352,6 @@
 						</trans-unit>
 					</group>
 					<group id="timetable">
-						<trans-unit id="name">
-							<source>Timetable</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5087,6 +5363,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Timetable</source>
+						</trans-unit>
 						<trans-unit id="height">
 							<source>Height</source>
 						</trans-unit>
@@ -5101,9 +5380,6 @@
 						</trans-unit>
 					</group>
 					<group id="touch">
-						<trans-unit id="name">
-							<source>Touch</source>
-						</trans-unit>
 						<group id="location">
 							<trans-unit id="name">
 								<source>Location</source>
@@ -5126,6 +5402,9 @@
 								<source>Y</source>
 							</trans-unit>
 						</group>
+						<trans-unit id="name">
+							<source>Touch</source>
+						</trans-unit>
 						<trans-unit id="jump_screen">
 							<source>JumpScreen</source>
 						</trans-unit>
@@ -5138,9 +5417,126 @@
 						<trans-unit id="command_option">
 							<source>CommandOption</source>
 						</trans-unit>
+						<trans-unit id="sound_command">
+							<source>Sound and command</source>
+						</trans-unit>
+						<trans-unit id="layer">
+							<source>Layer</source>
+						</trans-unit>
 					</group>
+					<group id="subject">
+						<trans-unit id="name">
+							<source>Subject</source>
+						</trans-unit>
+						<trans-unit id="base">
+							<source>Base</source>
+						</trans-unit>
+						<trans-unit id="baseoption">
+							<source>Base option</source>
+						</trans-unit>
+						<trans-unit id="suffix">
+							<source>Suffix</source>
+						</trans-unit>
+						<trans-unit id="suffixoption">
+							<source>Suffix option</source>
+						</trans-unit>
+					</group>
+					<group id="sound_command">
+						<group id="tree">
+							<trans-unit id="touch_element">
+								<source>Touch element</source>
+							</trans-unit>
+							<trans-unit id="sounds">
+								<source>Sounds</source>
+							</trans-unit>
+							<trans-unit id="commands">
+								<source>Commands</source>
+							</trans-unit>
+						</group>
+						<group id="edit_entry">
+							<group id="sound">
+								<trans-unit id="index">
+									<source>Index</source>
+								</trans-unit>
+							</group>
+							<group id="command">
+								<trans-unit id="name">
+									<source>Key</source>
+								</trans-unit>
+								<trans-unit id="option">
+									<source>Option</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Edit entry</source>
+							</trans-unit>
+							<trans-unit id="sound">
+								<source>Sound</source>
+							</trans-unit>
+							<trans-unit id="command">
+								<source>Command</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Sound and command</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="name">
+						<source>Panel settings</source>
+					</trans-unit>
 				</group>
 				<group id="sound_settings">
+					<group id="edit_entry">
+						<group id="section">
+							<trans-unit id="name">
+								<source>Section select</source>
+							</trans-unit>
+						</group>
+						<group id="key">
+							<trans-unit id="name">
+								<source>Key type select</source>
+							</trans-unit>
+						</group>
+						<group id="value">
+							<group id="position">
+								<trans-unit id="name">
+									<source>Position</source>
+								</trans-unit>
+								<trans-unit id="x">
+									<source>X</source>
+								</trans-unit>
+								<trans-unit id="y">
+									<source>Y</source>
+								</trans-unit>
+								<trans-unit id="z">
+									<source>Z</source>
+								</trans-unit>
+							</group>
+							<trans-unit id="name">
+								<source>Input value</source>
+							</trans-unit>
+							<trans-unit id="filename">
+								<source>Filename</source>
+							</trans-unit>
+							<trans-unit id="radius">
+								<source>Radius</source>
+							</trans-unit>
+							<trans-unit id="position">
+								<source>Position setting</source>
+							</trans-unit>
+						</group>
+						<trans-unit id="name">
+							<source>Edit entry</source>
+						</trans-unit>
+					</group>
+					<group id="message">
+						<trans-unit id="empty_filename">
+							<source>File name has not been entered.</source>
+						</trans-unit>
+						<trans-unit id="key_exist">
+							<source>The specified key is already set.</source>
+						</trans-unit>
+					</group>
 					<trans-unit id="name">
 						<source>Sound settings</source>
 					</trans-unit>
@@ -5156,62 +5552,8 @@
 					<trans-unit id="radius">
 						<source>Radius</source>
 					</trans-unit>
-					<group id="edit_entry">
-						<trans-unit id="name">
-							<source>Edit entry</source>
-						</trans-unit>
-						<group id="section">
-							<trans-unit id="name">
-								<source>Section select</source>
-							</trans-unit>
-						</group>
-						<group id="key">
-							<trans-unit id="name">
-								<source>Key type select</source>
-							</trans-unit>
-						</group>
-						<group id="value">
-							<trans-unit id="name">
-								<source>Input value</source>
-							</trans-unit>
-							<trans-unit id="filename">
-								<source>Filename</source>
-							</trans-unit>
-							<trans-unit id="radius">
-								<source>Radius</source>
-							</trans-unit>
-							<trans-unit id="position">
-								<source>Position setting</source>
-							</trans-unit>
-							<group id="position">
-								<trans-unit id="name">
-									<source>Position</source>
-								</trans-unit>
-								<trans-unit id="x">
-									<source>x coordinate</source>
-								</trans-unit>
-								<trans-unit id="y">
-									<source>y coordinate</source>
-								</trans-unit>
-								<trans-unit id="z">
-									<source>z coordinate</source>
-								</trans-unit>
-							</group>
-						</group>
-					</group>
-					<group id="message">
-						<trans-unit id="empty_filename">
-							<source>File name has not been entered.</source>
-						</trans-unit>
-						<trans-unit id="key_exist">
-							<source>The specified key is already set.</source>
-						</trans-unit>
-					</group>
 				</group>
 				<group id="status">
-					<trans-unit id="name">
-						<source>Status</source>
-					</trans-unit>
 					<group id="menu">
 						<trans-unit id="error">
 							<source>Error</source>
@@ -5226,6 +5568,9 @@
 							<source>Clear</source>
 						</trans-unit>
 					</group>
+					<trans-unit id="name">
+						<source>Status</source>
+					</trans-unit>
 					<trans-unit id="level">
 						<source>Level</source>
 					</trans-unit>
@@ -5256,7 +5601,83 @@
 						<source>This value must be a {0}floating-point number.</source>
 					</trans-unit>
 					<trans-unit id="invalid_color">
-						<source>invalid_color</source>
+						<source>Invalid HEX color</source>
+					</trans-unit>
+					<trans-unit id="number_exist">
+						<source>The specified number is already set.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_greater_than">
+						<source>Max must be greater than or equal to Min.</source>
+					</trans-unit>
+					<trans-unit id="mustbe_less_than">
+						<source>Min must be less than the Max.</source>
+					</trans-unit>
+				</group>
+				<group id="items">
+					<trans-unit id="filename">
+						<source>Filename</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
+					</trans-unit>
+					<trans-unit id="button_ok">
+						<source>OK</source>
+					</trans-unit>
+				</group>
+				<group id="import_export">
+					<group id="train">
+						<trans-unit id="name">
+							<source>Train setting file</source>
+						</trans-unit>
+						<trans-unit id="old_format">
+							<source>Old format</source>
+						</trans-unit>
+						<trans-unit id="traindat">
+							<source>Train.dat</source>
+						</trans-unit>
+						<trans-unit id="extensionscfg">
+							<source>Extensions.cfg</source>
+						</trans-unit>
+					</group>
+					<group id="panel">
+						<trans-unit id="name">
+							<source>Panel Setting File</source>
+						</trans-unit>
+						<trans-unit id="panel2cfg">
+							<source>Panel2.cfg</source>
+						</trans-unit>
+						<trans-unit id="panelxml">
+							<source>Panel.xml</source>
+						</trans-unit>
+					</group>
+					<group id="sound">
+						<trans-unit id="name">
+							<source>Sound setting file</source>
+						</trans-unit>
+						<trans-unit id="no_setting_file">
+							<source>No setting file</source>
+						</trans-unit>
+						<trans-unit id="soundcfg">
+							<source>Sound.cfg</source>
+						</trans-unit>
+						<trans-unit id="soundxml">
+							<source>Sound.xml</source>
+						</trans-unit>
+					</group>
+					<trans-unit id="import_name">
+						<source>Import</source>
+					</trans-unit>
+					<trans-unit id="export_name">
+						<source>Export</source>
+					</trans-unit>
+					<trans-unit id="folder">
+						<source>Folder</source>
+					</trans-unit>
+					<trans-unit id="type">
+						<source>Type</source>
 					</trans-unit>
 				</group>
 			</group>

--- a/source/OpenBVE/UserInterface/formMain.Packages.cs
+++ b/source/OpenBVE/UserInterface/formMain.Packages.cs
@@ -1014,7 +1014,7 @@ namespace OpenBve
 					TryLoadImage(pictureBoxPackageImage, "logo.png");
 					break;
 			}
-			labelInstallText.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"packages","creation_header"});
+			labelInstallText.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"packages","enter_details_header"});
 			textBoxPackageName.Text = currentPackage.Name;
 			textBoxPackageVersion.Text = currentPackage.Version;
 			textBoxPackageAuthor.Text = currentPackage.Author;


### PR DESCRIPTION
This PR:
- Reformat all XLIFF documents
- Synchronize `<source>` text and missing entries from en-US.xlf to all files
- Rename all instance of `openBVE` to `OpenBVE`
- Rename duplicated entry id (Those within the same group that is, which makes it unidentifiable)
- - `train_default`, `train_default_yes` and `train_default_no` is moved to `menu` group, fixes empty dialog box in the GL Menu when asked whether to use the route's default train.
- - `creation_header` has been split to `creation_header` (Create a package) and `enter_details_header` (Enter package details)

**Motivation:**
Transifex does not seems to be in sync anymore and no new translation appears. It also seems to untranslate duplicated units id across groups (Which is technically correct as defined by XLIFF specs), as such some string remains untranslatable.
I have plan to translate zh-HK locally, but I would rather have this PR merged before working on it.

I have explored different parts of UI in various languages and it seems to show no regression so far, so I hope everything did indeed go as planned. Any further amount of testings are welcome.

(For XLF file editing, I've tested and [POEdit](https://poedit.net) can edit all entries regardless of its id. Alternatively I've built [my own XLIFF editor](https://github.com/Kenny-Hui/xledit) which should just be good enough to work with OpenBVE translations, for now.)