### PR TITLE
Fix: RouteViewer Track Visualization showing ended track

### DIFF
--- a/source/LibRender2/Overlays/RailPath.cs
+++ b/source/LibRender2/Overlays/RailPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenBveApi.Colors;
 using OpenBveApi.Hosts;
 using OpenBveApi.Math;
@@ -76,33 +77,44 @@ namespace LibRender2.Overlays
 				return;
 			}
 
-			List<Vector3> points = new List<Vector3>();
+			List<List<Vector3>> sections = new List<List<Vector3>>{ new List<Vector3>() };
+			bool lastElementInvalid = false;
+			
 			for (int e = firstElement; e < lastElement; e++)
 			{
 				if (currentHost.Tracks[RailKey].Elements[e].WorldPosition != Vector3.Zero)
 				{
-					points.Add(new Vector3(currentHost.Tracks[RailKey].Elements[e].WorldPosition.X, currentHost.Tracks[RailKey].Elements[e].WorldPosition.Y + 0.5, currentHost.Tracks[RailKey].Elements[e].WorldPosition.Z));
+					bool invalidElement = currentHost.Tracks[RailKey].Elements[e].InvalidElement;
+					
+					if (invalidElement && lastElementInvalid)
+					{
+						if(sections.Last().Count > 0) sections.Add(new List<Vector3>());
+					}
+					else
+					{
+						sections.Last().Add(new Vector3(currentHost.Tracks[RailKey].Elements[e].WorldPosition.X, currentHost.Tracks[RailKey].Elements[e].WorldPosition.Y + 0.5, currentHost.Tracks[RailKey].Elements[e].WorldPosition.Z));
+					}
+					lastElementInvalid = invalidElement;
 				}
-						
 			}
 
-			if (points.Count == 0)
+			foreach (var points in sections)
 			{
-				return;
-			}
-			
-			GL.LineWidth(LineWidth);
-			GL.Begin(PrimitiveType.LineStrip);
-			
-			
-			for (int j = 0; j < points.Count; j++)
-			{
-				GL.Color3(Color.R, Color.G, Color.B);
-				GL.Vertex3(points[j].X, points[j].Y, -points[j].Z);
-			}
+				if (points.Count == 0) continue;
+				
+				GL.LineWidth(LineWidth);
+				GL.Begin(PrimitiveType.LineStrip);
+				
+				
+				for (int j = 0; j < points.Count; j++)
+				{
+					GL.Color3(Color.R, Color.G, Color.B);
+					GL.Vertex3(points[j].X, points[j].Y, -points[j].Z);
+				}
 
-			GL.End();
-			GL.LineWidth(1);
+				GL.End();
+				GL.LineWidth(1);
+			}
 		}
 
 


### PR DESCRIPTION
Currently the track preview for RouteViewer will show a rail path all the way from the first occurrence to the last occurrence of the rail index.
However some route reuses rail indexes for another purpose after ending the previous track, causing a "ghost" rail to appear, which creates some noises and isn't quite as helpful to developer.

This PR changes it to render a line for each interconnected section.

(Left is before, Right is after)
<img width="1892" height="526" alt="ba" src="https://github.com/user-attachments/assets/ee3b05b1-9ad2-4119-ac98-9a66468f0e81" />
