### PR TITLE
Restructure shadow mapping code

### DIFF
--- a/assets/Shaders/default.frag
+++ b/assets/Shaders/default.frag
@@ -28,26 +28,32 @@ in vec4 oViewPos;
 in vec2 oUv;
 in vec4 oColor;
 in vec4 oLightResult;
-uniform sampler2DShadow uShadowMap0;  // Cascade 0 (near)
-uniform sampler2DShadow uShadowMap1;  // Cascade 1 (mid)
-uniform sampler2DShadow uShadowMap2;  // Cascade 2 (far)
-uniform sampler2DShadow uShadowMap3;  // Cascade 3 (extra far)
-uniform float uCascadeFarDist0;
-uniform float uCascadeFarDist1;
-uniform float uCascadeFarDist2;
-uniform float uCascadeFarDist3;
-uniform float uCascadeBias0;
-uniform float uCascadeBias1;
-uniform float uCascadeBias2;
-uniform float uCascadeBias3;
-uniform float uNormalBias0;
-uniform float uNormalBias1;
-uniform float uNormalBias2;
-uniform float uNormalBias3;
-uniform float uShadowStrength;
-uniform bool  uShadowEnabled;
-uniform int   uCascadeCount;  // 2, 3, or 4
-uniform vec2  uAlphaTest;
+// --- SHADOW MAPPING ---
+uniform bool              uShadowEnabled;
+uniform float             uShadowStrength;
+uniform int               uShadowCascadeCount;
+
+uniform sampler2DShadow   uShadowMap0;
+uniform sampler2DShadow   uShadowMap1;
+uniform sampler2DShadow   uShadowMap2;
+uniform sampler2DShadow   uShadowMap3;
+
+uniform float             uShadowSplit0;      // Boundary where cascade 0 ends and 1 begins
+uniform float             uShadowSplit1;      // Boundary where cascade 1 ends and 2 begins
+uniform float             uShadowSplit2;      // Boundary where cascade 2 ends and 3 begins
+uniform float             uShadowSplit3;      // Final shadow distance boundary
+
+uniform float             uShadowBias0;
+uniform float             uShadowBias1;
+uniform float             uShadowBias2;
+uniform float             uShadowBias3;
+
+uniform float             uShadowNormalBias0;
+uniform float             uShadowNormalBias1;
+uniform float             uShadowNormalBias2;
+uniform float             uShadowNormalBias3;
+
+uniform vec2              uAlphaTest;
 uniform sampler2D uTexture;
 
 struct Light
@@ -66,7 +72,6 @@ in vec4  vPosLightSpace0;
 in vec4  vPosLightSpace1;
 in vec4  vPosLightSpace2;
 in vec4  vPosLightSpace3;
-in float vViewDepth;
 uniform int uMaterialFlags;
 uniform float uBrightness;
 uniform float uOpacity;
@@ -78,8 +83,8 @@ uniform float uFogDensity;
 uniform bool uFogIsLinear;
 out vec4 fragColor;
 
