### PR TITLE
Use a struct to pass object creation parameters

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -865,14 +865,14 @@ namespace LibRender2
 			VisibleObjects.Clear();
 		}
 
-		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition, bool DisableShadowCasting)
+		public int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, ObjectCreationParameters Parameters, double BlockLength)
 		{
 			Matrix4D Translate = Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z);
 			Matrix4D Rotate = (Matrix4D)new Transformation(LocalTransformation, WorldTransformation);
-			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, BlockLength, TrackPosition, DisableShadowCasting);
+			return CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, AccurateObjectDisposal, Parameters, BlockLength);
 		}
 
-		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition, bool DisableShadowCasting = false)
+		public int CreateStaticObject(Vector3 Position, StaticObject Prototype, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectDisposalMode AccurateObjectDisposal, ObjectCreationParameters Parameters, double BlockLength)
 		{
 			if (Prototype == null)
 			{
@@ -906,8 +906,8 @@ namespace LibRender2
 					}
 				}
 
-				startingDistance += (float)AccurateObjectDisposalZOffset;
-				endingDistance += (float)AccurateObjectDisposalZOffset;
+				startingDistance += (float)Parameters.AccurateObjectDisposalZOffset;
+				endingDistance += (float)Parameters.AccurateObjectDisposalZOffset;
 			}
 
 			const double minBlockLength = 20.0;
@@ -920,21 +920,21 @@ namespace LibRender2
 			switch (AccurateObjectDisposal)
 			{
 				case ObjectDisposalMode.Accurate:
-					startingDistance += (float)TrackPosition;
-					endingDistance += (float)TrackPosition;
-					double z = BlockLength * Math.Floor(TrackPosition / BlockLength);
-					StartingDistance = Math.Min(z - BlockLength, startingDistance);
-					EndingDistance = Math.Max(z + 2.0 * BlockLength, endingDistance);
-					startingDistance = (float)(BlockLength * Math.Floor(StartingDistance / BlockLength));
-					endingDistance = (float)(BlockLength * Math.Ceiling(EndingDistance / BlockLength));
+					startingDistance += (float)Parameters.TrackPosition;
+					endingDistance += (float)Parameters.TrackPosition;
+					double z = BlockLength * Math.Floor(Parameters.TrackPosition / BlockLength);
+					Parameters.StartingDistance = Math.Min(z - BlockLength, startingDistance);
+					Parameters.EndingDistance = Math.Max(z + 2.0 * BlockLength, endingDistance);
+					startingDistance = (float)(BlockLength * Math.Floor(Parameters.StartingDistance / BlockLength));
+					endingDistance = (float)(BlockLength * Math.Ceiling(Parameters.EndingDistance / BlockLength));
 					break;
 				case ObjectDisposalMode.Legacy:
-					startingDistance = (float)StartingDistance;
-					endingDistance = (float)EndingDistance;
+					startingDistance = (float)Parameters.StartingDistance;
+					endingDistance = (float)Parameters.EndingDistance;
 					break;
 				case ObjectDisposalMode.Mechanik:
-					startingDistance = (float) StartingDistance;
-					endingDistance = (float) EndingDistance + 1500;
+					startingDistance = (float)Parameters.StartingDistance;
+					endingDistance = (float)Parameters.EndingDistance + 1500;
 					if (startingDistance < 0)
 					{
 						startingDistance = 0;
@@ -949,7 +949,7 @@ namespace LibRender2
 				StartingDistance = startingDistance,
 				EndingDistance = endingDistance,
 				WorldPosition = Position,
-				DisableShadowCasting = DisableShadowCasting
+				DisableShadowCasting = Parameters.DisableShadowCasting
 			});
 			
 			foreach (MeshFace face in Prototype.Mesh.Faces)

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -348,14 +348,14 @@ namespace ObjectViewer {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, bool DisableShadowCasting)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, 25.0, TrackPosition, DisableShadowCasting);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, parameters, 25.0);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectCreationParameters parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, 25.0, TrackPosition);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, ObjectDisposalMode.Accurate, parameters, 25.0);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/ObjectViewer/Hosts.cs
+++ b/source/ObjectViewer/Hosts.cs
@@ -348,7 +348,7 @@ namespace ObjectViewer {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters parameters)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, ObjectCreationParameters parameters, Transformation WorldTransformation, Transformation LocalTransformation = null)
 		{
 			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, ObjectDisposalMode.Accurate, parameters, 25.0);
 		}

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -402,7 +402,7 @@ namespace ObjectViewer {
 				    {
 					    if (CurrentHost.LoadObject(Files[i], Encoding.UTF8, out UnifiedObject o))
 					    {
-						    o.CreateObject(Vector3.Zero, 0.0, 0.0, 0.0);
+						    o.CreateObject(Vector3.Zero, new ObjectCreationParameters());
 					    }
 					    
 				    }

--- a/source/OpenBVE/Graphics/NewRenderer.cs
+++ b/source/OpenBVE/Graphics/NewRenderer.cs
@@ -16,7 +16,6 @@ using OpenBveApi.Math;
 using OpenBveApi.Objects;
 using OpenBveApi.Routes;
 using OpenBveApi.Textures;
-using OpenBveApi.World;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
@@ -74,16 +73,6 @@ namespace OpenBve.Graphics
 			Program.FileSystem.AppendToLogFile("Renderer initialised successfully.");
 		}
 		
-		internal int CreateStaticObject(UnifiedObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectDisposalMode AccurateObjectDisposal, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double BlockLength, double TrackPosition)
-		{
-			if (!(Prototype is StaticObject obj))
-			{
-				Interface.AddMessage(MessageType.Error, false, "Attempted to use an animated object where only static objects are allowed.");
-				return -1;
-			}
-			return base.CreateStaticObject(obj, Position, WorldTransformation, LocalTransformation, AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, BlockLength, TrackPosition, false);
-		}
-
 		protected override void UpdateViewport(int width, int height)
 		{
 			_programLogo = null;

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -486,7 +486,7 @@ namespace OpenBve {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, ObjectCreationParameters Parameters, Transformation WorldTransformation, Transformation LocalTransformation = null)
 		{
 			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}

--- a/source/OpenBVE/System/Host.cs
+++ b/source/OpenBVE/System/Host.cs
@@ -486,14 +486,14 @@ namespace OpenBve {
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainBase)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, bool DisableShadowCasting)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, DisableShadowCasting);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectCreationParameters Parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)

