### PR TITLE
Hacks: Add workaround for some Panel.cfg issues

### DIFF
--- a/source/OpenBveApi/Textures/Textures.Functions.cs
+++ b/source/OpenBveApi/Textures/Textures.Functions.cs
@@ -55,15 +55,12 @@ namespace OpenBveApi.Textures {
 		    byte[] bytes;
 		    if (texture.Bytes == null)
 		    {
-			    texture.Origin.GetTexture(out Texture t);
-			    bytes = t.Bytes;
-		    }
-		    else
-		    {
-				bytes = texture.Bytes;
+			    texture.Origin.GetTexture(out texture);
 		    }
 		    
-		    int clipLeft = region.Left;
+		    bytes = texture.Bytes;
+
+			int clipLeft = region.Left;
 		    int clipTop = region.Top;
 		    int clipWidth = region.Width;
 		    int clipHeight = region.Height;

--- a/source/OpenBveApi/Textures/Textures.Functions.cs
+++ b/source/OpenBveApi/Textures/Textures.Functions.cs
@@ -52,7 +52,17 @@ namespace OpenBveApi.Textures {
 		        throw new ArgumentException();
 		    }
 		    int width = texture.Width;
-		    byte[] bytes = texture.Bytes;
+		    byte[] bytes;
+		    if (texture.Bytes == null)
+		    {
+			    texture.Origin.GetTexture(out Texture t);
+			    bytes = t.Bytes;
+		    }
+		    else
+		    {
+				bytes = texture.Bytes;
+		    }
+		    
 		    int clipLeft = region.Left;
 		    int clipTop = region.Top;
 		    int clipWidth = region.Width;
@@ -209,33 +219,57 @@ namespace OpenBveApi.Textures {
 				case PixelFormat.Grayscale:
 					for (int i = 0; i < source.Length; i++, targetIndex += 4)
 					{
-						Color24 c = transparencyTexture.GetPixel(i);
+						
 						target[targetIndex] = source[i];
 						target[targetIndex + 1] = source[i];
 						target[targetIndex + 2] = source[i];
-						target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						if (transparencyTexture.PixelFormat == PixelFormat.Grayscale || transparencyTexture.PixelFormat == PixelFormat.RGB)
+						{
+							Color24 c = transparencyTexture.GetPixel(i);
+							target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						}
+						else
+						{
+							target[i + 3] = System.Math.Min(source[i + 1], transparencyTexture.GetAlpha(i));
+						}
+						
 					}
 					break;
 				case PixelFormat.GrayscaleAlpha:
 					for (int i = 0; i < source.Length; i += 2, targetIndex += 4)
 					{
 						int pix = i / 2;
-						Color24 c = transparencyTexture.GetPixel(pix);
 						target[targetIndex] = source[i];
 						target[targetIndex + 1] = source[i];
 						target[targetIndex + 2] = source[i];
-						target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						if (transparencyTexture.PixelFormat == PixelFormat.Grayscale || transparencyTexture.PixelFormat == PixelFormat.RGB)
+						{
+							Color24 c = transparencyTexture.GetPixel(pix);
+							target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						}
+						else
+						{
+							target[i + 3] = System.Math.Min(source[i + 1], transparencyTexture.GetAlpha(pix));
+						}
 					}
 					break;
 				case PixelFormat.RGB:
 					for (int i = 0; i < source.Length; i += 3, targetIndex += 4)
 					{
 						int pix = i / 3;
-						Color24 c = transparencyTexture.GetPixel(pix);
 						target[targetIndex] = source[i];
 						target[targetIndex + 1] = source[i + 1];
 						target[targetIndex + 2] = source[i + 2];
-						target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						if (transparencyTexture.PixelFormat == PixelFormat.Grayscale ||
+						    transparencyTexture.PixelFormat == PixelFormat.RGB)
+						{
+							Color24 c = transparencyTexture.GetPixel(pix);
+							target[targetIndex + 3] = (byte)(255 * c.GetBrightness());
+						}
+						else
+						{
+							target[i + 3] = System.Math.Min(source[i + 3], transparencyTexture.GetAlpha(pix));
+						}
 					}
 					break;
 				case PixelFormat.RGBAlpha:
@@ -248,11 +282,19 @@ namespace OpenBveApi.Textures {
 					for (int i = 4; i < source.Length; i += 4)
 					{
 						int pix = i / 4;
-						Color24 c = transparencyTexture.GetPixel(pix);
 						target[i + 0] = source[i + 0];
 						target[i + 1] = source[i + 1];
 						target[i + 2] = source[i + 2];
-						target[i + 3] = (byte)(255 * c.GetBrightness());
+						if (transparencyTexture.PixelFormat == PixelFormat.Grayscale || transparencyTexture.PixelFormat == PixelFormat.RGB)
+						{
+							Color24 c = transparencyTexture.GetPixel(pix);
+							target[i + 3] = (byte)(255 * c.GetBrightness());
+						}
+						else
+						{
+							target[i + 3] = System.Math.Min(source[i + 3], transparencyTexture.GetAlpha(pix));
+						}
+							
 					}
 					break;
 			}

--- a/source/OpenBveApi/Textures/Textures.TextureParameters.cs
+++ b/source/OpenBveApi/Textures/Textures.TextureParameters.cs
@@ -13,7 +13,7 @@ namespace OpenBveApi.Textures
 		/// <summary>The color in the texture that should become transparent, or a null reference for no transparent color.</summary>
 		public readonly Color24? TransparentColor;
 		/// <summary>The alpha channel texture</summary>
-		public readonly Texture TransparencyTexture;
+		public Texture TransparencyTexture;
 
 		/// <summary>Texture parameters, which apply no changes.</summary>
 		public static TextureParameters NoChange = new TextureParameters(null, null);

--- a/source/OpenBveApi/Textures/Textures.TransparencyType.cs
+++ b/source/OpenBveApi/Textures/Textures.TransparencyType.cs
@@ -8,6 +8,8 @@
 		/// <summary>All pixels in the texture are either fully opaque or fully transparent.</summary>
 		Partial = 2,
 		/// <summary>Some pixels in the texture are neither fully opaque nor fully transparent.</summary>
-		Alpha = 3
+		Alpha = 3,
+		/// <summary>All pixels in the texture are fully transparent</summary>
+		Transparent
 	}
 }

