### PR TITLE
Implement near clip settings and viewing distance guards

### DIFF
--- a/assets/Languages/ca-ES.xlf
+++ b/assets/Languages/ca-ES.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ca-ES">
 		<body>
@@ -1451,6 +1451,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5812,3 +5828,4 @@ Seguiu les instruccions següents:
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/cs-CZ.xlf
+++ b/assets/Languages/cs-CZ.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="cs-CZ">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/de-CH.xlf
+++ b/assets/Languages/de-CH.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="de-CH">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/de-DE.xlf
+++ b/assets/Languages/de-DE.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="de-DE">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5695,3 +5711,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/en-GB.xlf
+++ b/assets/Languages/en-GB.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="en-GB">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5583,3 +5599,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -1117,6 +1117,18 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
 					</trans-unit>

--- a/assets/Languages/es-ES.xlf
+++ b/assets/Languages/es-ES.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="es-ES">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5695,3 +5711,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/fi-FI.xlf
+++ b/assets/Languages/fi-FI.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="fi-FI">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5693,3 +5709,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/fr-FR.xlf
+++ b/assets/Languages/fr-FR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="fr-FR">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5693,3 +5709,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/hu-HU.xlf
+++ b/assets/Languages/hu-HU.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="hu-HU">
 		<body>
@@ -1465,6 +1465,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5699,3 +5715,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/id-ID.xlf
+++ b/assets/Languages/id-ID.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="id-ID">
 		<body>
@@ -1442,6 +1442,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>

--- a/assets/Languages/it-IT.xlf
+++ b/assets/Languages/it-IT.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="it-IT">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/ja-JP.xlf
+++ b/assets/Languages/ja-JP.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ja-JP">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5964,3 +5980,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/ko-KR.xlf
+++ b/assets/Languages/ko-KR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ko-KR">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/ms_MY.xlf
+++ b/assets/Languages/ms_MY.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ms-MY">
 		<body>
@@ -1437,6 +1437,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5788,3 +5804,4 @@ Sila ikut arahan berikut:
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/nb_NO.xlf
+++ b/assets/Languages/nb_NO.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="nb-NO">
 		<body>
@@ -1448,6 +1448,22 @@
 					</trans-unit>
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5798,3 +5814,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/nl-NL.xlf
+++ b/assets/Languages/nl-NL.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="nl-NL">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5693,3 +5709,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/pl-PL.xlf
+++ b/assets/Languages/pl-PL.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pl-PL">
 		<body>
@@ -1440,6 +1440,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5791,3 +5807,4 @@ na oddzielne przyciski, aby uniknąć problemów ze zgodnością.
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/pt-BR.xlf
+++ b/assets/Languages/pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pt-BR">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/pt-PT.xlf
+++ b/assets/Languages/pt-PT.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="pt-PT">
 		<body>
@@ -1484,6 +1484,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -6226,3 +6242,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/ro-RO.xlf
+++ b/assets/Languages/ro-RO.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ro-RO">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5694,3 +5710,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/ru-RU.xlf
+++ b/assets/Languages/ru-RU.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="ru-RU">
 		<body>
@@ -1463,6 +1463,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>м</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5693,3 +5709,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/sk-SK.xlf
+++ b/assets/Languages/sk-SK.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="sk-SK">
 		<body>
@@ -1390,6 +1390,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5667,3 +5683,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/sv-SE.xlf
+++ b/assets/Languages/sv-SE.xlf
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version='1.0' encoding='utf-8'?>
 <ns0:xliff xmlns:ns0="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<ns0:file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="sv-SE">
 		<ns0:body>

--- a/assets/Languages/uk-UA.xlf
+++ b/assets/Languages/uk-UA.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="uk-UA">
 		<body>
@@ -1465,6 +1465,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>м</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5695,3 +5711,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/zh-CN.xlf
+++ b/assets/Languages/zh-CN.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-CN">
 		<body>
@@ -1465,6 +1465,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>米</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -6080,3 +6096,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/zh-HK.xlf
+++ b/assets/Languages/zh-HK.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-HK">
 		<body>
@@ -1470,6 +1470,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>米</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -6213,3 +6229,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/assets/Languages/zh-TW.xlf
+++ b/assets/Languages/zh-TW.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2.xsd">
 	<file datatype="plaintext" original="en-US.xlf" source-language="en-US" target-language="zh-TW">
 		<body>
@@ -1464,6 +1464,22 @@
 					<trans-unit id="quality_distance_viewingdistance_meters">
 						<source>m</source>
 						<target>m</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip">
+						<source>Near clip:</source>
+						<target>Near clip:</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_scenery">
+						<source>Near clip (scenery):</source>
+						<target>Near clip (scenery):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_cab">
+						<source>Near clip (cab):</source>
+						<target>Near clip (cab):</target>
+					</trans-unit>
+					<trans-unit id="quality_distance_nearclip_base">
+						<source>Near clip (base):</source>
+						<target>Near clip (base):</target>
 					</trans-unit>
 					<trans-unit id="quality_distance_motionblur">
 						<source>Motion blur:</source>
@@ -5693,3 +5709,4 @@
 		</body>
 	</file>
 </xliff>
+

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -55,7 +55,7 @@ namespace LibRender2
 		internal FileSystem fileSystem;
 
 		/// <summary>Holds a reference to the current options</summary>
-		internal BaseOptions currentOptions;
+		public BaseOptions CurrentOptions;
 
 		public List<ObjectState> StaticObjectStates;
 		public List<ObjectState> DynamicObjectStates;
@@ -298,12 +298,12 @@ namespace LibRender2
 
 		public Dictionary<Texture, HashSet<Vector3>> CubesToDraw = new Dictionary<Texture, HashSet<Vector3>>();
 
