### PR TITLE
Change: Optimize csv b3d object parser and object viewer autoreload performance

### DIFF
--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -41,6 +41,8 @@ namespace ObjectViewer {
 		/// <summary>The number of failed auto-reloads</summary>
         internal static int AutoReloadFailureCounter = 0;
         private static double reloadCheckTimer;
+		/// <summary>The list of loaded objects, cached to allow partial reloads</summary>
+		internal static UnifiedObject[] LoadedObjects = new UnifiedObject[0];
 
 		// mouse
 		internal static Vector3 MouseCameraPosition = Vector3.Zero;
@@ -162,6 +164,7 @@ namespace ObjectViewer {
 				if (filesToLoad.Count != 0)
 				{
 					Files = filesToLoad;
+					LoadedObjects = new UnifiedObject[Files.Count];
 				}
 	        }
 
@@ -311,8 +314,24 @@ namespace ObjectViewer {
 	        }
 	    }
 
-	    internal static void RefreshObjects(bool autoReload = false)
+	    internal static void RefreshObjects(int fileIndex = -1)
 	    {
+		    // If a specific file index is provided, only reload that file from disk.
+		    // Otherwise (or if the array is out of sync), do a full reload.
+		    if (fileIndex >= 0 && fileIndex < Files.Count && LoadedObjects.Length == Files.Count) {
+			    try {
+				    if (CurrentHost.LoadObject(Files[fileIndex], Encoding.UTF8, out UnifiedObject o)) {
+					    LoadedObjects[fileIndex] = o;
+				    }
+			    } catch {
+				    // If failed, we don't return here but continue to the reset/refresh logic
+				    // which will handle error reporting.
+			    }
+		    } else {
+			    LoadedObjects = new UnifiedObject[Files.Count];
+			    fileIndex = -1; // Force full load of all objects below
+		    }
+
 		    LightingRelative = -1.0;
 			Renderer.Reset();
 		    Game.Reset();
@@ -323,6 +342,7 @@ namespace ObjectViewer {
 			    {
 				    if(Files[i].EndsWith(".dat", StringComparison.InvariantCultureIgnoreCase) || Files[i].EndsWith(".xml", StringComparison.InvariantCultureIgnoreCase) || Files[i].EndsWith(".cfg", StringComparison.InvariantCultureIgnoreCase) || Files[i].EndsWith(".con", StringComparison.InvariantCultureIgnoreCase))
 				    {
+					    // Trains are still reloaded fully as they are complex collections
 					    string currentTrain = Files[i];
 						if (currentTrain.EndsWith("extensions.cfg", StringComparison.InvariantCultureIgnoreCase))
 					    {
@@ -370,19 +390,24 @@ namespace ObjectViewer {
 				    }
 				    else
 				    {
-					    if (CurrentHost.LoadObject(Files[i], Encoding.UTF8, out UnifiedObject o))
-					    {
-						    o.CreateObject(Vector3.Zero, 0.0, 0.0, 0.0);
+					    if (fileIndex == -1 || fileIndex == i) {
+						    if (CurrentHost.LoadObject(Files[i], Encoding.UTF8, out UnifiedObject o)) {
+							    LoadedObjects[i] = o;
+						    }
 					    }
-					    
+					    if (LoadedObjects[i] != null) {
+						    LoadedObjects[i].CreateObject(Vector3.Zero, 0.0, 0.0, 0.0);
+					    }
 				    }
 
 			    }
 			    catch (Exception ex)
 			    {
-				    if (!autoReload || AutoReloadFailureCounter > 5)
+					// Check if we are in an auto-reload context (passed from CheckFileChanges) via a flag if needed, 
+					// but here we use fileIndex != -1 as a proxy for auto-reload.
+				    if (fileIndex == -1 || AutoReloadFailureCounter > 5)
 				    {
-					    if (autoReload)
+					    if (fileIndex != -1)
 					    {
 							// failure counter must be above 5
 							Interface.CurrentOptions.AutoReloadObjects = false;
@@ -450,7 +475,7 @@ namespace ObjectViewer {
 		            }
 		            if (System.IO.File.GetLastWriteTimeUtc(Files[i]) > LastReloadTime)
 		            {
-			            RefreshObjects();
+			            RefreshObjects(i);
 			            return;
 		            }
 				}

--- a/source/OpenBveApi/Math/Math.cs
+++ b/source/OpenBveApi/Math/Math.cs
@@ -204,11 +204,20 @@ namespace OpenBveApi.Math {
 
 		private static string TrimInside(string Expression)
 		{
-			System.Text.StringBuilder Builder = new System.Text.StringBuilder(Expression.Length);
-			foreach (char c in Expression.Where(c => !char.IsWhiteSpace(c)))
+			if (string.IsNullOrEmpty(Expression)) return Expression;
+			
+			// Simple loop to remove whitespace without LINQ or StringBuilder overhead
+			int n = Expression.Length;
+			char[] result = new char[n];
+			int count = 0;
+			for (int i = 0; i < n; i++)
 			{
-				Builder.Append(c);
-			} return Builder.ToString();
+				if (!char.IsWhiteSpace(Expression[i]))
+				{
+					result[count++] = Expression[i];
+				}
+			}
+			return count == n ? Expression : new string(result, 0, count);
 		}
 
 		

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -108,6 +108,7 @@ namespace Object.CsvB3d
 			}
 			// read lines
 			List<string> Lines = System.IO.File.ReadAllLines(FileName, Encoding).ToList();
+			Dictionary<string, bool> fileExistsCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 			if (enabledHacks.BveTsHacks && multiColumn)
 			{
 				/*
@@ -150,6 +151,9 @@ namespace Object.CsvB3d
 			List<Vector3> Normals = new List<Vector3>();
 			bool CommentStarted = false;
 			Color24? lastTransparentColor = null;
+			// HashSet to store face vertex indices to avoid O(N^2) search during Z-fighting check.
+			// Using a string key of sorted indices since MeshFace is a struct and we need a reliable key.
+			HashSet<string> faceCache = new HashSet<string>();
 			for (int i = 0; i < Lines.Count; i++) {
 				{
 					// Strip OpenBVE original standard comments
@@ -207,9 +211,10 @@ namespace Object.CsvB3d
 						}
 					}
 				}
-				// collect arguments
+				// collect arguments by splitting the line by commas
 				string[] Arguments = Lines[i].Split(new[] { ',' }, StringSplitOptions.None);
 				for (int j = 0; j < Arguments.Length; j++) {
+					// Trim each argument to remove leading/trailing whitespace
 					Arguments[j] = Arguments[j].Trim();
 				}
 				{
@@ -291,6 +296,7 @@ namespace Object.CsvB3d
 								Builder.Apply(ref Object, enabledHacks.BveTsHacks);
 								Builder = new MeshBuilder(currentHost);
 								Normals = new List<Vector3>();
+								faceCache.Clear(); // reset face cache for the new mesh builder
 							} break;
 						case B3DCsvCommands.AddVertex:
 						case B3DCsvCommands.Vertex:
@@ -519,45 +525,23 @@ namespace Object.CsvB3d
 											}
 										}
 
-										int[] vertexIndices = (int[])a.Clone();
-										Array.Sort(vertexIndices);
-										for (int k = 0; k < Builder.Faces.Count; k++)
+										/*
+										 * Optimization: Use a HashSet to track existing faces by their vertex indices.
+										 * This avoids the O(N^2) loop through all previous faces in the MeshBuilder.
+										 */
+										if (isFace2)
 										{
-											/*
-											 * Some BVE2 content declares a Face2 twice with the vertices in a differing order, e.g.
-											 *
-											 * Face2 0, 1, 3, 2
-											 * Face2 1, 0, 2, 3
-											 *
-											 * Doing this in OpenBVE causes some very funky glitches with Z-fighting,
-											 * as it attempts to render both faces in the same space
-											 *
-											 * With this hack, the lighting may be off but the Z-fighting is gone
-											 * (BVE2 / BVE4 operate in a strict draw-order, so the most recent face is always on top,
-											 * wheras OpenBVE has no fixed draw order)
-											 */
-											MeshFace currentFace = Builder.Faces[k];
-											if (!isFace2 || (currentFace.Flags & FaceFlags.Face2Mask) == 0)
-											{
-												continue;
-											}
-
-											if (currentFace.Vertices.Length != a.Length)
-											{
-												continue;
-											}
-
-											int[] faceVertexIndices = new int[a.Length];
-											for (int v = 0; v < currentFace.Vertices.Length; v++)
-											{
-												faceVertexIndices[v] = currentFace.Vertices[v].Index;
-											}
-											Array.Sort(faceVertexIndices);
-											if (vertexIndices.SequenceEqual(faceVertexIndices))
+											int[] vertexIndices = (int[])a.Clone();
+											Array.Sort(vertexIndices);
+											string faceKey = string.Join("|", vertexIndices);
+											if (faceCache.Contains(faceKey))
 											{
 												q = false;
 											}
-											
+											else
+											{
+												faceCache.Add(faceKey);
+											}
 										}
 									}
 									if (q) {
@@ -1167,7 +1151,14 @@ namespace Object.CsvB3d
 											tday = null;
 										}
 										
-										if (!System.IO.File.Exists(tday))
+										// Cache results of File.Exists to avoid hitting the disk for the same file multiple times
+										bool tdayExists;
+										if (!fileExistsCache.TryGetValue(tday, out tdayExists))
+										{
+											tdayExists = System.IO.File.Exists(tday);
+											fileExistsCache[tday] = tdayExists;
+										}
+										if (!tdayExists)
 										{
 											bool hackFound = false;
 											if (enabledHacks.BveTsHacks)
@@ -1185,7 +1176,12 @@ namespace Object.CsvB3d
 												{
 													Arguments[0] = Arguments[0].Substring(7);
 													tday = Path.CombineFile(Path.GetDirectoryName(FileName), Arguments[0]);
-													if (System.IO.File.Exists(tday))
+													if (!fileExistsCache.TryGetValue(tday, out tdayExists))
+													{
+														tdayExists = System.IO.File.Exists(tday);
+														fileExistsCache[tday] = tdayExists;
+													}
+													if (tdayExists)
 													{
 														hackFound = true;
 													}
@@ -1195,7 +1191,12 @@ namespace Object.CsvB3d
 												{
 													Arguments[0] = Arguments[0].Substring(4);
 													tday = Path.CombineFile(Path.GetDirectoryName(FileName), Arguments[0]);
-													if (System.IO.File.Exists(tday))
+													if (!fileExistsCache.TryGetValue(tday, out tdayExists))
+												{
+													tdayExists = System.IO.File.Exists(tday);
+													fileExistsCache[tday] = tdayExists;
+												}
+												if (tdayExists)
 													{
 														hackFound = true;
 													}
@@ -1205,7 +1206,12 @@ namespace Object.CsvB3d
 												{
 													Arguments[0] = Arguments[0].Substring(3);
 													tday = Path.CombineFile(Path.GetDirectoryName(FileName), Arguments[0]);
-													if (System.IO.File.Exists(tday))
+													if (!fileExistsCache.TryGetValue(tday, out tdayExists))
+												{
+													tdayExists = System.IO.File.Exists(tday);
+													fileExistsCache[tday] = tdayExists;
+												}
+												if (tdayExists)
 													{
 														hackFound = true;
 													}
@@ -1245,7 +1251,13 @@ namespace Object.CsvB3d
 												}
 											}
 											
-											if (!System.IO.File.Exists(tnight) && !ignoreAsInvalid) {
+											bool tnightExists;
+											if (!fileExistsCache.TryGetValue(tnight, out tnightExists))
+											{
+												tnightExists = System.IO.File.Exists(tnight);
+												fileExistsCache[tnight] = tnightExists;
+											}
+											if (!tnightExists && !ignoreAsInvalid) {
 												currentHost.AddMessage(MessageType.Error, true, "The NighttimeTexture " + tnight + " could not be found in " + cmd + " at line " + (i + 1).ToString(Culture) + " in file " + FileName);
 												tnight = null;
 											}

--- a/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.Parser.cs
@@ -108,6 +108,8 @@ namespace Object.CsvB3d
 			}
 			// read lines
 			List<string> Lines = System.IO.File.ReadAllLines(FileName, Encoding).ToList();
+			// Cache results of File.Exists locally during this load operation to avoid redundant disk IO.
+			// This is created fresh every time the object is loaded/reloaded, so it is safe against file additions/deletions between loads.
 			Dictionary<string, bool> fileExistsCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 			if (enabledHacks.BveTsHacks && multiColumn)
 			{
@@ -525,10 +527,20 @@ namespace Object.CsvB3d
 											}
 										}
 
-										/*
-										 * Optimization: Use a HashSet to track existing faces by their vertex indices.
-										 * This avoids the O(N^2) loop through all previous faces in the MeshBuilder.
+										/* 
+										 * Some BVE2 content declares a Face2 twice with the vertices in a differing order, e.g.
+										 * Face2 0, 1, 3, 2
+										 * Face2 1, 0, 2, 3
+										 * Doing this in OpenBVE causes some very funky glitches with Z-fighting,
+										 * as it attempts to render both faces in the same space
+										 *
+										 * With this hack, the lighting may be off but the Z-fighting is gone
+										 * (BVE2 / BVE4 operate in a strict draw-order, so the most recent face is always on top,
+										 * wheras OpenBVE has no fixed draw order)
 										 */
+
+										// Optimization: Use a HashSet to track existing faces by their vertex indices.
+										// This avoids the O(N^2) loop through all previous faces in the MeshBuilder.
 										if (isFace2)
 										{
 											int[] vertexIndices = (int[])a.Clone();


### PR DESCRIPTION
- Implement HashSet face lookup in Plugin.Parser.cs
- Add IO caching for File.Exists results during texture loading.
- Optimize NumberFormats.TrimInside to reduce allocations.
- Implement partial reload in ObjectViewer via UnifiedObject caching.
- Add descriptive code comments for better readability.