-/// Samples a single cascade with 4-tap PCF via hardware comparison.
-float SampleCascade(sampler2DShadow shadowMap, vec4 posLightSpace, float bias, float normalBias)
+/// Samples a single cascade using hardware PCF.
+float GetCascadeShadowFactor(sampler2DShadow shadowMap, vec4 posLightSpace, float bias, float normalBias)
 {
     vec3 projCoords = posLightSpace.xyz / posLightSpace.w;
     projCoords = projCoords * 0.5 + 0.5;
@@ -116,43 +121,50 @@ float SampleCascade(sampler2DShadow shadowMap, vec4 posLightSpace, float bias, f
     return shadow;
 }
 
+/// Helper to sample a cascade by index.
 float SampleCascadeByIndex(int idx)
 {
-    if (idx == 0) return SampleCascade(uShadowMap0, vPosLightSpace0, uCascadeBias0, uNormalBias0);
-    if (idx == 1) return SampleCascade(uShadowMap1, vPosLightSpace1, uCascadeBias1, uNormalBias1);
-    if (idx == 2) return SampleCascade(uShadowMap2, vPosLightSpace2, uCascadeBias2, uNormalBias2);
-    if (idx == 3) return SampleCascade(uShadowMap3, vPosLightSpace3, uCascadeBias3, uNormalBias3);
+    if (idx == 0) return GetCascadeShadowFactor(uShadowMap0, vPosLightSpace0, uShadowBias0, uShadowNormalBias0);
+    if (idx == 1) return GetCascadeShadowFactor(uShadowMap1, vPosLightSpace1, uShadowBias1, uShadowNormalBias1);
+    if (idx == 2) return GetCascadeShadowFactor(uShadowMap2, vPosLightSpace2, uShadowBias2, uShadowNormalBias2);
+    if (idx == 3) return GetCascadeShadowFactor(uShadowMap3, vPosLightSpace3, uShadowBias3, uShadowNormalBias3);
     return 1.0;
 }
 
-float GetCascadeFarDist(int idx)
+/// Helper to get the split distance of a cascade by index.
+float GetShadowSplitDistance(int idx)
 {
-    if (idx == 0) return uCascadeFarDist0;
-    if (idx == 1) return uCascadeFarDist1;
-    if (idx == 2) return uCascadeFarDist2;
-    if (idx == 3) return uCascadeFarDist3;
+    if (idx == 0) return uShadowSplit0;
+    if (idx == 1) return uShadowSplit1;
+    if (idx == 2) return uShadowSplit2;
+    if (idx == 3) return uShadowSplit3;
     return 0.0;
 }
 
-/// Full CSM sampling with cascade selection and smooth blending.
-float CSMShadow()
+/// Calculates the final shadow factor using CSM with smooth blending.
+float CalculateShadowFactor()
 {
+    if (!uShadowEnabled) return 1.0;
+    
+    // Calculate view depth per-pixel for perspective correctness (crucial for large polygons like ground)
+    float vViewDepth = abs(oViewPos.z);
+
     float blendRange = 15.0;
     float shadow = 1.0;
-    int cascadeCount = uCascadeCount;
+    int cascadeCount = uShadowCascadeCount;
 
     for (int i = 0; i < cascadeCount; i++)
     {
-        float farDist = GetCascadeFarDist(i);
+        float splitDist = GetShadowSplitDistance(i);
 
-        if (vViewDepth < farDist)
+        if (vViewDepth < splitDist)
         {
             shadow = SampleCascadeByIndex(i);
 
             // Blend toward next cascade near the boundary
             if (i < cascadeCount - 1)
             {
-                float blendStart = farDist - blendRange;
+                float blendStart = splitDist - blendRange;
                 if (vViewDepth > blendStart)
                 {
                     float nextShadow = SampleCascadeByIndex(i + 1);
@@ -163,15 +175,15 @@ float CSMShadow()
             else
             {
                 // Last cascade: fade out at far edge
-                float fadeStart = farDist - blendRange * 2.0;
+                float fadeStart = splitDist - blendRange * 2.0;
                 if (vViewDepth > fadeStart)
                 {
-                    float t = (vViewDepth - fadeStart) / (farDist - fadeStart);
+                    float t = (vViewDepth - fadeStart) / (splitDist - fadeStart);
                     shadow = mix(shadow, 1.0, t);
                 }
             }
 
-            break;  // Found our cascade, stop searching
+            break;
         }
     }
 
@@ -238,11 +250,7 @@ void main(void)
 	 * as otherwise light coming through a semi-transparent material will 
 	 * affect it's final opacity, and hence whether its discarded or not
 	 */
-	float shadow = 1.0;
-	if (uShadowEnabled)
-	{
-		shadow = CSMShadow();
-	}
+	float shadow = CalculateShadowFactor();
 	
 	if ((uMaterialFlags & 1) == 0 && (uMaterialFlags & 4) == 0)
 	{

--- a/assets/Shaders/default.frag
+++ b/assets/Shaders/default.frag
@@ -102,7 +102,7 @@ float GetCascadeShadowFactor(sampler2DShadow shadowMap, vec4 posLightSpace, floa
     vec3 lightDir = normalize(uLight.position);
     float biasScale = clamp(1.0 - dot(normal, lightDir), 0.0, 1.0);
     // Multiply the base Z-bias by a slope factor to perfectly cure acne on thin meshes
-    float activeBias = bias * (1.1 + biasScale * normalBias); 
+    float activeBias = bias * (1.0 + biasScale * normalBias); 
 
     float currentDepth = projCoords.z - activeBias;
 

--- a/assets/Shaders/default.vert
+++ b/assets/Shaders/default.vert
@@ -79,7 +79,6 @@ out vec4 vPosLightSpace0;
 out vec4 vPosLightSpace1;
 out vec4 vPosLightSpace2;
 out vec4 vPosLightSpace3;
-out float vViewDepth;
 out vec3 vNormal;
 
 vec4 getLightResult()
@@ -222,8 +221,6 @@ void main()
 		vPosLightSpace1 = uLightSpaceMatrix1 * worldPos4;
 		vPosLightSpace2 = uLightSpaceMatrix2 * worldPos4;
 		vPosLightSpace3 = uLightSpaceMatrix3 * worldPos4;
-
-		vViewDepth = abs(oViewPos.z);
 	}
 	else
 	{
@@ -231,7 +228,6 @@ void main()
 		vPosLightSpace1 = vec4(0.0);
 		vPosLightSpace2 = vec4(0.0);
 		vPosLightSpace3 = vec4(0.0);
-		vViewDepth = 0.0;
 	}
 
 	oUv = (uCurrentTextureMatrix * vec4(iUv, 1.0, 1.0)).xy;

--- a/assets/Shaders/shadow_depth.vert
+++ b/assets/Shaders/shadow_depth.vert
@@ -90,7 +90,7 @@ void main()
 	// OpenBVE explicitly negates Z for world geometry.
 	pos.z = -pos.z;
 
-	vUv = (uTextureMatrix * vec4(iUv, 0.0, 1.0)).xy;
+	vUv = (uTextureMatrix * vec4(iUv, 1.0, 1.0)).xy;
 	gl_Position = uLightSpaceMatrix * uModelMatrix * vec4(pos, 1.0);
 }
 

--- a/assets/Shaders/shadow_depth.vert
+++ b/assets/Shaders/shadow_depth.vert
@@ -30,6 +30,7 @@ layout(location = 4) in ivec3 iMatrixChain;
 
 uniform mat4 uLightSpaceMatrix;
 uniform mat4 uModelMatrix;
+uniform mat4 uTextureMatrix;
 
 out vec2 vUv;
 
@@ -89,7 +90,7 @@ void main()
 	// OpenBVE explicitly negates Z for world geometry.
 	pos.z = -pos.z;
 
-	vUv = iUv;
+	vUv = (uTextureMatrix * vec4(iUv, 0.0, 1.0)).xy;
 	gl_Position = uLightSpaceMatrix * uModelMatrix * vec4(pos, 1.0);
 }
 

--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -18,7 +18,7 @@ using LibRender2.Overlays;
 using LibRender2.Primitives;
 using LibRender2.Screens;
 using LibRender2.Shaders;
-using LibRender2.Shadows;
+using LibRender2.ShadowMapping;
 using LibRender2.Text;
 using LibRender2.Textures;
 using LibRender2.Viewports;
@@ -157,20 +157,14 @@ namespace LibRender2
 
 		public Shader DefaultShader;
 		
-		/// <summary>Cascaded shadow map FBOs + depth textures.</summary>
-		public CascadedShadowMap CSMShadowMaps;
-		
-		/// <summary>Computes per-cascade light-space matrices.</summary>
-		public CascadedShadowCaster CSMCaster;
-		
-		/// <summary>The shadow depth shader for the depth-only pass.</summary>
-		public ShadowDepthShader ShadowDepthShaderProgram;
-		
+		/// <summary>Manages the Cascaded Shadow Mapping (CSM) system.</summary>
+		public Shadows Shadows;
+
 		/// <summary>Whether shadows are enabled.</summary>
-		public bool ShadowsEnabled = true;
+		public bool ShadowsEnabled => Shadows?.Enabled ?? false;
 
 		/// <summary>Shadow strength: 0=invisible, 1=full darkness.</summary>
-		public float ShadowStrength = 0.7f;
+		public float ShadowStrength => Shadows?.Strength ?? 0.7f;
 
 		/// <summary>Whether lighting is enabled in the debug options</summary>
 		public bool OptionLighting = true;
@@ -248,7 +242,7 @@ namespace LibRender2
 
 		protected internal Texture whitePixel;
 		/// <summary>A dummy 1x1 depth texture with comparison enabled, used when shadows are disabled to satisfy driver requirements.</summary>
-		private int nullDepthMap; 
+		internal int nullDepthMap; 
 
 		private bool logoError;
 
@@ -335,6 +329,7 @@ namespace LibRender2
 			Camera = new CameraProperties(this);
 			Lighting = new Lighting(this);
 			Marker = new Marker(this);
+			Shadows = new Shadows(this);
 
 			projectionMatrixList = new List<Matrix4D>();
 			viewMatrixList = new List<Matrix4D>();
@@ -474,90 +469,19 @@ namespace LibRender2
 			currentHost.RegisterTexture(Path.CombineFile(fileSystem.GetDataFolder("Menu"), "joystick.png"), TextureParameters.NoChange, out JoystickTexture);
 			currentHost.RegisterTexture(Path.CombineFile(fileSystem.GetDataFolder("Menu"), "raildriver.png"), TextureParameters.NoChange, out RailDriverTexture);
 
+			Lighting.Initialize();
+
 			if (AvailableNewRenderer)
 			{
-				InitializeShadows();
+				Shadows.Initialize();
 			}
 		}
 
-		/// <summary>
-		/// Initializes (or reinitializes) shadow mapping from current options.
-		/// Call after GL context creation and whenever shadow settings change.
-		/// </summary>
-		public void InitializeShadows()
-		{
-			// Read options
-			var opts = currentOptions;
-
-			// If shadows are off, dispose and disable
-			if (opts.ShadowResolution == ShadowMapResolution.Off)
-			{
-				DisposeShadows();
-				ShadowsEnabled = false;
-				fileSystem.AppendToLogFile("[CSM] Shadows disabled by user setting.");
-				return;
-			}
-
-			int resolution = Math.Max(1, (int)opts.ShadowResolution);
-			int cascadeCount = (int)opts.ShadowCascades;
-			double shadowDistance = opts.ShadowDrawDistance == ShadowDistance.ViewingDistance ? opts.ViewingDistance : (double)(int)opts.ShadowDrawDistance;
-			shadowDistance = Math.Max(1.0, shadowDistance);
-			float shadowStrength = (float)opts.ShadowStrength;
-
-			try
-			{
-				if (CSMShadowMaps == null)
-				{
-					// First-time creation
-					CSMShadowMaps = new CascadedShadowMap(cascadeCount, resolution);
-				}
-				else
-				{
-					// Hot-reload: resize existing maps
-					CSMShadowMaps.Resize(cascadeCount, resolution);
-				}
-
-				if (CSMCaster == null || cascadeCount != CSMCaster.CascadeCount)
-				{
-					// Create, or update if cascade count changed
-					CSMCaster = new CascadedShadowCaster(cascadeCount);
-				}
-
-				CSMCaster.ShadowDistance = shadowDistance;
-				CSMCaster.Resolution = resolution;
-				CSMCaster.SplitLambda = 0.75;
-				CSMCaster.DepthMargin = 150.0;
-
-				ShadowStrength = shadowStrength;
-
-				if (ShadowDepthShaderProgram == null)
-				{
-					ShadowDepthShaderProgram = new ShadowDepthShader(this, "shadow_depth", "shadow_depth", true);
-				}
-
-				ShadowsEnabled = true;
-
-				fileSystem.AppendToLogFile($"[CSM] Initialized: {cascadeCount} cascades, " + $"{resolution}×{resolution}, distance={shadowDistance}m, " + $"strength={shadowStrength:P0}");
-			}
-			catch (Exception ex)
-			{
-				fileSystem.AppendToLogFile($"[CSM] Init failed: {ex.Message}");
-				ShadowsEnabled = false;
-				// Purge lingering OpenGL error state if any, to avoid crashing later in ResetShader
-				GL.GetError();
-			}
-		}
+		/// <summary>Initializes (or reinitializes) shadow mapping from current options.</summary>
+		public void InitializeShadows() => Shadows.Initialize();
 
 		/// <summary>Disposes all shadow GPU resources.</summary>
-		public void DisposeShadows()
-		{
-			CSMShadowMaps?.Dispose();
-			CSMShadowMaps = null;
-			ShadowDepthShaderProgram?.Dispose();
-			ShadowDepthShaderProgram = null;
-			CSMCaster = null;
-			ShadowsEnabled = false;
-		}
+		public void DisposeShadows() => Shadows.Dispose();
 
 		/// <summary>
 		/// Call this when the user changes shadow settings at runtime
@@ -599,175 +523,13 @@ namespace LibRender2
 			while (GL.GetError() != ErrorCode.NoError) { }
 		}
 
-		/// <summary>
-		/// Performs the CSM shadow depth rendering pass for all opaque geometry.
-		/// </summary>
-		protected void PerformCSMShadowPass()
-		{
-			if (!ShadowsEnabled || CSMShadowMaps == null || CSMCaster == null || ShadowDepthShaderProgram == null)
-				return;
+		/// <summary>Performs the CSM shadow depth rendering pass for all geometry.</summary>
+		protected void PerformCSMShadowPass() => Shadows.RenderPass();
 
-			// 1. Get light direction pointing FROM the sun TOWARD the scene
-			// OptionLightPosition points to the sun, so we negate it for the shadow pass.
-			// OpenBVE world space is Z-forward, so we also negate the final Z for OpenGL space.
-			Vector3 lightDir = new Vector3(
-				-Lighting.OptionLightPosition.X,
-				-Lighting.OptionLightPosition.Y,
-				Lighting.OptionLightPosition.Z // -(-Z) from previous code
-			);
+		/// <summary>Binds cascading shadow data to the default shader.</summary>
+		protected void BindCSMToDefaultShader() => Shadows.Bind(DefaultShader);
 
-			// 2. Update cascade matrices
-			// Use CurrentViewMatrix (Z-negated) so the frustum corners match the world space
-			// that the shadow depth shader and shadow lookup shader both operate in.
-			if (lightDir.IsNullVector())
-			{
-				return;
-			}
-			CSMCaster.Resolution = CSMShadowMaps.Resolution;
-			if (currentOptions.ShadowDrawDistance == ShadowDistance.ViewingDistance)
-			{
-				CSMCaster.ShadowDistance = currentOptions.ViewingDistance;
-			}
-			CSMCaster.Update(lightDir, CurrentViewMatrix, CurrentProjectionMatrix, 0.1, Camera.VerticalViewingAngle, Screen.AspectRatio);
-
-			// 3. Setup rendering state
-			CurrentShader?.Deactivate();
-			ShadowDepthShaderProgram.Activate();
-			GL.Enable(EnableCap.DepthTest);
-			GL.DepthFunc(DepthFunction.Less);
-			GL.Disable(EnableCap.CullFace);
-			GL.DepthMask(true); // Ensure depth writes are enabled before clearing
-			ShadowDepthShaderProgram.SetTexture(0); // always use texture unit 0
-
-			for (int cascade = 0; cascade < CSMCaster.CascadeCount; cascade++)
-			{
-				CSMShadowMaps.BindCascadeForWriting(cascade);
-				GL.Clear(ClearBufferMask.DepthBufferBit);
-				ShadowDepthShaderProgram.SetLightSpaceMatrix(CSMCaster.LightSpaceMatrices[cascade]);
-
-				lock (VisibleObjects.LockObject)
-				{
-					int lastVAOHandle = -1;
-
-					// Add a helper to render a collection of faces into the shadow pass also avoiding duplicate loops for opaque and alpha collections.
-					Action<ICollection<FaceState>> renderFaces = faces =>
-					{
-						foreach (var face in faces)
-						{
-							if (face.Object.Prototype.Mesh.VAO == null) continue;
-							if (face.Object.DisableShadowCasting) continue;
-
-							Matrix4D modelMatrix = face.Object.ModelMatrix * Camera.TranslationMatrix;
-							ShadowDepthShaderProgram.SetModelMatrix(modelMatrix);
-
-							// Bind texture for alpha scissoring if the face has one
-							var material = face.Object.Prototype.Mesh.Materials[face.Face.Material];
-							if (material.DaytimeTexture != null && currentHost.LoadTexture(ref material.DaytimeTexture, (OpenGlTextureWrapMode)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)))
-							{
-								GL.ActiveTexture(TextureUnit.Texture0);
-								GL.BindTexture(TextureTarget.Texture2D,
-									material.DaytimeTexture.OpenGlTextures[(int)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)].Name);
-								ShadowDepthShaderProgram.SetHasTexture(true);
-							}
-							else
-							{
-								ShadowDepthShaderProgram.SetHasTexture(false);
-							}
-
-							// Set alpha cutoff + material alpha for all faces, so untextured semi-transparent
-							// geometry (e.g. glass with Color,80,80,160,90) is also correctly discarded
-							ShadowDepthShaderProgram.SetAlphaCutoff(0.5f);
-							ShadowDepthShaderProgram.SetMaterialAlpha(material.Color.A / 255.0f);
-							ShadowDepthShaderProgram.SetMaterialFlags(material.Flags);
-
-#pragma warning disable CS0618
-							ObjectState state = face.Object;
-							if (state.Matricies != null && state.Matricies.Length > 0)
-							{
-								ShadowDepthShaderProgram.SetCurrentAnimationMatricies(state);
-								GL.BindBufferBase(BufferTarget.UniformBuffer, 0, state.MatrixBufferIndex);
-							}
-#pragma warning restore CS0618
-
-							VertexArrayObject vao = (VertexArrayObject)face.Object.Prototype.Mesh.VAO;
-							if (vao.handle != lastVAOHandle)
-							{
-								vao.Bind();
-								lastVAOHandle = vao.handle;
-							}
-							PrimitiveType drawMode = GetPrimitiveType(face.Face.Flags);
-							vao.Draw(drawMode, face.Face.IboStartIndex, face.Face.Vertices.Length);
-						}
-					};
-
-					// Render both opaque and alpha-tested geometry into the shadow map.
-					// This ensures semi-transparent cutout objects (fences, trees, etc. using `transparent`) 
-					// cast proper silhouettes instead of being skipped.
-					renderFaces(VisibleObjects.OpaqueFaces);
-					renderFaces(VisibleObjects.AlphaFaces);
-				}
-				CSMShadowMaps.Unbind();
-			}
-
-			// 4. Restore state
-			GL.DepthFunc(DepthFunction.Lequal);
-			GL.CullFace(CullFaceMode.Front);
-			GL.Viewport(0, 0, Screen.Width, Screen.Height);
-
-			// Shadow pass corrupts the GL texture state without updating LastBoundTexture
-			// Clear it here so the main pass is forced to rebind the correct texture or whitePixel.
-			LastBoundTexture = null;
-		}
-
-		/// <summary>
-		/// Binds cascading shadow data to the default shader.
-		/// </summary>
-		protected void BindCSMToDefaultShader()
-		{
-			if (!ShadowsEnabled || CSMShadowMaps == null || CSMCaster == null)
-			{
-				DefaultShader.SetShadowEnabled(false);
-				// To satisfy strict OpenGL drivers (e.g. Apple/Intel), we must still bind a depth-compatible
-				// texture even if shadows are disabled, as the shader contains sampler2DShadow uniforms.
-				for (int i = 0; i < 4; i++)
-				{
-					GL.ActiveTexture(TextureUnit.Texture4 + i);
-					GL.BindTexture(TextureTarget.Texture2D, nullDepthMap);
-				}
-				GL.ActiveTexture(TextureUnit.Texture0);
-				return;
-			}
-
-			DefaultShader.Activate();
-			DefaultShader.SetShadowEnabled(true);
-			
-			// Read strength from current options (supports runtime changes)
-			DefaultShader.SetShadowStrength((float)currentOptions.ShadowStrength);
-			DefaultShader.SetCurrentViewMatrix(CurrentViewMatrix);
-
-			CSMShadowMaps.BindAllCascadesForReading(TextureUnit.Texture4);
-
-			int cascadeCount = CSMCaster.CascadeCount;
-			for (int i = 0; i < cascadeCount; i++)
-			{
-				DefaultShader.SetCascadeLightSpaceMatrix(i, CSMCaster.LightSpaceMatrices[i]);
-				DefaultShader.SetCascadeShadowMapUnit(i, 4 + i);
-				DefaultShader.SetCascadeFarDistance(i, (float)CSMCaster.CascadeFarDistances[i]);
-				DefaultShader.SetCascadeBias(i, CSMCaster.CascadeBiases[i] + (float)currentOptions.ShadowBias);
-				DefaultShader.SetNormalBias(i, (float)currentOptions.ShadowNormalBias);
-			}
-
-
-			// If fewer than max cascades, disable unused slots
-			for (int i = cascadeCount; i < 4; i++)
-			{
-				DefaultShader.SetCascadeFarDistance(i, 0.0f);
-			}
-
-			DefaultShader.SetCascadeCount(cascadeCount);
-		}
-
-		private PrimitiveType GetPrimitiveType(FaceFlags flags)
+		internal PrimitiveType GetPrimitiveType(FaceFlags flags)
 		{
 			switch (flags & FaceFlags.FaceTypeMask)
 			{

--- a/source/LibRender2/LibRender2.csproj
+++ b/source/LibRender2/LibRender2.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Shadows\CascadedShadowCaster.cs" />
     <Compile Include="Shadows\CascadedShadowMap.cs" />
     <Compile Include="Shadows\FrustumUtils.cs" />
+    <Compile Include="Shadows\Shadows.cs" />
     <Compile Include="Textures\TextureManager.cs" />
     <Compile Include="Text\Fonts.BlockedFonts.cs" />
     <Compile Include="Text\Fonts.cs" />

--- a/source/LibRender2/Menu/Menu.OptionType.cs
+++ b/source/LibRender2/Menu/Menu.OptionType.cs
@@ -1,4 +1,4 @@
-﻿//Simplified BSD License (BSD-2-Clause)
+//Simplified BSD License (BSD-2-Clause)
 //
 //Copyright (c) 2024, Maurizo M. Gavioli, The OpenBVE Project
 //
@@ -46,6 +46,8 @@ namespace LibRender2.Menu
 		/// <summary>Sets whether to automatically reload the current objects</summary>
 		AutoReloadObjects,
 		/// <summary>Sets the shadow quality</summary>
-		ShadowQuality
+		ShadowQuality,
+		/// <summary>Sets whether shadow casters are filtered per cascade</summary>
+		ShadowFilterCascades
 	}
 }

