### PR TITLE
[BVE5] Filter sounds to keep them only once for each car and adjust the default radius value

### DIFF
--- a/source/Plugins/Route.Bve5/Components/ScriptedTrain.cs
+++ b/source/Plugins/Route.Bve5/Components/ScriptedTrain.cs
@@ -404,7 +404,7 @@ namespace Route.Bve5
 				Sound3d.TryGetValue("key", out string Key);
 			
 				CarSound existingSound = scriptedTrain.CarSounds.Find(carsound => carsound.Key == Key);
-				if (existingSound != null && existingSound.Distance1 > 0 && existingSound.Distance2 > 0) {
+				if (existingSound != null && existingSound.Distance1 != null && existingSound.Distance2 != null) {
 					continue;
 				}
 
@@ -414,13 +414,16 @@ namespace Route.Bve5
 
 				Enum.TryParse(Function, true, out BVE5AISoundControl function);
 
-				if (string.IsNullOrEmpty(TempDistance1) || !NumberFormats.TryParseDoubleVb6(TempDistance1, out double Distance1))
-				{
-					Distance1 = 0.0;
+				double? Distance1 = null;
+				double? Distance2 = null;
+				double Distance1Parsed = 0;
+				double Distance2Parsed = 0;
+				
+				if (!string.IsNullOrEmpty(TempDistance1) && NumberFormats.TryParseDoubleVb6(TempDistance1, out Distance1Parsed)) {
+					Distance1 = Distance1Parsed;
 				}
-				if (string.IsNullOrEmpty(TempDistance2) || !NumberFormats.TryParseDoubleVb6(TempDistance2, out double Distance2))
-				{
-					Distance2 = 0.0;
+				if (!string.IsNullOrEmpty(TempDistance2) && NumberFormats.TryParseDoubleVb6(TempDistance2, out Distance2Parsed)) {
+					Distance2 = Distance2Parsed;
 				}
 
 				scriptedTrain.CarSounds.Add(new CarSound(Key, Distance1, Distance2, function));

--- a/source/Plugins/Route.Bve5/MapParser/Structures.cs
+++ b/source/Plugins/Route.Bve5/MapParser/Structures.cs
@@ -103,13 +103,13 @@ namespace Route.Bve5
 		private class CarSound
 		{
 			internal readonly string Key;
-			internal readonly double Distance1;
-			internal readonly double Distance2;
+			internal readonly double? Distance1;
+			internal readonly double? Distance2;
 			internal readonly BVE5AISoundControl Function;
 
-			internal double Radius => Distance1 > 0 && Distance2 > 0 ? Math.Abs(Distance2 - Distance1) / 2 : 4;
+			internal double Radius => Distance1.HasValue && Distance2.HasValue ? Math.Abs(Distance2.Value - Distance1.Value) / 2 : 4;
 
-			internal CarSound(string key, double distance1, double distance2, BVE5AISoundControl function)
+			internal CarSound(string key, double? distance1, double? distance2, BVE5AISoundControl function)
 			{
 				Key = key;
 				Distance1 = distance1;


### PR DESCRIPTION
Fixes https://github.com/leezer3/OpenBVE/issues/1233

This fix makes it so we only keep one sound of each key for the train.

In BVE5 it seems like sounds are being played not based on world car position, but on the distance behind the leading car, using distance1 and distance2 values.

The way it is handled in OpenBVE now is that we put all these sounds in CarSounds list and then play them for each car, using distance1 and distance2 only as radius. However, that means if we had 8 cars in a train and 8 sounds defined in the file (as I saw was the case on all routes I tested), then there are 64 sounds being played!! (ofc under a limit defined in OpenBVE settings). This is now fix because we keep only one type of sound in CarSounds list.

I used the default value of 4 for the sound radius, because I looked though mulitple routes and the difference between distance1 and distance2 was never greater than 8 (so it's that value divided by 2)

