### PR TITLE
Update Linux desktop launcher

### DIFF
--- a/debian/openbve.desktop
+++ b/debian/openbve.desktop
@@ -1,11 +1,13 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=openBVE
+Name=OpenBVE
 GenericName=Train simulator
+GenericName[ca]=Simulador ferroviari
 GenericName[de]=Zugsimulation
 Categories=Game;Simulation;
 Comment=Train/railway simulator compatible with 'BVE Trainsim' routes
+Comment[ca]=Simulador ferroviari compatible amb rutes del simulador BVE
 Terminal=false
 TryExec=openbve
 Exec=openbve


### PR DESCRIPTION
The desktop launcher used for Linux still had the old name without the initial caps. I have also translated the comment and generic name to Catalan.