--- a/source/OpenBveApi/Objects/Helpers/ObjectCreationParameters.cs
+++ b/source/OpenBveApi/Objects/Helpers/ObjectCreationParameters.cs
@@ -1,0 +1,82 @@
+﻿//Copyright (c) 2025, Christopher Lees, The OpenBVE Project
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//
+//1. Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+namespace OpenBveApi.Objects
+{
+	/// <summary>Helper struct for parameters to be applied when creating an object</summary>
+    public struct ObjectCreationParameters
+    {
+		/// <summary>The absolute track position at which the object is placed</summary>
+	    public double TrackPosition;
+		/// <summary>he Z-offset to be applied before calculating the position of the object for disposal</summary>
+	    public double AccurateObjectDisposalZOffset;
+		/// <summary>The track distance at which this object is displayed by the renderer</summary>
+		/// <remarks>Not valid in QuadTree visibility mode</remarks>
+	    public double StartingDistance;
+	    /// <summary>The track distance at which this object is hidden by the renderer</summary>
+	    /// <remarks>Not valid in QuadTree visibility mode</remarks>
+		public double EndingDistance;
+		/// <summary>The brightness value of this object</summary>
+	    public double Brightness;
+		/// <summary>Whether shadow casting is disabled for this object </summary>
+		public bool DisableShadowCasting;
+		/// <summary>The section index the object is linked to</summary>
+		public int SectionIndex;
+
+		/// <summary>Creates a new ObjectCreationParameters</summary>
+	    public ObjectCreationParameters(double trackPosition, double accurateObjectDisposalZOffset, double startingDistance, double endingDistance, double brightness, int sectionIndex = -1, bool disableShadowCasting = false)
+	    {
+		    TrackPosition = trackPosition;
+		    AccurateObjectDisposalZOffset = accurateObjectDisposalZOffset;
+		    StartingDistance = startingDistance;
+		    EndingDistance = endingDistance;
+			Brightness = brightness;
+			SectionIndex = sectionIndex;
+			DisableShadowCasting = disableShadowCasting;
+			
+	    }
+
+	    /// <summary>Creates a new ObjectCreationParameters</summary>
+		public ObjectCreationParameters(double trackPosition, double startingDistance, double endingDistance, double brightness, int sectionIndex) :
+			this(trackPosition, 0, startingDistance, endingDistance, brightness, sectionIndex)
+	    {
+	    }
+
+	    /// <summary>Creates a new ObjectCreationParameters</summary>
+		public ObjectCreationParameters(double trackPosition, double accurateObjectDisposalZOffset, double startingDistance, double endingDistance) 
+			: this(trackPosition, accurateObjectDisposalZOffset, startingDistance, endingDistance, 1.0) { }
+
+	    /// <summary>Creates a new ObjectCreationParameters</summary>
+		public ObjectCreationParameters(double trackPosition, double startingDistance, double endingDistance)
+			: this(trackPosition, 0, startingDistance, endingDistance, 1.0) { }
+
+	    /// <summary>Creates a new ObjectCreationParameters</summary>
+		public ObjectCreationParameters(double startingDistance, double endingDistance)
+			: this(startingDistance, 0, startingDistance, endingDistance, 1.0) { }
+
+		/// <summary>Returns a clone of the ObjectCreationParameters with DisableShadowCasting set</summary>
+		public ObjectCreationParameters WithoutShadow()
+		{
+			return new ObjectCreationParameters(TrackPosition, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Brightness, -1, true);
+		}
+	}
+}

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObjectCollection.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObjectCollection.cs
@@ -56,6 +56,7 @@ namespace OpenBveApi.Objects
 				}
 			}
 
+			double p = Parameters.AccurateObjectDisposalZOffset;
 			if (anyfree)
 			{
 				for (int i = 0; i < Objects.Length; i++)
@@ -68,12 +69,12 @@ namespace OpenBveApi.Objects
 							Matrix4D mat = Matrix4D.Identity;
 							mat *= Objects[i].States[0].Translation;
 							mat *= transformationMatrix;
-							double zOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
-
+							Parameters.AccurateObjectDisposalZOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
 							currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), Parameters);
 						}
 						else
 						{
+							Parameters.AccurateObjectDisposalZOffset = p;
 							Objects[i].Clone().CreateObject(Position, WorldTransformation, LocalTransformation, Parameters.SectionIndex, Parameters.TrackPosition);
 						}
 					}

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObjectCollection.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObjectCollection.cs
@@ -26,8 +26,7 @@ namespace OpenBveApi.Objects
 
 		/// <inheritdoc/>
 		public override void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation,
-			int SectionIndex, double StartingDistance, double EndingDistance,
-			double TrackPosition, double Brightness, bool DuplicateMaterials = false)
+			ObjectCreationParameters Parameters)
 		{
 			bool[] free = new bool[Objects.Length];
 			bool anyfree = false;
@@ -71,11 +70,11 @@ namespace OpenBveApi.Objects
 							mat *= transformationMatrix;
 							double zOffset = Objects[i].States[0].Translation.ExtractTranslation().Z * -1.0; //To calculate the Z-offset within the object, we want the untransformed co-ordinates, not the world co-ordinates
 
-							currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), zOffset, StartingDistance, EndingDistance, TrackPosition);
+							currentHost.CreateStaticObject(Objects[i].States[0].Prototype, Position, LocalTransformation, mat, Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z), Parameters);
 						}
 						else
 						{
-							Objects[i].Clone().CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition);
+							Objects[i].Clone().CreateObject(Position, WorldTransformation, LocalTransformation, Parameters.SectionIndex, Parameters.TrackPosition);
 						}
 					}
 				}
@@ -86,7 +85,7 @@ namespace OpenBveApi.Objects
 				{
 					if (Objects[i].States.Length != 0)
 					{
-						Objects[i].Clone().CreateObject(Position, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition);
+						Objects[i].Clone().CreateObject(Position, WorldTransformation, LocalTransformation, Parameters.SectionIndex, Parameters.TrackPosition);
 					}
 				}
 			}
@@ -106,8 +105,8 @@ namespace OpenBveApi.Objects
 				Vector3 v = Sounds[i].Position;
 				v.Rotate(LocalTransformation);
 				v.Rotate(WorldTransformation);
-				(Sounds[i] as WorldSound)?.CreateSound(Position + v, SectionIndex, TrackPosition);
-				(Sounds[i] as AnimatedWorldObjectStateSound)?.Create(Position + v, WorldTransformation, LocalTransformation, SectionIndex, TrackPosition);
+				(Sounds[i] as WorldSound)?.CreateSound(Position + v, Parameters.SectionIndex, Parameters.TrackPosition);
+				(Sounds[i] as AnimatedWorldObjectStateSound)?.Create(Position + v, WorldTransformation, LocalTransformation, Parameters.SectionIndex, Parameters.TrackPosition);
 			}
 		}
 

--- a/source/OpenBveApi/Objects/ObjectTypes/KeyframeAnimatedObject/KeyframeAnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/KeyframeAnimatedObject/KeyframeAnimatedObject.cs
@@ -75,13 +75,13 @@ namespace OpenBveApi.Objects
 		}
 
 		/// <inheritdoc />
-		public override void CreateObject(Vector3 position, Transformation worldTransformation, Transformation localTransformation, int sectionIndex, double startingDistance, double endingDistance, double trackPosition, double brightness, bool duplicateMaterials = false)
+		public override void CreateObject(Vector3 position, Transformation worldTransformation, Transformation localTransformation, ObjectCreationParameters parameters)
 		{
 			// Update animations
 			for (int i = 0; i < Animations.Count; i++)
 			{
 				int key = Animations.ElementAt(i).Key;
-				Animations[key].Update(null, IsReversed, position, trackPosition, 0); // current state not applicable, no hand-crafted functions
+				Animations[key].Update(null, IsReversed, position, parameters.TrackPosition, 0); // current state not applicable, no hand-crafted functions
 			}
 			Transformation finalTransformation = new Transformation(localTransformation, worldTransformation);
 			Matrix4D[] matriciesToShader = new Matrix4D[Matricies.Length];
@@ -110,7 +110,7 @@ namespace OpenBveApi.Objects
 				Direction = finalTransformation.Z,
 				Up = finalTransformation.Y,
 				Side = finalTransformation.X,
-				TrackPosition = trackPosition
+				TrackPosition = parameters.TrackPosition
 			};
 			currentHost.AnimatedWorldObjects[a] = currentObject;
 			currentHost.AnimatedWorldObjectsUsed++;

--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -585,7 +585,7 @@ namespace OpenBveApi.Objects
 		public override void CreateObject(Vector3 position, Transformation worldTransformation, Transformation localTransformation,
 			ObjectCreationParameters Parameters)
 		{
-			currentHost.CreateStaticObject(this, position, worldTransformation, localTransformation, Parameters);
+			currentHost.CreateStaticObject(this, position, Parameters, worldTransformation, localTransformation);
 		}
 
 		/// <inheritdoc />

