### PR TITLE
Implement smooth camera transition in exterior camera

### DIFF
--- a/assets/Languages/en-US.xlf
+++ b/assets/Languages/en-US.xlf
@@ -1204,6 +1204,18 @@
 					<trans-unit id="misc">
 						<source>Miscellaneous</source>
 					</trans-unit>
+					<trans-unit id="camera">
+						<source>Camera options</source>
+					</trans-unit>
+					<trans-unit id="camera_interior_transition">
+						<source>Smooth interior transition</source>
+					</trans-unit>
+					<trans-unit id="camera_exterior_transition">
+						<source>Smooth exterior transition</source>
+					</trans-unit>
+					<trans-unit id="camera_transition_duration">
+						<source>Transition duration (sec):</source>
+					</trans-unit>
 					<trans-unit id="misc_simulation">
 						<source>Detail of simulation</source>
 					</trans-unit>

--- a/source/LibRender2/Camera/Camera.cs
+++ b/source/LibRender2/Camera/Camera.cs
@@ -102,6 +102,21 @@ namespace LibRender2.Cameras
 		public CameraAlignment SavedTrack;
 		/// <summary>The current quad tree leaf node</summary>
 		public QuadTreeLeafNode QuadTreeLeaf;
+
+		/// <summary>The target camera car index for queued transitions</summary>
+		public int TargetCameraCar = -1;
+		/// <summary>The previous camera car index (used for transitions)</summary>
+		public int PreviousCameraCar = -1;
+		/// <summary>The current transition timer</summary>
+		public double CameraCarTransitionTimer = 0.0;
+		/// <summary>Whether the camera is transitioning between cars</summary>
+		public bool IsTransitioning = false;
+		/// <summary>The start anchor for mode transitions (fly-in)</summary>
+		public (Vector3 Position, Vector3 Direction, Vector3 Up, Vector3 Side, double TrackPosition, CameraAlignment Alignment) ModeTransitionStart;
+		/// <summary>The timer for mode transitions (fly-in)</summary>
+		public double ModeTransitionTimer = 1.0;
+		/// <summary>The duration of the camera car transition in seconds</summary>
+		public const double CameraCarTransitionDuration = 0.4;
 		
 		private Vector3 absolutePosition;
 		private CameraAlignment alignmentDirection;

--- a/source/OpenBVE/Game/World.cs
+++ b/source/OpenBVE/Game/World.cs
@@ -354,6 +354,16 @@ namespace OpenBve {
 				Program.Renderer.Camera.AbsoluteDirection = dF;
 				Program.Renderer.Camera.AbsoluteUp = uF;
 				Program.Renderer.Camera.AbsoluteSide = sF;
+
+				if (Program.Renderer.Camera.ModeTransitionTimer < 1.0)
+				{
+					double transitionProgress = Program.Renderer.Camera.ModeTransitionTimer;
+					var start = Program.Renderer.Camera.ModeTransitionStart;
+					Program.Renderer.Camera.AbsolutePosition = Vector3.CosineInterpolate(start.Position, Program.Renderer.Camera.AbsolutePosition, transitionProgress);
+					Program.Renderer.Camera.AbsoluteDirection = Vector3.CosineInterpolate(start.Direction, Program.Renderer.Camera.AbsoluteDirection, transitionProgress);
+					Program.Renderer.Camera.AbsoluteUp = Vector3.CosineInterpolate(start.Up, Program.Renderer.Camera.AbsoluteUp, transitionProgress);
+					Program.Renderer.Camera.AbsoluteSide = Vector3.CosineInterpolate(start.Side, Program.Renderer.Camera.AbsoluteSide, transitionProgress);
+				}
 			}
 		}
 	}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -172,9 +172,9 @@ namespace OpenBve
 				var trackFollower = Program.Renderer.CameraTrackFollower;
 
 				if (cameraProperties.IsTransitioning) cameraProperties.CameraCarTransitionTimer += RealTimeElapsed;
-				if (cameraProperties.ModeTransitionTimer < 1.0) cameraProperties.ModeTransitionTimer += RealTimeElapsed / 0.4;
+				if (cameraProperties.ModeTransitionTimer < 1.0) cameraProperties.ModeTransitionTimer += RealTimeElapsed / Interface.CurrentOptions.CameraTransitionSpeed;
 
