### PR TITLE
Fix Shadow visibility and settings reload in Route/Object Viewer

### DIFF
--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -274,6 +274,7 @@ namespace ObjectViewer
 			
 			Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_ov.cfg"));
 			Program.RefreshObjects();
+			this.DialogResult = DialogResult.OK;
 			Close();
 		}
 	}

--- a/source/RouteViewer/NewRendererR.cs
+++ b/source/RouteViewer/NewRendererR.cs
@@ -157,7 +157,9 @@ namespace RouteViewer
 
 			// render background
 			GL.Disable(EnableCap.DepthTest);
+			DefaultShader.SetShadowEnabled(false);
 			Program.CurrentRoute.UpdateBackground(timeElapsed, false);
+			DefaultShader.SetShadowEnabled(ShadowsEnabled);
 
 			// fog
 			float aa = Program.CurrentRoute.CurrentFog.Start;

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -157,6 +157,13 @@ namespace RouteViewer
 
         private void button1_Click(object sender, EventArgs e)
         {
+            ShadowMapResolution previousShadowResolution = Interface.CurrentOptions.ShadowResolution;
+	        ShadowDistance previousShadowDistance = Interface.CurrentOptions.ShadowDrawDistance;
+	        ShadowCascadeCount previousShadowCascades = Interface.CurrentOptions.ShadowCascades;
+	        double previousShadowStrength = Interface.CurrentOptions.ShadowStrength;
+	        double previousShadowBias = Interface.CurrentOptions.ShadowBias;
+	        double previousShadowNormalBias = Interface.CurrentOptions.ShadowNormalBias;
+
 			//Interpolation mode
 			InterpolationMode previousInterpolationMode = Interface.CurrentOptions.Interpolation;
 			switch (InterpolationMode.SelectedIndex)
@@ -282,7 +289,9 @@ namespace RouteViewer
 				}
 			}
 			//Check if interpolation mode or anisotropic filtering level has changed, and trigger a reload
-			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance)
+			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance ||
+			    previousShadowResolution != Interface.CurrentOptions.ShadowResolution || previousShadowDistance != Interface.CurrentOptions.ShadowDrawDistance || previousShadowCascades != Interface.CurrentOptions.ShadowCascades ||
+			    previousShadowStrength != Interface.CurrentOptions.ShadowStrength || previousShadowBias != Interface.CurrentOptions.ShadowBias || previousShadowNormalBias != Interface.CurrentOptions.ShadowNormalBias)
 			{
 				this.DialogResult = DialogResult.OK;
 			}


### PR DESCRIPTION
- Update Route Viewer FormOptions to return DialogResult.OK when shadow settings are modified, ensuring the main loop triggers a reload.
- Disable shadow casting on the background cylinder in Route Viewer to sync with main openbve exe and prevent visual artifacts.
- Set DialogResult.OK in Object Viewer options on close to ensure shadow settings are correctly applied immediately.