--- a/source/OpenBveApi/Textures/Textures.cs
+++ b/source/OpenBveApi/Textures/Textures.cs
@@ -169,6 +169,8 @@ namespace OpenBveApi.Textures {
 		public Texture(string path, TextureParameters parameters, Hosts.HostInterface currentHost)
 		{
 			Origin = new PathOrigin(path, parameters, currentHost);
+			Origin.GetTexture(out Texture t);
+			PixelFormat = t.PixelFormat;
 			MyOpenGlTextures = new OpenGlTexture[1][];
 			MyOpenGlTextures[0] = new[] {new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture()};
 			

--- a/source/OpenBveApi/Textures/Textures.cs
+++ b/source/OpenBveApi/Textures/Textures.cs
@@ -59,20 +59,39 @@ namespace OpenBveApi.Textures {
 			{
 				case PixelFormat.Grayscale:
 					firstByte = pix;
-					break;
+					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte], MyBytes[frame][firstByte]);
 				case PixelFormat.GrayscaleAlpha:
 					firstByte = 2 * pix;
-					break;
+					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte], MyBytes[frame][firstByte]);
 				case PixelFormat.RGB:
 					firstByte = 3 * pix;
-					break;
+					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte + 1], MyBytes[frame][firstByte + 2]);
 				case PixelFormat.RGBAlpha:
 					firstByte = 4 * pix;
-					break;
+					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte + 1], MyBytes[frame][firstByte + 2]);
 				default:
 					throw new Exception("Unable to get a pixel value with invalid data.");
 			}
-			return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte + 1], MyBytes[frame][firstByte + 2]);
+		}
+
+		/// <summary>Gets the alpha value of the given pixel</summary>
+		/// <param name="pix">The pixel index</param>
+		/// <param name="frame">The frame</param>
+		/// <returns></returns>
+		public byte GetAlpha(int pix, int frame = 0)
+		{
+			switch (PixelFormat)
+			{
+				case PixelFormat.Grayscale:
+				case PixelFormat.RGB:
+					return 255;
+				case PixelFormat.GrayscaleAlpha:
+					return MyBytes[frame][2 * pix + 1];
+				case PixelFormat.RGBAlpha:
+					return MyBytes[frame][4 * pix + 3];
+				default:
+					return 255;
+			}
 		}
 
 		/// <summary>Creates a new instance of this class.</summary>