-		public bool AvailableNewRenderer => currentOptions != null && currentOptions.IsUseNewRenderer && !ForceLegacyOpenGL;
+		public bool AvailableNewRenderer => CurrentOptions != null && CurrentOptions.IsUseNewRenderer && !ForceLegacyOpenGL;
 
 		protected BaseRenderer(HostInterface CurrentHost, BaseOptions CurrentOptions, FileSystem FileSystem)
 		{
 			currentHost = CurrentHost;
-			currentOptions = CurrentOptions;
+			CurrentOptions = CurrentOptions;
 			fileSystem = FileSystem;
 			if (CurrentHost.Application != HostApplication.TrainEditor && CurrentHost.Application != HostApplication.TrainEditor2)
 			{
@@ -320,7 +320,7 @@ namespace LibRender2
 
 			projectionMatrixList = new List<Matrix4D>();
 			viewMatrixList = new List<Matrix4D>();
-			Fonts = new Fonts(currentHost, this, currentOptions.Font);
+			Fonts = new Fonts(currentHost, this, CurrentOptions.Font);
 			VisibilityThread = new Thread(RunVisibiliityThread);
 			VisibilityThread.Start();
 			RenderThreadJobs = new ConcurrentQueue<ThreadStart>();
@@ -336,7 +336,7 @@ namespace LibRender2
 		[HandleProcessCorruptedStateExceptions] //As some graphics cards crash really nastily if we request unsupported features
 		public virtual void Initialize()
 		{
-			if (!ForceLegacyOpenGL && (currentOptions.IsUseNewRenderer || currentHost.Application != HostApplication.OpenBve)) // GL3 has already failed. Don't trigger unnecessary exceptions
+			if (!ForceLegacyOpenGL && (CurrentOptions.IsUseNewRenderer || currentHost.Application != HostApplication.OpenBve)) // GL3 has already failed. Don't trigger unnecessary exceptions
 			{
 				try
 				{
@@ -355,7 +355,7 @@ namespace LibRender2
 				catch
 				{
 					currentHost.AddMessage(MessageType.Error, false, "Initializing the default shaders failed- Falling back to legacy openGL.");
-					currentOptions.IsUseNewRenderer = false;
+					CurrentOptions.IsUseNewRenderer = false;
 					ForceLegacyOpenGL = true;
 					try
 					{
@@ -377,7 +377,7 @@ namespace LibRender2
 				{
 					// Shader failed to load, but no exception
 					currentHost.AddMessage(MessageType.Error, false, "Initializing the default shaders failed- Falling back to legacy openGL.");
-					currentOptions.IsUseNewRenderer = false;
+					CurrentOptions.IsUseNewRenderer = false;
 					ForceLegacyOpenGL = true;
 				}
 			}
@@ -451,12 +451,12 @@ namespace LibRender2
 		/// <remarks>We need to purge the current shader state and update lighting to avoid glitches</remarks>
 		public void SwitchOpenGLVersion()
 		{
-			if (currentOptions.IsUseNewRenderer && AvailableNewRenderer)
+			if (CurrentOptions.IsUseNewRenderer && AvailableNewRenderer)
 			{
 				DefaultShader.Activate();
 				DefaultShader.Deactivate();
 			}
-			currentOptions.IsUseNewRenderer = !currentOptions.IsUseNewRenderer;
+			CurrentOptions.IsUseNewRenderer = !CurrentOptions.IsUseNewRenderer;
 			Lighting.Initialize();
 		}
 
@@ -712,13 +712,13 @@ namespace LibRender2
 			ObjectsSortedByStartPointer = 0;
 			ObjectsSortedByEndPointer = 0;
 			
-			if (currentOptions.ObjectDisposalMode == ObjectDisposalMode.QuadTree)
+			if (CurrentOptions.ObjectDisposalMode == ObjectDisposalMode.QuadTree)
 			{
 				foreach (ObjectState state in StaticObjectStates)
 				{
 					VisibleObjects.quadTree.Add(state, Orientation3.Default);
 				}
-				VisibleObjects.quadTree.Initialize(currentOptions.QuadTreeLeafSize);
+				VisibleObjects.quadTree.Initialize(CurrentOptions.QuadTreeLeafSize);
 				UpdateQuadTreeVisibility();
 			}
 			else
@@ -769,7 +769,7 @@ namespace LibRender2
 
 		private void UpdateVisibility(double trackPosition)
 		{
-			if (currentOptions.ObjectDisposalMode == ObjectDisposalMode.QuadTree)
+			if (CurrentOptions.ObjectDisposalMode == ObjectDisposalMode.QuadTree)
 			{
 				UpdateQuadTreeVisibility();
 			}
@@ -969,7 +969,7 @@ namespace LibRender2
 			{
 				// Calling GL.GetString in this manner seems to be crashing the OS-X driver (No idea, but probably OpenTK....)
 				// As we only support newer Intel Macs, 16x AF is safe
-				currentOptions.AnisotropicFilteringMaximum = 16;
+				CurrentOptions.AnisotropicFilteringMaximum = 16;
 				return;
 			}
 			
@@ -981,17 +981,17 @@ namespace LibRender2
 				if (error == ErrorCode.InvalidEnum)
 				{
 					// Doing this on a forward compatible GL context fails with invalid enum
-					currentOptions.AnisotropicFilteringMaximum = 16;
+					CurrentOptions.AnisotropicFilteringMaximum = 16;
 					return;
 				}
 			}
 			catch
 			{
-				currentOptions.AnisotropicFilteringMaximum = 0;
-				currentOptions.AnisotropicFilteringLevel = 0;
+				CurrentOptions.AnisotropicFilteringMaximum = 0;
+				CurrentOptions.AnisotropicFilteringLevel = 0;
 				return;
 			}
-			currentOptions.AnisotropicFilteringMaximum = 0;
+			CurrentOptions.AnisotropicFilteringMaximum = 0;
 
 			foreach (string extension in Extensions)
 			{
@@ -1000,26 +1000,26 @@ namespace LibRender2
 					float n = GL.GetFloat((GetPName)ExtTextureFilterAnisotropic.MaxTextureMaxAnisotropyExt);
 					int MaxAF = (int)Math.Round(n);
 
-					if (MaxAF != currentOptions.AnisotropicFilteringMaximum)
+					if (MaxAF != CurrentOptions.AnisotropicFilteringMaximum)
 					{
-						currentOptions.AnisotropicFilteringMaximum = (int)Math.Round(n);
+						CurrentOptions.AnisotropicFilteringMaximum = (int)Math.Round(n);
 					}
 					break;
 				}
 			}
 
-			if (currentOptions.AnisotropicFilteringMaximum <= 0)
+			if (CurrentOptions.AnisotropicFilteringMaximum <= 0)
 			{
-				currentOptions.AnisotropicFilteringMaximum = 0;
-				currentOptions.AnisotropicFilteringLevel = 0;
+				CurrentOptions.AnisotropicFilteringMaximum = 0;
+				CurrentOptions.AnisotropicFilteringLevel = 0;
 			}
-			else if (currentOptions.AnisotropicFilteringLevel == 0 & currentOptions.AnisotropicFilteringMaximum > 0)
+			else if (CurrentOptions.AnisotropicFilteringLevel == 0 & CurrentOptions.AnisotropicFilteringMaximum > 0)
 			{
-				currentOptions.AnisotropicFilteringLevel = currentOptions.AnisotropicFilteringMaximum;
+				CurrentOptions.AnisotropicFilteringLevel = CurrentOptions.AnisotropicFilteringMaximum;
 			}
-			else if (currentOptions.AnisotropicFilteringLevel > currentOptions.AnisotropicFilteringMaximum)
+			else if (CurrentOptions.AnisotropicFilteringLevel > CurrentOptions.AnisotropicFilteringMaximum)
 			{
-				currentOptions.AnisotropicFilteringLevel = currentOptions.AnisotropicFilteringMaximum;
+				CurrentOptions.AnisotropicFilteringLevel = CurrentOptions.AnisotropicFilteringMaximum;
 			}
 		}
 		
@@ -1048,7 +1048,8 @@ namespace LibRender2
 
 			Screen.AspectRatio = Screen.Width / (double)Screen.Height;
 			Camera.HorizontalViewingAngle = 2.0 * Math.Atan(Math.Tan(0.5 * Camera.VerticalViewingAngle) * Screen.AspectRatio);
-			CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, 0.2, currentOptions.ViewingDistance);
+			double nearClip = Math.Max(0.01, CurrentOptions.NearClipBase);
+			CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, nearClip, CurrentOptions.ViewingDistance);
 		}
 
 		public void ResetShader(Shader shader)

--- a/source/LibRender2/Cursors/Cursor.cs
+++ b/source/LibRender2/Cursors/Cursor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -154,7 +154,7 @@ namespace LibRender2
 					CursorList.Add(new MouseCursor(Renderer, "nk.png", Image));
 				}
 			}
-			Renderer.currentOptions.CursorFileName = "nk.png";
+			Renderer.CurrentOptions.CursorFileName = "nk.png";
 		}
 	}
 }

--- a/source/LibRender2/Menu/AbstractMenu.cs
+++ b/source/LibRender2/Menu/AbstractMenu.cs
@@ -1,4 +1,4 @@
-﻿//Simplified BSD License (BSD-2-Clause)
+//Simplified BSD License (BSD-2-Clause)
 //
 //Copyright (c) 2024, Maurizo M. Gavioli, The OpenBVE Project
 //
@@ -114,10 +114,10 @@ namespace LibRender2.Menu
 		public Key MenuBackKey;
 
 		/// <summary>Creates a new menu instance</summary>