--- a/source/LibRender2/Menu/MenuEntries/MenuOption.cs
+++ b/source/LibRender2/Menu/MenuEntries/MenuOption.cs
@@ -1,4 +1,4 @@
-﻿//Simplified BSD License (BSD-2-Clause)
+//Simplified BSD License (BSD-2-Clause)
 //
 //Copyright (c) 2024, Maurizo M. Gavioli, The OpenBVE Project
 //
@@ -169,6 +169,9 @@ namespace LibRender2.Menu
 							break;
 					}
 					return;
+				case OptionType.ShadowFilterCascades:
+					CurrentlySelectedOption = BaseMenu.CurrentOptions.ShadowFilterCascades ? 0 : 1;
+					return;
 			}
 			CurrentlySelectedOption = 0;
 		}
@@ -315,6 +318,9 @@ namespace LibRender2.Menu
 							break;
 					}
 					BaseMenu.Renderer.InitializeShadows();
+					break;
+				case OptionType.ShadowFilterCascades:
+					BaseMenu.CurrentOptions.ShadowFilterCascades = !BaseMenu.CurrentOptions.ShadowFilterCascades;
 					break;
 
 			}

--- a/source/LibRender2/Shaders/Shader.cs
+++ b/source/LibRender2/Shaders/Shader.cs
@@ -43,30 +43,30 @@ namespace LibRender2.Shaders
 		public readonly VertexLayout VertexLayout;
 		public readonly UniformLayout UniformLayout;
 		private readonly int uShadowEnabledLocation;
-		private readonly int uLightSpaceMatrix0Location;
-		private readonly int uLightSpaceMatrix1Location;
-		private readonly int uLightSpaceMatrix2Location;
+		private readonly int uShadowStrengthLocation;
+		private readonly int uShadowCascadeCountLocation;
 		private readonly int uShadowMap0Location;
 		private readonly int uShadowMap1Location;
 		private readonly int uShadowMap2Location;
-		private readonly int uCascadeFarDist0Location;
-		private readonly int uCascadeFarDist1Location;
-		private readonly int uCascadeFarDist2Location;
-		private readonly int uCascadeBias0Location;
-		private readonly int uCascadeBias1Location;
-		private readonly int uCascadeBias2Location;
-		private readonly int uShadowStrengthLocation;
+		private readonly int uShadowMap3Location;
+		private readonly int uShadowSplit0Location;
+		private readonly int uShadowSplit1Location;
+		private readonly int uShadowSplit2Location;
+		private readonly int uShadowSplit3Location;
+		private readonly int uShadowBias0Location;
+		private readonly int uShadowBias1Location;
+		private readonly int uShadowBias2Location;
+		private readonly int uShadowBias3Location;
+		private readonly int uShadowNormalBias0Location;
+		private readonly int uShadowNormalBias1Location;
+		private readonly int uShadowNormalBias2Location;
+		private readonly int uShadowNormalBias3Location;
+		private readonly int uLightSpaceMatrix0Location;
+		private readonly int uLightSpaceMatrix1Location;
+		private readonly int uLightSpaceMatrix2Location;
+		private readonly int uLightSpaceMatrix3Location;
 		private readonly int uModelMatrixLocation;
 		private readonly int uCurrentViewMatrixLocation;
-		private readonly int uLightSpaceMatrix3Location;
-		private readonly int uShadowMap3Location;
-		private readonly int uCascadeFarDist3Location;
-		private readonly int uCascadeBias3Location;
-		private readonly int uNormalBias0Location;
-		private readonly int uNormalBias1Location;
-		private readonly int uNormalBias2Location;
-		private readonly int uNormalBias3Location;
-		private readonly int uCascadeCountLocation;
 
 
 		/// <summary>
@@ -79,30 +79,30 @@ namespace LibRender2.Shaders
 		public Shader(BaseRenderer Renderer, string vertexShaderName, string fragmentShaderName, bool isFromStream = false) : base(Renderer, vertexShaderName, fragmentShaderName, isFromStream, true)
 		{
 			uShadowEnabledLocation = GL.GetUniformLocation(Handle, "uShadowEnabled");
-			uLightSpaceMatrix0Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix0");
-			uLightSpaceMatrix1Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix1");
-			uLightSpaceMatrix2Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix2");
+			uShadowStrengthLocation = GL.GetUniformLocation(Handle, "uShadowStrength");
+			uShadowCascadeCountLocation = GL.GetUniformLocation(Handle, "uShadowCascadeCount");
 			uShadowMap0Location = GL.GetUniformLocation(Handle, "uShadowMap0");
 			uShadowMap1Location = GL.GetUniformLocation(Handle, "uShadowMap1");
 			uShadowMap2Location = GL.GetUniformLocation(Handle, "uShadowMap2");
-			uCascadeFarDist0Location = GL.GetUniformLocation(Handle, "uCascadeFarDist0");
-			uCascadeFarDist1Location = GL.GetUniformLocation(Handle, "uCascadeFarDist1");
-			uCascadeFarDist2Location = GL.GetUniformLocation(Handle, "uCascadeFarDist2");
-			uCascadeBias0Location = GL.GetUniformLocation(Handle, "uCascadeBias0");
-			uCascadeBias1Location = GL.GetUniformLocation(Handle, "uCascadeBias1");
-			uCascadeBias2Location = GL.GetUniformLocation(Handle, "uCascadeBias2");
-			uShadowStrengthLocation = GL.GetUniformLocation(Handle, "uShadowStrength");
+			uShadowMap3Location = GL.GetUniformLocation(Handle, "uShadowMap3");
+			uShadowSplit0Location = GL.GetUniformLocation(Handle, "uShadowSplit0");
+			uShadowSplit1Location = GL.GetUniformLocation(Handle, "uShadowSplit1");
+			uShadowSplit2Location = GL.GetUniformLocation(Handle, "uShadowSplit2");
+			uShadowSplit3Location = GL.GetUniformLocation(Handle, "uShadowSplit3");
+			uShadowBias0Location = GL.GetUniformLocation(Handle, "uShadowBias0");
+			uShadowBias1Location = GL.GetUniformLocation(Handle, "uShadowBias1");
+			uShadowBias2Location = GL.GetUniformLocation(Handle, "uShadowBias2");
+			uShadowBias3Location = GL.GetUniformLocation(Handle, "uShadowBias3");
+			uShadowNormalBias0Location = GL.GetUniformLocation(Handle, "uShadowNormalBias0");
+			uShadowNormalBias1Location = GL.GetUniformLocation(Handle, "uShadowNormalBias1");
+			uShadowNormalBias2Location = GL.GetUniformLocation(Handle, "uShadowNormalBias2");
+			uShadowNormalBias3Location = GL.GetUniformLocation(Handle, "uShadowNormalBias3");
+			uLightSpaceMatrix0Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix0");
+			uLightSpaceMatrix1Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix1");
+			uLightSpaceMatrix2Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix2");
+			uLightSpaceMatrix3Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix3");
 			uModelMatrixLocation = GL.GetUniformLocation(Handle, "uModelMatrix");
 			uCurrentViewMatrixLocation = GL.GetUniformLocation(Handle, "uCurrentViewMatrix");
-			uLightSpaceMatrix3Location = GL.GetUniformLocation(Handle, "uLightSpaceMatrix3");
-			uShadowMap3Location = GL.GetUniformLocation(Handle, "uShadowMap3");
-			uCascadeFarDist3Location = GL.GetUniformLocation(Handle, "uCascadeFarDist3");
-			uCascadeBias3Location = GL.GetUniformLocation(Handle, "uCascadeBias3");
-			uNormalBias0Location = GL.GetUniformLocation(Handle, "uNormalBias0");
-			uNormalBias1Location = GL.GetUniformLocation(Handle, "uNormalBias1");
-			uNormalBias2Location = GL.GetUniformLocation(Handle, "uNormalBias2");
-			uNormalBias3Location = GL.GetUniformLocation(Handle, "uNormalBias3");
-			uCascadeCountLocation = GL.GetUniformLocation(Handle, "uCascadeCount");
 
 			VertexLayout = GetVertexLayout();
 			UniformLayout = GetUniformLayout();
@@ -115,7 +115,7 @@ namespace LibRender2.Shaders
 			GL.ProgramUniform1(Handle, uShadowMap3Location, 7);
 			// Also ensure shadow is disabled by default
 			GL.ProgramUniform1(Handle, uShadowEnabledLocation, 0);
-			GL.ProgramUniform1(Handle, uCascadeCountLocation, 0);
+			GL.ProgramUniform1(Handle, uShadowCascadeCountLocation, 0);
 			GL.ProgramUniform1(Handle, uShadowStrengthLocation, 1.0f);
 		}
 		