@@ -213,6 +232,11 @@ namespace OpenBveApi.Textures {
 		{
 			get
 			{
+				if (MyBytes == null && Origin != null)
+				{
+					Origin.GetTexture(out Texture t);
+					return t.Bytes;
+				}
 				if (MultipleFrames == false)
 				{
 					return MyBytes[0];
@@ -333,24 +357,40 @@ namespace OpenBveApi.Textures {
 					transparencyType = TextureTransparencyType.Opaque;
 					break;
 				case PixelFormat.RGBAlpha:
+					transparencyType = TextureTransparencyType.Opaque;
 					for (int i = 3; i < this.MyBytes[CurrentFrame].Length; i += 4)
 					{
-						if (this.MyBytes[CurrentFrame][i] != 255)
-						{
-							for (int j = i; j < this.MyBytes[CurrentFrame].Length; j += 4)
-							{
-								if (this.MyBytes[CurrentFrame][j] != 0 & this.MyBytes[CurrentFrame][j] != 255)
-								{
-									transparencyType = TextureTransparencyType.Alpha;
-									return TextureTransparencyType.Alpha;
-								}
-							}
 
-							transparencyType = TextureTransparencyType.Partial;
-							return TextureTransparencyType.Partial;
+						switch (MyBytes[CurrentFrame][i])
+						{
+							case 0:
+								if (i == 3)
+								{
+									transparencyType = TextureTransparencyType.Transparent;
+								}
+								else
+								{
+									if (transparencyType == TextureTransparencyType.Opaque)
+									{
+										transparencyType = TextureTransparencyType.Partial;
+									}
+								}
+								break;
+							case 255:
+								if (transparencyType != TextureTransparencyType.Opaque)
+								{
+									transparencyType = TextureTransparencyType.Partial;
+								}
+								// nothing
+								break;
+							default:
+								transparencyType = TextureTransparencyType.Alpha;
+								return transparencyType;
 						}
 					}
-					break;
+
+					return transparencyType;
+				
 			}
 			return TextureTransparencyType.Opaque;
 		}

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -40,6 +40,9 @@ namespace Train.OpenBve
 		private double WorldLeft, WorldTop;
 		private double SemiHeight = 240;
 
+		private string PanelBackground;
+		private bool isBackground = true;
+
 		/// <summary>Parses a BVE1 panel.cfg file</summary>
 		/// <param name="TrainPath">The on-disk path to the train</param>
 		/// <param name="Encoding">The train's text encoding</param>
@@ -69,7 +72,7 @@ namespace Train.OpenBve
 			double WorldZ = Car.Driver.Z;
 			const double UpDownAngleConstant = -0.191986217719376;
 			// default background
-			string PanelBackground = Path.CombineFile(TrainPath, "panel.bmp");
+			PanelBackground = Path.CombineFile(TrainPath, "panel.bmp");
 
 			ConfigFile<PanelSections, PanelKey> cfg = new ConfigFile<PanelSections, PanelKey>(fileName, Plugin.CurrentHost);
 
@@ -81,10 +84,12 @@ namespace Train.OpenBve
 
 			if (File.Exists(PanelBackground))
 			{
-				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(null, Color24.Blue), out var panelTexture, true);
+				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(null, Color24.Blue), out Texture panelTexture, true);
 				SemiHeight = PanelSize.Y - panelTexture.Height;
 				CreateElement(Car, 0, SemiHeight, panelTexture.Width, panelTexture.Height, WorldZ + EyeDistance, panelTexture, Color32.White);
 			}
+
+			isBackground = false;
 
 			string compatibilityFolder = Plugin.FileSystem.GetDataFolder("Compatibility");
 			while (cfg.RemainingSubBlocks > 0)
@@ -759,6 +764,43 @@ namespace Train.OpenBve
 		// create element
 		private int CreateElement(CarBase Car, double Left, double Top, double Width, double Height, double WorldZ, Texture Texture, Color32 Color, bool AddStateToLastElement = false)
 		{
+			if (Plugin.CurrentOptions.EnableBveTsHacks && isBackground == false)
+			{
+				/*
+				 * In regions where the main panel texture is transparent,
+				 * BVE2 renders any other overlapping elements as transparent also
+				 *
+				 * e.g. Portuguese trains:
+				 * CP1400
+				 * CP2100
+				 * CP3500
+				 * CP4000
+				 *
+				 * All of these have junk extra elements in the main panel view
+				 * (Appears to have come from copy+pasting between trains)
+				 *
+				 * So, what we need to do is to extract the region of the main overlapping texture
+				 * Now, if this is *not* opaque, apply to the alpha channel
+				 */
+				Plugin.CurrentHost.QueryTextureDimensions(PanelBackground, out int tW, out int tH);
+				double clipWidth = Math.Min(Width, tW - Left);
+				double clipHeight = Math.Min(Height, tH - Top);
+				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(new TextureClipRegion((int)Left, (int)Top, (int)clipWidth, (int)clipHeight), Color24.Blue), out Texture temp, true);
+				temp.Origin.GetTexture(out Texture t);
+				switch (t.GetTransparencyType())
+				{
+					case TextureTransparencyType.Transparent:
+						Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 }, new Color24[] { });
+						break;
+					case TextureTransparencyType.Partial:
+						Texture.Origin.GetTexture(out Texture tt);
+						Texture = tt.ApplyParameters(new TextureParameters(null, null, t));
+						break;
+				}
+
+			}
+
+
 			// create object
 			StaticObject Object = new StaticObject(Plugin.CurrentHost);
 			Vector3[] v = new Vector3[4];

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -780,12 +780,13 @@ namespace Train.OpenBve
 				 * (Appears to have come from copy+pasting between trains)
 				 *
 				 * So, what we need to do is to extract the region of the main overlapping texture
