### PR TITLE
Improve physics of the brake systems

### DIFF
--- a/source/Plugins/Formats.OpenBve/Enums/TrainXML/Brake.cs
+++ b/source/Plugins/Formats.OpenBve/Enums/TrainXML/Brake.cs
@@ -21,6 +21,7 @@
 		EmergencyRate,
 		ReleaseRate,
 		Handle,
+		Volume,
 		LegacyPressureDistribution
 	}
 }

--- a/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/BVE/TrainDatParser.cs
@@ -1264,18 +1264,23 @@ namespace Train.OpenBve
 					Train.Cars[i].CarBrake.brakeType = BrakeType.Auxiliary;
 				}
 				Train.Cars[i].CarBrake.mainReservoir = new MainReservoir(MainReservoirMinimumPressure, MainReservoirMaximumPressure, 0.01, (trainBrakeType == BrakeSystemType.AutomaticAirBrake ? 0.25 : 0.075) / Cars);
+				Train.Cars[i].CarBrake.mainReservoir.Volume = 0.5; // Organization for Co-Operation between Railways specifies 340L to 680L main reservoir capacity for EMU, so let's pick something in the middle (in m³)
 				Train.Cars[i].CarBrake.airCompressor = new Compressor(5000.0, Train.Cars[i].CarBrake.mainReservoir, Train.Cars[i]);
 				Train.Cars[i].CarBrake.equalizingReservoir = new EqualizingReservoir(50000.0, 250000.0, 200000.0);
 				Train.Cars[i].CarBrake.equalizingReservoir.NormalPressure = 1.005 * OperatingPressure;
+				Train.Cars[i].CarBrake.equalizingReservoir.Volume = 0.015; // very small reservoir for observation, so guess at 15L
 				
 				Train.Cars[i].CarBrake.brakePipe = new BrakePipe(OperatingPressure, 10000000.0, 1500000.0, 5000000.0, trainBrakeType == BrakeSystemType.ElectricCommandBrake);
+				Train.Cars[i].CarBrake.brakePipe.Volume = Math.Pow(0.0175 * Math.PI, 2) * (Train.Cars.Length * 1.05); // Assuming Railway Group Standards 3.5cm diameter brake pipe, 5% extra length for bends etc.
 				{
 					double r = 200000.0 / BrakeCylinderEmergencyMaximumPressure - 1.0;
 					if (r < 0.1) r = 0.1;
 					if (r > 1.0) r = 1.0;
 					Train.Cars[i].CarBrake.auxiliaryReservoir = new AuxiliaryReservoir(0.975 * OperatingPressure, 200000.0, 0.5, r);
+					Train.Cars[i].CarBrake.auxiliaryReservoir.Volume = 0.16; // guessed 1/3 of main reservoir volume
 				}
 				Train.Cars[i].CarBrake.brakeCylinder = new BrakeCylinder(BrakeCylinderServiceMaximumPressure, BrakeCylinderEmergencyMaximumPressure, trainBrakeType == BrakeSystemType.AutomaticAirBrake ? BrakeCylinderUp : 0.3 * BrakeCylinderUp, BrakeCylinderUp, BrakeCylinderDown);
+				Train.Cars[i].CarBrake.brakeCylinder.Volume = 0.14; // 35cm diameter, 15cm stroke
 				Train.Cars[i].CarBrake.straightAirPipe = new StraightAirPipe(300000.0, 400000.0, 200000.0);
 				Train.Cars[i].CarBrake.JerkUp = JerkBrakeUp;
 				Train.Cars[i].CarBrake.JerkDown = JerkBrakeDown;

--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.BrakeNode.cs
@@ -18,6 +18,11 @@ namespace Train.OpenBve
 			double auxiliaryReservoirChargeRate = 200000.0;
 			double equalizingReservoirChargeRate = 200000.0, equalizingReservoirServiceRate = 50000.0, equalizingReservoirEmergencyRate = 250000.0;
 			double brakePipeNormalPressure = 0.0, brakePipeChargeRate = 10000000.0, brakePipeServiceRate = 1500000.0, brakePipeEmergencyRate = 5000000.0;
+			double brakePipeVolume = Math.Pow(0.0175 * Math.PI, 2) * (Train.Cars.Length * 1.05); // Assuming Railway Group Standards 3.5cm diameter brake pipe, 5% extra length for bends etc.
+			double mainReservoirVolume = 0.5; // Organization for Co-Operation between Railways specifies 340L to 680L main reservoir capacity for EMU, so let's pick something in the middle (in m³)
+			double auxiliaryReservoirVolume = 0.16; // guessed 1/3 of main reservoir volume
+			double equalizingReservoirVolume = 0.015; // very small reservoir for observation, so guess at 15L
+			double brakeCylinderVolume = 0.14; // 35cm diameter, 15cm stroke
 			double straightAirPipeServiceRate = 300000.0, straightAirPipeEmergencyRate = 400000.0, straightAirPipeReleaseRate = 200000.0;
 			double brakeCylinderServiceMaximumPressure = 440000.0, brakeCylinderEmergencyMaximumPressure = 440000.0, brakeCylinderEmergencyRate = 300000.0, brakeCylinderReleaseRate = 200000.0;
 			foreach (XmlNode c in brakeNode.ChildNodes)