@@ -462,15 +462,15 @@ namespace LibRender2.Shaders
 			GL.ProgramUniform1(Handle, loc, textureUnit);
 		}
 
-		public void SetCascadeFarDistance(int cascade, float distance)
+		public void SetShadowSplitDistance(int cascade, float distance)
 		{
 			int loc;
 			switch (cascade)
 			{
-				case 0: loc = uCascadeFarDist0Location; break;
-				case 1: loc = uCascadeFarDist1Location; break;
-				case 2: loc = uCascadeFarDist2Location; break;
-				case 3: loc = uCascadeFarDist3Location; break;
+				case 0: loc = uShadowSplit0Location; break;
+				case 1: loc = uShadowSplit1Location; break;
+				case 2: loc = uShadowSplit2Location; break;
+				case 3: loc = uShadowSplit3Location; break;
 				default: return;
 			}
 			GL.ProgramUniform1(Handle, loc, distance);
@@ -481,10 +481,10 @@ namespace LibRender2.Shaders
 			int loc;
 			switch (cascade)
 			{
-				case 0: loc = uCascadeBias0Location; break;
-				case 1: loc = uCascadeBias1Location; break;
-				case 2: loc = uCascadeBias2Location; break;
-				case 3: loc = uCascadeBias3Location; break;
+				case 0: loc = uShadowBias0Location; break;
+				case 1: loc = uShadowBias1Location; break;
+				case 2: loc = uShadowBias2Location; break;
+				case 3: loc = uShadowBias3Location; break;
 				default: return;
 			}
 			GL.ProgramUniform1(Handle, loc, bias);
@@ -495,18 +495,18 @@ namespace LibRender2.Shaders
 			int loc;
 			switch (cascade)
 			{
-				case 0: loc = uNormalBias0Location; break;
-				case 1: loc = uNormalBias1Location; break;
-				case 2: loc = uNormalBias2Location; break;
-				case 3: loc = uNormalBias3Location; break;
+				case 0: loc = uShadowNormalBias0Location; break;
+				case 1: loc = uShadowNormalBias1Location; break;
+				case 2: loc = uShadowNormalBias2Location; break;
+				case 3: loc = uShadowNormalBias3Location; break;
 				default: return;
 			}
 			GL.ProgramUniform1(Handle, loc, bias);
 		}
 
-		public void SetCascadeCount(int count)
+		public void SetShadowCascadeCount(int count)
 		{
-			GL.ProgramUniform1(Handle, uCascadeCountLocation, count);
+			GL.ProgramUniform1(Handle, uShadowCascadeCountLocation, count);
 		}
 
 		public void SetShadowStrength(float strength)

--- a/source/LibRender2/Shaders/ShadowDepthShader.cs
+++ b/source/LibRender2/Shaders/ShadowDepthShader.cs
@@ -37,6 +37,7 @@ namespace LibRender2.Shaders
 		private readonly int uAlphaCutoff;
 		private readonly int uMaterialAlpha; // Uniform location for material color alpha
 		private readonly int uMaterialFlags;
+		private readonly int uTextureMatrix;
 
 		public ShadowDepthShader(BaseRenderer Renderer,  string vertexShaderName, string fragmentShaderName, bool isFromStream = false) : base(Renderer, vertexShaderName, fragmentShaderName, isFromStream, false)
 		{
@@ -56,6 +57,7 @@ namespace LibRender2.Shaders
 			uAlphaCutoff = GL.GetUniformLocation(Handle, "uAlphaCutoff");
 			uMaterialAlpha = GL.GetUniformLocation(Handle, "uMaterialAlpha"); // Cache the material alpha location
 			uMaterialFlags = GL.GetUniformLocation(Handle, "uMaterialFlags");
+			uTextureMatrix = GL.GetUniformLocation(Handle, "uTextureMatrix");
 		}
 
 		public void SetLightSpaceMatrix(OpenBveApi.Math.Matrix4D m)
@@ -95,6 +97,12 @@ namespace LibRender2.Shaders
 		{
 			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
 			GL.UniformMatrix4(uModelMatrix, false, ref matrix);
+		}
+
+		public void SetTextureMatrix(OpenBveApi.Math.Matrix4D m)
+		{
+			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
+			GL.UniformMatrix4(uTextureMatrix, false, ref matrix);
 		}
 
 		public void SetCurrentAnimationMatricies(OpenBveApi.Objects.ObjectState objectState)

--- a/source/LibRender2/Shaders/ShadowDepthShader.cs
+++ b/source/LibRender2/Shaders/ShadowDepthShader.cs
@@ -66,6 +66,18 @@ namespace LibRender2.Shaders
 			GL.UniformMatrix4(uLightSpaceMatrix, false, ref matrix);
 		}
 