-		protected AbstractMenu(BaseRenderer renderer, BaseOptions currentOptions)
+		protected AbstractMenu(BaseRenderer renderer, BaseOptions CurrentOptions)
 		{
 			Renderer = renderer;
-			CurrentOptions = currentOptions;
+			CurrentOptions = CurrentOptions;
 		}
 
 		/// <summary>Initializes the menu system upon first use</summary>

--- a/source/LibRender2/Objects/ObjectLibrary.cs
+++ b/source/LibRender2/Objects/ObjectLibrary.cs
@@ -45,7 +45,7 @@ namespace LibRender2.Objects
 			AlphaFaces = myAlphaFaces.AsReadOnly();
 			OverlayOpaqueFaces = myOverlayOpaqueFaces.AsReadOnly();
 			OverlayAlphaFaces = myOverlayAlphaFaces.AsReadOnly();
-			quadTree = new QuadTree(renderer.currentOptions.ViewingDistance);
+			quadTree = new QuadTree(renderer.CurrentOptions.ViewingDistance);
 		}
 
 		private bool AddObject(ObjectState state)
@@ -184,7 +184,7 @@ namespace LibRender2.Objects
 						{
 							alpha = true;
 						}
-						else if (transparencyType == TextureTransparencyType.Partial && renderer.currentOptions.TransparencyMode == TransparencyMode.Quality)
+						else if (transparencyType == TextureTransparencyType.Partial && renderer.CurrentOptions.TransparencyMode == TransparencyMode.Quality)
 						{
 							alpha = true;
 						}
@@ -212,7 +212,7 @@ namespace LibRender2.Objects
 						{
 							alpha = true;
 						}
-						else if (transparencyType == TextureTransparencyType.Partial && renderer.currentOptions.TransparencyMode == TransparencyMode.Quality)
+						else if (transparencyType == TextureTransparencyType.Partial && renderer.CurrentOptions.TransparencyMode == TransparencyMode.Quality)
 						{
 							alpha = true;
 						}

--- a/source/LibRender2/Overlays/RailPath.cs
+++ b/source/LibRender2/Overlays/RailPath.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenBveApi.Colors;
@@ -64,7 +64,7 @@ namespace LibRender2.Overlays
 		/// <summary>Renders the path overlay</summary>
 		public void Render()
 		{
-			double halfDistance = (Math.Max(Renderer.currentOptions.ViewingDistance, 1000) / 2.0) * 1.1;
+			double halfDistance = (Math.Max(Renderer.CurrentOptions.ViewingDistance, 1000) / 2.0) * 1.1;
 			int numElements = (int)(halfDistance / BlockLength);
 			if (!Display || !Visible(Renderer.CameraTrackFollower.TrackPosition, out int startElement))
 			{

--- a/source/LibRender2/Textures/TextureManager.cs
+++ b/source/LibRender2/Textures/TextureManager.cs
@@ -503,7 +503,7 @@ namespace LibRender2.Textures
 				{
 					if (RegisteredTextures[i] != null && RegisteredTextures[i].OpenGlTextures[j].Used)
 					{
-						LoadTexture(ref RegisteredTextures[i], (OpenGlTextureWrapMode)j, CPreciseTimer.GetClockTicks(), renderer.currentOptions.Interpolation, renderer.currentOptions.AnisotropicFilteringLevel);
+						LoadTexture(ref RegisteredTextures[i], (OpenGlTextureWrapMode)j, CPreciseTimer.GetClockTicks(), renderer.CurrentOptions.Interpolation, renderer.CurrentOptions.AnisotropicFilteringLevel);
 					}
 
 				}

--- a/source/ObjectViewer/Options.cs
+++ b/source/ObjectViewer/Options.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -78,6 +78,7 @@ namespace ObjectViewer
 				Builder.AppendLine("windowWidth = " + Program.Renderer.Screen.Width.ToString(Culture));
 				Builder.AppendLine("windowHeight = " + Program.Renderer.Screen.Height.ToString(Culture));
 				Builder.AppendLine("isUseNewRenderer = " + (IsUseNewRenderer ? "true" : "false"));
+				Builder.AppendLine("nearclipbase = " + NearClipBase.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[quality]");
 				Builder.AppendLine("interpolation = " + Interpolation);
@@ -154,7 +155,15 @@ namespace ObjectViewer
 						case OptionsSection.Display:
 							block.TryGetValue(OptionsKey.WindowWidth, ref Interface.CurrentOptions.WindowWidth, NumberRange.Positive);
 							block.TryGetValue(OptionsKey.WindowHeight, ref Interface.CurrentOptions.WindowHeight, NumberRange.Positive);
-							block.GetValue(OptionsKey.IsUseNewRenderer, out Interface.CurrentOptions.IsUseNewRenderer);
+							block.TryGetValue(OptionsKey.IsUseNewRenderer, out Interface.CurrentOptions.IsUseNewRenderer);
+							block.TryGetValue(OptionsKey.NearClipBase, ref Interface.CurrentOptions.NearClipBase, NumberRange.Positive);
+							// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+							if (Interface.CurrentOptions.ViewingDistance <= Interface.CurrentOptions.NearClipBase)
+
+							{
+								Interface.CurrentOptions.ViewingDistance = (int)Math.Ceiling(Interface.CurrentOptions.NearClipBase) + 1;
+							}
+
 							break;
 						case OptionsSection.Quality:
 							block.GetEnumValue(OptionsKey.Interpolation, out Interface.CurrentOptions.Interpolation);

--- a/source/ObjectViewer/Options.cs
+++ b/source/ObjectViewer/Options.cs
@@ -155,7 +155,7 @@ namespace ObjectViewer
 						case OptionsSection.Display:
 							block.TryGetValue(OptionsKey.WindowWidth, ref Interface.CurrentOptions.WindowWidth, NumberRange.Positive);
 							block.TryGetValue(OptionsKey.WindowHeight, ref Interface.CurrentOptions.WindowHeight, NumberRange.Positive);
-							block.TryGetValue(OptionsKey.IsUseNewRenderer, out Interface.CurrentOptions.IsUseNewRenderer);
+							block.TryGetValue(OptionsKey.IsUseNewRenderer, ref Interface.CurrentOptions.IsUseNewRenderer);
 							block.TryGetValue(OptionsKey.NearClipBase, ref Interface.CurrentOptions.NearClipBase, NumberRange.Positive);
 							// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
 							if (Interface.CurrentOptions.ViewingDistance <= Interface.CurrentOptions.NearClipBase)

--- a/source/ObjectViewer/formOptions.Designer.cs
+++ b/source/ObjectViewer/formOptions.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectViewer
+namespace ObjectViewer
 {
     partial class formOptions
     {
@@ -32,6 +32,8 @@
             this.tabPageOptions = new System.Windows.Forms.TabPage();
             this.comboBoxOptimizeObjects = new System.Windows.Forms.ComboBox();
             this.labelOptimizeObjects = new System.Windows.Forms.Label();
+            this.labelNearClip = new System.Windows.Forms.Label();
+            this.nearClip = new System.Windows.Forms.NumericUpDown();
             this.comboBoxNewObjParser = new System.Windows.Forms.ComboBox();
             this.labelUseNewObjParser = new System.Windows.Forms.Label();
             this.comboBoxNewXParser = new System.Windows.Forms.ComboBox();
@@ -72,6 +74,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.AnsiotropicLevel)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.height)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.width)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nearClip)).BeginInit();
             this.tabPageKeys.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -89,6 +92,8 @@
             // 
             this.tabPageOptions.Controls.Add(this.comboBoxOptimizeObjects);
             this.tabPageOptions.Controls.Add(this.labelOptimizeObjects);
