### PR TITLE
Make message timeouts independent of game speed

### DIFF
--- a/source/OpenBVE/Game/MessageManager.TextualMessages.cs
+++ b/source/OpenBVE/Game/MessageManager.TextualMessages.cs
@@ -33,10 +33,11 @@ namespace OpenBve
 				ScreenReaderAnnounced = false;
 			}
 
-			public override void Update()
+			public override void Update(double timeElapsed)
 			{
-				//If our message timeout is greater than or equal to the current time, queue it for removal
-				bool remove = Program.CurrentRoute.SecondsSinceMidnight >= Timeout;
+				Timeout -= timeElapsed;
+				// If our message timeout has elapsed, queue it for removal
+				bool remove = Timeout <= 0;
 
 				switch (Depencency)
 				{

--- a/source/OpenBVE/Game/MessageManager.cs
+++ b/source/OpenBVE/Game/MessageManager.cs
@@ -144,11 +144,11 @@ namespace OpenBve
 		}
 
 		/// <summary>Updates all current messages</summary>
-		internal static void UpdateMessages()
+		internal static void UpdateMessages(double timeElapsed)
 		{
 			for (int i = TextualMessages.Count -1; i >= 0; i--)
 			{
-				TextualMessages[i].Update();
+				TextualMessages[i].Update(timeElapsed);
 				if (TextualMessages[i].QueueForRemoval)
 				{
 					TextualMessages.RemoveAt(i);
@@ -156,7 +156,7 @@ namespace OpenBve
 			}
 			for (int i = ImageMessages.Count - 1; i >= 0; i--)
 			{
-				ImageMessages[i].Update();
+				ImageMessages[i].Update(timeElapsed);
 				if (ImageMessages[i].QueueForRemoval)
 				{
 					ImageMessages.RemoveAt(i);

--- a/source/OpenBVE/Game/Score/Score.cs
+++ b/source/OpenBVE/Game/Score/Score.cs
@@ -375,7 +375,7 @@ namespace OpenBve
 					Array.Resize(ref ScoreMessages, n + 1);
 					ScoreMessages[n].Value = Value;
 					ScoreMessages[n].Text = Interface.GetScoreText(TextToken) + ": " + Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-					ScoreMessages[n].Timeout = Program.CurrentRoute.SecondsSinceMidnight + Duration;
+					ScoreMessages[n].Timeout = Duration;
 					ScoreMessages[n].RendererPosition = new Vector2(0.0, 0.0);
 					ScoreMessages[n].RendererAlpha = 0.0;
 					if (Value < 0.0)
@@ -416,7 +416,7 @@ namespace OpenBve
 					Array.Resize(ref ScoreMessages, n + 1);
 					ScoreMessages[n].Value = 0;
 					ScoreMessages[n].Text = Text.Length != 0 ? Text : "══════════";
-					ScoreMessages[n].Timeout = Program.CurrentRoute.SecondsSinceMidnight + Duration;
+					ScoreMessages[n].Timeout = Duration;
 					ScoreMessages[n].RendererPosition = new Vector2(0.0, 0.0);
 					ScoreMessages[n].RendererAlpha = 0.0;
 					ScoreMessages[n].Color = MessageColor.White;
@@ -425,13 +425,14 @@ namespace OpenBve
 		}
 
 		/// <summary>Updates all score messages displayed by the renderer</summary>
-		internal static void UpdateScoreMessages()
+		internal static void UpdateScoreMessages(double timeElapsed)
 		{
 			if (Interface.CurrentOptions.GameMode == GameMode.Arcade)
 			{
 				for (int i = 0; i < ScoreMessages.Length; i++)
 				{
-					if (Program.CurrentRoute.SecondsSinceMidnight >= ScoreMessages[i].Timeout & ScoreMessages[i].RendererAlpha == 0.0)
+					ScoreMessages[i].Timeout -= timeElapsed;
+					if (ScoreMessages[i].Timeout <= 0 & ScoreMessages[i].RendererAlpha == 0.0)
 					{
 						for (int j = i; j < ScoreMessages.Length - 1; j++)
 						{

--- a/source/OpenBVE/Graphics/Renderers/Overlays.ScoreMessages.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.ScoreMessages.cs
@@ -49,7 +49,7 @@ namespace OpenBve.Graphics.Renderers
 				bool preserve = false;
 				if ((element.Transition & HUD.Transition.Move) != 0)
 				{
-					if (Program.CurrentRoute.SecondsSinceMidnight < Game.ScoreMessages[j].Timeout)
+					if (Game.ScoreMessages[j].Timeout >= 0)
 					{
 						if (Game.ScoreMessages[j].RendererAlpha == 0.0)
 						{
@@ -110,7 +110,7 @@ namespace OpenBve.Graphics.Renderers
 				}
 				if ((element.Transition & HUD.Transition.Fade) != 0)
 				{
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Game.ScoreMessages[j].Timeout)
+					if (Game.ScoreMessages[j].Timeout <= 0)
 					{
 						Game.ScoreMessages[j].RendererAlpha -= timeElapsed;
 						if (Game.ScoreMessages[j].RendererAlpha < 0.0)
@@ -129,7 +129,7 @@ namespace OpenBve.Graphics.Renderers
 						preserve = true;
 					}
 				}
-				else if (Program.CurrentRoute.SecondsSinceMidnight > Game.ScoreMessages[j].Timeout)
+				else if (Game.ScoreMessages[j].Timeout < 0)
 				{
 					if (Math.Abs(Game.ScoreMessages[j].RendererPosition.X - tx) < 0.1 & Math.Abs(Game.ScoreMessages[j].RendererPosition.Y - ty) < 0.1)
 					{

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -343,7 +343,7 @@ namespace OpenBve
 				}
 				Game.CurrentScore.Update(TimeElapsed);
 				MessageManager.UpdateMessages(Program.Renderer.CurrentInterface != InterfaceType.Menu ? RealTimeElapsed : 0); // n.b. don't update message timeouts when in menu
-				Game.UpdateScoreMessages();
+				Game.UpdateScoreMessages(Program.Renderer.CurrentInterface != InterfaceType.Menu ? RealTimeElapsed : 0);
 
 				for (int i = 0; i < InputDevicePlugin.AvailablePluginInfos.Count; i++)
 				{

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -342,7 +342,7 @@ namespace OpenBve
 					}
 				}
 				Game.CurrentScore.Update(TimeElapsed);
-				MessageManager.UpdateMessages();
+				MessageManager.UpdateMessages(Program.Renderer.CurrentInterface != InterfaceType.Menu ? RealTimeElapsed : 0); // n.b. don't update message timeouts when in menu
 				Game.UpdateScoreMessages();
 
 				for (int i = 0; i < InputDevicePlugin.AvailablePluginInfos.Count; i++)
@@ -918,7 +918,7 @@ namespace OpenBve
 				if (TrainManager.PlayerTrain.Plugin != null && TrainManager.PlayerTrain.Plugin.SupportsAI == AISupport.None)
 				{
 					MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","aiunable"}),MessageDependency.None, GameMode.Expert,
-						MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+						MessageColor.White, 10, null);
 				}
 			}
 			
@@ -948,23 +948,23 @@ namespace OpenBve
 				if (filesNotFound != 0)
 				{
 					NotFound = filesNotFound + " file(s) not found";
-					MessageManager.AddMessage(NotFound, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					MessageManager.AddMessage(NotFound, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, 10, null);
 					
 				}
 				if (errors != 0 & warnings != 0)
 				{
 					Messages = errors + " error(s), " + warnings + " warning(s)";
-					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, 10, null);
 				}
 				else if (errors != 0)
 				{
 					Messages = errors + " error(s)";
-					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, 10, null);
 				}
 				else
 				{
 					Messages = warnings + " warning(s)";
-					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					MessageManager.AddMessage(Messages, MessageDependency.None, GameMode.Expert, MessageColor.Magenta, 10, null);
 				}
 				Program.CurrentRoute.Information.FilesNotFound = NotFound;
 				Program.CurrentRoute.Information.ErrorsAndWarnings = Messages;
@@ -972,8 +972,8 @@ namespace OpenBve
 				//This must be done after the simulation has init, as otherwise the timeout doesn't work
 				if (TrainManager.PluginError != null)
 				{
-					MessageManager.AddMessage(TrainManager.PluginError, MessageDependency.None, GameMode.Expert, MessageColor.Red, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
-					MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"errors","plugin_failure2"}), MessageDependency.None, GameMode.Expert, MessageColor.Red, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+					MessageManager.AddMessage(TrainManager.PluginError, MessageDependency.None, GameMode.Expert, MessageColor.Red, 5, null);
+					MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"errors","plugin_failure2"}), MessageDependency.None, GameMode.Expert, MessageColor.Red, 5, null);
 				}
 			}
 			loadComplete = true;

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -55,7 +55,7 @@ namespace OpenBve {
 		{
 			if (Message is string message)
 			{
-				MessageManager.AddMessage(message, MessageDependency.None, GameMode.Expert, MessageColor.Black, InGameTime + 10, null);
+				MessageManager.AddMessage(message, MessageDependency.None, GameMode.Expert, MessageColor.Black, 10, null);
 			}
 			else if(Message is AbstractMessage abstractMessage)
 			{

--- a/source/OpenBVE/System/Input/ProcessControls.Digital.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Digital.cs
@@ -54,14 +54,14 @@ namespace OpenBve
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior_lookahead"}),
 								MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 							lookahead = true;
 						}
 						else
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior"}),
 								MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 						}
 
 						Program.Renderer.Camera.CurrentMode = CameraViewMode.Interior;
@@ -128,14 +128,14 @@ namespace OpenBve
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior_lookahead"}),
 								MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 							lookahead = true;
 						}
 						else
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior"}),
 								MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 						}
 
 						Program.Renderer.Camera.CurrentMode = CameraViewMode.Interior;
@@ -205,12 +205,12 @@ namespace OpenBve
 						if (TrainManager.PlayerTrain.CurrentDirection == TrackDirection.Reverse)
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","exterior"}) + " " + (TrainManager.PlayerTrain.Cars.Length - TrainManager.PlayerTrain.CameraCar), MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 						}
 						else
 						{
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","exterior"}) + " " + (TrainManager.PlayerTrain.CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 						}
 						
 						for (int j = 0; j < TrainManager.PlayerTrain.Cars.Length; j++)
@@ -237,7 +237,7 @@ namespace OpenBve
 							Program.Renderer.Camera.CurrentMode = CameraViewMode.Track;
 							MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","track"}),
 								MessageDependency.CameraView, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+								MessageColor.White, 2, null);
 						}
 						else
 						{
@@ -247,7 +247,7 @@ namespace OpenBve
 								MessageManager.AddMessage(
 									Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","flybyzooming"}),
 									MessageDependency.CameraView, GameMode.Expert,
-									MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+									MessageColor.White, 2, null);
 							}
 							else
 							{
@@ -255,7 +255,7 @@ namespace OpenBve
 								MessageManager.AddMessage(
 									Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","flybynormal"}),
 									MessageDependency.CameraView, GameMode.Expert,
-									MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+									MessageColor.White, 2, null);
 							}
 						}
 