+		public void SetModelMatrix(OpenBveApi.Math.Matrix4D m)
+		{
+			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
+			GL.UniformMatrix4(uModelMatrix, false, ref matrix);
+		}
+
+		public void SetTextureMatrix(OpenBveApi.Math.Matrix4D m)
+		{
+			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
+			GL.UniformMatrix4(uTextureMatrix, false, ref matrix);
+		}
+
 		public void SetTexture(int unit)
 		{
 			GL.Uniform1(uTexture, unit);
@@ -91,18 +103,6 @@ namespace LibRender2.Shaders
 		public void SetMaterialFlags(MaterialFlags flags)
 		{
 			GL.Uniform1(uMaterialFlags, (int)flags);
-		}
-
-		public void SetModelMatrix(OpenBveApi.Math.Matrix4D m)
-		{
-			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
-			GL.UniformMatrix4(uModelMatrix, false, ref matrix);
-		}
-
-		public void SetTextureMatrix(OpenBveApi.Math.Matrix4D m)
-		{
-			OpenTK.Matrix4 matrix = ConvertToMatrix4(m);
-			GL.UniformMatrix4(uTextureMatrix, false, ref matrix);
 		}
 
 		public void SetCurrentAnimationMatricies(OpenBveApi.Objects.ObjectState objectState)

--- a/source/LibRender2/Shadows/CascadedShadowCaster.cs
+++ b/source/LibRender2/Shadows/CascadedShadowCaster.cs
@@ -1,7 +1,7 @@
 using System;
 using OpenBveApi.Math;
 
-namespace LibRender2.Shadows
+namespace LibRender2.ShadowMapping
 {
     /// <summary>
     /// Computes per-cascade light-space matrices by fitting an orthographic
@@ -29,8 +29,12 @@ namespace LibRender2.Shadows
         public Matrix4D[] LightSpaceMatrices { get; private set; }
 
 		/// <summary>Per-cascade split distances (view-space Z).</summary>
-		///<remarks>>Length = CascadeCount. Used in the fragment shader to pick cascade.</remarks> 
-		public float[] CascadeFarDistances { get; private set; }
+		/// <remarks>
+		/// Length = CascadeCount. Renamed from FarDistance to SplitDistance to better reflect
+		/// standard CSM/PSSM terminology. These values represent the frustum slice boundaries
+		/// in view-space Z where the shadow transition between cascades occurs.
+		/// </remarks> 
+		public float[] SplitDistances { get; private set; }
 
         /// <summary>Per-cascade depth bias for shadow acne prevention.</summary>
         public float[] CascadeBiases { get; private set; }
@@ -39,7 +43,7 @@ namespace LibRender2.Shadows
         {
             CascadeCount = cascadeCount;
             LightSpaceMatrices = new Matrix4D[cascadeCount];
-            CascadeFarDistances = new float[cascadeCount];
+            SplitDistances = new float[cascadeCount];
             CascadeBiases = new float[cascadeCount];
 
             for (int i = 0; i < cascadeCount; i++)
@@ -137,7 +141,7 @@ namespace LibRender2.Shadows
                 Matrix4D.CreateOrthographic(orthoSize * 2.0, orthoSize * 2.0, zNear, zFar, out Matrix4D lightProj);
 
                 LightSpaceMatrices[i] = lightView * lightProj;
-                CascadeFarDistances[i] = (float)splits[i + 1];
+                SplitDistances[i] = (float)splits[i + 1];
 
                 // Z-Bias: Convert physical texel size into a Depth Buffer fraction.
                 // This ensures we push the depth exactly enough to cure acne, but no more.

--- a/source/LibRender2/Shadows/CascadedShadowMap.cs
+++ b/source/LibRender2/Shadows/CascadedShadowMap.cs
@@ -1,7 +1,7 @@
 using System;
 using OpenTK.Graphics.OpenGL;
 
-namespace LibRender2.Shadows
+namespace LibRender2.ShadowMapping
 {
     /// <summary>
     /// Manages multiple depth-only FBOs for Cascaded Shadow Mapping.

--- a/source/LibRender2/Shadows/FrustumUtils.cs
+++ b/source/LibRender2/Shadows/FrustumUtils.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using OpenBveApi.Math;
 
-namespace LibRender2.Shadows
+namespace LibRender2.ShadowMapping
 {
 	/// <summary>
 	/// Utility class for camera frustum calculations, specifically for Cascaded Shadow Mapping.

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using LibRender2.Objects;
+using LibRender2.Shaders;
+using OpenBveApi.Graphics;
+using OpenBveApi.Interface;
+using OpenBveApi.Math;
+using OpenBveApi.Objects;
+using OpenBveApi.Textures;
+using OpenTK.Graphics.OpenGL;
+
+namespace LibRender2.ShadowMapping
+{
+	/// <summary>
+	/// Manages the Cascaded Shadow Mapping (CSM) system, including depth passes and shader binding.
+	/// </summary>
+	public class Shadows
+	{
+		private readonly BaseRenderer renderer;
+
+		/// <summary>The shadow map textures and framebuffers.</summary>
+		internal CascadedShadowMap Map;
+		/// <summary>The math engine for computing cascade frustums and matrices.</summary>
+		internal CascadedShadowCaster Caster;
+		/// <summary>The shader used for rendering the shadow depth pass.</summary>
+		internal ShadowDepthShader DepthShader;
+
+		/// <summary>Whether shadows are currently active.</summary>
+		public bool Enabled;
+		/// <summary>The current darkness of the shadows (0.0 to 1.0).</summary>
+		public float Strength;
+
+		public Shadows(BaseRenderer renderer)
+		{
+			this.renderer = renderer;
+		}
+
+		/// <summary>
+		/// Initializes (or reinitializes) shadow mapping from current options.
+		/// </summary>
+		public void Initialize()
+		{
+			var opts = renderer.currentOptions;
+
+			if (opts.ShadowResolution == ShadowMapResolution.Off)
+			{
+				Dispose();
+				Enabled = false;
+				renderer.fileSystem.AppendToLogFile("[CSM] Shadows disabled by user setting.");
+				return;
+			}
+
+			int resolution = Math.Max(1, (int)opts.ShadowResolution);
+			int cascadeCount = (int)opts.ShadowCascades;
+			double shadowDistance = opts.ShadowDrawDistance == ShadowDistance.ViewingDistance ? opts.ViewingDistance : (double)(int)opts.ShadowDrawDistance;
+			shadowDistance = Math.Max(1.0, shadowDistance);
+			Strength = (float)opts.ShadowStrength;
+
+			try
+			{
+				if (Map == null)
+				{
+					Map = new CascadedShadowMap(cascadeCount, resolution);
+				}
+				else
+				{
+					Map.Resize(cascadeCount, resolution);
+				}
+
+				if (Caster == null || cascadeCount != Caster.CascadeCount)
+				{
+					Caster = new CascadedShadowCaster(cascadeCount);
+				}
+
+				Caster.ShadowDistance = shadowDistance;
+				Caster.Resolution = resolution;
+				Caster.SplitLambda = 0.75;
+				Caster.DepthMargin = 150.0;
+
+				if (DepthShader == null)
+				{
+					DepthShader = new ShadowDepthShader(renderer, "shadow_depth", "shadow_depth", true);
+				}
+
+				Enabled = true;
+				renderer.fileSystem.AppendToLogFile($"[CSM] Initialized: {cascadeCount} cascades, {resolution}×{resolution}, distance={shadowDistance}m, strength={Strength:P0}");
+			}
+			catch (Exception ex)
+			{
+				renderer.fileSystem.AppendToLogFile($"[CSM] Init failed: {ex.Message}");
+				Enabled = false;
+				GL.GetError();
+			}
+		}
+
+		/// <summary>
+		/// Performs the shadow depth pass for all cascades.
+		/// </summary>
+		public void RenderPass()
+		{
+			if (!Enabled || Map == null || Caster == null || DepthShader == null)
+			{
+				return;
+			}
+
+			// 1. Get light direction pointing FROM the sun TOWARD the scene
+			// Sun position is in OpenBVE coordinates (X: right, Y: up, Z: backward)
+			// Light direction needs to be negated for some components to match the shadow math.
+			Vector3 lightDir = new Vector3(
+				-renderer.Lighting.OptionLightPosition.X,
+				-renderer.Lighting.OptionLightPosition.Y,
+				renderer.Lighting.OptionLightPosition.Z
+			);
+
+			if (lightDir.IsNullVector())
+			{
+				return;
+			}
+
+			// 2. Update cascade matrices
+			// NOTE: We pass renderer.CurrentViewMatrix here which reflects the camera's rotation.
+			// The Caster will use this to align the shadow frustums with the view direction.
+			Caster.Resolution = Map.Resolution;
+			if (renderer.currentOptions.ShadowDrawDistance == ShadowDistance.ViewingDistance)
+			{
+				Caster.ShadowDistance = renderer.currentOptions.ViewingDistance;
+			}
+			Caster.Update(lightDir, renderer.CurrentViewMatrix, renderer.CurrentProjectionMatrix, 0.1, renderer.Camera.VerticalViewingAngle, renderer.Screen.AspectRatio);
+
+			// 3. Setup state for depth pass
+			renderer.CurrentShader?.Deactivate();
+			DepthShader.Activate();
+			GL.Enable(EnableCap.DepthTest);
+			GL.DepthFunc(DepthFunction.Less);
+			GL.Disable(EnableCap.CullFace);
+			GL.DepthMask(true);
+			DepthShader.SetTexture(0);
+
+			for (int i = 0; i < Caster.CascadeCount; i++)
+			{
+				Map.BindCascadeForWriting(i);
+				GL.Clear(ClearBufferMask.DepthBufferBit);
+				DepthShader.SetLightSpaceMatrix(Caster.LightSpaceMatrices[i]);
+
+				lock (renderer.VisibleObjects.LockObject)
+				{
+					int lastVAO = -1;
+					// Render both opaque and alpha-tested geometry (AlphaFaces).
+					// Alpha-tested objects (like trees) need to cast shadows for realism.
+					RenderFaces(renderer.VisibleObjects.OpaqueFaces, ref lastVAO);
+					RenderFaces(renderer.VisibleObjects.AlphaFaces, ref lastVAO); 
+				}
+				Map.Unbind();
+			}
+
+			// 4. Restore state
+			GL.DepthFunc(DepthFunction.Lequal);
+			GL.CullFace(CullFaceMode.Front);
+			GL.Viewport(0, 0, renderer.Screen.Width, renderer.Screen.Height);
+			// Shadow pass corrupts the GL texture state, so ensure we null it out
+			// so the next render pass re-binds what it needs.
+			renderer.LastBoundTexture = null;
+		}
+
+		/// <summary>
+		/// Renders a collection of faces while minimizing VAO and texture state switches.
+		/// </summary>
+		/// <param name="faces">The faces to render.</param>
+		/// <param name="lastVAO">A reference to the last bound VAO handle, to avoid redundant binds.</param>
+		private void RenderFaces(IEnumerable<FaceState> faces, ref int lastVAO)
+		{
+			foreach (var face in faces)
+			{
+				if (face.Object.Prototype.Mesh.VAO == null || face.Object.DisableShadowCasting)
+				{
+					continue;
+				}
+
+				Matrix4D modelMatrix = face.Object.ModelMatrix * renderer.Camera.TranslationMatrix;
+				DepthShader.SetModelMatrix(modelMatrix);
+
+				var material = face.Object.Prototype.Mesh.Materials[face.Face.Material];
+				if (material.DaytimeTexture != null && renderer.currentHost.LoadTexture(ref material.DaytimeTexture, (OpenGlTextureWrapMode)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)))
+				{
+					GL.ActiveTexture(TextureUnit.Texture0);
+					GL.BindTexture(TextureTarget.Texture2D, material.DaytimeTexture.OpenGlTextures[(int)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)].Name);
+					DepthShader.SetHasTexture(true);
+				}
+				else
+				{
+					DepthShader.SetHasTexture(false);
+				}
+
+				DepthShader.SetAlphaCutoff(0.5f);
+				DepthShader.SetMaterialAlpha(material.Color.A / 255.0f);
+				DepthShader.SetMaterialFlags(material.Flags);
+
+				ObjectState state = face.Object;
+				if (state.Matricies != null && state.Matricies.Length > 0)
+				{
+					DepthShader.SetCurrentAnimationMatricies(state);
+					GL.BindBufferBase(BufferTarget.UniformBuffer, 0, state.MatrixBufferIndex);
+				}
+
+				VertexArrayObject vao = (VertexArrayObject)face.Object.Prototype.Mesh.VAO;
+				if (vao.handle != lastVAO)
+				{
+					vao.Bind();
+					lastVAO = vao.handle;
+				}
+				PrimitiveType drawMode = renderer.GetPrimitiveType(face.Face.Flags);
+				vao.Draw(drawMode, face.Face.IboStartIndex, face.Face.Vertices.Length);
+			}
+		}
+
+		/// <summary>
+		/// Binds shadow data to the main scene shader.
+		/// </summary>
+		public void Bind(Shader shader)
+		{
+			if (!Enabled || Map == null || Caster == null)
+			{
+				shader.SetShadowEnabled(false);
+				// To satisfy strict OpenGL drivers, always bind something to the shadow map units
+				// even if shadow is disabled, to avoid "sampler collision" errors.
+				for (int i = 0; i < 4; i++)
+				{
+					GL.ActiveTexture(TextureUnit.Texture4 + i);
+					GL.BindTexture(TextureTarget.Texture2D, renderer.nullDepthMap);
+				}
+				GL.ActiveTexture(TextureUnit.Texture0);
+				return;
+			}
+
+			shader.Activate();
+			shader.SetShadowEnabled(true);
+			shader.SetShadowStrength((float)renderer.currentOptions.ShadowStrength);
+			shader.SetCurrentViewMatrix(renderer.CurrentViewMatrix);
+
+			Map.BindAllCascadesForReading(TextureUnit.Texture4);
+
+			int cascadeCount = Caster.CascadeCount;
+			for (int i = 0; i < cascadeCount; i++)
+			{
+				shader.SetCascadeLightSpaceMatrix(i, Caster.LightSpaceMatrices[i]);
+				shader.SetCascadeShadowMapUnit(i, 4 + i);
+				// Split distance = the view-space Z where this cascade ends.
+				shader.SetShadowSplitDistance(i, (float)Caster.SplitDistances[i]);
+				shader.SetCascadeBias(i, Caster.CascadeBiases[i] + (float)renderer.currentOptions.ShadowBias);
+				shader.SetNormalBias(i, (float)renderer.currentOptions.ShadowNormalBias);
+			}
+
+			for (int i = cascadeCount; i < 4; i++)
+			{
+				shader.SetShadowSplitDistance(i, 0.0f);
+			}
+			shader.SetShadowCascadeCount(cascadeCount);
+		}
+
+		/// <summary>
+		/// Disposes shadow resources.
+		/// </summary>
+		public void Dispose()
+		{
+			Map?.Dispose();
+			Map = null;
+			DepthShader?.Dispose();
+			DepthShader = null;
+			Caster = null;
+			Enabled = false;
+		}
+	}
+}

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -249,7 +249,7 @@ namespace LibRender2.ShadowMapping
 				shader.SetCascadeLightSpaceMatrix(i, Caster.LightSpaceMatrices[i]);
 				shader.SetCascadeShadowMapUnit(i, 4 + i);
 				// Split distance = the view-space Z where this cascade ends.
-				shader.SetShadowSplitDistance(i, (float)Caster.SplitDistances[i]);
+				shader.SetShadowSplitDistance(i, (float)Caster.SplitDistances[i + 1]);
 				shader.SetCascadeBias(i, Caster.CascadeBiases[i] + (float)renderer.currentOptions.ShadowBias);
 				shader.SetNormalBias(i, (float)renderer.currentOptions.ShadowNormalBias);
 			}

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -153,10 +153,16 @@ namespace LibRender2.ShadowMapping
 				lock (renderer.VisibleObjects.LockObject)
 				{
 					int lastVAO = -1;
-					// Render both opaque and alpha-tested geometry (AlphaFaces).
-					// Alpha-tested objects (like trees) need to cast shadows for realism.
-					RenderFaces(renderer.VisibleObjects.OpaqueFaces, ref lastVAO);
-					RenderFaces(renderer.VisibleObjects.AlphaFaces, ref lastVAO); 
+					/*
+					 * Culling Per-Cascade:
+					 * Distant objects don't need to be rendered into near-field high-res shadow maps.
+					 * We use a safety margin (150m) to catch long shadows from tall objects.
+					 */
+					double maxDistance = renderer.currentOptions.ShadowFilterCascades ? Caster.SplitDistances[i] + 150.0 : double.MaxValue;
+					double maxDistanceSquared = maxDistance * maxDistance;
+
+					RenderFacesFiltered(renderer.VisibleObjects.OpaqueFaces, ref lastVAO, maxDistanceSquared);
+					RenderFacesFiltered(renderer.VisibleObjects.AlphaFaces, ref lastVAO, maxDistanceSquared); 
 				}
 				Map.Unbind();
 			}
@@ -177,6 +183,19 @@ namespace LibRender2.ShadowMapping
 		/// <param name="lastVAO">A reference to the last bound VAO handle, to avoid redundant binds.</param>
 		private void RenderFaces(IEnumerable<FaceState> faces, ref int lastVAO)
 		{
+			RenderFacesFiltered(faces, ref lastVAO, double.MaxValue);
+		}
+
+		/// <summary>
+		/// Renders a collection of faces filtered by distance to optimize per-cascade draw calls.
+		/// </summary>
+		/// <param name="faces">The faces to render.</param>
+		/// <param name="lastVAO">A reference to the last bound VAO handle, to avoid redundant binds.</param>
+		/// <param name="maxDistanceSquared">The squared maximum distance from camera for an object to cast shadows into this cascade.</param>
+		private void RenderFacesFiltered(IEnumerable<FaceState> faces, ref int lastVAO, double maxDistanceSquared)
+		{
+			Vector3 cameraPos = renderer.Camera.AbsolutePosition;
+
 			foreach (var face in faces)
 			{
 				if (face.Object.Prototype.Mesh.VAO == null || face.Object.DisableShadowCasting)
@@ -185,6 +204,20 @@ namespace LibRender2.ShadowMapping
 				}
 
 				ObjectState state = face.Object;
+
+				// Per-cascade distance culling
+				if (maxDistanceSquared < double.MaxValue)
+				{
+					double dx = state.WorldPosition.X - cameraPos.X;
+					double dy = state.WorldPosition.Y - cameraPos.Y;
+					double dz = state.WorldPosition.Z - cameraPos.Z;
+
+					if (dx * dx + dy * dy + dz * dz > maxDistanceSquared)
+					{
+						continue;
+					}
+				}
+
 				DepthShader.SetModelMatrix(state.ModelMatrix * renderer.Camera.TranslationMatrix);
 				DepthShader.SetTextureMatrix(state.TextureTranslation);
 

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -176,10 +176,15 @@ namespace LibRender2.ShadowMapping
 					continue;
 				}
 
-				Matrix4D modelMatrix = face.Object.ModelMatrix * renderer.Camera.TranslationMatrix;
-				DepthShader.SetModelMatrix(modelMatrix);
+				ObjectState state = face.Object;
+				DepthShader.SetModelMatrix(state.ModelMatrix * renderer.Camera.TranslationMatrix);
+				DepthShader.SetTextureMatrix(state.TextureTranslation);
 
 				var material = face.Object.Prototype.Mesh.Materials[face.Face.Material];
+				if ((material.Flags & MaterialFlags.NoShadow) != 0 || material.BlendMode == MeshMaterialBlendMode.Additive)
+				{
+					continue;
+				}
 				if (material.DaytimeTexture != null && renderer.currentHost.LoadTexture(ref material.DaytimeTexture, (OpenGlTextureWrapMode)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)))
 				{
 					GL.ActiveTexture(TextureUnit.Texture0);
@@ -194,8 +199,7 @@ namespace LibRender2.ShadowMapping
 				DepthShader.SetAlphaCutoff(0.5f);
 				DepthShader.SetMaterialAlpha(material.Color.A / 255.0f);
 				DepthShader.SetMaterialFlags(material.Flags);
-
-				ObjectState state = face.Object;
+				
 				if (state.Matricies != null && state.Matricies.Length > 0)
 				{
 					DepthShader.SetCurrentAnimationMatricies(state);

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -132,7 +132,15 @@ namespace LibRender2.ShadowMapping
 			DepthShader.Activate();
 			GL.Enable(EnableCap.DepthTest);
 			GL.DepthFunc(DepthFunction.Less);
-			GL.Disable(EnableCap.CullFace);
+			if (renderer.OptionBackFaceCulling)
+			{
+				GL.Enable(EnableCap.CullFace);
+				GL.CullFace(CullFaceMode.Front); // OpenBVE culls Front faces by default
+			}
+			else
+			{
+				GL.Disable(EnableCap.CullFace);
+			}
 			GL.DepthMask(true);
 			DepthShader.SetTexture(0);
 
@@ -212,6 +220,18 @@ namespace LibRender2.ShadowMapping
 					vao.Bind();
 					lastVAO = vao.handle;
 				}
+				if (renderer.OptionBackFaceCulling)
+				{
+					if ((face.Face.Flags & FaceFlags.Face2Mask) != 0)
+					{
+						// Double-sided faces (Face2) must not be culled to ensure they cast shadows from both sides
+						GL.Disable(EnableCap.CullFace);
+					}
+					else
+					{
+						GL.Enable(EnableCap.CullFace);
+					}
+				}
 				PrimitiveType drawMode = renderer.GetPrimitiveType(face.Face.Flags);
 				vao.Draw(drawMode, face.Face.IboStartIndex, face.Face.Vertices.Length);
 			}