-				double carTransitionProgress = Math.Min(1.0, cameraProperties.CameraCarTransitionTimer / CameraProperties.CameraCarTransitionDuration);
+				double carTransitionProgress = Math.Min(1.0, cameraProperties.CameraCarTransitionTimer / Interface.CurrentOptions.CameraTransitionSpeed);
 				if (carTransitionProgress >= 1.0)
 				{
 					cameraProperties.IsTransitioning = false;

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -31,6 +31,7 @@ using OpenBveApi.Routes;
 using OpenTK.Graphics.OpenGL;
 using RouteManager2.MessageManager;
 using SoundManager;
+using TrainManager.Car;
 using TrainManager.Trains;
 using Path = System.IO.Path;
 using Vector2 = OpenTK.Vector2;
@@ -167,8 +168,56 @@ namespace OpenBve
 			// update in one piece
 			if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior | Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead | Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior)
 			{
+				var cameraProperties = Program.Renderer.Camera;
+				var trackFollower = Program.Renderer.CameraTrackFollower;
+
+				if (cameraProperties.IsTransitioning) cameraProperties.CameraCarTransitionTimer += RealTimeElapsed;
+				if (cameraProperties.ModeTransitionTimer < 1.0) cameraProperties.ModeTransitionTimer += RealTimeElapsed / 0.4;
+
+				double carTransitionProgress = Math.Min(1.0, cameraProperties.CameraCarTransitionTimer / CameraProperties.CameraCarTransitionDuration);
+				if (carTransitionProgress >= 1.0)
+				{
+					cameraProperties.IsTransitioning = false;
+					if (cameraProperties.TargetCameraCar != -1)
+					{
+						cameraProperties.PreviousCameraCar = TrainManager.PlayerTrain.CameraCar;
+						TrainManager.PlayerTrain.CameraCar = cameraProperties.TargetCameraCar;
+						cameraProperties.TargetCameraCar = -1;
+						cameraProperties.IsTransitioning = true;
+						cameraProperties.CameraCarTransitionTimer = 0.0;
+						carTransitionProgress = 0.0;
+					}
+				}
+
+				CarBase previousCar = (cameraProperties.IsTransitioning && cameraProperties.PreviousCameraCar != -1) ? TrainManager.PlayerTrain.Cars[cameraProperties.PreviousCameraCar] : null;
 				//Update the in-car camera based upon the current driver car (Cabview or passenger view)
-				TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.CameraCar].UpdateCamera();
+				TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.CameraCar].UpdateCamera(previousCar, carTransitionProgress);
+
+				if (cameraProperties.ModeTransitionTimer < 1.0)
+				{
+					double modeTransitionLinear = Math.Min(1.0, cameraProperties.ModeTransitionTimer);
+					double modeTransitionCosine = (1.0 - Math.Cos(modeTransitionLinear * Math.PI)) / 2.0;
+					var startAnchor = cameraProperties.ModeTransitionStart;
+
+					trackFollower.WorldPosition = OpenBveApi.Math.Vector3.CosineInterpolate(startAnchor.Position, trackFollower.WorldPosition, modeTransitionLinear);
+					trackFollower.WorldDirection = OpenBveApi.Math.Vector3.CosineInterpolate(startAnchor.Direction, trackFollower.WorldDirection, modeTransitionLinear);
+					trackFollower.WorldDirection.Normalize();
+					trackFollower.WorldUp = OpenBveApi.Math.Vector3.CosineInterpolate(startAnchor.Up, trackFollower.WorldUp, modeTransitionLinear);
+					trackFollower.WorldUp.Normalize();
+					trackFollower.WorldSide = OpenBveApi.Math.Vector3.CosineInterpolate(startAnchor.Side, trackFollower.WorldSide, modeTransitionLinear);
+					trackFollower.WorldSide.Normalize();
+					trackFollower.UpdateAbsolute(
+						startAnchor.TrackPosition + (trackFollower.TrackPosition - startAnchor.TrackPosition) * modeTransitionCosine,
+						false,
+						false);
+
+					// Smoothly decay alignment back to zero
+					cameraProperties.AlignmentDirection.Yaw = startAnchor.Alignment.Yaw * (1.0 - modeTransitionCosine);
+					cameraProperties.AlignmentDirection.Pitch = startAnchor.Alignment.Pitch * (1.0 - modeTransitionCosine);
+					cameraProperties.AlignmentDirection.Roll = startAnchor.Alignment.Roll * (1.0 - modeTransitionCosine);
+					cameraProperties.AlignmentDirection.Position = startAnchor.Alignment.Position * (1.0 - modeTransitionCosine);
+					cameraProperties.AlignmentDirection.Zoom = startAnchor.Alignment.Zoom + (0.0 - startAnchor.Alignment.Zoom) * modeTransitionCosine;
+				}
 			}
 			
 			if (Program.Renderer.Camera.CurrentRestriction == CameraRestrictionMode.NotAvailable || Program.Renderer.Camera.CurrentRestriction == CameraRestrictionMode.Restricted3D)

--- a/source/OpenBVE/System/Input/ProcessControls.Digital.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Digital.cs
@@ -61,7 +61,7 @@ namespace OpenBve
 						Game.Menu.PushMenu(MenuType.Quit);
 						break;
 					case Translations.Command.CameraInterior:
