### PR TITLE
Change: Update Azure Pipelines to windows-2022

### DIFF
--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -39,11 +39,6 @@ jobs:
       command: 'install'
       installPackageId: 'netfx-4.6.2-devpack'
       
-  - task: ChocolateyCommand@0
-    inputs:
-      command: 'install'
-      installPackageId: 'netfx-4.6.2-devpack'
-      
   - task: NuGetToolInstaller@1
 
   - task: NuGetCommand@2

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -39,11 +39,6 @@ jobs:
       command: 'install'
       installPackageId: 'netfx-4.6.2-devpack'
       
-  - task: ChocolateyCommand@0
-    inputs:
-      command: 'install'
-      installPackageId: 'netfx-4.6.2-devpack'
-      
   - task: NuGetToolInstaller@1
 
   - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,11 +34,6 @@ jobs:
       command: 'install'
       installPackageId: 'netfx-4.6.2-devpack'
       
-  - task: ChocolateyCommand@0
-    inputs:
-      command: 'install'
-      installPackageId: 'netfx-4.6.2-devpack'
-      
   - task: NuGetToolInstaller@1
 
   - task: NuGetCommand@2


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/5167

This PR updates the Azure pipelines runner images to `windows-2022`

Requires the Chocolatey Azure devops extension:
https://github.com/chocolatey-community/chocolatey-azuredevops

