### PR TITLE
Improve train loading progress bar

### DIFF
--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -1130,7 +1130,7 @@ namespace OpenBve
 				if (Program.TrainManager.Trains.Count != 0)
 				{
 					//Trains are not loaded until after the route
-					finalTrainProgress = (Loading.CurrentTrain * trainProgressWeight) + trainProgressWeight * trainProgress;
+					finalTrainProgress = (Loading.LoadedTrain * trainProgressWeight) + trainProgressWeight * trainProgress;
 				}
 				else
 				{

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -19,8 +19,8 @@ using Path = OpenBveApi.Path;
 namespace OpenBve {
 	internal static class Loading
 	{
-		/// <summary>The current train loading index</summary>
-		internal static int CurrentTrain;
+		/// <summary>The number of trains that have been loaded so far</summary>
+		internal static int LoadedTrain;
 		/// <summary>Set this member to true to cancel loading</summary>
 		internal static bool Cancel
 		{
@@ -404,7 +404,8 @@ namespace OpenBve {
 			{
 				Program.TrainManager.Trains.Add(new TrainBase(TrainState.Bogus, TrainType.PreTrain));
 			}
-			
+
+			LoadedTrain = 0;
 			// load trains
 			for (int k = 0; k < Program.TrainManager.Trains.Count; k++) {
 
@@ -415,6 +416,7 @@ namespace OpenBve {
 					{
 						
 						Program.CurrentHost.Plugins[i].Train.LoadTrain(CurrentTrainEncoding, CurrentTrainFolder, ref currentTrain, ref Interface.CurrentControls);
+						LoadedTrain++;
 						break;
 					}
 				}
@@ -445,9 +447,6 @@ namespace OpenBve {
 				Program.CurrentRoute.UpdateAllSections();
 			}
 			// load plugin
-
-
-			CurrentTrain = 0;
 			for (int i = 0; i < Program.TrainManager.Trains.Count; i++) {
 				if ( Program.TrainManager.Trains[i].State != TrainState.Bogus) {
 					if ( Program.TrainManager.Trains[i].IsPlayerTrain) {
@@ -468,8 +467,6 @@ namespace OpenBve {
 						}
 					}
 				}
-				CurrentTrain++;
-
 			}
 		}
 

--- a/source/Plugins/Train.OpenBve/Panel/PanelAnimatedXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelAnimatedXmlParser.cs
@@ -268,6 +268,8 @@ namespace Train.OpenBve
 						}
 						break;
 				}
+
+				currentSectionElement++;
 			}
 		}
 

--- a/source/Plugins/Train.OpenBve/Plugin.cs
+++ b/source/Plugins/Train.OpenBve/Plugin.cs
@@ -257,7 +257,6 @@ namespace Train.OpenBve
 		    // add panel section
 		    if (currentTrain.IsPlayerTrain) {	
 			    ParsePanelConfig(currentTrain, encoding);
-			    LastProgress = 0.6;
 			    Thread.Sleep(1);
 			    if (Cancel)
 			    {
@@ -266,6 +265,10 @@ namespace Train.OpenBve
 			    }
 			    FileSystem.AppendToLogFile("Train panel loaded sucessfully.");
 		    }
+
+		    CurrentProgress = 0.5;
+		    LastProgress = 0.5;
+		    
 			// add exterior section
 			if (currentTrain.State != TrainState.Bogus)
 			{
@@ -304,6 +307,10 @@ namespace Train.OpenBve
 					IsLoading = false;
 					return false;
 				}
+				
+				CurrentProgress = 0.75;
+				LastProgress = 0.75;
+				
 				//Stores the current array index of the bogie object to add
 				//Required as there are two bogies per car, and we're using a simple linear array....
 				int currentBogieObject = 0;
@@ -398,6 +405,7 @@ namespace Train.OpenBve
 					currentTrain.Cars[0].Sounds.Motor = new BVEMotorSound(currentTrain.Cars[0], 18.0, MotorSoundTables);
 				}
 			}
+			CurrentProgress = 1;
 			// place cars
 			currentTrain.PlaceCars(0.0);
 			currentControls = CurrentControls;

--- a/source/Plugins/Train.OpenBve/Train/BVE/ExtensionsCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/BVE/ExtensionsCfgParser.cs
@@ -51,8 +51,12 @@ namespace Train.OpenBve
 					return;
 				}
 				ConfigFile<ExtensionCfgSection, ExtensionCfgKey> cfg = new ConfigFile<ExtensionCfgSection, ExtensionCfgKey>(Lines, Plugin.CurrentHost);
+
+				double perBlockProgress = cfg.RemainingSubBlocks == 0 ? 0.25 : 0.25 / cfg.RemainingSubBlocks;
+				int readBlocks = 0;
 				while (cfg.RemainingSubBlocks > 0)
 				{
+					Plugin.CurrentProgress = Plugin.LastProgress + perBlockProgress * readBlocks;
 					Block<ExtensionCfgSection, ExtensionCfgKey> block = cfg.ReadNextBlock();
 					switch (block.Key)
 					{
@@ -201,6 +205,8 @@ namespace Train.OpenBve
 							}
 							break;
 					}
+
+					readBlocks++;
 				}
 				
 				// check for car objects and reverse if necessary

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
@@ -69,9 +69,12 @@ namespace Train.OpenBve
 				}
 
 				int carIndex = 0;
+
+				double perCarProgress = 0.25 / DocumentNodes.Count;
 				//Use the index here for easy access to the car count
 				for (int i = 0; i < DocumentNodes.Count; i++)
 				{
+					Plugin.CurrentProgress = Plugin.LastProgress + perCarProgress * i;
 					if (carIndex > Train.Cars.Length - 1)
 					{
 						Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "WARNING: A total of " + DocumentNodes.Count + " cars were specified in XML file " + fileName + " whilst only " + Train.Cars.Length + " were specified in the train.dat file.");


### PR DESCRIPTION
This PR improves the progress bar of the train section in the loading screen, which for some time now cannot reach to 100%:
- Add missing progress increment in PanelAnimatedXmlParser
- Add progress reporting when loading train.xml/extensions.cfg
- Fix `CurrentTrain` counter getting incremented when loading train plugins rather than when loading trains