### PR TITLE
Fix: Error when specifying PlayerPath switch name

### DIFF
--- a/source/Plugins/Route.CsvRw/Namespaces/Track/Track.cs
+++ b/source/Plugins/Route.CsvRw/Namespaces/Track/Track.cs
@@ -3545,7 +3545,7 @@ namespace CsvRwRouteParser
 					string switchName = string.Empty;
 					if (Arguments.Length >= 3 && Arguments[2].Length > 0)
 					{
-						switchName = Arguments[4];
+						switchName = Arguments[2];
 					}
 
 					if (idx != 0)


### PR DESCRIPTION
When specifying a switch name with `.PlayerPath` as specified in the documentation (e.g. `.PlayerPath 0;3;Test Siding)`, the parser will error out as it looked for the wrong argument (Out of bound array)