### PR TITLE
Fix: Camera Rotation issue & In-game Message not displaying

### DIFF
--- a/source/OpenBVE/Game/MessageManager.TextualMessages.cs
+++ b/source/OpenBVE/Game/MessageManager.TextualMessages.cs
@@ -131,11 +131,11 @@ namespace OpenBve
 				{
 					if (Timeout == double.PositiveInfinity)
 					{
-						Timeout = Program.CurrentRoute.SecondsSinceMidnight - 1.0;
+						Timeout = -1.0;
 					}
 					//Remove the message if it has completely faded out
 					//NOTE: The fadeout is done in the renderer itself...
-					if (Program.CurrentRoute.SecondsSinceMidnight >= Timeout & RendererAlpha == 0.0)
+					if (Timeout <= 0 & RendererAlpha == 0.0)
 					{
 						QueueForRemoval = true;
 					}

--- a/source/OpenBVE/Graphics/Renderers/Overlays.GameMessages.cs
+++ b/source/OpenBVE/Graphics/Renderers/Overlays.GameMessages.cs
@@ -57,7 +57,7 @@ namespace OpenBve.Graphics.Renderers
 				bool preserve = false;
 				if ((Element.Transition & HUD.Transition.Move) != 0)
 				{
-					if (Program.CurrentRoute.SecondsSinceMidnight < mm.Timeout)
+					if (mm.Timeout > 0)
 					{
 						if (mm.RendererAlpha == 0.0)
 						{
@@ -118,7 +118,7 @@ namespace OpenBve.Graphics.Renderers
 				}
 				if ((Element.Transition & HUD.Transition.Fade) != 0)
 				{
-					if (Program.CurrentRoute.SecondsSinceMidnight >= mm.Timeout)
+					if (mm.Timeout <= 0)
 					{
 						mm.RendererAlpha -= TimeElapsed;
 						if (mm.RendererAlpha < 0.0)
@@ -137,7 +137,7 @@ namespace OpenBve.Graphics.Renderers
 						preserve = true;
 					}
 				}
-				else if (Program.CurrentRoute.SecondsSinceMidnight > mm.Timeout)
+				else if (mm.Timeout < 0)
 				{
 					if (Math.Abs(mm.RendererPosition.X - tx) < 0.1 & Math.Abs(mm.RendererPosition.Y - ty) < 0.1)
 					{

--- a/source/OpenBVE/System/Input/ProcessControls.Analog.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Analog.cs
@@ -219,6 +219,11 @@ namespace OpenBve
 						Program.Renderer.Camera.Move(Control.Command, Control.AnalogState);
 						break;
 					case Translations.Command.CameraRotateLeft:
+					case Translations.Command.CameraRotateRight:
+					case Translations.Command.CameraRotateUp:
+					case Translations.Command.CameraRotateDown:
+					case Translations.Command.CameraRotateCCW:
+					case Translations.Command.CameraRotateCW:
 						Program.Renderer.Camera.Rotate(Control.Command, Control.AnalogState);
 						break;
 					case Translations.Command.CameraZoomIn:

--- a/source/OpenBVE/System/Input/ProcessControls.Digital.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Digital.cs
@@ -894,7 +894,7 @@ namespace OpenBve
 						break;
 					case Translations.Command.AccessibilityCurrentSpeed:
 						string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","train_currentspeed"}).Replace("[speed]", $"{TrainManagerBase.PlayerTrain.CurrentSpeed * 3.6:0.0}") + "km/h";
-						Program.CurrentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
+						Program.CurrentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 						break;
 					case Translations.Command.AccessibilityNextSignal:
 						Section nextSection = TrainManagerBase.CurrentRoute.NextSection(TrainManagerBase.PlayerTrain.FrontCarTrackPosition);
@@ -902,7 +902,7 @@ namespace OpenBve
 						{
 							double tPos = nextSection.TrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition;
 							string st = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","route_nextsection_aspect"}).Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[aspect]", nextSection.CurrentAspect.ToString());
-							Program.CurrentHost.AddMessage(st, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
+							Program.CurrentHost.AddMessage(st, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 						}
 						break;
 					case Translations.Command.AccessibilityNextStation:
@@ -913,7 +913,7 @@ namespace OpenBve
 							//Aspect announce to be triggered via a separate keybind
 							double tPos = nextStation.DefaultTrackPosition - TrainManagerBase.PlayerTrain.FrontCarTrackPosition;
 							string stt = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","route_nextstation"}).Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[name]", nextStation.Name);
-							Program.CurrentHost.AddMessage(stt, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, Program.CurrentHost.InGameTime + 10.0, null);
+							Program.CurrentHost.AddMessage(stt, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 							nextStation.AccessibilityAnnounced = true;
 						}
 						break;

--- a/source/RouteManager2/CurrentRoute.cs
+++ b/source/RouteManager2/CurrentRoute.cs
@@ -575,7 +575,7 @@ namespace RouteManager2
 			if (PointsOfInterest[j].Text != null)
 			{
 				double n = 3.0 + 0.5 * Math.Sqrt(PointsOfInterest[j].Text.Length);
-				currentHost.AddMessage(PointsOfInterest[j].Text, MessageDependency.PointOfInterest, GameMode.Expert, MessageColor.White, SecondsSinceMidnight + n, null);
+				currentHost.AddMessage(PointsOfInterest[j].Text, MessageDependency.PointOfInterest, GameMode.Expert, MessageColor.White, n, null);
 			}
 
 			return true;

--- a/source/TrainManager/Handles/Handles.AirBrake.cs
+++ b/source/TrainManager/Handles/Handles.AirBrake.cs
@@ -102,7 +102,7 @@ namespace TrainManager.Handles
 				}
 
 				if (!TrainManagerBase.CurrentOptions.Accessibility) return;
-				TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+				TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 			}
 		}
 

--- a/source/TrainManager/Handles/Handles.Brake.cs
+++ b/source/TrainManager/Handles/Handles.Brake.cs
@@ -142,7 +142,7 @@ namespace TrainManager.Handles
 			}
 			TrainManagerBase.currentHost.AddBlackBoxEntry();
 			if (!TrainManagerBase.CurrentOptions.Accessibility) return;
-			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 		}
 
 		public override void ApplySafetyState(int newState)