+            this.tabPageOptions.Controls.Add(this.nearClip);
+            this.tabPageOptions.Controls.Add(this.labelNearClip);
             this.tabPageOptions.Controls.Add(this.comboBoxNewObjParser);
             this.tabPageOptions.Controls.Add(this.labelUseNewObjParser);
             this.tabPageOptions.Controls.Add(this.comboBoxNewXParser);
@@ -136,6 +141,43 @@
             this.labelOptimizeObjects.Size = new System.Drawing.Size(131, 13);
             this.labelOptimizeObjects.TabIndex = 46;
             this.labelOptimizeObjects.Text = "Object Optimization Mode:";
+            // 
+            // labelNearClip
+            // 
+            this.labelNearClip.AutoSize = true;
+            this.labelNearClip.Location = new System.Drawing.Point(10, 327);
+            this.labelNearClip.Name = "labelNearClip";
+            this.labelNearClip.Size = new System.Drawing.Size(73, 13);
+            this.labelNearClip.TabIndex = 48;
+            this.labelNearClip.Text = "Near Clip (m):";
+            // 
+            // nearClip
+            // 
+            this.nearClip.DecimalPlaces = 3;
+            this.nearClip.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.nearClip.Location = new System.Drawing.Point(160, 327);
+            this.nearClip.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.nearClip.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.nearClip.Name = "nearClip";
+            this.nearClip.Size = new System.Drawing.Size(121, 20);
+            this.nearClip.TabIndex = 49;
+            this.nearClip.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            65536});
             // 
             // comboBoxNewObjParser
             // 
@@ -520,6 +562,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.AnsiotropicLevel)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.height)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.width)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nearClip)).EndInit();
             this.tabPageKeys.ResumeLayout(false);
             this.tabPageKeys.PerformLayout();
             this.ResumeLayout(false);
@@ -564,6 +607,8 @@
 		private System.Windows.Forms.Label labelRight;
 		private System.Windows.Forms.ComboBox comboBoxLeft;
 		private System.Windows.Forms.Label labelLeft;
+		private System.Windows.Forms.Label labelNearClip;
+		private System.Windows.Forms.NumericUpDown nearClip;
 		private System.Windows.Forms.Button CloseButton;
 		private System.Windows.Forms.Label labelControls;
 	}

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using LibRender2.Viewports;
 using ObjectViewer.Graphics;
 using OpenBveApi;
 using OpenBveApi.Graphics;
+using OpenBveApi.Interface;
 using OpenBveApi.Input;
 using OpenBveApi.Objects;
 using OpenTK.Graphics;
@@ -18,6 +19,11 @@ namespace ObjectViewer
 			InterpolationMode.SelectedIndex = (int) Interface.CurrentOptions.Interpolation;
 			AnsiotropicLevel.Value = Interface.CurrentOptions.AnisotropicFilteringLevel;
 			AntialiasingLevel.Value = Interface.CurrentOptions.AntiAliasingLevel;
+			nearClip.Value = (decimal)Interface.CurrentOptions.NearClipBase;
+			if (Translations.CurrentLanguageCode != "en-US")
+			{
+				labelNearClip.Text = Translations.GetInterfaceString(OpenBveApi.Hosts.HostApplication.OpenBve, new[] { "options", "quality_distance_nearclip" });
+			}
 			TransparencyQuality.SelectedIndex = Interface.CurrentOptions.TransparencyMode == TransparencyMode.Performance ? 0 : 2;
 			width.Value = Program.Renderer.Screen.Width;
 			height.Value = Program.Renderer.Screen.Height;
@@ -135,6 +141,12 @@ namespace ObjectViewer
 			Interface.CurrentOptions.CameraMoveDown = (Key)comboBoxDown.SelectedItem;
 			Interface.CurrentOptions.CameraMoveForward = (Key)comboBoxForwards.SelectedItem;
 			Interface.CurrentOptions.CameraMoveBackward = (Key)comboBoxBackwards.SelectedItem;
+			Interface.CurrentOptions.NearClipBase = (double)nearClip.Value;
+			// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+			if (Interface.CurrentOptions.ViewingDistance <= Interface.CurrentOptions.NearClipBase)
+			{
+				Interface.CurrentOptions.ViewingDistance = (int)Math.Ceiling(Interface.CurrentOptions.NearClipBase) + 1;
+			}
 			Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_ov.cfg"));
 			Program.RefreshObjects();
 			Close();

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -98,10 +98,12 @@ namespace OpenBve.Graphics
 			{
 				case ViewportMode.Scenery:
 					double cd = Program.CurrentRoute.CurrentBackground is BackgroundObject b ? Math.Max(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance, b.ClipDistance) : Program.CurrentRoute.CurrentBackground.BackgroundImageDistance;
-					CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, 0.5, cd);
+					double nearClipScenery = Math.Max(0.01, Program.Renderer.CurrentOptions.NearClipScenery);
+					CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, nearClipScenery, cd);
 					break;
 				case ViewportMode.Cab:
-					CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, 0.025, 50.0);
+					double nearClipCab = Math.Max(0.01, Program.Renderer.CurrentOptions.NearClipCab);
+					CurrentProjectionMatrix = Matrix4D.CreatePerspectiveFieldOfView(Camera.VerticalViewingAngle, Screen.AspectRatio, nearClipCab, 50.0);
 					break;
 			}
 
@@ -511,7 +513,7 @@ namespace OpenBve.Graphics
 			OptionLighting = true;
 		}
 
-		public NewRenderer(HostInterface currentHost, BaseOptions currentOptions, FileSystem fileSystem) : base(currentHost, currentOptions, fileSystem)
+		public NewRenderer(HostInterface currentHost, BaseOptions CurrentOptions, FileSystem fileSystem) : base(currentHost, CurrentOptions, fileSystem)
 		{
 		}
 	}

--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -301,6 +301,9 @@ namespace OpenBve
 				Builder.AppendLine("transparencyMode = " + ((int)TransparencyMode).ToString(Culture));
 				Builder.AppendLine("oldtransparencymode = " + (OldTransparencyMode ? "true" : "false"));
 				Builder.AppendLine("viewingDistance = " + ViewingDistance.ToString(Culture));
+				Builder.AppendLine("nearclipscenery = " + NearClipScenery.ToString(Culture));
+				Builder.AppendLine("nearclipcab = " + NearClipCab.ToString(Culture));
+				Builder.AppendLine("nearclipbase = " + NearClipBase.ToString(Culture));
 				Builder.AppendLine("quadLeafSize = " + QuadTreeLeafSize.ToString(Culture));
 				Builder.AppendLine("motionBlur = " + MotionBlur);
 				Builder.AppendLine("fpslimit = " + FPSLimit.ToString(Culture));
@@ -464,6 +467,17 @@ namespace OpenBve
 							block.GetValue(OptionsKey.ForwardsCompatibleContext, out CurrentOptions.ForceForwardsCompatibleContext);
 							block.TryGetValue(OptionsKey.ViewingDistance, ref Interface.CurrentOptions.ViewingDistance, NumberRange.Positive);
 							block.TryGetValue(OptionsKey.QuadLeafSize, ref Interface.CurrentOptions.QuadTreeLeafSize, NumberRange.Positive);