@@ -249,7 +269,7 @@ namespace LibRender2.ShadowMapping
 				shader.SetCascadeLightSpaceMatrix(i, Caster.LightSpaceMatrices[i]);
 				shader.SetCascadeShadowMapUnit(i, 4 + i);
 				// Split distance = the view-space Z where this cascade ends.
-				shader.SetShadowSplitDistance(i, (float)Caster.SplitDistances[i + 1]);
+				shader.SetShadowSplitDistance(i, (float)Caster.SplitDistances[i]);
 				shader.SetCascadeBias(i, Caster.CascadeBiases[i] + (float)renderer.currentOptions.ShadowBias);
 				shader.SetNormalBias(i, (float)renderer.currentOptions.ShadowNormalBias);
 			}

--- a/source/ObjectViewer/formOptions.Designer.cs
+++ b/source/ObjectViewer/formOptions.Designer.cs
@@ -90,6 +90,8 @@ namespace ObjectViewer
             this.numericUpDownShadowBias = new System.Windows.Forms.NumericUpDown();
             this.labelShadowNormalBias = new System.Windows.Forms.Label();
             this.numericUpDownShadowNormalBias = new System.Windows.Forms.NumericUpDown();
+            this.labelShadowFilterCascades = new System.Windows.Forms.Label();
+            this.checkBoxShadowFilterCascades = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPageOptions.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.AntialiasingLevel)).BeginInit();
@@ -453,6 +455,8 @@ namespace ObjectViewer
             this.tabPageShadows.Controls.Add(this.numericUpDownShadowBias);
             this.tabPageShadows.Controls.Add(this.labelShadowNormalBias);
             this.tabPageShadows.Controls.Add(this.numericUpDownShadowNormalBias);
+            this.tabPageShadows.Controls.Add(this.checkBoxShadowFilterCascades);
+            this.tabPageShadows.Controls.Add(this.labelShadowFilterCascades);
             this.tabPageShadows.AutoScroll = true;
             this.tabPageShadows.Location = new System.Drawing.Point(4, 22);
             this.tabPageShadows.Name = "tabPageShadows";
@@ -557,7 +561,7 @@ namespace ObjectViewer
             // 
             this.labelSunDirection.AutoSize = true;
             this.labelSunDirection.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelSunDirection.Location = new System.Drawing.Point(6, 190);
+            this.labelSunDirection.Location = new System.Drawing.Point(6, 220);
             this.labelSunDirection.Name = "labelSunDirection";
             this.labelSunDirection.Size = new System.Drawing.Size(96, 15);
             this.labelSunDirection.TabIndex = 36;
@@ -566,7 +570,7 @@ namespace ObjectViewer
             // labelSunAzimuth
             // 
             this.labelSunAzimuth.AutoSize = true;
-            this.labelSunAzimuth.Location = new System.Drawing.Point(6, 212);
+            this.labelSunAzimuth.Location = new System.Drawing.Point(6, 242);
             this.labelSunAzimuth.Name = "labelSunAzimuth";
             this.labelSunAzimuth.Size = new System.Drawing.Size(47, 13);
             this.labelSunAzimuth.TabIndex = 37;
@@ -574,7 +578,7 @@ namespace ObjectViewer
             // 
             // trackBarSunAzimuth
             // 
-            this.trackBarSunAzimuth.Location = new System.Drawing.Point(6, 228);
+            this.trackBarSunAzimuth.Location = new System.Drawing.Point(6, 258);
             this.trackBarSunAzimuth.Maximum = 180;
             this.trackBarSunAzimuth.Minimum = -180;
             this.trackBarSunAzimuth.Name = "trackBarSunAzimuth";
@@ -587,7 +591,7 @@ namespace ObjectViewer
             // labelSunAzimuthValue
             // 
             this.labelSunAzimuthValue.AutoSize = true;
-            this.labelSunAzimuthValue.Location = new System.Drawing.Point(247, 232);
+            this.labelSunAzimuthValue.Location = new System.Drawing.Point(247, 262);
             this.labelSunAzimuthValue.Name = "labelSunAzimuthValue";
             this.labelSunAzimuthValue.Size = new System.Drawing.Size(31, 13);
             this.labelSunAzimuthValue.TabIndex = 39;
@@ -596,7 +600,7 @@ namespace ObjectViewer
             // labelSunElevation
             // 
             this.labelSunElevation.AutoSize = true;
-            this.labelSunElevation.Location = new System.Drawing.Point(6, 276);
+            this.labelSunElevation.Location = new System.Drawing.Point(6, 306);
             this.labelSunElevation.Name = "labelSunElevation";
             this.labelSunElevation.Size = new System.Drawing.Size(54, 13);
             this.labelSunElevation.TabIndex = 40;
@@ -604,7 +608,7 @@ namespace ObjectViewer
             // 
             // trackBarSunElevation
             // 
-            this.trackBarSunElevation.Location = new System.Drawing.Point(6, 292);
+            this.trackBarSunElevation.Location = new System.Drawing.Point(6, 322);
             this.trackBarSunElevation.Maximum = 90;
             this.trackBarSunElevation.Minimum = -90;
             this.trackBarSunElevation.Name = "trackBarSunElevation";
@@ -617,7 +621,7 @@ namespace ObjectViewer
             // labelSunElevationValue
             // 
             this.labelSunElevationValue.AutoSize = true;
-            this.labelSunElevationValue.Location = new System.Drawing.Point(247, 296);
+            this.labelSunElevationValue.Location = new System.Drawing.Point(247, 326);
             this.labelSunElevationValue.Name = "labelSunElevationValue";
             this.labelSunElevationValue.Size = new System.Drawing.Size(25, 13);
             this.labelSunElevationValue.TabIndex = 42;
@@ -828,6 +832,24 @@ namespace ObjectViewer
             this.checkBoxAutoReload.TabIndex = 49;
             this.checkBoxAutoReload.UseVisualStyleBackColor = true;
             // 
+            // labelShadowFilterCascades
+            // 
+            this.labelShadowFilterCascades.AutoSize = true;
+            this.labelShadowFilterCascades.Location = new System.Drawing.Point(6, 190);
+            this.labelShadowFilterCascades.Name = "labelShadowFilterCascades";
+            this.labelShadowFilterCascades.Size = new System.Drawing.Size(126, 13);
+            this.labelShadowFilterCascades.TabIndex = 54;
+            this.labelShadowFilterCascades.Text = "Per-cascade culling:";
+            // 
+            // checkBoxShadowFilterCascades
+            // 
+            this.checkBoxShadowFilterCascades.AutoSize = true;
+            this.checkBoxShadowFilterCascades.Location = new System.Drawing.Point(160, 190);
+            this.checkBoxShadowFilterCascades.Name = "checkBoxShadowFilterCascades";
+            this.checkBoxShadowFilterCascades.Size = new System.Drawing.Size(15, 14);
+            this.checkBoxShadowFilterCascades.TabIndex = 55;
+            this.checkBoxShadowFilterCascades.UseVisualStyleBackColor = true;
+            // 
             // formOptions
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -925,5 +947,7 @@ namespace ObjectViewer
 		private System.Windows.Forms.NumericUpDown numericUpDownShadowNormalBias;
 		private System.Windows.Forms.CheckBox checkBoxAutoReload;
 		private System.Windows.Forms.Label labelAutoReloadChanged;
+		private System.Windows.Forms.Label labelShadowFilterCascades;
+		private System.Windows.Forms.CheckBox checkBoxShadowFilterCascades;
 	}
 }

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -64,10 +64,6 @@ namespace ObjectViewer
 			numericUpDownShadowStrength.Value = (decimal)(Interface.CurrentOptions.ShadowStrength * 100.0);
 			numericUpDownShadowBias.Value = (decimal)Interface.CurrentOptions.ShadowBias;
 			numericUpDownShadowNormalBias.Value = (decimal)Interface.CurrentOptions.ShadowNormalBias;
-			if (numericUpDownShadowBias.Value == 0)
-			{
-				numericUpDownShadowBias.Value = 0.000050m;
-			}
 
 
 			// Initialize sun direction sliders from current light position

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -86,6 +86,7 @@ namespace ObjectViewer
 			comboBoxBackwards.DataSource = Enum.GetValues(typeof(Key));
 			comboBoxBackwards.SelectedItem = Interface.CurrentOptions.CameraMoveBackward;
 			checkBoxAutoReload.Checked = Interface.CurrentOptions.AutoReloadObjects;