--- a/source/TrainManager/Handles/Handles.EmergencyBrake.cs
+++ b/source/TrainManager/Handles/Handles.EmergencyBrake.cs
@@ -102,7 +102,7 @@ namespace TrainManager.Handles
 			if (!TrainManagerBase.CurrentOptions.Accessibility) return;
 			if (Driver)
 			{
-				TrainManagerBase.currentHost.AddMessage(Translations.QuickReferences.HandleEmergency, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);	
+				TrainManagerBase.currentHost.AddMessage(Translations.QuickReferences.HandleEmergency, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);	
 			}
 		}
 

--- a/source/TrainManager/Handles/Handles.LocoBrake.cs
+++ b/source/TrainManager/Handles/Handles.LocoBrake.cs
@@ -112,7 +112,7 @@ namespace TrainManager.Handles
 				TrainManagerBase.currentHost.AddBlackBoxEntry();
 
 				if (!TrainManagerBase.CurrentOptions.Accessibility) return;
-				TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+				TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 			
 		}
 

--- a/source/TrainManager/Handles/Handles.Power.cs
+++ b/source/TrainManager/Handles/Handles.Power.cs
@@ -165,7 +165,7 @@ namespace TrainManager.Handles
 			TrainManagerBase.currentHost.AddBlackBoxEntry();
 
 			if (!TrainManagerBase.CurrentOptions.Accessibility) return;
-			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 			
 		}
 

--- a/source/TrainManager/Handles/Handles.Reverser.cs
+++ b/source/TrainManager/Handles/Handles.Reverser.cs
@@ -73,7 +73,7 @@ namespace TrainManager.Handles
 			if (a == (int)Driver) return;
 
 			if (!TrainManagerBase.CurrentOptions.Accessibility) return;
-			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+			TrainManagerBase.currentHost.AddMessage(GetNotchDescription(out _), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 		}
 
 		/// <summary>Gets the description string for this notch</summary>

--- a/source/TrainManager/SafetySystems/Overspeed.cs
+++ b/source/TrainManager/SafetySystems/Overspeed.cs
@@ -45,7 +45,7 @@ namespace TrainManager.SafetySystems
 				if (previousRouteLimit != baseTrain.CurrentRouteLimit)
 				{
 					//Show for 10s and announce the current speed limit if screen reader present
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","route_newlimit"}), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","route_newlimit"}), MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 				}
 			}
 

--- a/source/TrainManager/SafetySystems/StationAdjustAlarm.cs
+++ b/source/TrainManager/SafetySystems/StationAdjustAlarm.cs
@@ -34,7 +34,7 @@ namespace TrainManager.SafetySystems
 					AdjustAlarm.Play(baseTrain.Cars[baseTrain.DriverCar], false);
 					if (baseTrain.IsPlayerTrain)
 					{
-						TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve,  new [] {"message","station_correct"}), MessageDependency.None, GameMode.Normal, MessageColor.Orange, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+						TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve,  new [] {"message","station_correct"}), MessageDependency.None, GameMode.Normal, MessageColor.Orange, 5.0, null);
 					}
 					Lit = true;
 				}