+							block.TryGetValue(OptionsKey.NearClipScenery, ref Interface.CurrentOptions.NearClipScenery, NumberRange.Positive);
+							block.TryGetValue(OptionsKey.NearClipCab, ref Interface.CurrentOptions.NearClipCab, NumberRange.Positive);
+							block.TryGetValue(OptionsKey.NearClipBase, ref Interface.CurrentOptions.NearClipBase, NumberRange.Positive);
+							// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+							double maxNearClip = Math.Max(Interface.CurrentOptions.NearClipScenery, Math.Max(Interface.CurrentOptions.NearClipCab, Interface.CurrentOptions.NearClipBase));
+
+							if (Interface.CurrentOptions.ViewingDistance <= maxNearClip)
+							{
+								Interface.CurrentOptions.ViewingDistance = (int)Math.Ceiling(maxNearClip) + 1;
+							}
+
 							block.TryGetValue(OptionsKey.UIScaleFactor, ref CurrentOptions.UserInterfaceScaleFactor);
 							break;
 						case OptionsSection.Quality:

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -183,6 +183,12 @@ namespace OpenBve {
             this.labelAnisotropic = new System.Windows.Forms.Label();
             this.comboboxInterpolation = new System.Windows.Forms.ComboBox();
             this.labelInterpolation = new System.Windows.Forms.Label();
+            this.labelNearClipScenery = new System.Windows.Forms.Label();
+            this.updownNearClipScenery = new System.Windows.Forms.NumericUpDown();
+            this.labelNearClipCab = new System.Windows.Forms.Label();
+            this.updownNearClipCab = new System.Windows.Forms.NumericUpDown();
+            this.labelNearClipBase = new System.Windows.Forms.Label();
+            this.updownNearClipBase = new System.Windows.Forms.NumericUpDown();
             this.trackbarTransparency = new System.Windows.Forms.TrackBar();
             this.panelOptionsRight = new System.Windows.Forms.Panel();
             this.groupBoxOther = new System.Windows.Forms.GroupBox();
@@ -520,6 +526,9 @@ namespace OpenBve {
             this.groupBoxRailDriver.SuspendLayout();
             this.groupboxDistance.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.updownDistance)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipScenery)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipCab)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipBase)).BeginInit();
             this.groupboxControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackbarJoystickAxisThreshold)).BeginInit();
             this.groupboxVerbosity.SuspendLayout();
@@ -2603,7 +2612,7 @@ namespace OpenBve {
             this.panelOptionsRight.Controls.Add(this.groupboxSound);
             this.panelOptionsRight.Location = new System.Drawing.Point(332, 72);
             this.panelOptionsRight.Name = "panelOptionsRight";
-            this.panelOptionsRight.Size = new System.Drawing.Size(316, 579);
+            this.panelOptionsRight.Size = new System.Drawing.Size(316, 620);
             this.panelOptionsRight.TabIndex = 17;
             // 
             // groupBoxOther
@@ -2613,7 +2622,7 @@ namespace OpenBve {
             this.groupBoxOther.Controls.Add(this.comboBoxTimeTableDisplayMode);
             this.groupBoxOther.Controls.Add(this.labelTimeTableDisplayMode);
             this.groupBoxOther.ForeColor = System.Drawing.Color.Black;
-            this.groupBoxOther.Location = new System.Drawing.Point(0, 468);
+            this.groupBoxOther.Location = new System.Drawing.Point(0, 543);
             this.groupBoxOther.Name = "groupBoxOther";
             this.groupBoxOther.Size = new System.Drawing.Size(316, 48);
             this.groupBoxOther.TabIndex = 19;
@@ -2652,7 +2661,7 @@ namespace OpenBve {
             this.groupBoxRailDriver.Controls.Add(this.comboBoxRailDriverUnits);
             this.groupBoxRailDriver.Controls.Add(this.labelRailDriverSpeedUnits);
             this.groupBoxRailDriver.ForeColor = System.Drawing.Color.Black;
-            this.groupBoxRailDriver.Location = new System.Drawing.Point(0, 230);
+            this.groupBoxRailDriver.Location = new System.Drawing.Point(0, 305);
             this.groupBoxRailDriver.Name = "groupBoxRailDriver";
             this.groupBoxRailDriver.Size = new System.Drawing.Size(316, 75);
             this.groupBoxRailDriver.TabIndex = 21;
@@ -2706,6 +2715,12 @@ namespace OpenBve {
             // 
             this.groupboxDistance.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupboxDistance.Controls.Add(this.updownNearClipBase);
+            this.groupboxDistance.Controls.Add(this.labelNearClipBase);
+            this.groupboxDistance.Controls.Add(this.updownNearClipCab);
+            this.groupboxDistance.Controls.Add(this.labelNearClipCab);
+            this.groupboxDistance.Controls.Add(this.updownNearClipScenery);
+            this.groupboxDistance.Controls.Add(this.labelNearClipScenery);
             this.groupboxDistance.Controls.Add(this.comboboxMotionBlur);
             this.groupboxDistance.Controls.Add(this.labelMotionBlur);
             this.groupboxDistance.Controls.Add(this.labelDistanceUnit);
@@ -2714,7 +2729,7 @@ namespace OpenBve {
             this.groupboxDistance.ForeColor = System.Drawing.Color.Black;
             this.groupboxDistance.Location = new System.Drawing.Point(0, 0);
             this.groupboxDistance.Name = "groupboxDistance";
-            this.groupboxDistance.Size = new System.Drawing.Size(316, 80);
+            this.groupboxDistance.Size = new System.Drawing.Size(316, 155);
             this.groupboxDistance.TabIndex = 8;
             this.groupboxDistance.TabStop = false;
             this.groupboxDistance.Text = "Distance effects";
@@ -2740,6 +2755,129 @@ namespace OpenBve {
             this.labelMotionBlur.TabIndex = 3;
             this.labelMotionBlur.Text = "Motion blur:";
             this.labelMotionBlur.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // labelNearClipScenery
+            // 
+            this.labelNearClipScenery.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelNearClipScenery.AutoEllipsis = true;
+            this.labelNearClipScenery.Location = new System.Drawing.Point(5, 75);
+            this.labelNearClipScenery.Name = "labelNearClipScenery";
+            this.labelNearClipScenery.Size = new System.Drawing.Size(136, 18);
+            this.labelNearClipScenery.TabIndex = 5;
+            this.labelNearClipScenery.Text = "Near clip (Scenery):";
+            this.labelNearClipScenery.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // updownNearClipScenery
+            // 
+            this.updownNearClipScenery.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.updownNearClipScenery.DecimalPlaces = 3;
+            this.updownNearClipScenery.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.updownNearClipScenery.Location = new System.Drawing.Point(144, 73);
+            this.updownNearClipScenery.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.updownNearClipScenery.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.updownNearClipScenery.Name = "updownNearClipScenery";
+            this.updownNearClipScenery.Size = new System.Drawing.Size(152, 20);
+            this.updownNearClipScenery.TabIndex = 6;
+            this.updownNearClipScenery.Value = new decimal(new int[] {
+            5,
+            0,
+            0,
+            65536});
+            // 
+            // labelNearClipCab
+            // 
+            this.labelNearClipCab.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelNearClipCab.AutoEllipsis = true;
+            this.labelNearClipCab.Location = new System.Drawing.Point(5, 100);
+            this.labelNearClipCab.Name = "labelNearClipCab";
+            this.labelNearClipCab.Size = new System.Drawing.Size(136, 18);
+            this.labelNearClipCab.TabIndex = 7;
+            this.labelNearClipCab.Text = "Near clip (Cab):";
+            this.labelNearClipCab.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // updownNearClipCab
+            // 
+            this.updownNearClipCab.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.updownNearClipCab.DecimalPlaces = 3;
+            this.updownNearClipCab.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            196608});
+            this.updownNearClipCab.Location = new System.Drawing.Point(144, 98);
+            this.updownNearClipCab.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.updownNearClipCab.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.updownNearClipCab.Name = "updownNearClipCab";
+            this.updownNearClipCab.Size = new System.Drawing.Size(152, 20);
+            this.updownNearClipCab.TabIndex = 8;
+            this.updownNearClipCab.Value = new decimal(new int[] {
+            25,
+            0,
+            0,
+            196608});
+            // 
+            // labelNearClipBase
+            // 
+            this.labelNearClipBase.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelNearClipBase.AutoEllipsis = true;
+            this.labelNearClipBase.Location = new System.Drawing.Point(5, 125);
+            this.labelNearClipBase.Name = "labelNearClipBase";
+            this.labelNearClipBase.Size = new System.Drawing.Size(136, 18);
+            this.labelNearClipBase.TabIndex = 9;
+            this.labelNearClipBase.Text = "Near clip (Base):";
+            this.labelNearClipBase.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // updownNearClipBase
+            // 
+            this.updownNearClipBase.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.updownNearClipBase.DecimalPlaces = 3;
+            this.updownNearClipBase.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.updownNearClipBase.Location = new System.Drawing.Point(144, 123);
+            this.updownNearClipBase.Maximum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.updownNearClipBase.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.updownNearClipBase.Name = "updownNearClipBase";
+            this.updownNearClipBase.Size = new System.Drawing.Size(152, 20);
+            this.updownNearClipBase.TabIndex = 10;
+            this.updownNearClipBase.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            65536});
             // 
             // labelDistanceUnit
             // 
@@ -2795,7 +2933,7 @@ namespace OpenBve {
             this.groupboxControls.Controls.Add(this.checkboxJoysticksUsed);
             this.groupboxControls.Controls.Add(this.labelJoystickAxisThreshold);
             this.groupboxControls.ForeColor = System.Drawing.Color.Black;
-            this.groupboxControls.Location = new System.Drawing.Point(0, 144);
+            this.groupboxControls.Location = new System.Drawing.Point(0, 219);
             this.groupboxControls.Name = "groupboxControls";
             this.groupboxControls.Size = new System.Drawing.Size(316, 80);
             this.groupboxControls.TabIndex = 10;
@@ -2856,7 +2994,7 @@ namespace OpenBve {
             this.groupboxVerbosity.Controls.Add(this.checkboxErrorMessages);
             this.groupboxVerbosity.Controls.Add(this.checkboxWarningMessages);
             this.groupboxVerbosity.ForeColor = System.Drawing.Color.Black;
-            this.groupboxVerbosity.Location = new System.Drawing.Point(0, 396);
+            this.groupboxVerbosity.Location = new System.Drawing.Point(0, 471);
             this.groupboxVerbosity.Name = "groupboxVerbosity";
             this.groupboxVerbosity.Size = new System.Drawing.Size(316, 64);
             this.groupboxVerbosity.TabIndex = 12;
@@ -2903,7 +3041,7 @@ namespace OpenBve {
             this.groupboxSimulation.Controls.Add(this.checkboxCollisions);
             this.groupboxSimulation.Controls.Add(this.checkboxToppling);
             this.groupboxSimulation.ForeColor = System.Drawing.Color.Black;
-            this.groupboxSimulation.Location = new System.Drawing.Point(0, 310);
+            this.groupboxSimulation.Location = new System.Drawing.Point(0, 385);
             this.groupboxSimulation.Name = "groupboxSimulation";
             this.groupboxSimulation.Size = new System.Drawing.Size(316, 80);
             this.groupboxSimulation.TabIndex = 11;
@@ -2973,7 +3111,7 @@ namespace OpenBve {
             this.groupboxSound.Controls.Add(this.updownSoundNumber);
             this.groupboxSound.Controls.Add(this.labelSoundNumber);
             this.groupboxSound.ForeColor = System.Drawing.Color.Black;
-            this.groupboxSound.Location = new System.Drawing.Point(0, 88);
+            this.groupboxSound.Location = new System.Drawing.Point(0, 163);
             this.groupboxSound.Name = "groupboxSound";
             this.groupboxSound.Size = new System.Drawing.Size(316, 48);
             this.groupboxSound.TabIndex = 9;
@@ -6032,6 +6170,9 @@ namespace OpenBve {
             this.groupBoxRailDriver.PerformLayout();
             this.groupboxDistance.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.updownDistance)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipScenery)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipCab)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.updownNearClipBase)).EndInit();
             this.groupboxControls.ResumeLayout(false);
             this.groupboxControls.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackbarJoystickAxisThreshold)).EndInit();