--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -583,10 +583,9 @@ namespace OpenBveApi.Objects
 
 		/// <summary>Callback function to create the object within the world</summary>
 		public override void CreateObject(Vector3 position, Transformation worldTransformation, Transformation localTransformation,
-			int sectionIndex, double startingDistance, double endingDistance,
-			double trackPosition, double brightness, bool disableShadowCasting = false)
+			ObjectCreationParameters Parameters)
 		{
-			currentHost.CreateStaticObject(this, position, worldTransformation, localTransformation, 0.0, startingDistance, endingDistance, trackPosition, disableShadowCasting);
+			currentHost.CreateStaticObject(this, position, worldTransformation, localTransformation, Parameters);
 		}
 
 		/// <inheritdoc />

--- a/source/OpenBveApi/Objects/ObjectTypes/UnifiedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/UnifiedObject.cs
@@ -11,9 +11,9 @@ namespace OpenBveApi.Objects
 		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
 		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
 		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, double StartingDistance, double EndingDistance, double TrackPosition)
+		public void CreateObject(Vector3 Position, ObjectCreationParameters Parameters)
 		{
-			CreateObject(Position, Transformation.NullTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
+			CreateObject(Position, Transformation.NullTransformation, Transformation.NullTransformation, Parameters);
 		}
 
 		/// <summary>Creates the object within the worldspace using a single track based transforms</summary>
@@ -22,9 +22,9 @@ namespace OpenBveApi.Objects
 		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
 		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
 		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, double StartingDistance, double EndingDistance, double TrackPosition)
+		public void CreateObject(Vector3 Position, Transformation WorldTransformation, ObjectCreationParameters Parameters)
 		{
-			CreateObject(Position, WorldTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
+			CreateObject(Position, WorldTransformation, Transformation.NullTransformation, Parameters);
 		}
 
 		/// <summary>Creates the object within the world</summary>
@@ -34,22 +34,7 @@ namespace OpenBveApi.Objects
 		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
 		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
 		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		public void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double StartingDistance, double EndingDistance, double TrackPosition)
-		{
-			CreateObject(Position, WorldTransformation, LocalTransformation, -1, StartingDistance, EndingDistance, TrackPosition, 1.0);
-		}
-
-		/// <summary>Creates the object within the world</summary>
-		/// <param name="Position">The world position</param>
-		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
-		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="SectionIndex">The section index (If placed via Track.SigF)</param>
-		/// <param name="StartingDistance">The track distance at which this is displayed by the renderer</param>
-		/// <param name="EndingDistance">The track distance at which this hidden by the renderer</param>
-		/// <param name="TrackPosition">The absolute track position at which this object is placed</param>
-		/// <param name="Brightness">The brightness value of this object</param>
-		/// <param name="DuplicateMaterials">Whether the materials are to be duplicated (Not set when creating BVE4 signals)</param>
-		public abstract void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, int SectionIndex, double StartingDistance, double EndingDistance, double TrackPosition, double Brightness, bool DuplicateMaterials = false);
+		public abstract void CreateObject(Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters);
 
 		/// <summary>Call this method to optimize the object</summary>
 		/// <param name="PreserveVerticies">Whether duplicate vertices are to be preserved (Takes less time)</param>

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Objects\Helpers\Material.cs" />
     <Compile Include="Objects\Helpers\MeshBuilder.cs" />
     <Compile Include="Objects\Helpers\ModelExporter.cs" />
+    <Compile Include="Objects\Helpers\ObjectCreationParameters.cs" />
     <Compile Include="Objects\Mesh.cs" />
     <Compile Include="Objects\MeshFace.cs" />
     <Compile Include="Objects\MeshFaceVertex.cs" />

--- a/source/OpenBveApi/System/Hosts/HostInterface.cs
+++ b/source/OpenBveApi/System/Hosts/HostInterface.cs
@@ -399,13 +399,9 @@ namespace OpenBveApi.Hosts {
 		/// <param name="Position">The world position</param>
 		/// <param name="WorldTransformation">The world transformation to apply (e.g. ground, rail)</param>
 		/// <param name="LocalTransformation">The local transformation to apply in order to rotate the model</param>
-		/// <param name="AccurateObjectDisposalZOffset">The offset for accurate Z-disposal</param>
-		/// <param name="StartingDistance">The absolute route based starting distance for the object</param>
-		/// <param name="EndingDistance">The absolute route based ending distance for the object</param>
-		/// <param name="TrackPosition">The absolute route based track position</param>
-		/// <param name="DisableShadowCasting">Whether to disable shadow casting for this object</param>
+		/// <param name="Parameters">The object creation parameters</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, ObjectCreationParameters Parameters, Transformation WorldTransformation, Transformation LocalTransformation = null)
 		{
 			return -1;
 		}
@@ -419,10 +415,7 @@ namespace OpenBveApi.Hosts {
 		/// </param>
 		/// <param name="Rotate">The rotation matrix to apply</param>
 		/// <param name="Translate">The translation matrix to apply</param>
-		/// <param name="AccurateObjectDisposalZOffset">The offset for accurate Z-disposal</param>
-		/// <param name="StartingDistance">The absolute route based starting distance for the object</param>
-		/// <param name="EndingDistance">The absolute route based ending distance for the object</param>
-		/// <param name="TrackPosition">The absolute route based track position</param>
+		/// <param name="Parameters">The object creation parameters</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
 		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectCreationParameters Parameters)
 		{

--- a/source/OpenBveApi/System/Hosts/HostInterface.cs
+++ b/source/OpenBveApi/System/Hosts/HostInterface.cs
@@ -405,7 +405,7 @@ namespace OpenBveApi.Hosts {
 		/// <param name="TrackPosition">The absolute route based track position</param>
 		/// <param name="DisableShadowCasting">Whether to disable shadow casting for this object</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, bool DisableShadowCasting)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
 		{
 			return -1;
 		}
@@ -424,7 +424,7 @@ namespace OpenBveApi.Hosts {
 		/// <param name="EndingDistance">The absolute route based ending distance for the object</param>
 		/// <param name="TrackPosition">The absolute route based track position</param>
 		/// <returns>The index to the created object, or -1 if this call fails</returns>
-		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition)
+		public virtual int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectCreationParameters Parameters)
 		{
 			return -1;
 		}

--- a/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
@@ -346,30 +346,28 @@ namespace Route.Bve5
 								double sRadiusH = Data.Blocks[i].Rails[s].RadiusH;
 								double sx1 = i < Data.Blocks.Count - 1 ? Data.Blocks[i + 1].Rails[s].Position.X : sx0;
 
-								string key = Data.Blocks[i].Cracks[k].Key;
-								double tpos = Data.Blocks[i].Cracks[k].TrackPosition;
 								Vector3 wpos;
-								Transformation Transformation;
+								Transformation railTransformation;
 								if (j == 0)
 								{
-									GetPrimaryRailTransformation(Position, Data.Blocks, i, Data.Blocks[i].Cracks[k], Direction, out wpos, out Transformation);
+									GetPrimaryRailTransformation(Position, Data.Blocks, i, Data.Blocks[i].Cracks[k], Direction, out wpos, out railTransformation);
 								}
 								else
 								{
-									GetSecondaryRailTransformation(Position, Direction, Data.Blocks, i, railKey, Data.Blocks[i].Cracks[k], out wpos, out Transformation);
+									GetSecondaryRailTransformation(Position, Direction, Data.Blocks, i, railKey, Data.Blocks[i].Cracks[k], out wpos, out railTransformation);
 								}
 
-								double pInterpolateX0 = GetTrackCoordinate(StartingDistance, px0, nextStartingDistance, px1, pRadiusH, tpos);
-								double pInterpolateX1 = GetTrackCoordinate(StartingDistance, px0, nextStartingDistance, px1, pRadiusH, tpos + InterpolateInterval);
-								double sInterpolateX0 = GetTrackCoordinate(StartingDistance, sx0, nextStartingDistance, sx1, sRadiusH, tpos);
-								double sInterpolateX1 = GetTrackCoordinate(StartingDistance, sx0, nextStartingDistance, sx1, sRadiusH, tpos + InterpolateInterval);
+								double pInterpolateX0 = GetTrackCoordinate(StartingDistance, px0, nextStartingDistance, px1, pRadiusH, Data.Blocks[i].Cracks[k].TrackPosition);
+								double pInterpolateX1 = GetTrackCoordinate(StartingDistance, px0, nextStartingDistance, px1, pRadiusH, Data.Blocks[i].Cracks[k].TrackPosition + InterpolateInterval);
+								double sInterpolateX0 = GetTrackCoordinate(StartingDistance, sx0, nextStartingDistance, sx1, sRadiusH, Data.Blocks[i].Cracks[k].TrackPosition);
+								double sInterpolateX1 = GetTrackCoordinate(StartingDistance, sx0, nextStartingDistance, sx1, sRadiusH, Data.Blocks[i].Cracks[k].TrackPosition + InterpolateInterval);
 								double d0 = sInterpolateX0 - pInterpolateX0;
 								double d1 = sInterpolateX1 - pInterpolateX1;
 
-								if(Data.Objects.TryGetValue(key, out UnifiedObject obj) && obj != null)
+								if(Data.Objects.TryGetValue(Data.Blocks[i].Cracks[k].Key, out UnifiedObject obj) && obj != null)
 								{
 									UnifiedObject crack = d0 < 0.0 ? obj.TransformRight(d0, d1) : obj.TransformLeft(d0, d1);
-									crack.CreateObject(wpos, Transformation, new Transformation(0.0, 0.0, 0.0), new ObjectCreationParameters(tpos, StartingDistance, EndingDistance));
+									crack.CreateObject(wpos, railTransformation, new ObjectCreationParameters(Data.Blocks[i].Cracks[k].TrackPosition, StartingDistance, EndingDistance));
 								}
 							}
 						}