@@ -67,6 +72,13 @@ namespace Train.OpenBve
 											compressorMaximumPressure = 780000.0;
 										}
 										break;
+									case BrakeXMLKey.Volume:
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out mainReservoirVolume) | mainReservoirVolume <= 0.0)
+										{
+											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid main reservoir volume defined for Car " + carIndex + " in XML file " + fileName);
+											mainReservoirVolume = 0.5;
+										}
+										break;
 								}
 							}
 						}
@@ -84,6 +96,13 @@ namespace Train.OpenBve
 										{
 											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid auxiliary reservoir charge rate defined for Car " + carIndex + " in XML file " + fileName);
 											auxiliaryReservoirChargeRate = 200000.0;
+										}
+										break;
+									case BrakeXMLKey.Volume:
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out auxiliaryReservoirVolume) | auxiliaryReservoirVolume <= 0.0)
+										{
+											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid auxiliary reservoir volume defined for Car " + carIndex + " in XML file " + fileName);
+											auxiliaryReservoirVolume = 0.5;
 										}
 										break;
 								}
@@ -117,6 +136,13 @@ namespace Train.OpenBve
 										{
 											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid equalizing reservoir emergency rate defined for Car " + carIndex + " in XML file " + fileName);
 											equalizingReservoirEmergencyRate = 50000.0;
+										}
+										break;
+									case BrakeXMLKey.Volume:
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out equalizingReservoirVolume) | equalizingReservoirVolume <= 0.0)
+										{
+											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid equalizing reservoir volume defined for Car " + carIndex + " in XML file " + fileName);
+											equalizingReservoirVolume = 0.015;
 										}
 										break;
 								}
@@ -157,6 +183,13 @@ namespace Train.OpenBve
 										{
 											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid brake pipe emergency rate defined for Car " + carIndex + " in XML file " + fileName);
 											brakePipeEmergencyRate = 400000.0;
+										}
+										break;
+									case BrakeXMLKey.Volume:
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out brakePipeVolume) | brakePipeVolume <= 0.0)
+										{
+											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid brake pipe volume defined for Car " + carIndex + " in XML file " + fileName);
+											brakePipeVolume = Math.Pow(0.0175 * Math.PI, 2) * Train.Cars.Length;
 										}
 										break;
 								}
@@ -232,6 +265,13 @@ namespace Train.OpenBve
 											brakeCylinderReleaseRate = 200000.0;
 										}
 										break;
+									case BrakeXMLKey.Volume:
+										if (!NumberFormats.TryParseDoubleVb6(cc.InnerText, out brakeCylinderVolume) | brakeCylinderVolume <= 0.0)
+										{
+											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Invalid brake cylinder volume defined for Car " + carIndex + " in XML file " + fileName);
+											brakeCylinderVolume = 0.5;
+										}
+										break;
 								}
 							}
 						}
@@ -254,16 +294,20 @@ namespace Train.OpenBve
 			}
 			
 			Train.Cars[carIndex].CarBrake.mainReservoir = new MainReservoir(compressorMinimumPressure, compressorMaximumPressure, 0.01, (Train.Handles.Brake is AirBrakeHandle ? 0.25 : 0.075) / Train.Cars.Length);
+			Train.Cars[carIndex].CarBrake.mainReservoir.Volume = mainReservoirVolume;
 			Train.Cars[carIndex].CarBrake.airCompressor = new Compressor(compressorRate, Train.Cars[carIndex].CarBrake.mainReservoir, Train.Cars[carIndex]);
 			Train.Cars[carIndex].CarBrake.equalizingReservoir = new EqualizingReservoir(equalizingReservoirServiceRate, equalizingReservoirEmergencyRate, equalizingReservoirChargeRate);
 			Train.Cars[carIndex].CarBrake.equalizingReservoir.NormalPressure = 1.005 * brakePipeNormalPressure;
-				
+			Train.Cars[carIndex].CarBrake.equalizingReservoir.Volume = equalizingReservoirVolume;
+
 			Train.Cars[carIndex].CarBrake.brakePipe = new BrakePipe(brakePipeNormalPressure, brakePipeChargeRate, brakePipeServiceRate, brakePipeEmergencyRate, Train.Cars[0].CarBrake is ElectricCommandBrake);