-				 * Now, if this is *not* opaque, apply to the alpha channel
+				 * Now, if this is *not* opaque, apply as a mask to the alpha channel
+				 *
 				 */
 				Plugin.CurrentHost.QueryTextureDimensions(PanelBackground, out int tW, out int tH);
 				double clipWidth = Math.Min(Width, tW - Left);
-				double clipHeight = Math.Min(Height, tH - Top);
-				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(new TextureClipRegion((int)Left, (int)Top, (int)clipWidth, (int)clipHeight), Color24.Blue), out Texture temp, true);
+				double clipHeight = Math.Min(Height, tH + SemiHeight - Top);
+				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(new TextureClipRegion((int)Left, (int)(Top - SemiHeight), (int)clipWidth, (int)clipHeight), Color24.Blue), out Texture temp, true);
 				temp.Origin.GetTexture(out Texture t);
 				switch (t.GetTransparencyType())
 				{

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -86,7 +86,7 @@ namespace Train.OpenBve
 			{
 				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(null, Color24.Blue), out Texture panelTexture, true);
 				SemiHeight = PanelSize.Y - panelTexture.Height;
-				CreateElement(Car, 0, SemiHeight, panelTexture.Width, panelTexture.Height, WorldZ + EyeDistance, panelTexture, Color32.White);
+				CreateElement(Car, 0, SemiHeight, panelTexture.Width, panelTexture.Height, WorldZ + EyeDistance, false, panelTexture, Color32.White);
 			}
 
 			isBackground = false;
@@ -176,14 +176,14 @@ namespace Train.OpenBve
 						if (!string.IsNullOrEmpty(Background) && File.Exists(Background))
 						{
 							Plugin.CurrentHost.RegisterTexture(Background, new TextureParameters(null, Color24.Blue), out var pressureBackgroundTexture, true);
-							CreateElement(Car, Center.X - 0.5 * pressureBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * pressureBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, pressureBackgroundTexture);
+							CreateElement(Car, Center.X - 0.5 * pressureBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * pressureBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, false, pressureBackgroundTexture);
 						}
 
 						// cover
 						if (!string.IsNullOrEmpty(Cover) && File.Exists(Cover))
 						{
 							Plugin.CurrentHost.RegisterTexture(Cover, new TextureParameters(null, Color24.Blue), out var pressureCoverTexture, true);
-							CreateElement(Car, Center.X - 0.5 * pressureCoverTexture.Width, Center.Y + SemiHeight - 0.5 * pressureCoverTexture.Height, WorldZ + EyeDistance - 6.0 * StackDistance, pressureCoverTexture);
+							CreateElement(Car, Center.X - 0.5 * pressureCoverTexture.Width, Center.Y + SemiHeight - 0.5 * pressureCoverTexture.Height, WorldZ + EyeDistance - 6.0 * StackDistance, false, pressureCoverTexture);
 						}
 
 						if (Type == 0)