@@ -380,16 +378,16 @@ namespace Route.Bve5
 							for (int k = 0; k < Data.Blocks[i].Signals[j].Count; k++)
 							{
 								Vector3 wpos;
-								Transformation Transformation;
+								Transformation railTransformation;
 								if (j == 0)
 								{
-									GetPrimaryRailTransformation(Position, Data.Blocks, i, Data.Blocks[i].Signals[j][k], Direction, out wpos, out Transformation);
+									GetPrimaryRailTransformation(Position, Data.Blocks, i, Data.Blocks[i].Signals[j][k], Direction, out wpos, out railTransformation);
 								}
 								else
 								{
-									GetSecondaryRailTransformation(Position, Direction, Data.Blocks, i, railKey, Data.Blocks[i].Signals[j][k], out wpos, out Transformation);
+									GetSecondaryRailTransformation(Position, Direction, Data.Blocks, i, railKey, Data.Blocks[i].Signals[j][k], out wpos, out railTransformation);
 								}
-								wpos += Data.Blocks[i].Signals[j][k].Position * Transformation;
+								wpos += Data.Blocks[i].Signals[j][k].Position * railTransformation;
 
 								SignalData sd = Data.SignalObjects.Find(data => data.Key.Equals(Data.Blocks[i].Signals[j][k].Key, StringComparison.InvariantCultureIgnoreCase));
 								if (sd != null)
@@ -433,7 +431,7 @@ namespace Route.Bve5
 											aoc.Objects[m].RefreshRate = refreshRate;
 										}
 
-										aoc.CreateObject(wpos, Transformation, new Transformation(Data.Blocks[i].Signals[j][k].Yaw, Data.Blocks[i].Signals[j][k].Pitch, Data.Blocks[i].Signals[j][k].Roll), new ObjectCreationParameters(Data.Blocks[i].Signals[j][k].TrackPosition, StartingDistance, EndingDistance, 1.0, Data.Blocks[i].Signals[j][k].SectionIndex));
+										aoc.CreateObject(wpos, railTransformation, new Transformation(Data.Blocks[i].Signals[j][k].Yaw, Data.Blocks[i].Signals[j][k].Pitch, Data.Blocks[i].Signals[j][k].Roll), new ObjectCreationParameters(Data.Blocks[i].Signals[j][k].TrackPosition, StartingDistance, EndingDistance, 1.0, Data.Blocks[i].Signals[j][k].SectionIndex));
 									}
 								}
 							}

--- a/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
+++ b/source/Plugins/Route.Bve5/MapParser/ApplyRouteData.cs
@@ -327,7 +327,7 @@ namespace Route.Bve5
 
 								wpos += Data.Blocks[i].FreeObjects[railKey][k].Position * Transformation;
 								Data.Objects.TryGetValue(key, out UnifiedObject obj);
-								obj?.CreateObject(wpos, Transformation, new Transformation(Data.Blocks[i].FreeObjects[railKey][k].Yaw, Data.Blocks[i].FreeObjects[railKey][k].Pitch, Data.Blocks[i].FreeObjects[railKey][k].Roll), -1, StartingDistance, EndingDistance, Data.Blocks[i].FreeObjects[railKey][k].TrackPosition, 1.0);
+								obj?.CreateObject(wpos, Transformation, new Transformation(Data.Blocks[i].FreeObjects[railKey][k].Yaw, Data.Blocks[i].FreeObjects[railKey][k].Pitch, Data.Blocks[i].FreeObjects[railKey][k].Roll), new ObjectCreationParameters(Data.Blocks[i].FreeObjects[railKey][k].TrackPosition, StartingDistance, EndingDistance));
 							}
 						}
 
@@ -369,7 +369,7 @@ namespace Route.Bve5
 								if(Data.Objects.TryGetValue(key, out UnifiedObject obj) && obj != null)
 								{
 									UnifiedObject crack = d0 < 0.0 ? obj.TransformRight(d0, d1) : obj.TransformLeft(d0, d1);
-									crack.CreateObject(wpos, Transformation, new Transformation(0.0, 0.0, 0.0), -1, StartingDistance, EndingDistance, tpos, 1.0);
+									crack.CreateObject(wpos, Transformation, new Transformation(0.0, 0.0, 0.0), new ObjectCreationParameters(tpos, StartingDistance, EndingDistance));
 								}
 							}
 						}
@@ -433,7 +433,7 @@ namespace Route.Bve5
 											aoc.Objects[m].RefreshRate = refreshRate;
 										}
 
-										aoc.CreateObject(wpos, Transformation, new Transformation(Data.Blocks[i].Signals[j][k].Yaw, Data.Blocks[i].Signals[j][k].Pitch, Data.Blocks[i].Signals[j][k].Roll), Data.Blocks[i].Signals[j][k].SectionIndex, StartingDistance, EndingDistance, Data.Blocks[i].Signals[j][k].TrackPosition, 1.0);
+										aoc.CreateObject(wpos, Transformation, new Transformation(Data.Blocks[i].Signals[j][k].Yaw, Data.Blocks[i].Signals[j][k].Pitch, Data.Blocks[i].Signals[j][k].Roll), new ObjectCreationParameters(Data.Blocks[i].Signals[j][k].TrackPosition, StartingDistance, EndingDistance, 1.0, Data.Blocks[i].Signals[j][k].SectionIndex));
 									}
 								}
 							}

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -633,7 +633,7 @@ namespace CsvRwRouteParser
 					int gi = Data.Blocks[i].Cycle[ci];
 					if (Data.Structure.Ground.ContainsKey(gi))
 					{
-						Data.Structure.Ground[Data.Blocks[i].Cycle[ci]].CreateObject(Position + new Vector3(0.0, -Data.Blocks[i].Height, 0.0), GroundTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, StartingDistance, 1.0, true);
+						Data.Structure.Ground[Data.Blocks[i].Cycle[ci]].CreateObject(Position + new Vector3(0.0, -Data.Blocks[i].Height, 0.0), GroundTransformation, Transformation.NullTransformation, new ObjectCreationParameters(StartingDistance, EndingDistance));
 					}
 				}
 				// ground-aligned free objects