-						// camera: interior
+						// camera: interior (Handle camera transition from exterior mode to cab mode)
 						SaveCameraSettings();
 						if (Program.Renderer.Camera.CurrentMode != CameraViewMode.InteriorLookAhead & Program.Renderer.Camera.CurrentRestriction == CameraRestrictionMode.NotAvailable)
 						{
@@ -77,13 +77,35 @@ namespace OpenBve
 								MessageColor.White, 2, null);
 						}
 
+						bool hasCab = TrainManager.PlayerTrain.Cars[0].InteriorCamera != null || TrainManager.PlayerTrain.Cars[0].HasInteriorView;
+						bool isAtCabCar = TrainManager.PlayerTrain.CameraCar == 0 || TrainManager.PlayerTrain.CameraCar == TrainManager.PlayerTrain.DriverCar;
+						bool transition = false;
+						// Transition only if switching from Exterior mode and at the head of the train (Car 0 or Driver Car)
+						if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior && isAtCabCar && hasCab)
+						{
+							Program.Renderer.Camera.ModeTransitionStart = (
+									Program.Renderer.Camera.AbsolutePosition,
+									Program.Renderer.Camera.AbsoluteDirection,
+									Program.Renderer.Camera.AbsoluteUp,
+									Program.Renderer.Camera.AbsoluteSide,
+									Program.Renderer.CameraTrackFollower.TrackPosition,
+								new CameraAlignment(
+									Program.Renderer.Camera.AlignmentDirection.Position,
+									Program.Renderer.Camera.AlignmentDirection.Yaw,
+									Program.Renderer.Camera.AlignmentDirection.Pitch,
+									Program.Renderer.Camera.AlignmentDirection.Roll,
+									Program.Renderer.Camera.AlignmentDirection.TrackPosition,
+									Program.Renderer.Camera.AlignmentDirection.Zoom)
+							);
+							transition = true;
+						}
 						Program.Renderer.Camera.CurrentMode = CameraViewMode.Interior;
 						RestoreCameraSettings();
 						for (int j = 0; j < TrainManager.PlayerTrain.Cars.Length; j++)
 						{
 							if (j == TrainManager.PlayerTrain.CameraCar)
 							{
-								if (TrainManager.PlayerTrain.Cars[j].CarSections.ContainsKey(CarSectionType.Interior))
+								if (TrainManager.PlayerTrain.Cars[j].HasInteriorView)
 								{
 									TrainManager.PlayerTrain.Cars[j].ChangeCarSection(CarSectionType.Interior);
 								}
@@ -106,7 +128,10 @@ namespace OpenBve
 							TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar].ChangeCarSection(CarSectionType.Interior);
 						}
 						
-						Program.Renderer.Camera.AlignmentDirection = new CameraAlignment();
+						if (!hasCab)
+						{
+							Program.Renderer.Camera.AlignmentDirection = new CameraAlignment();
+						}
 						Program.Renderer.Camera.AlignmentSpeed = new CameraAlignment();
 						Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
 						World.UpdateAbsoluteCamera(TimeElapsed);
@@ -122,6 +147,11 @@ namespace OpenBve
 						if (lookahead)
 						{
 							Program.Renderer.Camera.CurrentMode = CameraViewMode.InteriorLookAhead;
+						}
+
+						if (transition)
+						{
+							Program.Renderer.Camera.ModeTransitionTimer = 0.0;
 						}
 						break;
 					case Translations.Command.CameraHeadOutLeft:
@@ -256,7 +286,29 @@ namespace OpenBve
 						}
 						break;
 					case Translations.Command.CameraExterior:
-						// camera: exterior
+						// camera: exterior (Handle camera transition from cab mode to exterior mode)
+						bool hasCabLeaving = TrainManager.PlayerTrain.Cars[0].InteriorCamera != null || TrainManager.PlayerTrain.Cars[0].HasInteriorView;
+						bool isAtCabCarLeaving = TrainManager.PlayerTrain.CameraCar == 0 || TrainManager.PlayerTrain.CameraCar == TrainManager.PlayerTrain.DriverCar;
+						bool transitionLeaving = false;
+						// Transition only if switching from Interior mode and at the head of the train
+						if ((Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior || Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead) && isAtCabCarLeaving && hasCabLeaving)
+						{
+							Program.Renderer.Camera.ModeTransitionStart = (
+									Program.Renderer.Camera.AbsolutePosition,
+									Program.Renderer.Camera.AbsoluteDirection,
+									Program.Renderer.Camera.AbsoluteUp,
+									Program.Renderer.Camera.AbsoluteSide,
+									Program.Renderer.CameraTrackFollower.TrackPosition,
+								new CameraAlignment(
+									Program.Renderer.Camera.AlignmentDirection.Position,
+									Program.Renderer.Camera.AlignmentDirection.Yaw,
+									Program.Renderer.Camera.AlignmentDirection.Pitch,
+									Program.Renderer.Camera.AlignmentDirection.Roll,
+									Program.Renderer.Camera.AlignmentDirection.TrackPosition,
+									Program.Renderer.Camera.AlignmentDirection.Zoom)
+							);
+							transitionLeaving = true;
+						}
 						SaveCameraSettings();
 						Program.Renderer.Camera.CurrentMode = CameraViewMode.Exterior;
 						RestoreCameraSettings();