--- a/source/TrainManager/Train/RequestStop.cs
+++ b/source/TrainManager/Train/RequestStop.cs
@@ -41,7 +41,7 @@ namespace TrainManager.Trains
 					//If message is not empty, add it
 					if (!string.IsNullOrEmpty(stopRequest.PassMessage) && IsPlayerTrain)
 					{
-						TrainManagerBase.currentHost.AddMessage(stopRequest.PassMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+						TrainManagerBase.currentHost.AddMessage(stopRequest.PassMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, 10.0, null);
 					}
 
 					return;
@@ -52,7 +52,7 @@ namespace TrainManager.Trains
 				//If message is not empty, add it
 				if (!string.IsNullOrEmpty(stopRequest.StopMessage) && IsPlayerTrain)
 				{
-					TrainManagerBase.currentHost.AddMessage(stopRequest.StopMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					TrainManagerBase.currentHost.AddMessage(stopRequest.StopMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, 10.0, null);
 				}
 			}
 			else
@@ -66,7 +66,7 @@ namespace TrainManager.Trains
 				//If message is not empty, add it
 				if (!string.IsNullOrEmpty(stopRequest.PassMessage) && IsPlayerTrain)
 				{
-					TrainManagerBase.currentHost.AddMessage(stopRequest.PassMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+					TrainManagerBase.currentHost.AddMessage(stopRequest.PassMessage, MessageDependency.None, GameMode.Normal, MessageColor.White, 10.0, null);
 				}
 			}
 		}

--- a/source/TrainManager/Train/Station.cs
+++ b/source/TrainManager/Train/Station.cs
@@ -69,13 +69,13 @@ namespace TrainManager.Trains
 						{
 							string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_passed"});
 							s = s.Replace("[name]", TrainManagerBase.CurrentRoute.Stations[stationIndex].Name);
-							TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Orange, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+							TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Orange, 10.0, null);
 						}
 						else if (TrainManagerBase.CurrentRoute.Stations[stationIndex].PlayerStops() & StationState == TrainStopState.Boarding)
 						{
 							string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message","station_passed_boarding"});
 							s = s.Replace("[name]", TrainManagerBase.CurrentRoute.Stations[stationIndex].Name);
-							TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Red, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+							TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Red, 10.0, null);
 						}
 					}
 
@@ -240,7 +240,7 @@ namespace TrainManager.Trains
 									s = s.Replace("[name]", TrainManagerBase.CurrentRoute.Stations[i].Name);
 									s = s.Replace("[time]", b);
 									s = s.Replace("[difference]", c);
-									TrainManagerBase.currentHost.AddMessage(s, MessageDependency.StationArrival, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 10.0, null);
+									TrainManagerBase.currentHost.AddMessage(s, MessageDependency.StationArrival, GameMode.Normal, MessageColor.White, 10.0, null);
 									if (TrainManagerBase.CurrentRoute.Stations[i].Type == StationType.Normal)
 									{
 										s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_deadline"});
@@ -481,11 +481,11 @@ namespace TrainManager.Trains
 											break; // Only trigger messages for the player train
 										if (!TrainManagerBase.CurrentRoute.Stations[i].OpenLeftDoors & !TrainManagerBase.CurrentRoute.Stations[i].OpenRightDoors | Specs.DoorCloseMode != DoorMode.Manual)
 										{
-											TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart"}), MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+											TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart"}), MessageDependency.None, GameMode.Normal, MessageColor.White, 5.0, null);
 										}
 										else
 										{
-											TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart_closedoors"}), MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+											TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart_closedoors"}), MessageDependency.None, GameMode.Normal, MessageColor.White, 5.0, null);
 										}
 
 										break;
@@ -505,7 +505,7 @@ namespace TrainManager.Trains
 							StationState = TrainStopState.Completed;
 							if (IsPlayerTrain & TrainManagerBase.CurrentRoute.Stations[i].Type == StationType.Normal)
 							{
-								TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart"}), MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+								TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"message","station_depart"}), MessageDependency.None, GameMode.Normal, MessageColor.White, 5.0, null);
 							}
 						}
 					}

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -351,7 +351,7 @@ namespace TrainManager.Trains
 							if (!nextSection.AccessibilityAnnounced && tPos < 500)
 							{
 								string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message", "route_nextsection" }).Replace("[distance]", $"{tPos:0.0}") + "m";
-								TrainManagerBase.currentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+								TrainManagerBase.currentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 								nextSection.AccessibilityAnnounced = true;
 							}
 						}