@@ -647,7 +647,7 @@ namespace CsvRwRouteParser
 				if (!PreviewOnly && Data.Structure.WeatherObjects.ContainsKey(Data.Blocks[i].WeatherObject))
 				{
 					UnifiedObject obj = Data.Structure.WeatherObjects[Data.Blocks[i].WeatherObject];
-					obj.CreateObject(Position, GroundTransformation, Data.Blocks[i].Height, StartingDistance, EndingDistance);
+					obj.CreateObject(Position, GroundTransformation, new ObjectCreationParameters(StartingDistance, EndingDistance));
 				}
 				// rail-aligned objects
 				{
@@ -768,6 +768,8 @@ namespace CsvRwRouteParser
 							CurrentRoute.Tracks[railKey].Elements[n].IsDriveable = Data.Blocks[i].Rails[railKey].IsDriveable;
 						}
 
+						ObjectCreationParameters railParameters = new ObjectCreationParameters(StartingDistance, EndingDistance);
+
 						if (!PreviewOnly)
 						{
 							if (railKey > 0 && !Data.Blocks[i].Rails[railKey].RailStarted)
@@ -784,7 +786,7 @@ namespace CsvRwRouteParser
 
 							if (Data.Structure.RailObjects.ContainsKey(Data.Blocks[i].RailType[railKey]))
 							{
-								Data.Structure.RailObjects[Data.Blocks[i].RailType[railKey]]?.CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+								Data.Structure.RailObjects[Data.Blocks[i].RailType[railKey]]?.CreateObject(pos, RailTransformation, railParameters);
 							}
 
 							// points of interest
@@ -819,22 +821,24 @@ namespace CsvRwRouteParser
 								}
 							}
 
+							
+
 							// poles
 							if (Data.Blocks[i].RailPole.Length > railKey)
 							{
-								Data.Blocks[i].RailPole[railKey].Create(Data.Structure.Poles, pos, RailTransformation, Direction, planar, updown, StartingDistance, EndingDistance);
+								Data.Blocks[i].RailPole[railKey].Create(Data.Structure.Poles, pos, RailTransformation, Direction, planar, updown, railParameters);
 							}
 
 							// walls
 							if (Data.Blocks[i].RailWall.ContainsKey(railKey))
 							{
-								Data.Blocks[i].RailWall[railKey].Create(pos, RailTransformation, StartingDistance, EndingDistance);
+								Data.Blocks[i].RailWall[railKey].Create(pos, RailTransformation, railParameters);
 							}
 
 							// dikes
 							if (Data.Blocks[i].RailDike.ContainsKey(railKey))
 							{
-								Data.Blocks[i].RailDike[railKey].Create(pos, RailTransformation, StartingDistance, EndingDistance);
+								Data.Blocks[i].RailDike[railKey].Create(pos, RailTransformation, railParameters);
 							}
 
 							// sounds
@@ -852,20 +856,20 @@ namespace CsvRwRouteParser
 								// primary rail
 								if (Data.Blocks[i].Forms[k].PrimaryRail == railKey)
 								{
-									Data.Blocks[i].Forms[k].CreatePrimaryRail(Data.Blocks[i], Data.Blocks[i + 1], pos, RailTransformation, StartingDistance, EndingDistance);
+									Data.Blocks[i].Forms[k].CreatePrimaryRail(Data.Blocks[i], Data.Blocks[i + 1], pos, RailTransformation, railParameters);
 								}
 
 								// secondary rail
 								if (Data.Blocks[i].Forms[k].SecondaryRail == railKey)
 								{
-									Data.Blocks[i].Forms[k].CreateSecondaryRail(Data.Blocks[i], pos, RailTransformation, StartingDistance, EndingDistance);
+									Data.Blocks[i].Forms[k].CreateSecondaryRail(Data.Blocks[i], pos, RailTransformation, railParameters);
 								}
 							}
 
 							// cracks
 							for (int k = 0; k < Data.Blocks[i].Cracks.Length; k++)
 							{
-								Data.Blocks[i].Cracks[k].Create(railKey, RailTransformation, pos, Data.Blocks[i], Data.Blocks[i + 1], Data.Structure, StartingDistance, EndingDistance);
+								Data.Blocks[i].Cracks[k].Create(railKey, RailTransformation, pos, Data.Blocks[i], Data.Blocks[i + 1], Data.Structure, railParameters);
 							}
 
 							// free objects

--- a/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
@@ -49,7 +49,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackL[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, Parameters.WithoutShadow());
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, Parameters.WithoutShadow(), RailTransformation);
 					}
 				}
 				else if (d0 > 0.0)
@@ -61,7 +61,7 @@ namespace CsvRwRouteParser
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackR[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, Parameters.WithoutShadow());
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, Parameters.WithoutShadow(), RailTransformation);
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Crack.cs
@@ -21,7 +21,7 @@ namespace CsvRwRouteParser
 			FileName = fileName;
 		}
 
-		internal void Create(int CurrentRail, Transformation RailTransformation, Vector3 pos, Block CurrentBlock, Block NextBlock, StructureData Structure, double StartingDistance, double EndingDistance)
+		internal void Create(int CurrentRail, Transformation RailTransformation, Vector3 pos, Block CurrentBlock, Block NextBlock, StructureData Structure, ObjectCreationParameters Parameters)
 		{
 			if (PrimaryRail != CurrentRail)
 			{
@@ -32,7 +32,7 @@ namespace CsvRwRouteParser
 			double px1 = PrimaryRail > 0 ? NextBlock.Rails[PrimaryRail].RailEnd.X : 0.0;
 			if (SecondaryRail < 0 || !CurrentBlock.Rails.ContainsKey(SecondaryRail) || !CurrentBlock.Rails[SecondaryRail].RailStarted)
 			{
-				Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Crack at track position " + StartingDistance.ToString(Culture) + " in file " + FileName);
+				Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Crack at track position " + Parameters.StartingDistance.ToString(Culture) + " in file " + FileName);
 			}
 			else
 			{
@@ -44,24 +44,24 @@ namespace CsvRwRouteParser
 				{
 					if (!Structure.CrackL.ContainsKey(Type))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "CrackStructureIndex references a CrackL not loaded in Track.Crack at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "CrackStructureIndex references a CrackL not loaded in Track.Crack at track position " + Parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackL[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, true);
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, Parameters.WithoutShadow());
 					}
 				}
 				else if (d0 > 0.0)
 				{
 					if (!Structure.CrackR.ContainsKey(Type))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "CrackStructureIndex references a CrackR not loaded in Track.Crack at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "CrackStructureIndex references a CrackR not loaded in Track.Crack at track position " + Parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
 						StaticObject Crack = (StaticObject) Structure.CrackR[Type].Transform(d0, d1);
-						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, 0.0, StartingDistance, EndingDistance, StartingDistance, true);
+						Plugin.CurrentHost.CreateStaticObject(Crack, pos, RailTransformation, Transformation.NullTransformation, Parameters.WithoutShadow());
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
@@ -36,27 +36,27 @@ namespace CsvRwRouteParser
 
 		internal readonly StructureData Structure;
 		private readonly CultureInfo Culture = CultureInfo.InvariantCulture;
-		internal void CreatePrimaryRail(Block currentBlock, Block nextBlock, Vector3 pos, Transformation railTransformation, double startingDistance, double endingDistance)
+		internal void CreatePrimaryRail(Block currentBlock, Block nextBlock, Vector3 pos, Transformation railTransformation, ObjectCreationParameters parameters)
 		{
 			
 			if (SecondaryRail == SecondaryRailStub)
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+					Structure.FormL[FormType].CreateObject(pos, railTransformation, parameters);
 					if (RoofType > 0)
 					{
 						if (!Structure.RoofL.ContainsKey(RoofType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.RoofL[RoofType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+							Structure.RoofL[RoofType].CreateObject(pos, railTransformation, parameters);
 						}
 					}
 				}
@@ -65,40 +65,40 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+					Structure.FormL[FormType].CreateObject(pos, railTransformation, parameters);
 				}
 
 				if (!Structure.FormCL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, railTransformation, Transformation.NullTransformation, parameters);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofL[RoofType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+						Structure.RoofL[RoofType].CreateObject(pos, railTransformation, parameters);
 					}
 
 					if (!Structure.RoofCL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, railTransformation, Transformation.NullTransformation, parameters);
 					}
 				}
 			}