@@ -282,6 +334,11 @@ namespace OpenBve
 						Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
 						World.UpdateAbsoluteCamera(TimeElapsed);
 						Program.Renderer.UpdateViewingDistances(Program.CurrentRoute.CurrentBackground.BackgroundImageDistance);
+
+						if (transitionLeaving)
+						{
+							Program.Renderer.Camera.ModeTransitionTimer = 0.0;
+						}
 						break;
 					case Translations.Command.CameraTrack:
 					case Translations.Command.CameraFlyBy:

--- a/source/OpenBVE/System/Input/ProcessControls.Digital.cs
+++ b/source/OpenBVE/System/Input/ProcessControls.Digital.cs
@@ -81,7 +81,7 @@ namespace OpenBve
 						bool isAtCabCar = TrainManager.PlayerTrain.CameraCar == 0 || TrainManager.PlayerTrain.CameraCar == TrainManager.PlayerTrain.DriverCar;
 						bool transition = false;
 						// Transition only if switching from Exterior mode and at the head of the train (Car 0 or Driver Car)
-						if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior && isAtCabCar && hasCab)
+						if (Program.Renderer.Camera.CurrentMode == CameraViewMode.Exterior && isAtCabCar && hasCab && Interface.CurrentOptions.CameraInteriorTransition)
 						{
 							Program.Renderer.Camera.ModeTransitionStart = (
 									Program.Renderer.Camera.AbsolutePosition,
@@ -291,7 +291,7 @@ namespace OpenBve
 						bool isAtCabCarLeaving = TrainManager.PlayerTrain.CameraCar == 0 || TrainManager.PlayerTrain.CameraCar == TrainManager.PlayerTrain.DriverCar;
 						bool transitionLeaving = false;
 						// Transition only if switching from Interior mode and at the head of the train
-						if ((Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior || Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead) && isAtCabCarLeaving && hasCabLeaving)
+						if ((Program.Renderer.Camera.CurrentMode == CameraViewMode.Interior || Program.Renderer.Camera.CurrentMode == CameraViewMode.InteriorLookAhead) && isAtCabCarLeaving && hasCabLeaving && Interface.CurrentOptions.CameraExteriorTransition)
 						{
 							Program.Renderer.Camera.ModeTransitionStart = (
 									Program.Renderer.Camera.AbsolutePosition,

--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -105,6 +105,13 @@ namespace OpenBve
 			internal int FPSLimit;
 
 			internal bool DailyBuildUpdates;
+
+			/// <summary>Whether smooth transitions are enabled for interior camera modes</summary>
+			internal bool CameraInteriorTransition;
+			/// <summary>Whether smooth transitions are enabled for exterior camera modes</summary>
+			internal bool CameraExteriorTransition;
+			/// <summary>The duration of camera transitions in seconds</summary>
+			internal double CameraTransitionSpeed;
 			
 			/// <summary>Creates a new instance of the options class with default values set</summary>
 			internal Options()
@@ -179,6 +186,9 @@ namespace OpenBve
 				UseGDIDecoders = false;
 				EnableBve5ScriptedTrain = true;
 				UserInterfaceScaleFactor = 1;
+				CameraInteriorTransition = true;
+				CameraExteriorTransition = true;
+				CameraTransitionSpeed = 0.4;
 				CultureInfo currentCultureInfo = CultureInfo.CurrentCulture;
 				switch (Program.CurrentHost.Platform)
 				{
@@ -292,6 +302,9 @@ namespace OpenBve
 				Builder.AppendLine("isUseNewRenderer = " + (IsUseNewRenderer ? "true" : "false"));
 				Builder.AppendLine("forwardsCompatibleContext = " + (ForceForwardsCompatibleContext ? "true" : "false"));
 				Builder.AppendLine("uiscalefactor = " + UserInterfaceScaleFactor);
+				Builder.AppendLine("cameraInteriorTransition = " + (CameraInteriorTransition ? "true" : "false"));
+				Builder.AppendLine("cameraExteriorTransition = " + (CameraExteriorTransition ? "true" : "false"));
+				Builder.AppendLine("cameraTransitionSpeed = " + CameraTransitionSpeed.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[quality]");
 				Builder.AppendLine("interpolation = " + Interpolation);
@@ -485,6 +498,13 @@ namespace OpenBve
 							}
 
 							block.TryGetValue(OptionsKey.UIScaleFactor, ref CurrentOptions.UserInterfaceScaleFactor);
+							block.GetValue(OptionsKey.CameraInteriorTransition, out CurrentOptions.CameraInteriorTransition);
+							block.GetValue(OptionsKey.CameraExteriorTransition, out CurrentOptions.CameraExteriorTransition);
+							block.TryGetValue(OptionsKey.CameraTransitionSpeed, ref CurrentOptions.CameraTransitionSpeed, NumberRange.Positive);
+							if (CurrentOptions.CameraTransitionSpeed == 0)
+							{
+								CurrentOptions.CameraTransitionSpeed = 0.4;
+							}
 							break;
 						case OptionsSection.Quality:
 							block.GetEnumValue(OptionsKey.Interpolation, out Interface.CurrentOptions.Interpolation);

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -162,6 +162,11 @@ namespace OpenBve {
             this.groupboxSound = new System.Windows.Forms.GroupBox();
             this.updownSoundNumber = new System.Windows.Forms.NumericUpDown();
             this.labelSoundNumber = new System.Windows.Forms.Label();
+            this.groupboxCamera = new System.Windows.Forms.GroupBox();
+            this.checkboxCameraInteriorTransition = new System.Windows.Forms.CheckBox();
+            this.checkboxCameraExteriorTransition = new System.Windows.Forms.CheckBox();
+            this.labelCameraTransitionSpeed = new System.Windows.Forms.Label();
+            this.updownCameraTransitionSpeed = new System.Windows.Forms.NumericUpDown();
             this.panelOptionsPage2 = new System.Windows.Forms.Panel();
             this.groupboxDistance = new System.Windows.Forms.GroupBox();
             this.updownNearClipBase = new System.Windows.Forms.NumericUpDown();
@@ -536,6 +541,8 @@ namespace OpenBve {
             this.groupboxSimulation.SuspendLayout();
             this.groupboxSound.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.updownSoundNumber)).BeginInit();
+            this.groupboxCamera.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.updownCameraTransitionSpeed)).BeginInit();
             this.panelOptionsPage2.SuspendLayout();
             this.groupboxDistance.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.updownNearClipBase)).BeginInit();
@@ -2400,6 +2407,7 @@ namespace OpenBve {
             // panelOptionsPage2
             // 
             this.panelOptionsPage2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(243)))), ((int)(((byte)(255)))), ((int)(((byte)(243)))));
