### PR TITLE
Train plugins: include forward/backward tolerance in elapseData

### DIFF
--- a/source/OpenBveApi/Runtime/Route/Station.cs
+++ b/source/OpenBveApi/Runtime/Route/Station.cs
@@ -35,6 +35,12 @@ namespace OpenBveApi.Runtime
 		/// <summary>The stop position applicable to the current train.</summary>
 		[DataMember]
 		public double StopPosition;
+		/// <summary>The forward tolerance applicable to the stop position.</summary>
+		[DataMember]
+		public double ForwardTolerance;
+		/// <summary>The backward tolerance applicable to the stop position.</summary>
+		[DataMember]
+		public double BackwardTolerance;
 		/// <summary>The stop mode for this station</summary>
 		[DataMember]
 		public StationStopMode StopMode;
@@ -101,6 +107,30 @@ namespace OpenBveApi.Runtime
 			OpenRightDoors = s.OpenRightDoors;
 			DefaultTrackPosition = s.DefaultTrackPosition;
 			StopPosition = stopPosition;
+			ForwardTolerance = s.ForwardTolerance;
+			BackwardTolerance = s.BackwardTolerance;
+			StopMode = s.StopMode;
+			Type = s.Type;
+		}
+
+		/// <summary>Creates a train-specific station with stop tolerance values</summary>
+		/// <param name="s">The base station</param>
+		/// <param name="stopPosition">The stop position applicable to our train</param>
+		/// <param name="forwardTolerance">The forward tolerance applicable to the stop point</param>
+		/// <param name="backwardTolerance">The backward tolerance applicable to the stop point</param>
+		public Station(Station s, double stopPosition, double forwardTolerance, double backwardTolerance)
+		{
+			Name = s.Name;
+			ArrivalTime = s.ArrivalTime;
+			DepartureTime = s.DepartureTime;
+			ExpectedTimeStopped = s.ExpectedTimeStopped;
+			ForceStopSignal = s.ForceStopSignal;
+			OpenLeftDoors = s.OpenLeftDoors;
+			OpenRightDoors = s.OpenRightDoors;
+			DefaultTrackPosition = s.DefaultTrackPosition;
+			StopPosition = stopPosition;
+			ForwardTolerance = forwardTolerance;
+			BackwardTolerance = backwardTolerance;
 			StopMode = s.StopMode;
 			Type = s.Type;
 		}

--- a/source/TrainManager/SafetySystems/Plugin/Plugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/Plugin.cs
@@ -108,13 +108,17 @@ namespace TrainManager.SafetySystems
 				foreach (RouteStation selectedStation in TrainManagerBase.CurrentRoute.Stations)
 				{
 					double stopPosition = -1;
+					double forwardTolerance = -1;
+					double backwardTolerance = -1;
 					int stopIdx = TrainManagerBase.CurrentRoute.Stations[s].GetStopIndex(Train.NumberOfCars);
 					if (selectedStation.Stops.Length != 0)
 					{
 						stopPosition = selectedStation.Stops[stopIdx].TrackPosition;
+						forwardTolerance = selectedStation.Stops[stopIdx].ForwardTolerance;
+						backwardTolerance = selectedStation.Stops[stopIdx].BackwardTolerance;
 					}
 
-					Station i = new Station(selectedStation, stopPosition);
+					Station i = new Station(selectedStation, stopPosition, forwardTolerance, backwardTolerance);
 					currentRouteStations.Add(i);
 					s++;
 				}


### PR DESCRIPTION
This PR changes the runtime API's `Station` class to include properties for forward/backward tolerance. It is now possible, for example, to simulate an ATC system that prevents doors from opening outside specific stop areas.

The old constructor's signature is intact for compatibility with existing plugins.

Closes #1076 