@@ -6156,6 +6297,12 @@ namespace OpenBve {
         private System.Windows.Forms.GroupBox groupboxDistance;
         private System.Windows.Forms.NumericUpDown updownDistance;
         private System.Windows.Forms.Label labelDistance;
+        private System.Windows.Forms.Label labelNearClipScenery;
+        private System.Windows.Forms.NumericUpDown updownNearClipScenery;
+        private System.Windows.Forms.Label labelNearClipCab;
+        private System.Windows.Forms.NumericUpDown updownNearClipCab;
+        private System.Windows.Forms.Label labelNearClipBase;
+        private System.Windows.Forms.NumericUpDown updownNearClipBase;
         private System.Windows.Forms.GroupBox groupboxInterpolation;
         private System.Windows.Forms.ComboBox comboboxInterpolation;
         private System.Windows.Forms.Label labelInterpolation;

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -447,6 +447,9 @@ namespace OpenBve {
 			}
 			updownAntiAliasing.Value = Interface.CurrentOptions.AntiAliasingLevel;
 			updownDistance.Value = Interface.CurrentOptions.ViewingDistance;
+			updownNearClipScenery.Value = (decimal)Interface.CurrentOptions.NearClipScenery;
+			updownNearClipCab.Value = (decimal)Interface.CurrentOptions.NearClipCab;
+			updownNearClipBase.Value = (decimal)Interface.CurrentOptions.NearClipBase;
 			comboboxMotionBlur.Items.Clear();
 			comboboxMotionBlur.Items.AddRange(new object[] { "", "", "", "" });
 			comboboxMotionBlur.SelectedIndex = (int)Interface.CurrentOptions.MotionBlur;
@@ -687,6 +690,9 @@ namespace OpenBve {
 			//Viewing distance and motion blur
 			labelDistance.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_viewingdistance"});
 			labelDistanceUnit.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_viewingdistance_meters"});
+			labelNearClipScenery.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_nearclip_scenery"});
+			labelNearClipCab.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_nearclip_cab"});
+			labelNearClipBase.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_nearclip_base"});
 			labelMotionBlur.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_motionblur"});
 			comboboxMotionBlur.Items[0] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_motionblur_none"});
 			comboboxMotionBlur.Items[1] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","quality_distance_motionblur_low"});
@@ -1079,12 +1085,24 @@ namespace OpenBve {
 			Interface.CurrentOptions.AnisotropicFilteringLevel = (int)Math.Round(updownAnisotropic.Value);
 			Interface.CurrentOptions.AntiAliasingLevel = (int)Math.Round(updownAntiAliasing.Value);
 			Interface.CurrentOptions.TransparencyMode = (TransparencyMode)trackbarTransparency.Value;
+			Interface.CurrentOptions.NearClipScenery = (double)updownNearClipScenery.Value;
+			Interface.CurrentOptions.NearClipCab = (double)updownNearClipCab.Value;
+			Interface.CurrentOptions.NearClipBase = (double)updownNearClipBase.Value;
 			int newViewingDistance = (int)Math.Round(updownDistance.Value);
+			// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+			double maxNearClip = Math.Max(Interface.CurrentOptions.NearClipScenery, Math.Max(Interface.CurrentOptions.NearClipCab, Interface.CurrentOptions.NearClipBase));
+
+
+			if (newViewingDistance <= maxNearClip)
+			{
+				newViewingDistance = (int)Math.Ceiling(maxNearClip) + 1;
+			}
 			if (newViewingDistance != Interface.CurrentOptions.ViewingDistance)
 			{
 				Interface.CurrentOptions.ViewingDistance = newViewingDistance;
 				Interface.CurrentOptions.QuadTreeLeafSize = Math.Max(50, (int)Math.Ceiling(Interface.CurrentOptions.ViewingDistance / 10.0d) * 10); // quad tree size set to 10% of viewing distance to the nearest 10
 			}
+
 			
 			
 			Interface.CurrentOptions.MotionBlur = (MotionBlurMode)comboboxMotionBlur.SelectedIndex;

--- a/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
+++ b/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedMember.Global
 // ReSharper disable InconsistentNaming
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace OpenBveApi
@@ -34,6 +34,9 @@ namespace OpenBveApi
 		ViewingDistance,
 		QuadLeafSize,
 		UIScaleFactor,
+		NearClipScenery,
+		NearClipCab,
+		NearClipBase,
 		// Quality
 		Interpolation,
 		AnisotropicFilteringLevel,

--- a/source/OpenBveApi/System/BaseOptions.cs
+++ b/source/OpenBveApi/System/BaseOptions.cs
@@ -113,6 +113,12 @@ namespace OpenBveApi
 		public bool EnableBve5ScriptedTrain;
 		/// <summary>The scale factor for the user interface</summary>
 		public int UserInterfaceScaleFactor;
+		/// <summary>The near clipping plane for scenery</summary>
+		public double NearClipScenery = 0.5;
+		/// <summary>The near clipping plane for the cab</summary>
+		public double NearClipCab = 0.025;
+		/// <summary>The near clipping plane for the base renderer</summary>
+		public double NearClipBase = 0.2;
 
 		/// <summary>Saves the options to the specified filename</summary>
 		/// <param name="fileName">The filename to save the options to</param>

--- a/source/OpenBveApi/System/Hosts.Plugins.cs
+++ b/source/OpenBveApi/System/Hosts.Plugins.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -12,7 +12,7 @@ namespace OpenBveApi.Hosts
 	{
 		/// <summary>Loads all non-runtime plugins.</summary>
 		/// <returns>Whether loading all plugins was successful.</returns>
-		public bool LoadPlugins(FileSystem.FileSystem fileSystem, BaseOptions currentOptions, out string errorMessage, object trainManagerReference = null, object rendererReference = null)
+		public bool LoadPlugins(FileSystem.FileSystem fileSystem, BaseOptions CurrentOptions, out string errorMessage, object trainManagerReference = null, object rendererReference = null)
 		{
 			if (Plugins != null && Plugins.Length != 0)
 			{
@@ -105,7 +105,7 @@ namespace OpenBveApi.Hosts
 
 						if (plugin.Texture != null | plugin.Sound != null | plugin.Object != null | plugin.Route != null | plugin.Train != null)
 						{
-							plugin.Load(this, fileSystem, currentOptions, trainManagerReference, rendererReference);
+							plugin.Load(this, fileSystem, CurrentOptions, trainManagerReference, rendererReference);
 							list.Add(plugin);
 						}
 						else if (!iruntime)

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -841,7 +841,7 @@ namespace RouteViewer
 			return s;
 		}
 
-		public NewRenderer(HostInterface currentHost, BaseOptions currentOptions, FileSystem fileSystem) : base(currentHost, currentOptions, fileSystem)
+		public NewRenderer(HostInterface currentHost, BaseOptions CurrentOptions, FileSystem fileSystem) : base(currentHost, CurrentOptions, fileSystem)
 		{
 			Screen.Width = Interface.CurrentOptions.WindowWidth;
 			Screen.Height = Interface.CurrentOptions.WindowHeight;

--- a/source/RouteViewer/Options.cs
+++ b/source/RouteViewer/Options.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -40,6 +40,7 @@ namespace RouteViewer
 				Builder.AppendLine("windowHeight = " + Program.Renderer.Screen.Height.ToString(Culture));
 				Builder.AppendLine("isUseNewRenderer = " + (IsUseNewRenderer ? "true" : "false"));
 				Builder.AppendLine("viewingdistance = " + ViewingDistance);
+				Builder.AppendLine("nearclipbase = " + NearClipBase.ToString(Culture));
 				Builder.AppendLine("quadleafsize = " + QuadTreeLeafSize);
 				Builder.AppendLine();
 				Builder.AppendLine("[quality]");
@@ -106,6 +107,14 @@ namespace RouteViewer
 							block.GetValue(OptionsKey.IsUseNewRenderer, out Interface.CurrentOptions.IsUseNewRenderer);
 							block.TryGetValue(OptionsKey.ViewingDistance, ref Interface.CurrentOptions.ViewingDistance, NumberRange.Positive);
 							block.TryGetValue(OptionsKey.QuadLeafSize, ref Interface.CurrentOptions.QuadTreeLeafSize, NumberRange.Positive);
+							block.TryGetValue(OptionsKey.NearClipBase, ref Interface.CurrentOptions.NearClipBase, NumberRange.Positive);
+							// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+							if (Interface.CurrentOptions.ViewingDistance <= Interface.CurrentOptions.NearClipBase)
+
+							{
+								Interface.CurrentOptions.ViewingDistance = (int)Math.Ceiling(Interface.CurrentOptions.NearClipBase) + 1;
+							}
+
 							break;
 						case OptionsSection.Quality:
 							block.GetEnumValue(OptionsKey.Interpolation, out Interface.CurrentOptions.Interpolation);

--- a/source/RouteViewer/RouteViewer.csproj
+++ b/source/RouteViewer/RouteViewer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <NoWarn>$(NoWarn),IDE1006</NoWarn>
@@ -187,8 +187,8 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <!-- Set LBA flag -->
-    <Exec Condition="'$(OS)' != 'Unix'" Command="$(TargetDir)DevTools\LBAHeader.exe $(TargetDir)OpenBve.exe" />
-    <Exec Condition="'$(OS)' == 'Unix'" Command="mono $(TargetDir)DevTools/LBAHeader.exe $(TargetDir)OpenBve.exe" />
+    <Exec Condition="'$(OS)' != 'Unix'" Command="&quot;$(TargetDir)DevTools\LBAHeader.exe&quot; &quot;$(TargetDir)OpenBve.exe&quot;" />
+    <Exec Condition="'$(OS)' == 'Unix'" Command="mono &quot;$(TargetDir)DevTools/LBAHeader.exe&quot; &quot;$(TargetDir)OpenBve.exe&quot;" />
     <!-- Copy in dependancies -->
     <!-- NOTE: Whilst AtsPluginProxy.dll is Windows specific, we still want to copy it in the auto-generated nightly builds -->
     <ItemGroup>

--- a/source/RouteViewer/formOptions.Designer.cs
+++ b/source/RouteViewer/formOptions.Designer.cs
@@ -57,11 +57,14 @@ namespace RouteViewer
 			this.comboBoxNewXParser = new System.Windows.Forms.ComboBox();
 			this.label15 = new System.Windows.Forms.Label();
 			this.numericUpDownViewingDistance = new System.Windows.Forms.NumericUpDown();
+			this.labelNearClip = new System.Windows.Forms.Label();
+			this.numericUpDownNearClip = new System.Windows.Forms.NumericUpDown();
 			((System.ComponentModel.ISupportInitialize)(this.width)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.height)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.AnsiotropicLevel)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.AntialiasingLevel)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownViewingDistance)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownNearClip)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// InterpolationMode
@@ -139,7 +142,7 @@ namespace RouteViewer
 			// 
 			// button1
 			// 
-			this.button1.Location = new System.Drawing.Point(211, 447);
+			this.button1.Location = new System.Drawing.Point(211, 473);
 			this.button1.Name = "button1";
 			this.button1.Size = new System.Drawing.Size(75, 23);
 			this.button1.TabIndex = 9;
@@ -389,11 +392,50 @@ namespace RouteViewer
             0,
             0});
 			// 
