### PR TITLE
Fix: Regression in XML train plugin parsing

### DIFF
--- a/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
+++ b/source/Plugins/Train.OpenBve/Train/XML/TrainXmlParser.cs
@@ -285,7 +285,7 @@ namespace Train.OpenBve
 						switch (key)
 						{
 							case TrainXMLKey.Plugin:
-								if (DocumentNodes[i].HasChildNodes)
+								if (DocumentNodes[i].ChildNodes.OfType<XmlElement>().Any())
 								{
 									bool loadForAI = false;
 									string pluginFile = string.Empty;


### PR DESCRIPTION
Introduced in https://github.com/leezer3/OpenBVE/commit/d1ea76d983c5ea0f6a8572f0d3469b9096d620d4

Since text node is also a type of child node, `HasChildNodes` would always be true even with the old way of specifying plugin (`<plugin>path_to_plugin.dll</plugin>`), which cause existing train XML to fail to load.

Changes it to look for child XML Elements instead, if not then fallback to the old way of loading plugin using InnerText.