@@ -293,7 +293,7 @@ namespace OpenBve
 								Program.Renderer.Camera.CurrentMode = CameraViewMode.Track;
 								MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","track"}),
 									MessageDependency.CameraView, GameMode.Expert,
-									MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+									MessageColor.White, 2, null);
 							}
 
 							double z = Program.Renderer.Camera.Alignment.Position.Z;
@@ -338,7 +338,7 @@ namespace OpenBve
 								Program.Renderer.Camera.CurrentMode = CameraViewMode.Track;
 								MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","track"}),
 									MessageDependency.CameraView, GameMode.Expert,
-									MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+									MessageColor.White, 2, null);
 							}
 
 							double z = Program.Renderer.Camera.Alignment.Position.Z;
@@ -434,7 +434,7 @@ namespace OpenBve
 								Program.Renderer.Camera.CurrentRestriction = CameraRestrictionMode.NotAvailable;
 								MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","camerarestriction_off"}),
 									MessageDependency.CameraView, GameMode.Expert,
-									MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+									MessageColor.White, 2, null);
 								break;
 							case CameraRestrictionMode.NotAvailable:
 								Program.Renderer.Camera.CurrentRestriction = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].CameraRestrictionMode;
@@ -442,7 +442,7 @@ namespace OpenBve
 								{
 									MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","camerarestriction_on"}),
 										MessageDependency.CameraView, GameMode.Expert,
-										MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+										MessageColor.White, 2, null);
 								}
 
 								break;