-			// formOptions
+			// labelNearClip
+			// 
+			this.labelNearClip.AutoSize = true;
+			this.labelNearClip.Location = new System.Drawing.Point(12, 438);
+			this.labelNearClip.Name = "labelNearClip";
+			this.labelNearClip.Size = new System.Drawing.Size(109, 13);
+			this.labelNearClip.TabIndex = 36;
+			this.labelNearClip.Text = "Near Clip (m):";
+			// 
+			// numericUpDownNearClip
+			// 
+			this.numericUpDownNearClip.DecimalPlaces = 3;
+			this.numericUpDownNearClip.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+			this.numericUpDownNearClip.Location = new System.Drawing.Point(166, 436);
+			this.numericUpDownNearClip.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+			this.numericUpDownNearClip.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+			this.numericUpDownNearClip.Name = "numericUpDownNearClip";
+			this.numericUpDownNearClip.Size = new System.Drawing.Size(120, 20);
+			this.numericUpDownNearClip.TabIndex = 35;
+			this.numericUpDownNearClip.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            65536});
+			// 
+			// FormOptions
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(311, 482);
+			this.ClientSize = new System.Drawing.Size(311, 508);
+			this.Controls.Add(this.labelNearClip);
+			this.Controls.Add(this.numericUpDownNearClip);
 			this.Controls.Add(this.label15);
 			this.Controls.Add(this.numericUpDownViewingDistance);
 			this.Controls.Add(this.label12);