@@ -365,7 +365,7 @@ namespace TrainManager.Trains
 							if (!nextStation.AccessibilityAnnounced && tPos < 500)
 							{
 								string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message", "route_nextstation" }).Replace("[distance]", $"{tPos:0.0}") + "m".Replace("[name]", nextStation.Name);
-								TrainManagerBase.currentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+								TrainManagerBase.currentHost.AddMessage(s, MessageDependency.AccessibilityHelper, GameMode.Normal, MessageColor.White, 10.0, null);
 								nextStation.AccessibilityAnnounced = true;
 							}
 						}
@@ -514,7 +514,7 @@ namespace TrainManager.Trains
 						double a = (3.6 * CurrentSectionLimit) * TrainManagerBase.CurrentOptions.SpeedConversionFactor;
 						s = s.Replace("[speed]", a.ToString("0", CultureInfo.InvariantCulture));
 						s = s.Replace("[unit]", TrainManagerBase.CurrentOptions.UnitOfSpeed);
-						TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Red, TrainManagerBase.currentHost.InGameTime + 5.0, null);
+						TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Normal, MessageColor.Red, 5.0, null);
 					}
 				}
 			}
@@ -1056,7 +1056,7 @@ namespace TrainManager.Trains
 				{
 					CameraCar++;
 					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new [] {"notification","exterior"}) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
-						MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+						MessageColor.White, 2.0, null);
 				}
 			}
 			else
@@ -1064,7 +1064,7 @@ namespace TrainManager.Trains
 				if (CameraCar > 0)
 				{
 					CameraCar--;
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new [] {"notification","exterior"}) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 2.0, null);
+					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new [] {"notification","exterior"}) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert, MessageColor.White, 2.0, null);
 				}
 			}
 
@@ -1148,7 +1148,7 @@ namespace TrainManager.Trains
 			Cars[DriverCar].Sounds.CoupleCab?.Play(1.0, 1.0, Cars[DriverCar], false);
 
 			string message = Translations.GetInterfaceString(HostApplication.OpenBve, front ? new[] { "notification", "couple_front" } : new[] { "notification", "couple_rear" }).Replace("[number]", trainBase.Cars.Length.ToString());
-			TrainManagerBase.currentHost.AddMessage(message, MessageDependency.None, GameMode.Normal, MessageColor.White, TrainManagerBase.CurrentRoute.SecondsSinceMidnight + 5.0, null);
+			TrainManagerBase.currentHost.AddMessage(message, MessageDependency.None, GameMode.Normal, MessageColor.White, 5.0, null);
 		}
 
 		public void ContactSignaller()
@@ -1158,7 +1158,7 @@ namespace TrainManager.Trains
 			{
 				// not a valid section to access
 				string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message", "signal_access_invalid" });
-				TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+				TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.White, 10.0, null);
 			}
 			else
 			{
@@ -1166,14 +1166,14 @@ namespace TrainManager.Trains
 				{
 					// section is free of trains, so can be permissively accessed
 					string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message", "signal_access_granted" });
-					TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.White, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+					TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.White, 10.0, null);
 					sct.SignallerPermission = true;
 				}
 				else
 				{
 					// not free, access denied
 					string s = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "message", "signal_access_denied" });
-					TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.Red, TrainManagerBase.currentHost.InGameTime + 10.0, null);
+					TrainManagerBase.currentHost.AddMessage(s, MessageDependency.None, GameMode.Expert, MessageColor.Red, 10.0, null);
 					sct.SignallerPermission = false;
 				}
 			}


### PR DESCRIPTION
This PR addresses primarily 2 things:
1. In https://github.com/leezer3/OpenBVE/commit/ac6e9576262a94f0177b98f6d359548cb772f1dd, only the keybind for camera left rotation is handled after the refactor, rendering the keys to rotate the camera to the right/up/down/tilting inoperative.
2. The rendering code for message overlay have not been updated since Message Timeout is changed to not be tied to in-game time, rendering any message that didn't add the in-game time invisible. (Bug since v1.11.2.5)
2a. Per above, many messages still include the in-game time when specifying the message timeout (But it appeared to worked fine previously as the rendering code has not been changed), this PR should address most if not all of such cases.