@@ -453,13 +453,13 @@ namespace OpenBve
 								{
 									MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","camerarestriction_off"}),
 										MessageDependency.CameraView, GameMode.Expert,
-										MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+										MessageColor.White, 2, null);
 								}
 								else
 								{
 									MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","camerarestriction_on"}),
 										MessageDependency.CameraView, GameMode.Expert,
-										MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+										MessageColor.White, 2, null);
 								}
 
 								break;
@@ -920,7 +920,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","switchexterior_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 
@@ -930,7 +930,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","unable_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 
@@ -939,13 +939,13 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","fixed_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 						MessageManager.AddMessage(
 							Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","exterior_uncouplefront"}) + " " + (TrainManager.PlayerTrain.CameraCar + 1),
 							MessageDependency.None, GameMode.Expert,
-							MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+							MessageColor.White, 5, null);
 						TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.CameraCar].Uncouple(true, false);
 						break;
 					case Translations.Command.UncoupleRear:
@@ -959,7 +959,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","switchexterior_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 
@@ -968,7 +968,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","unable_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 
@@ -977,13 +977,13 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","fixed_uncouple"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 							return;
 						}
 						MessageManager.AddMessage(
 							Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","exterior_uncouplerear"}) + " " + (TrainManager.PlayerTrain.CameraCar + 1),
 							MessageDependency.None, GameMode.Expert,
-							MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+							MessageColor.White, 5, null);
 						TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.CameraCar].Uncouple(false, true);
 						break;
 					case Translations.Command.TimetableToggle:
@@ -1046,7 +1046,7 @@ namespace OpenBve
 						break;
 					case Translations.Command.DebugRendererMode:
 						Interface.CurrentOptions.IsUseNewRenderer = !Interface.CurrentOptions.IsUseNewRenderer;
-						MessageManager.AddMessage($"Renderer mode: {(Program.Renderer.AvailableNewRenderer ? "New renderer" : "Original renderer")}", MessageDependency.None, GameMode.Expert, MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+						MessageManager.AddMessage($"Renderer mode: {(Program.Renderer.AvailableNewRenderer ? "New renderer" : "Original renderer")}", MessageDependency.None, GameMode.Expert, MessageColor.White, 10, null);
 						break;
 					case Translations.Command.MiscAI:
 						// option: AI
@@ -1055,7 +1055,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 						}
 						else
 						{
@@ -1068,7 +1068,7 @@ namespace OpenBve
 									MessageManager.AddMessage(
 										Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","aiunable"}),
 										MessageDependency.None, GameMode.Expert,
-										MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+										MessageColor.White, 10, null);
 								}
 							}
 							else
@@ -1117,8 +1117,7 @@ namespace OpenBve
 							Translations.GetInterfaceString(HostApplication.OpenBve, Program.Renderer.OptionBackFaceCulling
 								? new[] {"notification","backfaceculling_on"}
 								: new[] {"notification","backfaceculling_off"}), MessageDependency.None,