@@ -433,6 +475,7 @@ namespace RouteViewer
 			((System.ComponentModel.ISupportInitialize)(this.AnsiotropicLevel)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.AntialiasingLevel)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownViewingDistance)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDownNearClip)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
@@ -469,5 +512,7 @@ namespace RouteViewer
 		private System.Windows.Forms.ComboBox comboBoxNewXParser;
 		private System.Windows.Forms.Label label15;
 		private System.Windows.Forms.NumericUpDown numericUpDownViewingDistance;
+		private System.Windows.Forms.Label labelNearClip;
+		private System.Windows.Forms.NumericUpDown numericUpDownNearClip;
 	}
 }

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -1,6 +1,7 @@
 using LibRender2.Viewports;
 using OpenBveApi;
 using OpenBveApi.Graphics;
+using OpenBveApi.Interface;
 using OpenBveApi.Objects;
 using OpenTK.Graphics;
 using System;
@@ -25,7 +26,12 @@ namespace RouteViewer
 			checkBoxProgressBar.Checked = Interface.CurrentOptions.LoadingProgressBar;
 			comboBoxNewXParser.SelectedIndex = (int) Interface.CurrentOptions.CurrentXParser;
 			comboBoxNewObjParser.SelectedIndex = (int) Interface.CurrentOptions.CurrentObjParser;
-			numericUpDownViewingDistance.Value = Math.Min(Interface.CurrentOptions.ViewingDistance, numericUpDownViewingDistance.Minimum);
+			numericUpDownViewingDistance.Value = (decimal)Interface.CurrentOptions.ViewingDistance;
+			numericUpDownNearClip.Value = (decimal)Interface.CurrentOptions.NearClipBase;
+			if (Translations.CurrentLanguageCode != "en-US")
+			{
+				labelNearClip.Text = Translations.GetInterfaceString(OpenBveApi.Hosts.HostApplication.OpenBve, new[] { "options", "quality_distance_nearclip" });
+			}
         }
 
         internal static DialogResult ShowOptions()
@@ -43,6 +49,7 @@ namespace RouteViewer
 	    private readonly int previousAntialiasingLevel = Interface.CurrentOptions.AntiAliasingLevel;
 	    private readonly int previousAnisotropicLevel = Interface.CurrentOptions.AnisotropicFilteringLevel;
 	    private readonly int previousViewingDistance = Interface.CurrentOptions.ViewingDistance;
+	    private readonly double previousNearClipBase = Interface.CurrentOptions.NearClipBase;
 	    private bool GraphicsModeChanged = false;
 
         private void button1_Click(object sender, EventArgs e)
@@ -126,7 +133,15 @@ namespace RouteViewer
 				}
 			}
 			Interface.CurrentOptions.ViewingDistance = (int)numericUpDownViewingDistance.Value;
+			Interface.CurrentOptions.NearClipBase = (double)numericUpDownNearClip.Value;
+			// ensure viewing distance is greater than the near clipping plane to avoid rendering issues
+			if (Interface.CurrentOptions.ViewingDistance <= Interface.CurrentOptions.NearClipBase)
+
+			{
+				Interface.CurrentOptions.ViewingDistance = (int)Math.Ceiling(Interface.CurrentOptions.NearClipBase) + 1;
+			}
 			Interface.CurrentOptions.QuadTreeLeafSize = Math.Max(50, (int)Math.Ceiling(Interface.CurrentOptions.ViewingDistance / 10.0d) * 10); // quad tree size set to 10% of viewing distance to the nearest 10
+
 			Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_rv.cfg"));
 			for (int i = 0; i < Program.CurrentHost.Plugins.Length; i++)
 			{
@@ -137,7 +152,7 @@ namespace RouteViewer
 				}
 			}
 			//Check if interpolation mode or anisotropic filtering level has changed, and trigger a reload
-			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance)
+			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance || Interface.CurrentOptions.NearClipBase != previousNearClipBase)
 			{
 				this.DialogResult = DialogResult.OK;
 			}

--- a/source/TrainEditor2/Graphics/NewRenderer.cs
+++ b/source/TrainEditor2/Graphics/NewRenderer.cs
@@ -1,4 +1,4 @@
-﻿using LibRender2;
+using LibRender2;
 using OpenBveApi;
 using OpenBveApi.FileSystem;
 using OpenBveApi.Hosts;
@@ -15,7 +15,7 @@ namespace TrainEditor2.Graphics
 			GL.Disable(EnableCap.CullFace);
 		}
 
-		public NewRenderer(HostInterface currentHost, BaseOptions currentOptions, FileSystem fileSystem) : base(currentHost, currentOptions, fileSystem)
+		public NewRenderer(HostInterface currentHost, BaseOptions CurrentOptions, FileSystem fileSystem) : base(currentHost, CurrentOptions, fileSystem)
 		{
 		}
 	}

--- a/source/TrainEditor2/Systems/Options.cs
+++ b/source/TrainEditor2/Systems/Options.cs
@@ -1,4 +1,4 @@
-﻿using Formats.OpenBve;
+using Formats.OpenBve;
 using OpenBveApi;
 using System;
 using System.Globalization;
@@ -32,6 +32,7 @@ namespace TrainEditor2.Systems
 					builder.AppendLine("[language]");
 					builder.AppendLine("code = " + LanguageCode);
 					File.WriteAllText(fileName, builder.ToString(), new UTF8Encoding(true));
+
 				}
 				catch
 				{


### PR DESCRIPTION
- Add configurable near clipping planes for scenery and cab views.
- Implement safety guards ensuring ViewingDistance > NearClip.
- Refactor Renderer.currentOptions to a public property for project-wide access.
- Update UI and add localizations sections for near clip.

Tested on windows 11, local builds with main openbve program, object viewer and route viewer.

This is QOL (quality of life) feature, useful for scenario like closer inspection in object viewer or route viewer and in main game player can simulate the feeling like passenger by using f2 camera mode and put the camera near a chair and train window but without the clipping. 

Any suggestion or is welcome, especially for testing this PR with Linux or macOS because im not familiar and didn't have it.