+            this.panelOptionsPage2.Controls.Add(this.groupboxCamera);
             this.panelOptionsPage2.Controls.Add(this.groupboxDistance);
             this.panelOptionsPage2.Controls.Add(this.groupboxShadows);
             this.panelOptionsPage2.Location = new System.Drawing.Point(0, 72);
@@ -2639,6 +2647,77 @@ namespace OpenBve {
             this.groupboxShadows.TabIndex = 30;
             this.groupboxShadows.TabStop = false;
             this.groupboxShadows.Text = "Shadows";
+            // 
+            // groupboxCamera
+            // 
+            this.groupboxCamera.Controls.Add(this.checkboxCameraInteriorTransition);
+            this.groupboxCamera.Controls.Add(this.checkboxCameraExteriorTransition);
+            this.groupboxCamera.Controls.Add(this.labelCameraTransitionSpeed);
+            this.groupboxCamera.Controls.Add(this.updownCameraTransitionSpeed);
+            this.groupboxCamera.ForeColor = System.Drawing.Color.Black;
+            this.groupboxCamera.Location = new System.Drawing.Point(330, 0);
+            this.groupboxCamera.Name = "groupboxCamera";
+            this.groupboxCamera.Size = new System.Drawing.Size(321, 120);
+            this.groupboxCamera.TabIndex = 22;
+            this.groupboxCamera.TabStop = false;
+            this.groupboxCamera.Text = "Camera options";
+            // 
+            // checkboxCameraInteriorTransition
+            // 
+            this.checkboxCameraInteriorTransition.AutoSize = true;
+            this.checkboxCameraInteriorTransition.Location = new System.Drawing.Point(8, 21);
+            this.checkboxCameraInteriorTransition.Name = "checkboxCameraInteriorTransition";
+            this.checkboxCameraInteriorTransition.Size = new System.Drawing.Size(150, 17);
+            this.checkboxCameraInteriorTransition.TabIndex = 0;
+            this.checkboxCameraInteriorTransition.Text = "Smooth interior transition";
+            this.checkboxCameraInteriorTransition.UseVisualStyleBackColor = true;
+            // 
+            // checkboxCameraExteriorTransition
+            // 
+            this.checkboxCameraExteriorTransition.AutoSize = true;
+            this.checkboxCameraExteriorTransition.Location = new System.Drawing.Point(8, 44);
+            this.checkboxCameraExteriorTransition.Name = "checkboxCameraExteriorTransition";
+            this.checkboxCameraExteriorTransition.Size = new System.Drawing.Size(150, 17);
+            this.checkboxCameraExteriorTransition.TabIndex = 1;
+            this.checkboxCameraExteriorTransition.Text = "Smooth exterior transition";
+            this.checkboxCameraExteriorTransition.UseVisualStyleBackColor = true;
+            // 
+            // labelCameraTransitionSpeed
+            // 
+            this.labelCameraTransitionSpeed.AutoSize = true;
+            this.labelCameraTransitionSpeed.Location = new System.Drawing.Point(8, 73);
+            this.labelCameraTransitionSpeed.Name = "labelCameraTransitionSpeed";
+            this.labelCameraTransitionSpeed.Size = new System.Drawing.Size(130, 13);
+            this.labelCameraTransitionSpeed.TabIndex = 2;
+            this.labelCameraTransitionSpeed.Text = "Transition duration (sec):";
+            // 
+            // updownCameraTransitionSpeed
+            // 
+            this.updownCameraTransitionSpeed.DecimalPlaces = 1;
+            this.updownCameraTransitionSpeed.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.updownCameraTransitionSpeed.Location = new System.Drawing.Point(200, 71);
+            this.updownCameraTransitionSpeed.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            65536});
+            this.updownCameraTransitionSpeed.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.updownCameraTransitionSpeed.Name = "updownCameraTransitionSpeed";
+            this.updownCameraTransitionSpeed.Size = new System.Drawing.Size(52, 20);
+            this.updownCameraTransitionSpeed.TabIndex = 3;
+            this.updownCameraTransitionSpeed.Value = new decimal(new int[] {
+            4,
+            0,
+            0,
+            65536});
             // 
             // labelShadowResolution
             // 