@@ -195,7 +195,7 @@ namespace Train.OpenBve
 								{
 									TextureFile = Path.CombineFile(compatibilityFolder, k == 0 ? "needle_pressuregauge_lower.png" : "needle_pressuregauge_upper.png");
 									Plugin.CurrentHost.RegisterTexture(TextureFile, TextureParameters.NoChange, out var pressureNeedleTexture, true);
-									int j = CreateElement(Car, Center.X - Radius * pressureNeedleTexture.AspectRatio, Center.Y + SemiHeight - Radius, 2.0 * Radius * pressureNeedleTexture.AspectRatio, 2.0 * Radius, WorldZ + EyeDistance - (4 + k) * StackDistance, pressureNeedleTexture, NeedleColor[k]);
+									int j = CreateElement(Car, Center.X - Radius * pressureNeedleTexture.AspectRatio, Center.Y + SemiHeight - Radius, 2.0 * Radius * pressureNeedleTexture.AspectRatio, 2.0 * Radius, WorldZ + EyeDistance - (4 + k) * StackDistance, true, pressureNeedleTexture, NeedleColor[k]);
 									Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateZDirection = Vector3.Backward;
 									Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateXDirection = Vector3.Right;
 									Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateYDirection = Vector3.Cross(Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateZDirection, Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateXDirection);
@@ -230,7 +230,7 @@ namespace Train.OpenBve
 							// leds
 							if (NeedleType[1] != 0)
 							{
-								int j = CreateElement(Car, Center.X - Radius, Center.Y + SemiHeight - Radius, 2.0 * Radius, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, null, NeedleColor[1]);
+								int j = CreateElement(Car, Center.X - Radius, Center.Y + SemiHeight - Radius, 2.0 * Radius, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, true, null, NeedleColor[1]);
 								double x0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.X;
 								double y0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.Y;
 								double z0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.Z;
@@ -343,14 +343,14 @@ namespace Train.OpenBve
 						{
 							// background/led
 							Plugin.CurrentHost.RegisterTexture(Background, new TextureParameters(null, Color24.Blue), out var speedometerBackgroundTexture, true);
-							CreateElement(Car, Center.X - 0.5 * speedometerBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * speedometerBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, speedometerBackgroundTexture);
+							CreateElement(Car, Center.X - 0.5 * speedometerBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * speedometerBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, false, speedometerBackgroundTexture);
 						}
 
 						if (!string.IsNullOrEmpty(Cover))
 						{
 							// cover
 							Plugin.CurrentHost.RegisterTexture(Cover, new TextureParameters(null, Color24.Blue), out var speedometerCoverTexture, true);
-							CreateElement(Car, Center.X - 0.5 * speedometerCoverTexture.Width, Center.Y + SemiHeight - 0.5 * speedometerCoverTexture.Height, WorldZ + EyeDistance - 6.0 * StackDistance, speedometerCoverTexture);
+							CreateElement(Car, Center.X - 0.5 * speedometerCoverTexture.Width, Center.Y + SemiHeight - 0.5 * speedometerCoverTexture.Height, WorldZ + EyeDistance - 6.0 * StackDistance, false, speedometerCoverTexture);
 						}
 
 						if (!string.IsNullOrEmpty(ATCPath))
@@ -420,11 +420,11 @@ namespace Train.OpenBve
 									Plugin.CurrentHost.RegisterTexture(ATCPath, new TextureParameters(new TextureClipRegion(j * atcHeight, 0, atcHeight, atcHeight), Color24.Blue), out var ATCTexture, true);
 									if (j == 0)
 									{
-										k = CreateElement(Car, x, y, atcHeight, atcHeight, WorldZ + EyeDistance - 4.0 * StackDistance, ATCTexture, Color32.White);
+										k = CreateElement(Car, x, y, atcHeight, atcHeight, WorldZ + EyeDistance - 4.0 * StackDistance, false, ATCTexture, Color32.White);
 									}
 									else
 									{
-										CreateElement(Car, x, y, atcHeight, atcHeight, WorldZ + EyeDistance - 4.0 * StackDistance, ATCTexture, Color32.White, true);
+										CreateElement(Car, x, y, atcHeight, atcHeight, WorldZ + EyeDistance - 4.0 * StackDistance, false, ATCTexture, Color32.White, true);
 									}
 								}
 
@@ -437,7 +437,7 @@ namespace Train.OpenBve
 							// needle
 							TextureFile = Path.CombineFile(compatibilityFolder, "needle_speedometer.png");
 							Plugin.CurrentHost.RegisterTexture(TextureFile, TextureParameters.NoChange, out var speedometerNeedleTexture, true);
-							int j = CreateElement(Car, Center.X - Radius * speedometerNeedleTexture.AspectRatio, Center.Y + SemiHeight - Radius, 2.0 * Radius * speedometerNeedleTexture.AspectRatio, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, speedometerNeedleTexture, needleColor);
+							int j = CreateElement(Car, Center.X - Radius * speedometerNeedleTexture.AspectRatio, Center.Y + SemiHeight - Radius, 2.0 * Radius * speedometerNeedleTexture.AspectRatio, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, true, speedometerNeedleTexture, needleColor);
 							Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateZDirection = Vector3.Backward;
 							Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateXDirection = Vector3.Right;
 							Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateYDirection = Vector3.Cross(Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateZDirection, Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].RotateXDirection);
@@ -449,7 +449,7 @@ namespace Train.OpenBve
 						{
 							// led
 							if (!needleColorOverridden) needleColor = Color32.Black;
-							int j = CreateElement(Car, Center.X - Radius, Center.Y + SemiHeight - Radius, 2.0 * Radius, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, null, needleColor);
+							int j = CreateElement(Car, Center.X - Radius, Center.Y + SemiHeight - Radius, 2.0 * Radius, 2.0 * Radius, WorldZ + EyeDistance - 5.0 * StackDistance, true, null, needleColor);
 							double x0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.X;
 							double y0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.Y;
 							double z0 = Car.CarSections[CarSectionType.Interior].Groups[0].Elements[j].States[0].Prototype.Mesh.Vertices[0].Coordinates.Z;
@@ -589,11 +589,11 @@ namespace Train.OpenBve
 							{
 								if (j == 0)
 								{
-									k = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White);
+									k = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White);
 								}
 								else
 								{
-									CreateElement(Car, Corner.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White, true);
+									CreateElement(Car, Corner.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White, true);
 								}
 							}
 							Car.CarSections[CarSectionType.Interior].Groups[0].Elements[k].StateFunction = new FunctionScript(Plugin.CurrentHost, "speedometer abs " + UnitFactor.ToString(Culture) + " * ~ 100 >= <> 100 quotient 10 mod 10 ?", false);