@@ -106,40 +106,40 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormR[FormType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+					Structure.FormR[FormType].CreateObject(pos, railTransformation, parameters);
 				}
 
 				if (!Structure.FormCR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, railTransformation, Transformation.NullTransformation, parameters);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofR[RoofType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+						Structure.RoofR[RoofType].CreateObject(pos, railTransformation, parameters);
 					}
 
 					if (!Structure.RoofCR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, railTransformation, Transformation.NullTransformation,parameters);
 					}
 				}
 			}
@@ -149,7 +149,7 @@ namespace CsvRwRouteParser
 				double px1 = PrimaryRail > 0 ? nextBlock.Rails[PrimaryRail].RailEnd.X : 0.0;
 				if (SecondaryRail < 0 || !currentBlock.Rails.ContainsKey(SecondaryRail) || !currentBlock.Rails[SecondaryRail].RailStarted)
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName);
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RailIndex2 is out of range in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName);
 				}
 				else
 				{
@@ -159,42 +159,42 @@ namespace CsvRwRouteParser
 					{
 						if (!Structure.FormL.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.FormL[FormType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+							Structure.FormL[FormType].CreateObject(pos, railTransformation, parameters);
 						}
 
 						if (!Structure.FormCL.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
 							StaticObject formC = (StaticObject) Structure.FormCL[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation, parameters);
 						}
 
 						if (RoofType > 0)
 						{
 							if (!Structure.RoofL.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
-								Structure.RoofL[RoofType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+								Structure.RoofL[RoofType].CreateObject(pos, railTransformation, parameters);
 							}
 
 							if (!Structure.RoofCL.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
 								StaticObject roofC = (StaticObject) Structure.RoofCL[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation,parameters);
 							}
 						}
 					}
@@ -202,42 +202,42 @@ namespace CsvRwRouteParser
 					{
 						if (!Structure.FormR.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
-							Structure.FormR[FormType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+							Structure.FormR[FormType].CreateObject(pos, railTransformation, parameters);
 						}
 
 						if (!Structure.FormCR.ContainsKey(FormType))
 						{
-							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+							Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormCR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 						}
 						else
 						{
 							StaticObject formC = (StaticObject) Structure.FormCR[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation,parameters);
 						}
 
 						if (RoofType > 0)
 						{
 							if (!Structure.RoofR.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
-								Structure.RoofR[RoofType].CreateObject(pos, railTransformation, startingDistance, endingDistance, startingDistance);
+								Structure.RoofR[RoofType].CreateObject(pos, railTransformation, parameters);
 							}
 
 							if (!Structure.RoofCR.ContainsKey(RoofType))
 							{
-								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + startingDistance.ToString(Culture) + " in file " + FileName + ".");
+								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofCR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 							}
 							else
 							{
 								StaticObject roofC = (StaticObject) Structure.RoofCR[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation, 0.0, startingDistance, endingDistance, startingDistance, false);
+								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation,parameters);
 							}
 						}
 					}
@@ -246,7 +246,7 @@ namespace CsvRwRouteParser
 
 		}
 
-		internal void CreateSecondaryRail(Block currentBlock, Vector3 pos, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		internal void CreateSecondaryRail(Block currentBlock, Vector3 pos, Transformation RailTransformation, ObjectCreationParameters parameters)
 		{
 			double px = 0.0;
 			if (currentBlock.Rails.ContainsKey(PrimaryRail))
@@ -258,22 +258,22 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormL.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormL[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormL[FormType].CreateObject(pos, RailTransformation, parameters);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofL.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofL not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofL[RoofType].CreateObject(pos, RailTransformation, parameters);
 					}
 				}
 			}
@@ -281,22 +281,22 @@ namespace CsvRwRouteParser
 			{
 				if (!Structure.FormR.ContainsKey(FormType))
 				{
-					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+					Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex references a FormR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 				}
 				else
 				{
-					Structure.FormR[FormType].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Structure.FormR[FormType].CreateObject(pos, RailTransformation, parameters);
 				}
 
 				if (RoofType > 0)
 				{
 					if (!Structure.RoofR.ContainsKey(RoofType))
 					{
-						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + StartingDistance.ToString(Culture) + " in file " + FileName + ".");
+						Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex references a RoofR not loaded in Track.Form at track position " + parameters.StartingDistance.ToString(Culture) + " in file " + FileName + ".");
 					}
 					else
 					{
-						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Transformation.NullTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Structure.RoofR[RoofType].CreateObject(pos, RailTransformation, Transformation.NullTransformation, parameters);
 					}
 				}
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Form.cs
@@ -78,7 +78,7 @@ namespace CsvRwRouteParser
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, railTransformation, Transformation.NullTransformation, parameters);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCL[FormType], pos, parameters, railTransformation);
 				}
 
 				if (RoofType > 0)
@@ -98,7 +98,7 @@ namespace CsvRwRouteParser
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, railTransformation, Transformation.NullTransformation, parameters);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCL[RoofType], pos, parameters, railTransformation);
 					}
 				}
 			}
@@ -119,7 +119,7 @@ namespace CsvRwRouteParser
 				}
 				else
 				{
-					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, railTransformation, Transformation.NullTransformation, parameters);
+					Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.FormCR[FormType], pos, parameters, railTransformation);
 				}
 
 				if (RoofType > 0)
@@ -139,7 +139,7 @@ namespace CsvRwRouteParser
 					}
 					else
 					{
-						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, railTransformation, Transformation.NullTransformation,parameters);
+						Plugin.CurrentHost.CreateStaticObject((StaticObject) Structure.RoofCR[RoofType], pos, parameters, railTransformation);
 					}
 				}
 			}
@@ -173,7 +173,7 @@ namespace CsvRwRouteParser
 						else
 						{
 							StaticObject formC = (StaticObject) Structure.FormCL[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation, parameters);
+							Plugin.CurrentHost.CreateStaticObject(formC, pos, parameters, railTransformation);
 						}
 
 						if (RoofType > 0)
@@ -194,7 +194,7 @@ namespace CsvRwRouteParser
 							else
 							{
 								StaticObject roofC = (StaticObject) Structure.RoofCL[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation,parameters);
+								Plugin.CurrentHost.CreateStaticObject(roofC, pos, parameters, railTransformation);
 							}
 						}
 					}