+			checkBoxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
 		}
 
 		private void InitializeSunSliders()
@@ -109,6 +110,7 @@ namespace ObjectViewer
 			trackBarSunAzimuth.Enabled = enabled;
 
 			trackBarSunElevation.Enabled = enabled;
+			checkBoxShadowFilterCascades.Enabled = enabled;
 		}
 
 		private void comboBoxShadowResolution_SelectedIndexChanged(object sender, EventArgs e)
@@ -278,6 +280,7 @@ namespace ObjectViewer
 			Interface.CurrentOptions.ShadowStrength = (double)numericUpDownShadowStrength.Value / 100.0;
 			Interface.CurrentOptions.ShadowBias = (double)numericUpDownShadowBias.Value;
 			Interface.CurrentOptions.ShadowNormalBias = (double)numericUpDownShadowNormalBias.Value;
+			Interface.CurrentOptions.ShadowFilterCascades = checkBoxShadowFilterCascades.Checked;
 			
 			Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_ov.cfg"));
 			Program.RefreshObjects();

--- a/source/OpenBVE/Game/Menu/Menu.SingleMenu.cs
+++ b/source/OpenBVE/Game/Menu/Menu.SingleMenu.cs
@@ -224,7 +224,7 @@ namespace OpenBve
 						Align = TextAlignment.TopLeft;
 						break;
 					case MenuType.Options:
-						Items = new MenuEntry[11];
+						Items = new MenuEntry[12];
 						Items[0] = new MenuCaption(menu, Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"panel","options"}));
 						Items[1] = new MenuOption(menu, OptionType.ScreenResolution, Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","resolution"}), Program.Renderer.Screen.AvailableResolutions.ToArray());
 						Items[2] = new MenuOption(menu, OptionType.FullScreen, Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"options","display_mode_fullscreen"}), new[] { "true", "false" });
@@ -250,7 +250,8 @@ namespace OpenBve
 							Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "options", "shadows_resolution_high" }),
 							Translations.GetInterfaceString(HostApplication.OpenBve, new[] { "options", "shadows_resolution_ultra" })
 						});
-						Items[10] = new MenuCommand(menu, Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"menu","back"}), MenuTag.MenuBack, 0);
+						Items[10] = new MenuOption(menu, OptionType.ShadowFilterCascades, "Per-cascade culling", new[] { "true", "false" });
+						Items[11] = new MenuCommand(menu, Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"menu","back"}), MenuTag.MenuBack, 0);
 						Align = TextAlignment.TopLeft;
 						break;
 					case MenuType.RouteList:

--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -325,6 +325,7 @@ namespace OpenBve
 				Builder.AppendLine("shadowstrength = " + ShadowStrength.ToString(Culture));
 				Builder.AppendLine("shadowbias = " + ShadowBias.ToString(Culture));
 				Builder.AppendLine("shadownormalbias = " + ShadowNormalBias.ToString(Culture));