@@ -604,11 +604,11 @@ namespace Train.OpenBve
 							{
 								if (j == 0)
 								{
-									k = CreateElement(Car, Corner.X + Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White);
+									k = CreateElement(Car, Corner.X + Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White);
 								}
 								else
 								{
-									CreateElement(Car, Corner.X + Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White, true);
+									CreateElement(Car, Corner.X + Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White, true);
 								}
 							}
 							Car.CarSections[CarSectionType.Interior].Groups[0].Elements[k].StateFunction = new FunctionScript(Plugin.CurrentHost, "speedometer abs " + UnitFactor.ToString(Culture) + " * ~ 10 >= <> 10 quotient 10 mod 10 ?", false);
@@ -619,11 +619,11 @@ namespace Train.OpenBve
 							{
 								if (j == 0)
 								{
-									k = CreateElement(Car, Corner.X + 2.0 * Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White);
+									k = CreateElement(Car, Corner.X + 2.0 * Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White);
 								}
 								else
 								{
-									CreateElement(Car, Corner.X + 2.0 * Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, digitalNumberTextures[j], Color32.White, true);
+									CreateElement(Car, Corner.X + 2.0 * Size.X, Corner.Y + SemiHeight, Size.X, Size.Y, WorldZ + EyeDistance - 7.0 * StackDistance, false, digitalNumberTextures[j], Color32.White, true);
 								}
 							}
 
@@ -644,8 +644,8 @@ namespace Train.OpenBve
 
 						Plugin.CurrentHost.RegisterTexture(turnOnPath, new TextureParameters(null, Color24.Blue), out var t0, true);
 						Plugin.CurrentHost.RegisterTexture(turnOffPath, new TextureParameters(null, Color24.Blue), out var t1, true);
-						int elementIndex = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, WorldZ + EyeDistance - 2.0 * StackDistance, t0);
-						CreateElement(Car, Corner.X, Corner.Y + SemiHeight, WorldZ + EyeDistance - 2.0 * StackDistance, t1, true);
+						int elementIndex = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, WorldZ + EyeDistance - 2.0 * StackDistance, false, t0);
+						CreateElement(Car, Corner.X, Corner.Y + SemiHeight, WorldZ + EyeDistance - 2.0 * StackDistance, false, t1, true);
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[elementIndex].StateFunction = new FunctionScript(Plugin.CurrentHost, "doors 0 !=", false);
 						break;
 					case PanelSections.Watch:
@@ -663,13 +663,13 @@ namespace Train.OpenBve
 						if (!string.IsNullOrEmpty(Background))
 						{
 							Plugin.CurrentHost.RegisterTexture(Background, new TextureParameters(null, Color24.Blue), out var watchBackgroundTexture, true);
-							CreateElement(Car, Center.X - 0.5 * watchBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * watchBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, watchBackgroundTexture);
+							CreateElement(Car, Center.X - 0.5 * watchBackgroundTexture.Width, Center.Y + SemiHeight - 0.5 * watchBackgroundTexture.Height, WorldZ + EyeDistance - 3.0 * StackDistance, false, watchBackgroundTexture);
 						}
 
 						// hour
 						TextureFile = Path.CombineFile(compatibilityFolder, "needle_hour.png");
 						Plugin.CurrentHost.RegisterTexture(TextureFile, TextureParameters.NoChange, out var hourTexture, true);
-						int handElement = CreateElement(Car, Center.X - handRadius * hourTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * hourTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 4.0 * StackDistance, hourTexture, handColor);
+						int handElement = CreateElement(Car, Center.X - handRadius * hourTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * hourTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 4.0 * StackDistance, true, hourTexture, handColor);
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection = Vector3.Backward;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection = Vector3.Right;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateYDirection = Vector3.Cross(Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection, Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection);
@@ -678,7 +678,7 @@ namespace Train.OpenBve
 						// minute
 						TextureFile = Path.CombineFile(compatibilityFolder, "needle_minute.png");
 						Plugin.CurrentHost.RegisterTexture(TextureFile, TextureParameters.NoChange, out var minuteTexture, true);