@@ -216,7 +216,7 @@ namespace CsvRwRouteParser
 						else
 						{
 							StaticObject formC = (StaticObject) Structure.FormCR[FormType].Transform(d0, d1);
-							Plugin.CurrentHost.CreateStaticObject(formC, pos, railTransformation, Transformation.NullTransformation,parameters);
+							Plugin.CurrentHost.CreateStaticObject(formC, pos, parameters, railTransformation);
 						}
 
 						if (RoofType > 0)
@@ -237,7 +237,7 @@ namespace CsvRwRouteParser
 							else
 							{
 								StaticObject roofC = (StaticObject) Structure.RoofCR[RoofType].Transform(d0, d1);
-								Plugin.CurrentHost.CreateStaticObject(roofC, pos, railTransformation, Transformation.NullTransformation,parameters);
+								Plugin.CurrentHost.CreateStaticObject(roofC, pos, parameters, railTransformation);
 							}
 						}
 					}

--- a/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
@@ -31,7 +31,7 @@ namespace CsvRwRouteParser
 			double dz = TrackPosition - StartingDistance;
 			WorldPosition += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
 			FreeObjects.TryGetValue(Type, out UnifiedObject obj);
-			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, TrackPosition);
+			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance));
 		}
 
 		internal void CreateGroundAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation GroundTransformation, Vector2 Direction, double Height, double StartingDistance, double EndingDistance)
@@ -39,7 +39,7 @@ namespace CsvRwRouteParser
 			double d = TrackPosition - StartingDistance;
 			Vector3 wpos = WorldPosition + new Vector3(Direction.X * d + Direction.Y * Position.X, Position.Y - Height, Direction.Y * d - Direction.X * Position.X);
 			FreeObjects.TryGetValue(Type, out UnifiedObject obj);
-			obj?.CreateObject(wpos, GroundTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, TrackPosition);
+			obj?.CreateObject(wpos, GroundTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance));
 		}
 	}
 }

--- a/source/Plugins/Route.CsvRw/Structures/Route/PatternObj.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/PatternObj.cs
@@ -51,7 +51,7 @@ namespace CsvRwRouteParser
 			double dz = LastPlacement - StartingDistance;
 			WorldPosition += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
 			FreeObjects.TryGetValue(Types[LastType], out UnifiedObject obj);
-			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(), StartingDistance, EndingDistance, LastPlacement);
+			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(), new ObjectCreationParameters(StartingDistance, EndingDistance));
 
 			if (Types.Length > 1)
 			{

--- a/source/Plugins/Route.CsvRw/Structures/Route/Pole.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Pole.cs
@@ -18,13 +18,13 @@ namespace CsvRwRouteParser
 		/// <summary>The structure type</summary>
 		internal int Type;
 
-		internal void Create(PoleDictionary Poles, Vector3 WorldPosition, Transformation RailTransformation, Vector2 Direction, double planar, double updown, double StartingDistance, double EndingDistance)
+		internal void Create(PoleDictionary Poles, Vector3 WorldPosition, Transformation RailTransformation, Vector2 Direction, double planar, double updown, ObjectCreationParameters parameters)
 		{
 			if (!Exists)
 			{
 				return;
 			}
-			double dz = StartingDistance / Interval;
+			double dz = parameters.StartingDistance / Interval;
 			dz -= Math.Floor(dz + 0.5);
 			if (dz >= -0.01 && dz <= 0.01)
 			{
@@ -32,12 +32,12 @@ namespace CsvRwRouteParser
 				{
 					if (Location <= 0.0)
 					{
-						Poles[0][Type].CreateObject(WorldPosition, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Poles[0][Type].CreateObject(WorldPosition, RailTransformation, parameters);
 					}
 					else
 					{
 						UnifiedObject Pole = Poles[0][Type].Mirror();
-						Pole.CreateObject(WorldPosition, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+						Pole.CreateObject(WorldPosition, RailTransformation, parameters);
 					}
 				}
 				else
@@ -51,7 +51,7 @@ namespace CsvRwRouteParser
 					double sz = -Direction.X;
 					Vector3 wpos = WorldPosition + new Vector3(sx * dx + w.X * dz, w.Y * dz, sz * dx + w.Z * dz);
 					int type = Type;
-					Poles[m][type].CreateObject(wpos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					Poles[m][type].CreateObject(wpos, RailTransformation, parameters);
 				}
 			}
 		}

--- a/source/Plugins/Route.CsvRw/Structures/Route/Station.Stop.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/Station.Stop.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 using RouteManager2.Stations;
 
@@ -34,7 +35,7 @@ namespace CsvRwRouteParser
 				{
 					return;
 				}
-				CompatibilityObjects.StopPost.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, tpos, b);
+				CompatibilityObjects.StopPost.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(tpos, 0, StartingDistance, EndingDistance, b));
 			}
 		}
 

--- a/source/Plugins/Route.CsvRw/Structures/Route/WallDike.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/WallDike.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 
 namespace CsvRwRouteParser
@@ -31,7 +32,7 @@ namespace CsvRwRouteParser
 			return w;
 		}
 
-		internal void Create(Vector3 pos, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		internal void Create(Vector3 pos, Transformation RailTransformation, ObjectCreationParameters parameters)
 		{
 			if (!Exists)
 			{
@@ -41,7 +42,7 @@ namespace CsvRwRouteParser
 			{
 				if (leftObjects.ContainsKey(Type))
 				{
-					leftObjects[Type].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);	
+					leftObjects[Type].CreateObject(pos, RailTransformation, parameters);	
 				}
 				
 			}
@@ -49,7 +50,7 @@ namespace CsvRwRouteParser
 			{
 				if (rightObjects.ContainsKey(Type))
 				{
-					rightObjects[Type].CreateObject(pos, RailTransformation, StartingDistance, EndingDistance, StartingDistance);
+					rightObjects[Type].CreateObject(pos, RailTransformation, parameters);
 				}
 				
 			}

--- a/source/Plugins/Route.CsvRw/Structures/Signals/Signal.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/Signal.cs
@@ -1,4 +1,5 @@
 ﻿using OpenBveApi.Math;
+using OpenBveApi.Objects;
 using OpenBveApi.World;
 using RouteManager2.SignalManager;
 
@@ -30,7 +31,7 @@ namespace CsvRwRouteParser
 				 */
 				Vector3 wpos2 = new Vector3(wpos);
 				wpos2 += Position.X * RailTransformation.X + dz * RailTransformation.Z;
-				CompatibilityObjects.SignalPost.CreateObject(wpos2, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, Brightness);
+				CompatibilityObjects.SignalPost.CreateObject(wpos2, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, Brightness));
 			}
 			if (ShowObject)
 			{

--- a/source/Plugins/Route.CsvRw/Structures/Signals/SignalData.BVE4.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/SignalData.BVE4.cs
@@ -112,7 +112,7 @@ namespace CsvRwRouteParser
 
 				aoc.Objects[0].StateFunction = new FunctionScript(Plugin.CurrentHost, expr, false);
 				aoc.Objects[0].RefreshRate = 1.0 + 0.01 * Plugin.RandomNumberGenerator.NextDouble();
-				aoc.CreateObject(wpos, RailTransformation, LocalTransformation, SectionIndex, StartingDistance, EndingDistance, TrackPosition, 1.0);
+				aoc.CreateObject(wpos, RailTransformation, LocalTransformation, new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance, SectionIndex));
 			}
 		}
 	}