-							GameMode.Expert, MessageColor.White,
-							Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+							GameMode.Expert, MessageColor.White, 2, null);
 						break;
 					case Translations.Command.MiscCPUMode:
 						// option: limit frame rate
@@ -1127,8 +1126,7 @@ namespace OpenBve
 							Translations.GetInterfaceString(HostApplication.OpenBve, LimitFramerate
 								? new[] {"notification","cpu_low"}
 								: new[] {"notification","cpu_normal"}), MessageDependency.None,
-							GameMode.Expert, MessageColor.White,
-							Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+							GameMode.Expert, MessageColor.White, 2, null);
 						break;
 					case Translations.Command.DebugBrakeSystems:
 						// option: brake systems
@@ -1137,7 +1135,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 						}
 						else
 						{
@@ -1165,8 +1163,7 @@ namespace OpenBve
 								MessageManager.AddMessage(
 									Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 									MessageDependency.None, GameMode.Expert,
-									MessageColor.White,
-									Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+									MessageColor.White, 5, null);
 							}
 							else
 							{
@@ -1175,8 +1172,7 @@ namespace OpenBve
 									TimeFactor.ToString(
 										System.Globalization.CultureInfo.InvariantCulture) + "x",
 									MessageDependency.None, GameMode.Expert,
-									MessageColor.White,
-									Program.CurrentRoute.SecondsSinceMidnight + 5.0 * TimeFactor, null);
+									MessageColor.White, 5, null);
 							}
 						}
 						break;
@@ -1187,7 +1183,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 						}
 						else
 						{
@@ -1202,7 +1198,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 						}
 						else
 						{
@@ -1216,7 +1212,7 @@ namespace OpenBve
 							MessageManager.AddMessage(
 								Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","notavailableexpert"}),
 								MessageDependency.None, GameMode.Expert,
-								MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								MessageColor.White, 5, null);
 						}
 						else
 						{

--- a/source/OpenBVE/System/Input/ProcessControls.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.cs
@@ -69,14 +69,14 @@ namespace OpenBve
 					{
 						MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior_lookahead"}),
 							MessageDependency.CameraView, GameMode.Expert,
-							MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+							MessageColor.White, 2, null);
 						lookahead = true;
 					}
 					else
 					{
 						MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","interior"}),
 							MessageDependency.CameraView, GameMode.Expert,
-							MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+							MessageColor.White, 2, null);
 					}
 
 					Program.Renderer.Camera.CurrentMode = CameraViewMode.Interior;
@@ -139,7 +139,7 @@ namespace OpenBve
 					TrainManager.PlayerTrain.AI = new Game.SimpleHumanDriverAI(TrainManager.PlayerTrain, Double.PositiveInfinity);
 					if (TrainManager.PlayerTrain.Plugin != null && TrainManager.PlayerTrain.Plugin.SupportsAI == AISupport.None)
 					{
-						MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","aiunable"}), MessageDependency.None, GameMode.Expert, MessageColor.White, Program.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+						MessageManager.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"notification","aiunable"}), MessageDependency.None, GameMode.Expert, MessageColor.White, 10, null);
 					}
 
 				}

--- a/source/RouteManager2/MessageManager/AbstractMessage.cs
+++ b/source/RouteManager2/MessageManager/AbstractMessage.cs
@@ -59,8 +59,9 @@ namespace RouteManager2.MessageManager
 		public abstract void AddMessage(double currentTime);
 
 		/// <summary>Called once a frame to update the message</summary>
-		public virtual void Update()
+		public virtual void Update(double timeElapsed)
 		{
+			Timeout -= timeElapsed;
 		}
 	}
 }

--- a/source/RouteManager2/MessageManager/MessageTypes/GeneralMessage.cs
+++ b/source/RouteManager2/MessageManager/MessageTypes/GeneralMessage.cs
@@ -91,12 +91,7 @@ namespace RouteManager2.MessageManager.MessageTypes
 				Color = MessageColor;
 
 			}