-						handElement = CreateElement(Car, Center.X - handRadius * minuteTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * minuteTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 5.0 * StackDistance, minuteTexture, handColor);
+						handElement = CreateElement(Car, Center.X - handRadius * minuteTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * minuteTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 5.0 * StackDistance, true, minuteTexture, handColor);
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection = Vector3.Backward;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection = Vector3.Right;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateYDirection = Vector3.Cross(Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection, Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection);
@@ -687,7 +687,7 @@ namespace Train.OpenBve
 						// second
 						TextureFile = Path.CombineFile(compatibilityFolder, "needle_second.png");
 						Plugin.CurrentHost.RegisterTexture(TextureFile, TextureParameters.NoChange, out var secondTexture, true);
-						handElement = CreateElement(Car, Center.X - handRadius * secondTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * secondTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 6.0 * StackDistance, secondTexture, handColor);
+						handElement = CreateElement(Car, Center.X - handRadius * secondTexture.AspectRatio, Center.Y + SemiHeight - handRadius, 2.0 * handRadius * secondTexture.AspectRatio, 2.0 * handRadius, WorldZ + EyeDistance - 6.0 * StackDistance, true, secondTexture, handColor);
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection = Vector3.Backward;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection = Vector3.Right;
 						Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateYDirection = Vector3.Cross(Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateZDirection, Car.CarSections[CarSectionType.Interior].Groups[0].Elements[handElement].RotateXDirection);
@@ -719,11 +719,11 @@ namespace Train.OpenBve
 								Plugin.CurrentHost.RegisterTexture(brakeIndicatorPath, new TextureParameters(clip, Color24.Blue), out var brakeIndicatorTexture);
 								if (j == 0)
 								{
-									k = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, indicatorWidth, h, WorldZ + EyeDistance - StackDistance, brakeIndicatorTexture, Color32.White);
+									k = CreateElement(Car, Corner.X, Corner.Y + SemiHeight, indicatorWidth, h, WorldZ + EyeDistance - StackDistance, false, brakeIndicatorTexture, Color32.White);
 								}
 								else
 								{
-									CreateElement(Car, Corner.X, Corner.Y + SemiHeight,  indicatorWidth, h, WorldZ + EyeDistance - StackDistance, brakeIndicatorTexture, Color32.White, true);
+									CreateElement(Car, Corner.X, Corner.Y + SemiHeight,  indicatorWidth, h, WorldZ + EyeDistance - StackDistance, false, brakeIndicatorTexture, Color32.White, true);
 								}
 							}
 
@@ -756,13 +756,13 @@ namespace Train.OpenBve
 			}
 		}
 
-		private int CreateElement(CarBase Car, double Left, double Top, double WorldZ, Texture Texture, bool AddStateToLastElement = false)
+		private int CreateElement(CarBase Car, double Left, double Top, double WorldZ, bool IsNeedle, Texture Texture, bool AddStateToLastElement = false)
 		{
-			return CreateElement(Car, Left, Top, Texture.Width, Texture.Height, WorldZ, Texture, Color32.White, AddStateToLastElement);
+			return CreateElement(Car, Left, Top, Texture.Width, Texture.Height, WorldZ, IsNeedle, Texture, Color32.White, AddStateToLastElement);
 		}
 
 		// create element
-		private int CreateElement(CarBase Car, double Left, double Top, double Width, double Height, double WorldZ, Texture Texture, Color32 Color, bool AddStateToLastElement = false)
+		private int CreateElement(CarBase Car, double Left, double Top, double Width, double Height, double WorldZ, bool IsNeedle, Texture Texture, Color32 Color, bool AddStateToLastElement = false)
 		{
 			if (Plugin.CurrentOptions.EnableBveTsHacks && isBackground == false)
 			{
@@ -790,11 +790,21 @@ namespace Train.OpenBve
 				switch (t.GetTransparencyType())
 				{
 					case TextureTransparencyType.Transparent:
+						// totally hidden
 						Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 }, new Color24[] { });
 						break;
 					case TextureTransparencyType.Partial:
-						Texture.Origin.GetTexture(out Texture tt);
-						Texture = tt.ApplyParameters(new TextureParameters(null, null, t));
+						if (IsNeedle)
+						{
+							// as needles rotate, we can't just apply a mask and have to hide the whole thing
+							Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 }, new Color24[] { });
+						}
+						else
+						{
+							Texture.Origin.GetTexture(out Texture tt);
+							Texture = tt.ApplyParameters(new TextureParameters(null, null, t));
+						}
+						
 						break;
 				}
 

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -40,7 +40,7 @@ namespace Train.OpenBve
 		private double WorldLeft, WorldTop;
 		private double SemiHeight = 240;
 
-		private string PanelBackground;
+		private Texture panelTexture;
 		private bool isBackground = true;
 
 		/// <summary>Parses a BVE1 panel.cfg file</summary>