--- a/source/Plugins/Route.CsvRw/Structures/Signals/Transponder.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Signals/Transponder.cs
@@ -83,11 +83,11 @@ namespace CsvRwRouteParser
 				wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
 				if (BeaconStructureIndex == -2)
 				{
-					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), -1, StartingDistance, EndingDistance, TrackPosition, Brightness);
+					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance));
 				}
 				else
 				{
-					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, TrackPosition);
+					obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance));
 				}
 			}
 		}

--- a/source/Plugins/Route.CsvRw/Structures/Trains/DestinationEvent.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/DestinationEvent.cs
@@ -39,7 +39,7 @@ namespace CsvRwRouteParser
 				double dz = TrackPosition - StartingDistance;
 				wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
 				double tpos = TrackPosition;
-				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, tpos);
+				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(tpos, StartingDistance, EndingDistance));
 			}
 		}
 }

--- a/source/Plugins/Route.CsvRw/Structures/Trains/HornBlow.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/HornBlow.cs
@@ -35,8 +35,7 @@ namespace CsvRwRouteParser
 				double dy = Position.Y;
 				double dz = TrackPosition - StartingDistance;
 				wpos += dx * RailTransformation.X + dy * RailTransformation.Y + dz * RailTransformation.Z;
-				double tpos = TrackPosition;
-				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), StartingDistance, EndingDistance, tpos);
+				obj.CreateObject(wpos, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPosition, StartingDistance, EndingDistance));
 			}
 		}
 	}

--- a/source/Plugins/Route.CsvRw/Structures/Trains/Limit.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Trains/Limit.cs
@@ -41,7 +41,7 @@ namespace CsvRwRouteParser
 				{
 					return;
 				}
-				CompatibilityObjects.LimitPostInfinite.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+				CompatibilityObjects.LimitPostInfinite.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 			}
 			else
 			{
@@ -51,7 +51,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostLeft.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+					CompatibilityObjects.LimitPostLeft.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 				}
 				else if (Cource > 0)
 				{
@@ -59,7 +59,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostRight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+					CompatibilityObjects.LimitPostRight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 				}
 				else
 				{
@@ -67,7 +67,7 @@ namespace CsvRwRouteParser
 					{
 						return;
 					}
-					CompatibilityObjects.LimitPostStraight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+					CompatibilityObjects.LimitPostStraight.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 				}
 
 				double lim = Speed / UnitOfSpeed;
@@ -86,7 +86,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), TextureParameters.NoChange, out o.Mesh.Materials[0].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 					}
 					else
 					{
@@ -116,7 +116,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), TextureParameters.NoChange, out o.Mesh.Materials[1].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 					}
 					else
 					{
@@ -151,7 +151,7 @@ namespace CsvRwRouteParser
 							Plugin.CurrentHost.RegisterTexture(OpenBveApi.Path.CombineFile(CompatibilityObjects.LimitGraphicsPath, "limit_" + d0 + ".png"), TextureParameters.NoChange, out o.Mesh.Materials[2].DaytimeTexture);
 						}
 
-						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, -1, StartingDistance, EndingDistance, TrackPosition, b);
+						o.CreateObject(wpos, RailTransformation, Transformation.NullTransformation, new ObjectCreationParameters(TrackPosition, 0, StartingDistance, EndingDistance, b));
 					}
 					else
 					{

--- a/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
+++ b/source/Plugins/Route.Mechanik/MechanikRouteParser.cs
@@ -756,7 +756,7 @@ namespace MechanikRouteParser
 					Transformation t = new Transformation(Math.Atan2(worldDirection.X, worldDirection.Y), 0, 0);
 					for (int j = 0; j < currentRouteData.Blocks[i].Objects.Count; j++)
 					{
-						AvailableObjects[currentRouteData.Blocks[i].Objects[j].objectIndex].Object.CreateObject(worldPosition + eyePosition, t, StartingDistance, StartingDistance + 25, 100);
+						AvailableObjects[currentRouteData.Blocks[i].Objects[j].objectIndex].Object.CreateObject(worldPosition + eyePosition, t, new ObjectCreationParameters(StartingDistance, StartingDistance + 25));
 					}
 					foreach (Semaphore signal in currentRouteData.Blocks[i].Signals)
 					{

--- a/source/RouteManager2/SignalManager/SignalObject.Animated.cs
+++ b/source/RouteManager2/SignalManager/SignalObject.Animated.cs
@@ -22,7 +22,7 @@ namespace RouteManager2.SignalManager
 		/// <summary>Creates the object within the game world</summary>
 		public override void Create(Vector3 wpos, Transformation railTransformation, Transformation localTransformation, int sectionIndex, double startingDistance, double endingDistance, double trackPosition, double brightness)
 		{
-			Object.CreateObject(wpos, railTransformation, localTransformation, sectionIndex, startingDistance, endingDistance, trackPosition, 1.0);
+			Object.CreateObject(wpos, railTransformation, localTransformation, new ObjectCreationParameters(trackPosition, startingDistance, endingDistance, 1.0, sectionIndex));
 		}
 	}
 }

--- a/source/RouteManager2/SignalManager/SignalObject.Compatability.cs
+++ b/source/RouteManager2/SignalManager/SignalObject.Compatability.cs
@@ -59,7 +59,7 @@ namespace RouteManager2.SignalManager
 				}
 				aoc.Objects[0].StateFunction = new FunctionScript(currentHost, expr, false);
 				aoc.Objects[0].RefreshRate = 1.0 + 0.01 * new Random().NextDouble();
-				aoc.CreateObject(wpos, railTransformation, localTransformation, sectionIndex, startingDistance, endingDistance, trackPosition, brightness);
+				aoc.CreateObject(wpos, railTransformation, localTransformation, new ObjectCreationParameters(trackPosition, startingDistance, endingDistance, 1.0, sectionIndex));
 			}
 		}
 

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -482,7 +482,7 @@ namespace RouteViewer
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainManager.Train)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, ObjectCreationParameters Parameters, Transformation WorldTransformation, Transformation LocalTransformation = null)
 		{
 			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}

--- a/source/RouteViewer/System/Host.cs
+++ b/source/RouteViewer/System/Host.cs
@@ -482,14 +482,14 @@ namespace RouteViewer
 			FunctionScripts.ExecuteFunctionScript(functionScript, (TrainManager.Train)train, CarIndex, Position, TrackPosition, SectionIndex, IsPartOfTrain, TimeElapsed, CurrentState);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition, bool DisableShadowCasting)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation WorldTransformation, Transformation LocalTransformation, ObjectCreationParameters Parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition, DisableShadowCasting);
+			return Program.Renderer.CreateStaticObject(Prototype, Position, WorldTransformation, LocalTransformation, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}
 
-		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, double AccurateObjectDisposalZOffset, double StartingDistance, double EndingDistance, double TrackPosition)
+		public override int CreateStaticObject(StaticObject Prototype, Vector3 Position, Transformation LocalTransformation, Matrix4D Rotate, Matrix4D Translate, ObjectCreationParameters Parameters)
 		{
-			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, AccurateObjectDisposalZOffset, StartingDistance, EndingDistance, Program.CurrentRoute.BlockLength, TrackPosition);
+			return Program.Renderer.CreateStaticObject(Position, Prototype, LocalTransformation, Rotate, Translate, Program.CurrentRoute.AccurateObjectDisposal, Parameters, Program.CurrentRoute.BlockLength);
 		}
 
 		public override void CreateDynamicObject(ref ObjectState internalObject)


### PR DESCRIPTION
The current code implimentation passes a large number of parameters through multiple methods when creating an object within the worldspace.

These are often unncessary (set to default values).

This PR changes it to use a single unified hellper struct, with associated construtor overloads.

Low risk.