+				Builder.AppendLine("shadowfiltercascades = " + (ShadowFilterCascades ? "true" : "false"));
 				Builder.AppendLine("fpslimit = " + FPSLimit.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[objectOptimization]");
@@ -525,6 +526,7 @@ namespace OpenBve
 							if (CurrentOptions.ShadowBias > 1.0) CurrentOptions.ShadowBias = 1.0;
 							block.TryGetValue(OptionsKey.ShadowNormalBias, ref CurrentOptions.ShadowNormalBias);
 							if (CurrentOptions.ShadowNormalBias < 0.0) CurrentOptions.ShadowNormalBias = 0.0;
+							block.GetValue(OptionsKey.ShadowFilterCascades, out Interface.CurrentOptions.ShadowFilterCascades);
 							block.GetValue(OptionsKey.FPSLimit, out CurrentOptions.FPSLimit);
 							if (CurrentOptions.FPSLimit < 0)
 							{

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -183,6 +183,7 @@ namespace OpenBve {
             this.groupboxShadows = new System.Windows.Forms.GroupBox();
             this.labelShadowResolution = new System.Windows.Forms.Label();
             this.comboboxShadowResolution = new System.Windows.Forms.ComboBox();
+            this.checkboxShadowFilterCascades = new System.Windows.Forms.CheckBox();
             this.labelShadowDistance = new System.Windows.Forms.Label();
             this.comboboxShadowDistance = new System.Windows.Forms.ComboBox();
             this.labelShadowCascades = new System.Windows.Forms.Label();
@@ -2640,10 +2641,11 @@ namespace OpenBve {
             this.groupboxShadows.Controls.Add(this.updownShadowBias);
             this.groupboxShadows.Controls.Add(this.labelShadowNormalBias);
             this.groupboxShadows.Controls.Add(this.updownShadowNormalBias);
+            this.groupboxShadows.Controls.Add(this.checkboxShadowFilterCascades);
             this.groupboxShadows.ForeColor = System.Drawing.Color.Black;
             this.groupboxShadows.Location = new System.Drawing.Point(0, 155);
             this.groupboxShadows.Name = "groupboxShadows";
-            this.groupboxShadows.Size = new System.Drawing.Size(321, 210);
+            this.groupboxShadows.Size = new System.Drawing.Size(321, 240);
             this.groupboxShadows.TabIndex = 30;
             this.groupboxShadows.TabStop = false;
             this.groupboxShadows.Text = "Shadows";
@@ -2743,6 +2745,16 @@ namespace OpenBve {
             this.comboboxShadowResolution.Size = new System.Drawing.Size(168, 21);
             this.comboboxShadowResolution.TabIndex = 1;
             this.comboboxShadowResolution.SelectedIndexChanged += new System.EventHandler(this.comboboxShadowResolution_SelectedIndexChanged);
+            // 
+            // checkboxShadowFilterCascades
+            // 
+            this.checkboxShadowFilterCascades.AutoSize = true;
+            this.checkboxShadowFilterCascades.Location = new System.Drawing.Point(8, 215);
+            this.checkboxShadowFilterCascades.Name = "checkboxShadowFilterCascades";
+            this.checkboxShadowFilterCascades.Size = new System.Drawing.Size(150, 17);
+            this.checkboxShadowFilterCascades.TabIndex = 14;
+            this.checkboxShadowFilterCascades.Text = "Per-cascade culling";
+            this.checkboxShadowFilterCascades.UseVisualStyleBackColor = true;
             // 
             // labelShadowDistance
             // 
@@ -6566,6 +6578,7 @@ namespace OpenBve {
         private System.Windows.Forms.Panel panelOptionsRight;
         private System.Windows.Forms.Label labelShadowResolution;
         private System.Windows.Forms.ComboBox comboboxShadowResolution;
+        private System.Windows.Forms.CheckBox checkboxShadowFilterCascades;
         private System.Windows.Forms.Label labelShadowDistance;
         private System.Windows.Forms.ComboBox comboboxShadowDistance;
         private System.Windows.Forms.Label labelShadowCascades;

--- a/source/OpenBVE/UserInterface/formMain.Options.cs
+++ b/source/OpenBVE/UserInterface/formMain.Options.cs
@@ -53,6 +53,7 @@ namespace OpenBve {
 			labelShadowStrengthValue.Enabled = shadowEnabled;
 			updownShadowBias.Enabled = shadowEnabled;
 			updownShadowNormalBias.Enabled = shadowEnabled;
+			checkboxShadowFilterCascades.Enabled = shadowEnabled;
 
 			if (!shadowEnabled)
 			{

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -494,10 +494,12 @@ namespace OpenBve {
 			labelShadowStrengthValue.Text = trackbarShadowStrength.Value + @"%";
 			updownShadowBias.Value = (decimal)Interface.CurrentOptions.ShadowBias;
 			updownShadowNormalBias.Value = (decimal)Interface.CurrentOptions.ShadowNormalBias;
+			checkboxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
 			// Enable/disable shadow sub-controls based on resolution setting
 			bool shadowEnabled = Interface.CurrentOptions.ShadowResolution != ShadowMapResolution.Off;
 			comboboxShadowDistance.Enabled = shadowEnabled;
 			comboboxShadowCascades.Enabled = shadowEnabled;
+			checkboxShadowFilterCascades.Enabled = shadowEnabled;
 			trackbarShadowStrength.Enabled = shadowEnabled;
 			updownShadowBias.Enabled = shadowEnabled;
 			updownShadowNormalBias.Enabled = shadowEnabled;
@@ -1233,6 +1235,7 @@ namespace OpenBve {
 			Interface.CurrentOptions.ShadowStrength = trackbarShadowStrength.Value / 100.0;
 			Interface.CurrentOptions.ShadowBias = (double)updownShadowBias.Value;
 			Interface.CurrentOptions.ShadowNormalBias = (double)updownShadowNormalBias.Value;
+			Interface.CurrentOptions.ShadowFilterCascades = checkboxShadowFilterCascades.Checked;
 			Interface.CurrentOptions.GameMode = (GameMode)comboboxMode.SelectedIndex;
 			Interface.CurrentOptions.BlackBox = checkboxBlackBox.Checked;
 			Interface.CurrentOptions.LoadingSway = checkBoxLoadingSway.Checked;

--- a/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/AnimatedObject/AnimatedObject.cs
@@ -719,6 +719,7 @@ namespace OpenBveApi.Objects
 				double dz = -Camera.Alignment.Position.Z;
 				Vector3 add = Camera.AbsolutePosition + dx * Camera.AbsoluteSide + dy * Camera.AbsoluteUp + dz * Camera.AbsoluteDirection;
 				internalObject.Translation = Matrix4D.CreateTranslation(add.X, add.Y, -add.Z);
+				internalObject.WorldPosition = add;
 			}
 			else
 			{
@@ -727,6 +728,7 @@ namespace OpenBveApi.Objects
 
 				// translate
 				internalObject.Translation = Matrix4D.CreateTranslation(Position.X, Position.Y, -Position.Z);
+				internalObject.WorldPosition = Position;
 			}
 
 			if (ColorFunction != null && Colors != null)

--- a/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
+++ b/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
@@ -56,6 +56,7 @@ namespace OpenBveApi
 		ShadowStrength,
 		ShadowBias,
 		ShadowNormalBias,
+		ShadowFilterCascades,
 		LightAzimuth,
 
 		LightElevation,

--- a/source/OpenBveApi/System/BaseOptions.cs
+++ b/source/OpenBveApi/System/BaseOptions.cs
@@ -93,6 +93,8 @@ namespace OpenBveApi
 		public double ShadowBias = 0.000005; // default synced to 0.000005
 		/// <summary>Shadow normal bias (slope scale multiplier) to perfectly cure acne on curved/thin meshes.</summary>
 		public double ShadowNormalBias = 2.0;
+		/// <summary>Whether to filter shadow casters per cascade to improve performance.</summary>
+		public bool ShadowFilterCascades = true;
 
 
 		/// <summary>The sun azimuth in degrees</summary>

--- a/source/OpenBveApi/System/BaseOptions.cs
+++ b/source/OpenBveApi/System/BaseOptions.cs
@@ -90,7 +90,7 @@ namespace OpenBveApi
 		/// <summary>Shadow darkness strength. 0.0 = invisible, 1.0 = full black.</summary>
 		public double ShadowStrength = 0.7;
 		/// <summary>Shadow bias to prevent shadow acne.</summary>
-		public double ShadowBias = 0.000050; // default synced to 0.000050
+		public double ShadowBias = 0.000005; // default synced to 0.000005
 		/// <summary>Shadow normal bias (slope scale multiplier) to perfectly cure acne on curved/thin meshes.</summary>
 		public double ShadowNormalBias = 2.0;
 

--- a/source/RouteViewer/formOptions.Designer.cs
+++ b/source/RouteViewer/formOptions.Designer.cs
@@ -78,6 +78,8 @@ namespace RouteViewer
             this.numericUpDownShadowBias = new System.Windows.Forms.NumericUpDown();
             this.labelShadowNormalBias = new System.Windows.Forms.Label();
             this.numericUpDownShadowNormalBias = new System.Windows.Forms.NumericUpDown();
+            this.labelShadowFilterCascades = new System.Windows.Forms.Label();
+            this.checkBoxShadowFilterCascades = new System.Windows.Forms.CheckBox();
             this.labelNearClip = new System.Windows.Forms.Label();
             this.numericUpDownNearClip = new System.Windows.Forms.NumericUpDown();
             this.button1 = new System.Windows.Forms.Button();
@@ -488,6 +490,8 @@ namespace RouteViewer
             this.tabPageShadows.Controls.Add(this.numericUpDownShadowBias);
             this.tabPageShadows.Controls.Add(this.labelShadowNormalBias);
             this.tabPageShadows.Controls.Add(this.numericUpDownShadowNormalBias);
+            this.tabPageShadows.Controls.Add(this.checkBoxShadowFilterCascades);
+            this.tabPageShadows.Controls.Add(this.labelShadowFilterCascades);
             this.tabPageShadows.Location = new System.Drawing.Point(4, 22);
             this.tabPageShadows.Name = "tabPageShadows";
             this.tabPageShadows.Padding = new System.Windows.Forms.Padding(3);
@@ -586,7 +590,7 @@ namespace RouteViewer
             // 
             this.labelSunDirection.AutoSize = true;
             this.labelSunDirection.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelSunDirection.Location = new System.Drawing.Point(6, 190);
+            this.labelSunDirection.Location = new System.Drawing.Point(6, 220);
             this.labelSunDirection.Name = "labelSunDirection";
             this.labelSunDirection.Size = new System.Drawing.Size(94, 15);
             this.labelSunDirection.TabIndex = 36;
@@ -595,7 +599,7 @@ namespace RouteViewer
             // labelSunAzimuth
             // 
             this.labelSunAzimuth.AutoSize = true;
-            this.labelSunAzimuth.Location = new System.Drawing.Point(6, 212);
+            this.labelSunAzimuth.Location = new System.Drawing.Point(6, 242);
             this.labelSunAzimuth.Name = "labelSunAzimuth";
             this.labelSunAzimuth.Size = new System.Drawing.Size(47, 13);
             this.labelSunAzimuth.TabIndex = 37;
@@ -603,7 +607,7 @@ namespace RouteViewer
             // 
             // trackBarSunAzimuth
             // 
-            this.trackBarSunAzimuth.Location = new System.Drawing.Point(6, 228);
+            this.trackBarSunAzimuth.Location = new System.Drawing.Point(6, 258);
             this.trackBarSunAzimuth.Maximum = 180;
             this.trackBarSunAzimuth.Minimum = -180;
             this.trackBarSunAzimuth.Name = "trackBarSunAzimuth";
@@ -616,7 +620,7 @@ namespace RouteViewer
             // labelSunAzimuthValue
             // 
             this.labelSunAzimuthValue.AutoSize = true;
-            this.labelSunAzimuthValue.Location = new System.Drawing.Point(247, 232);
+            this.labelSunAzimuthValue.Location = new System.Drawing.Point(247, 262);
             this.labelSunAzimuthValue.Name = "labelSunAzimuthValue";
             this.labelSunAzimuthValue.Size = new System.Drawing.Size(29, 13);
             this.labelSunAzimuthValue.TabIndex = 39;
@@ -625,7 +629,7 @@ namespace RouteViewer
             // labelSunElevation
             // 
             this.labelSunElevation.AutoSize = true;
-            this.labelSunElevation.Location = new System.Drawing.Point(6, 276);
+            this.labelSunElevation.Location = new System.Drawing.Point(6, 306);
             this.labelSunElevation.Name = "labelSunElevation";
             this.labelSunElevation.Size = new System.Drawing.Size(54, 13);
             this.labelSunElevation.TabIndex = 40;
@@ -633,7 +637,7 @@ namespace RouteViewer
             // 
             // trackBarSunElevation
             // 
-            this.trackBarSunElevation.Location = new System.Drawing.Point(6, 292);
+            this.trackBarSunElevation.Location = new System.Drawing.Point(6, 322);
             this.trackBarSunElevation.Maximum = 90;
             this.trackBarSunElevation.Minimum = -90;
             this.trackBarSunElevation.Name = "trackBarSunElevation";
@@ -646,7 +650,7 @@ namespace RouteViewer
             // labelSunElevationValue
             // 
             this.labelSunElevationValue.AutoSize = true;
-            this.labelSunElevationValue.Location = new System.Drawing.Point(247, 296);
+            this.labelSunElevationValue.Location = new System.Drawing.Point(247, 326);
             this.labelSunElevationValue.Name = "labelSunElevationValue";
             this.labelSunElevationValue.Size = new System.Drawing.Size(23, 13);
             this.labelSunElevationValue.TabIndex = 42;
@@ -715,6 +719,24 @@ namespace RouteViewer
             0,
             0,
             0});
+            // 
+            // labelShadowFilterCascades
+            // 
+            this.labelShadowFilterCascades.AutoSize = true;
+            this.labelShadowFilterCascades.Location = new System.Drawing.Point(6, 194);
+            this.labelShadowFilterCascades.Name = "labelShadowFilterCascades";
+            this.labelShadowFilterCascades.Size = new System.Drawing.Size(126, 13);
+            this.labelShadowFilterCascades.TabIndex = 54;
+            this.labelShadowFilterCascades.Text = "Per-cascade culling:";
+            // 
+            // checkBoxShadowFilterCascades
+            // 
+            this.checkBoxShadowFilterCascades.AutoSize = true;
+            this.checkBoxShadowFilterCascades.Location = new System.Drawing.Point(160, 194);
+            this.checkBoxShadowFilterCascades.Name = "checkBoxShadowFilterCascades";
+            this.checkBoxShadowFilterCascades.Size = new System.Drawing.Size(15, 14);
+            this.checkBoxShadowFilterCascades.TabIndex = 55;
+            this.checkBoxShadowFilterCascades.UseVisualStyleBackColor = true;
             // 
             // labelNearClip
             // 
@@ -828,7 +850,7 @@ namespace RouteViewer
         private System.Windows.Forms.NumericUpDown numericUpDownViewingDistance;
         private System.Windows.Forms.Label labelNearClip;
         private System.Windows.Forms.NumericUpDown numericUpDownNearClip;
-		private System.Windows.Forms.Label labelShadowResolution;
+        private System.Windows.Forms.Label labelShadowResolution;
         private System.Windows.Forms.ComboBox comboBoxShadowResolution;
         private System.Windows.Forms.Label labelShadowDistance;
         private System.Windows.Forms.ComboBox comboBoxShadowDistance;
@@ -847,5 +869,7 @@ namespace RouteViewer
         private System.Windows.Forms.NumericUpDown numericUpDownShadowBias;
         private System.Windows.Forms.Label labelShadowNormalBias;
         private System.Windows.Forms.NumericUpDown numericUpDownShadowNormalBias;
+        private System.Windows.Forms.Label labelShadowFilterCascades;
+        private System.Windows.Forms.CheckBox checkBoxShadowFilterCascades;
     }
 }

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -66,10 +66,6 @@ namespace RouteViewer
             if (numericUpDownShadowStrength.Value < 1) numericUpDownShadowStrength.Value = 1;
             numericUpDownShadowStrength.Refresh();
             numericUpDownShadowBias.Value = (decimal)Interface.CurrentOptions.ShadowBias;
-            if (numericUpDownShadowBias.Value == 0)
-            {
-                numericUpDownShadowBias.Value = 0.000050m;
-            }
             numericUpDownShadowBias.Refresh();
 
             numericUpDownShadowNormalBias.DecimalPlaces = 2;

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -88,6 +88,7 @@ namespace RouteViewer
 			{
 				labelNearClip.Text = Translations.GetInterfaceString(OpenBveApi.Hosts.HostApplication.OpenBve, new[] { "options", "quality_distance_nearclip" });
 			}
+			checkBoxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
         }
 
         private void InitializeSunSliders()
@@ -111,6 +112,7 @@ namespace RouteViewer
 
             trackBarSunAzimuth.Enabled = enabled;
             trackBarSunElevation.Enabled = enabled;
+            checkBoxShadowFilterCascades.Enabled = enabled;
         }
 
         private void comboBoxShadowResolution_SelectedIndexChanged(object sender, EventArgs e)
@@ -172,6 +174,7 @@ namespace RouteViewer
 	        double previousShadowStrength = Interface.CurrentOptions.ShadowStrength;
 	        double previousShadowBias = Interface.CurrentOptions.ShadowBias;
 	        double previousShadowNormalBias = Interface.CurrentOptions.ShadowNormalBias;
+	        bool previousShadowFilterCascades = Interface.CurrentOptions.ShadowFilterCascades;
 
 			//Interpolation mode
 			InterpolationMode previousInterpolationMode = Interface.CurrentOptions.Interpolation;
@@ -289,6 +292,7 @@ namespace RouteViewer
             Interface.CurrentOptions.ShadowStrength = (double)numericUpDownShadowStrength.Value / 100.0;
             Interface.CurrentOptions.ShadowBias = (double)numericUpDownShadowBias.Value;
             Interface.CurrentOptions.ShadowNormalBias = (double)numericUpDownShadowNormalBias.Value;
+            Interface.CurrentOptions.ShadowFilterCascades = checkBoxShadowFilterCascades.Checked;
 
 
             
@@ -309,7 +313,7 @@ namespace RouteViewer
 			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance ||
 			    previousShadowResolution != Interface.CurrentOptions.ShadowResolution || previousShadowDistance != Interface.CurrentOptions.ShadowDrawDistance || previousShadowCascades != Interface.CurrentOptions.ShadowCascades ||
 			    previousShadowStrength != Interface.CurrentOptions.ShadowStrength || previousShadowBias != Interface.CurrentOptions.ShadowBias || previousShadowNormalBias != Interface.CurrentOptions.ShadowNormalBias || 
-			    Interface.CurrentOptions.NearClipBase != previousNearClipBase)
+			    Interface.CurrentOptions.NearClipBase != previousNearClipBase || previousShadowFilterCascades != Interface.CurrentOptions.ShadowFilterCascades)
 			{
 				this.DialogResult = DialogResult.OK;
 			}


### PR DESCRIPTION
Restructured the shadow system into a modular manager-based

what changes:

Shadows Manager: Created `LibRender2.ShadowMapping.Shadows` to encapsulate all CSM functionality (initialization, FBO management, depth pass orchestration, and shader binding).
Decoupling: BaseRenderer.cs was cleaned of several hundred lines of shadow-specific logic. It now delegates to the Shadows manager.

Uniform Renaming: 
Old: `uCascadeFarDist` -> New: `uShadowSplit[N]`
Old: `uCascadeCount` -> New: `uShadowCascadeCount`
Also renamed `CascadeFarDistances` to `SplitDistances` in the logic.

Precision Fix for Large Polygons
Moved the vViewDepth calculation from the vertex shader to the fragment shader. This ensures that large polygons (like the 500m ground or floor mesh in B3D) receive accurate shadow calculations even when their vertices are far outside the shadow frustum, it was a glitch when i test in object viewer if shadow range set to near (150m).

Namespace Fix: Renamed namespace to `LibRender2.ShadowMapping` to prevent conflicts with the `BaseRenderer.Shadows `property.
Also fixed visibility of internal fields like nullDepthMap.