### PR TITLE
Fix: nearclip and autoreload settings was stacked in object viewer.

### DIFF
--- a/source/ObjectViewer/formOptions.Designer.cs
+++ b/source/ObjectViewer/formOptions.Designer.cs
@@ -115,7 +115,7 @@ namespace ObjectViewer
             this.tabControl1.Location = new System.Drawing.Point(1, 12);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(312, 381);
+            this.tabControl1.Size = new System.Drawing.Size(312, 411);
             this.tabControl1.TabIndex = 26;
             // 
             // tabPageOptions
@@ -149,7 +149,7 @@ namespace ObjectViewer
             this.tabPageOptions.Location = new System.Drawing.Point(4, 22);
             this.tabPageOptions.Name = "tabPageOptions";
             this.tabPageOptions.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageOptions.Size = new System.Drawing.Size(304, 355);
+            this.tabPageOptions.Size = new System.Drawing.Size(304, 385);
             this.tabPageOptions.TabIndex = 0;
             this.tabPageOptions.Text = "Options";
             this.tabPageOptions.UseVisualStyleBackColor = true;
@@ -812,16 +812,17 @@ namespace ObjectViewer
             // 
             // labelAutoReloadChanged
             // 
-            this.labelAutoReloadChanged.Location = new System.Drawing.Point(10, 324);
+            this.labelAutoReloadChanged.AutoSize = true;
+            this.labelAutoReloadChanged.Location = new System.Drawing.Point(10, 353);
             this.labelAutoReloadChanged.Name = "labelAutoReloadChanged";
-            this.labelAutoReloadChanged.Size = new System.Drawing.Size(131, 28);
+            this.labelAutoReloadChanged.Size = new System.Drawing.Size(201, 13);
             this.labelAutoReloadChanged.TabIndex = 48;
             this.labelAutoReloadChanged.Text = "Automatically Reload Changed Objects:";
             // 
             // checkBoxAutoReload
             // 
             this.checkBoxAutoReload.AutoSize = true;
-            this.checkBoxAutoReload.Location = new System.Drawing.Point(265, 328);
+            this.checkBoxAutoReload.Location = new System.Drawing.Point(265, 353);
             this.checkBoxAutoReload.Name = "checkBoxAutoReload";
             this.checkBoxAutoReload.Size = new System.Drawing.Size(15, 14);
             this.checkBoxAutoReload.TabIndex = 49;
@@ -831,10 +832,10 @@ namespace ObjectViewer
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(311, 434);
+            this.ClientSize = new System.Drawing.Size(311, 464);
             this.Controls.Add(this.CloseButton);
             this.Controls.Add(this.tabControl1);
-            this.MinimumSize = new System.Drawing.Size(330, 400);
+            this.MinimumSize = new System.Drawing.Size(330, 500);
             this.Name = "formOptions";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;


### PR DESCRIPTION
<img width="372" height="475" alt="image" src="https://github.com/user-attachments/assets/64bca594-b7e6-4f6c-97b2-222712ef3288" />