@@ -72,7 +72,7 @@ namespace Train.OpenBve
 			double WorldZ = Car.Driver.Z;
 			const double UpDownAngleConstant = -0.191986217719376;
 			// default background
-			PanelBackground = Path.CombineFile(TrainPath, "panel.bmp");
+			string PanelBackground = Path.CombineFile(TrainPath, "panel.bmp");
 
 			ConfigFile<PanelSections, PanelKey> cfg = new ConfigFile<PanelSections, PanelKey>(fileName, Plugin.CurrentHost);
 
@@ -84,7 +84,7 @@ namespace Train.OpenBve
 
 			if (File.Exists(PanelBackground))
 			{
-				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(null, Color24.Blue), out Texture panelTexture, true);
+				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(null, Color24.Blue), out panelTexture, true);
 				SemiHeight = PanelSize.Y - panelTexture.Height;
 				CreateElement(Car, 0, SemiHeight, panelTexture.Width, panelTexture.Height, WorldZ + EyeDistance, false, panelTexture, Color32.White);
 			}
@@ -783,10 +783,10 @@ namespace Train.OpenBve
 				 * Now, if this is *not* opaque, apply as a mask to the alpha channel
 				 *
 				 */
-				Plugin.CurrentHost.QueryTextureDimensions(PanelBackground, out int tW, out int tH);
-				double clipWidth = Math.Min(Width, tW - Left);
-				double clipHeight = Math.Min(Height, tH + SemiHeight - Top);
-				Plugin.CurrentHost.RegisterTexture(PanelBackground, new TextureParameters(new TextureClipRegion((int)Left, (int)(Top - SemiHeight), (int)clipWidth, (int)clipHeight), Color24.Blue), out Texture temp, true);
+				double clipWidth = Math.Min(Width, panelTexture.Width - Left);
+				double clipHeight = Math.Min(Height, panelTexture.Height + SemiHeight - Top);
+				Texture temp = panelTexture.ApplyParameters(new TextureParameters(new TextureClipRegion((int)Left, (int)(Top - SemiHeight), (int)clipWidth, (int)clipHeight), Color24.Blue));
+				
 				temp.Origin.GetTexture(out Texture t);
 				switch (t.GetTransparencyType())
 				{

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -785,7 +785,8 @@ namespace Train.OpenBve
 				 */
 				double clipWidth = Math.Min(Width, panelTexture.Width - Left);
 				double clipHeight = Math.Min(Height, panelTexture.Height + SemiHeight - Top);
-				Texture temp = panelTexture.ApplyParameters(new TextureParameters(new TextureClipRegion((int)Left, (int)(Top - SemiHeight), (int)clipWidth, (int)clipHeight), Color24.Blue));
+				Texture temp = panelTexture.ApplyParameters(new TextureParameters(new TextureClipRegion(Math.Max(0, (int)Left)
+					, Math.Max(0, (int)(Top - SemiHeight)), (int)clipWidth, (int)clipHeight), Color24.Blue));
 				
 				temp.Origin.GetTexture(out Texture t);
 				switch (t.GetTransparencyType())


### PR DESCRIPTION
This PR adds a workaround for an 'interesting' issue I've just discovered in trains using a **panel.cfg**

This is our main panel image from a broken train:
<img width="481" height="441" alt="Panel" src="https://github.com/user-attachments/assets/3c5112da-a488-4f40-8562-faea80c5523e" />

The **panel.cfg** declares two gauges, a speedometer and a pressure meter as follows:
```
[PressureMeter]
UpperHand=BC:220,220,220
Radius=26
Background=PrsBack
Cover=PrsOn
Center=95,63
Unit=kPa
Maximum=1150

[Speedometer]
Hand=255,255,250
Radius=38
Background=VlcBack
Cover=VlcOn
Center=241,94
Maximum=160
```

The majority of these reside within the transparent area.

This produces the following result on the current master branch:
<img width="962" height="632" alt="issue" src="https://github.com/user-attachments/assets/055ebf76-1c6e-4c61-9d6e-4e67544868e3" />

Obviously (?!), neither of these should be present. 

Testing with BVE2 reveals that any item within the transparent area of the main panel image is ignored:
<img width="652" height="511" alt="bve2" src="https://github.com/user-attachments/assets/fc4fa0c9-57bf-456a-b3b4-389309b4909a" />

(Note the very slight overlap above the windscreen wiper where we can see the erroneous image)

This PR does some very hacky texture clipping and then applies it to the transparency channel.

This is our final result:
<img width="962" height="632" alt="issue2" src="https://github.com/user-attachments/assets/b7ed014c-0a09-4512-8730-43d9a50f3fbf" />

Leaving this as a PR at the minute whilst I test some more- This has a large potential to break things.....