-
-			if (Timeout != double.PositiveInfinity)
-			{
-				Timeout += currentTime;
-			}
-
+			
 			QueueForRemoval = false;
 		}
 

--- a/source/RouteManager2/MessageManager/MessageTypes/MarkerImage.cs
+++ b/source/RouteManager2/MessageManager/MessageTypes/MarkerImage.cs
@@ -25,8 +25,9 @@ namespace RouteManager2.MessageManager.MessageTypes
 			currentHost.AddMarker(texture, Vector2.Null);
 		}
 
-		public override void Update()
+		public override void Update(double timeElapsed)
 		{
+			Timeout -= timeElapsed;
 			if (QueueForRemoval)
 			{
 				currentHost.RemoveMarker(texture);

--- a/source/RouteManager2/MessageManager/MessageTypes/TextureMessage.cs
+++ b/source/RouteManager2/MessageManager/MessageTypes/TextureMessage.cs
@@ -68,8 +68,9 @@ namespace RouteManager2.MessageManager.MessageTypes
 			}
 		}
 
-		public override void Update()
+		public override void Update(double timeElapsed)
 		{
+			Timeout -= timeElapsed;
 			if (QueueForRemoval)
 			{
 				switch (currentTexture)

--- a/source/RouteViewer/Game/MessageManager.cs
+++ b/source/RouteViewer/Game/MessageManager.cs
@@ -58,11 +58,11 @@ namespace RouteViewer
 		}
 
 		/// <summary>Updates all current messages</summary>
-		internal static void UpdateMessages()
+		internal static void UpdateMessages(double timeElapsed)
 		{
 			for (int i = TextualMessages.Count -1; i >= 0; i--)
 			{
-				TextualMessages[i].Update();
+				TextualMessages[i].Update(timeElapsed);
 				if (TextualMessages[i].QueueForRemoval)
 				{
 					TextualMessages.RemoveAt(i);
@@ -70,7 +70,7 @@ namespace RouteViewer
 			}
 			for (int i = ImageMessages.Count - 1; i >= 0; i--)
 			{
-				ImageMessages[i].Update();
+				ImageMessages[i].Update(timeElapsed);
 				if (ImageMessages[i].QueueForRemoval)
 				{
 					ImageMessages.RemoveAt(i);

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -88,7 +88,7 @@ namespace RouteViewer
             }
             Program.Renderer.Lighting.UpdateLighting(Program.CurrentRoute.SecondsSinceMidnight, Program.CurrentRoute.LightDefinitions);
             Program.Renderer.RenderScene(TimeElapsed);
-            MessageManager.UpdateMessages();
+            MessageManager.UpdateMessages(TimeElapsed);
             SwapBuffers();
             
         }

--- a/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
+++ b/source/TrainManager/SafetySystems/Plugin/NetPlugin.cs
@@ -409,7 +409,7 @@ namespace TrainManager.SafetySystems
 		/// <param name="Time">The time in seconds for which to display the message</param>
 		internal void AddInterfaceMessage(string Message, MessageColor Color, double Time)
 		{
-			TrainManagerBase.currentHost.AddMessage(Message, MessageDependency.Plugin, GameMode.Expert, Color, TrainManagerBase.currentHost.InGameTime + Time, null);
+			TrainManagerBase.currentHost.AddMessage(Message, MessageDependency.Plugin, GameMode.Expert, Color, Time, null);
 		}
 
 		/// <summary>May be called from a .Net plugin, in order to add a score to the post-game log</summary>


### PR DESCRIPTION
Message timeouts are currently expressed as an in-game time.
This however causes issues when time acceleration is used, as a message will stay on-screen for 5 times less than intended.

This PR changes the timeouts to be an exact real-time, using the RealTimeElapsed variable, not the in-game time.
Message timeouts are also now not updated whilst in the in-game menu.

Doing this as a PR as it touches a whole bunch of code, and I want to double-check things.....

Marginally related:
https://github.com/leezer3/OpenBVE/issues/1182
(I appear to have first noticed this 4 years ago and promptly forgot about it...)