### PR TITLE
Fix: Sanders-related issues

### DIFF
--- a/source/TrainManager/Car/Systems/Sanders.cs
+++ b/source/TrainManager/Car/Systems/Sanders.cs
@@ -71,7 +71,7 @@ namespace TrainManager.Car.Systems
 				return;
 			}
 
-			if (State != SandersState.Inactive)
+			if (State == SandersState.Active)
 			{
 				if ((ActivationSound != null && !ActivationSound.IsPlaying) || ActivationSound == null)
 				{
@@ -98,7 +98,7 @@ namespace TrainManager.Car.Systems
 			}
 			else
 			{
-				if (SandingRate > 0 && SandingRate < double.MaxValue)
+				if (State == SandersState.Active && SandingRate > 0 && SandingRate < double.MaxValue)
 				{
 					SandLevel -= SandingRate * timeElapsed;
 				}
@@ -179,10 +179,7 @@ namespace TrainManager.Car.Systems
 				ActivationSound?.Play(Car, false);
 			}
 
-			if (willBeActive)
-			{
-				State = SandersState.Active;
-			}
+			State = willBeActive ? SandersState.Active : SandersState.Inactive;
 		}
 
 		public void Toggle()


### PR DESCRIPTION
This fixes the following issues observed in the current version of OpenBVE:
- The sand level gets decremented even when the sanders are not deployed at all
- The sander loop sound continues to play even when there's no more sand
- The sander State will only ever get set to **Active** in `SetActive`, meaning sanders cannot be de-activated once activated