@@ -6383,6 +6462,9 @@ namespace OpenBve {
             this.groupboxSimulation.PerformLayout();
             this.groupboxSound.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.updownSoundNumber)).EndInit();
+            this.groupboxCamera.ResumeLayout(false);
+            this.groupboxCamera.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.updownCameraTransitionSpeed)).EndInit();
             this.panelOptionsPage2.ResumeLayout(false);
             this.groupboxDistance.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.updownNearClipBase)).EndInit();
@@ -6935,6 +7017,11 @@ namespace OpenBve {
 		private System.Windows.Forms.Button buttonMSTSTrainsetDirectory;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.TextBox textBoxMSTSTrainsetDirectory;
+		private System.Windows.Forms.GroupBox groupboxCamera;
+		private System.Windows.Forms.CheckBox checkboxCameraInteriorTransition;
+		private System.Windows.Forms.CheckBox checkboxCameraExteriorTransition;
+		private System.Windows.Forms.Label labelCameraTransitionSpeed;
+		private System.Windows.Forms.NumericUpDown updownCameraTransitionSpeed;
 		private System.Windows.Forms.Panel panelOptionsPage2;
 	}
 }

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -522,6 +522,9 @@ namespace OpenBve {
 			checkBoxEnableKiosk.Checked = Interface.CurrentOptions.KioskMode;
 			numericUpDownKioskTimeout.Value = (decimal)Interface.CurrentOptions.KioskModeTimer;
 			checkBoxAccessibility.Checked = Interface.CurrentOptions.Accessibility;
+			checkboxCameraInteriorTransition.Checked = Interface.CurrentOptions.CameraInteriorTransition;
+			checkboxCameraExteriorTransition.Checked = Interface.CurrentOptions.CameraExteriorTransition;
+			updownCameraTransitionSpeed.Value = (decimal)Interface.CurrentOptions.CameraTransitionSpeed;
 			ListInputDevicePlugins();
 			if (Program.CurrentHost.MonoRuntime)
 			{
@@ -772,6 +775,10 @@ namespace OpenBve {
 			comboboxShadowCascades.Items[2] = Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "options", "shadows_cascades_4" });
 			//Simulation
 			groupboxSimulation.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","misc_simulation"});
+			groupboxCamera.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","camera"});
+			checkboxCameraInteriorTransition.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","camera_interior_transition"});
+			checkboxCameraExteriorTransition.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","camera_exterior_transition"});
+			labelCameraTransitionSpeed.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","camera_transition_duration"});
 			checkboxToppling.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","misc_simulation_toppling"});
 			checkboxCollisions.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","misc_simulation_collisions"});
 			checkboxDerailments.Text = Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","misc_simulation_derailments"});
@@ -1245,6 +1252,9 @@ namespace OpenBve {
 			Interface.CurrentOptions.CurrentObjParser = (ObjParsers)comboBoxObjparser.SelectedIndex;
 			Interface.CurrentOptions.Panel2ExtendedMode = checkBoxPanel2Extended.Checked;
 			Interface.CurrentOptions.Accessibility = checkBoxAccessibility.Checked;
+			Interface.CurrentOptions.CameraInteriorTransition = checkboxCameraInteriorTransition.Checked;
+			Interface.CurrentOptions.CameraExteriorTransition = checkboxCameraExteriorTransition.Checked;
+			Interface.CurrentOptions.CameraTransitionSpeed = (double)updownCameraTransitionSpeed.Value;
 			switch (trackBarHUDSize.Value)
 			{
 				case 0:

--- a/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
+++ b/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
@@ -38,6 +38,9 @@ namespace OpenBveApi
 		NearClipCab,
 		NearClipBase,
 		AutoReloadObjects,
+		CameraInteriorTransition,
+		CameraExteriorTransition,
+		CameraTransitionSpeed,
 		// Quality
 		Interpolation,
 		AnisotropicFilteringLevel,

--- a/source/TrainManager/Car/CarBase.cs
+++ b/source/TrainManager/Car/CarBase.cs
@@ -1143,34 +1143,46 @@ namespace TrainManager.Car
 		}
 
 		/// <summary>Updates the position of the camera relative to this car</summary>
-		public void UpdateCamera()
+		public void UpdateCamera(CarBase previousCar = null, double mu = 1.0)
 		{
-			Vector3 direction = new Vector3(FrontAxle.Follower.WorldPosition - RearAxle.Follower.WorldPosition);
-			direction *= direction.Magnitude();
-			double sx = direction.Z * Up.Y - direction.Y * Up.Z;
-			double sy = direction.X * Up.Z - direction.Z * Up.X;
-			double sz = direction.Y * Up.X - direction.X * Up.Y;
-			double rx = 0.5 * (FrontAxle.Follower.WorldPosition.X + RearAxle.Follower.WorldPosition.X);
-			double ry = 0.5 * (FrontAxle.Follower.WorldPosition.Y + RearAxle.Follower.WorldPosition.Y);
-			double rz = 0.5 * (FrontAxle.Follower.WorldPosition.Z + RearAxle.Follower.WorldPosition.Z);
-			Vector3 cameraPosition;
-			Vector3 driverPosition = HasInteriorView ? Driver : baseTrain.Cars[baseTrain.DriverCar].Driver;
-			cameraPosition.X = rx + sx * driverPosition.X + Up.X * driverPosition.Y + direction.X * driverPosition.Z;
-			cameraPosition.Y = ry + sy * driverPosition.X + Up.Y * driverPosition.Y + direction.Y * driverPosition.Z;
-			cameraPosition.Z = rz + sz * driverPosition.X + Up.Z * driverPosition.Y + direction.Z * driverPosition.Z;
+			var a2 = GetAnchor();
+			var trackFollower = TrainManagerBase.Renderer.CameraTrackFollower;
+			if (previousCar != null && mu < 1.0)
+			{
+				var a1 = previousCar.GetAnchor();
+				trackFollower.WorldPosition = Vector3.CosineInterpolate(a1.worldPosition, a2.worldPosition, mu);
+				trackFollower.WorldDirection = Vector3.CosineInterpolate(a1.worldDirection, a2.worldDirection, mu);
+				trackFollower.WorldUp = Vector3.CosineInterpolate(a1.worldUp, a2.worldUp, mu);
+				trackFollower.WorldSide = Vector3.CosineInterpolate(a1.worldSide, a2.worldSide, mu);
+				double mu2 = (1.0 - Math.Cos(mu * Math.PI)) / 2.0;
+				trackFollower.UpdateAbsolute(a1.trackPosition + (a2.trackPosition - a1.trackPosition) * mu2, false, false);
+			}
+			else
+			{
+				trackFollower.WorldPosition = a2.worldPosition; 
+				trackFollower.WorldDirection = a2.worldDirection; 
+				trackFollower.WorldUp = a2.worldUp; 
+				trackFollower.WorldSide = a2.worldSide;
+				trackFollower.UpdateAbsolute(a2.trackPosition, false, false);
+			}
+		}
 
-			TrainManagerBase.Renderer.CameraTrackFollower.WorldPosition = cameraPosition;
-			TrainManagerBase.Renderer.CameraTrackFollower.WorldDirection = direction;
-			TrainManagerBase.Renderer.CameraTrackFollower.WorldUp = new Vector3(Up);
-			TrainManagerBase.Renderer.CameraTrackFollower.WorldSide = new Vector3(sx, sy, sz);
-			double f = (Driver.Z - RearAxle.Position) / (FrontAxle.Position - RearAxle.Position);
-			if (double.IsNaN(f))
+		public (Vector3 worldPosition, Vector3 worldDirection, Vector3 worldUp, Vector3 worldSide, double trackPosition) GetAnchor()
+		{
+			Vector3 worldDirection = FrontAxle.Follower.WorldPosition - RearAxle.Follower.WorldPosition;
+			worldDirection.Normalize();
+			Vector3 worldSide = Vector3.Cross(Up, worldDirection);
+			Vector3 worldPosition = 0.5 * (FrontAxle.Follower.WorldPosition + RearAxle.Follower.WorldPosition);
+			Vector3 driverPosition = HasInteriorView ? Driver : baseTrain.Cars[baseTrain.DriverCar].Driver;
+			worldPosition += worldSide * driverPosition.X + Up * driverPosition.Y + worldDirection * driverPosition.Z;
+			double interpolationRatio = (Driver.Z - RearAxle.Position) / (FrontAxle.Position - RearAxle.Position);
+			if (double.IsNaN(interpolationRatio))
 			{
 				// car with both axles at zero and a driver position of zero creates NaN (guarded against in original BVE parser)
-				f = 0;
+				interpolationRatio = 0;
 			}
-			double tp = (1.0 - f) * RearAxle.Follower.TrackPosition + f * FrontAxle.Follower.TrackPosition;
-			TrainManagerBase.Renderer.CameraTrackFollower.UpdateAbsolute(tp, false, false);
+			double trackPosition = (1.0 - interpolationRatio) * RearAxle.Follower.TrackPosition + interpolationRatio * FrontAxle.Follower.TrackPosition;
+			return (worldPosition, worldDirection, new Vector3(Up), worldSide, trackPosition);
 		}
 
 		public void UpdateSpeed(double TimeElapsed, double DecelerationDueToMotor, double DecelerationDueToBrake, out double Speed)

--- a/source/TrainManager/Train/TrainBase.cs
+++ b/source/TrainManager/Train/TrainBase.cs
@@ -1,3 +1,4 @@
+using LibRender2.Cameras;
 using LibRender2.Screens;
 using LibRender2.Trains;
 using OpenBveApi;
@@ -1098,25 +1099,31 @@ namespace TrainManager.Trains
 				// If in the reverse direction, the last car is Car0 and the direction of increase is reversed
 				shouldIncrement = !shouldIncrement;
 			}
-
-			if (shouldIncrement)
+			
+			int currentTarget = TrainManagerBase.Renderer.Camera.TargetCameraCar != -1 ? TrainManagerBase.Renderer.Camera.TargetCameraCar : CameraCar;
+			int nextCar = shouldIncrement ? currentTarget + 1 : currentTarget - 1;
+			
+			if (nextCar >= 0 && nextCar < Cars.Length)
 			{
-				if (CameraCar < Cars.Length - 1)
+				TrainManagerBase.Renderer.Camera.TargetCameraCar = nextCar;
+				
+				if (!TrainManagerBase.Renderer.Camera.IsTransitioning)
 				{
-					CameraCar++;
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new [] {"notification","exterior"}) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert,
-						MessageColor.White, 2.0, null);
+					TrainManagerBase.Renderer.Camera.PreviousCameraCar = CameraCar;
+					CameraCar = nextCar;
+					TrainManagerBase.Renderer.Camera.TargetCameraCar = -1;
+					TrainManagerBase.Renderer.Camera.IsTransitioning = true;
+					TrainManagerBase.Renderer.Camera.CameraCarTransitionTimer = 0.0;
 				}
+				
+				TrainManagerBase.currentHost.AddMessage(
+					Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "notification", "exterior" }) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - nextCar : nextCar + 1),
+					MessageDependency.CameraView,
+					GameMode.Expert,
+					MessageColor.White,
+					2.0,
+					null);
 			}
-			else
-			{
-				if (CameraCar > 0)
-				{
-					CameraCar--;
-					TrainManagerBase.currentHost.AddMessage(Translations.GetInterfaceString(HostApplication.OpenBve, new [] {"notification","exterior"}) + " " + (CurrentDirection == TrackDirection.Reverse ? Cars.Length - CameraCar : CameraCar + 1), MessageDependency.CameraView, GameMode.Expert, MessageColor.White, 2.0, null);
-				}
-			}
-
 		}
 
 		public override void Couple(AbstractTrain train, bool front)


### PR DESCRIPTION
now camera should move smoothly between cars in camera F2 mode, and also to cab view (only smooth if use 3d cab or using panel.animated).

still need a bit of tweak if we click the camera change too fast.

preview 

https://github.com/user-attachments/assets/7f84594f-1113-4f26-816a-f6cf442e906d