+			Train.Cars[carIndex].CarBrake.brakePipe.Volume = brakePipeVolume;
 			{
 				double r = 200000.0 / brakeCylinderEmergencyMaximumPressure - 1.0;
 				if (r < 0.1) r = 0.1;
 				if (r > 1.0) r = 1.0;
 				Train.Cars[carIndex].CarBrake.auxiliaryReservoir = new AuxiliaryReservoir(0.975 * brakePipeNormalPressure, auxiliaryReservoirChargeRate, 0.5, r);
+				Train.Cars[carIndex].CarBrake.auxiliaryReservoir.Volume = auxiliaryReservoirVolume;
 			}
 			Train.Cars[carIndex].CarBrake.brakeCylinder = new BrakeCylinder(brakeCylinderServiceMaximumPressure, brakeCylinderEmergencyMaximumPressure, Train.Handles.Brake is AirBrakeHandle ? brakeCylinderEmergencyRate : 0.3 * brakeCylinderEmergencyRate, brakeCylinderEmergencyRate, brakeCylinderReleaseRate);
 			Train.Cars[carIndex].CarBrake.straightAirPipe = new StraightAirPipe(straightAirPipeServiceRate, straightAirPipeEmergencyRate, straightAirPipeReleaseRate);

--- a/source/TrainManager/Brake/AirBrake/Components/BrakeCylinder.cs
+++ b/source/TrainManager/Brake/AirBrake/Components/BrakeCylinder.cs
@@ -15,6 +15,9 @@
 		internal readonly double ServiceChargeRate;
 		/// <summary>The pressure release rate in Pa/s</summary>
 		internal readonly double ReleaseRate;
+		/// <summary>he brake cylinder volume</summary>
+		public double Volume;
+
 		internal double SoundPlayedForPressure;
 
 		/// <summary>Creates a functional brake cylinder</summary>

--- a/source/TrainManager/Brake/AirBrake/Components/BrakePipe.cs
+++ b/source/TrainManager/Brake/AirBrake/Components/BrakePipe.cs
@@ -15,6 +15,8 @@
 		internal readonly double EmergencyRate;
 		/// <summary>The number of pascals leaked by the brake pipe each second</summary>
 		public readonly double LeakRate = 500000.0;
+		/// <summary>The volume of the brake pipe</summary>
+		public double Volume = 0;
 
 		/// <summary>Creates a functional brake pipe</summary>
 		public BrakePipe(double normalPressure, double chargeRate, double serviceRate, double emergencyRate, bool electricCommand)

--- a/source/TrainManager/Brake/AirBrake/Components/Reservoirs.cs
+++ b/source/TrainManager/Brake/AirBrake/Components/Reservoirs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace TrainManager.BrakeSystems
 {
@@ -15,6 +15,8 @@ namespace TrainManager.BrakeSystems
 		internal readonly double BrakePipeCoefficient;
 		/// <summary>The co-efficient used when transferring pressure to the brake cylinder</summary>
 		internal readonly double BrakeCylinderCoefficient;
+		/// <summary>The volume of the reservoir</summary>
+		public double Volume;
 
 		public AuxiliaryReservoir(double maximumPressure, double chargeRate, double brakePipeCoefficient, double brakeCylinderCoefficent)
 		{
@@ -39,6 +41,8 @@ namespace TrainManager.BrakeSystems
 		public double CurrentPressure;
 		/// <summary>The normal pressure</summary>
 		public double NormalPressure;
+		/// <summary>The volume of the reservoir</summary>
+		public double Volume;
 
 		public EqualizingReservoir(double serviceRate, double emergencyRate, double chargeRate)
 		{
@@ -71,6 +75,8 @@ namespace TrainManager.BrakeSystems
 		internal readonly double EqualizingReservoirCoefficient;
 		/// <summary>The co-efficient used when transferring pressure to the brake pipe</summary>
 		internal readonly double BrakePipeCoefficient;
+		/// <summary>The volume of the reservoir</summary>
+		public double Volume;
 
 		/// <summary>Creates a functional main reservoir</summary>
 		public MainReservoir(double minimumPressure, double maximumPressure, double equalizingReservoirCoefficient, double brakePipeCoefficient)


### PR DESCRIPTION
In order to actually correctly simulate real world physics for brake system airflow, we need to set the volumes of each component. (a pressure is meaningless without the volume)

This PR sets / stores a 'sensible' air volume for each component of the braking system. Need to investigate implimenting the actual algorithms next.

References:
https://www.sciencedirect.com/science/article/pii/S1877705817319604
https://www.bluebell-railway.co.uk/bluebell/cw/hra_tech/Air-brake-systems.pdf
https://www.bluebell-railway.co.uk/bluebell/cw/hra_tech/CEPS-1019-overhaul-of-vacuum-cylinders.pdf
https://asmedigitalcollection.asme.org/computationalnonlinear/article/12/5/051017/474452/Railway-Air-Brake-Model-and-Parallel-Computing
