### PR TITLE
Change: Use List<T> for expressions in CSV RW parser

### DIFF
--- a/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
+++ b/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
@@ -14,7 +14,7 @@ namespace CsvRwRouteParser
 	{
 		internal Dictionary<string, RoutefilePatch> availableRoutefilePatches = new Dictionary<string, RoutefilePatch>();
 
-		private void CheckForAvailablePatch(string FileName, ref RouteData Data, ref Expression[] Expressions, bool PreviewOnly)
+		private void CheckForAvailablePatch(string FileName, ref RouteData Data, ref List<Expression> Expressions, bool PreviewOnly)
 		{
 			if (Plugin.CurrentOptions.EnableBveTsHacks == false)
 			{
@@ -97,7 +97,7 @@ namespace CsvRwRouteParser
 
 				if (patch.ColonFix)
 				{
-					for (int i = 0; i < Expressions.Length; i++)
+					for (int i = 0; i < Expressions.Count; i++)
 					{
 						Expressions[i].Text = Expressions[i].Text.Replace(':', ';');
 					}

--- a/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
+++ b/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
@@ -14,7 +14,7 @@ namespace CsvRwRouteParser
 	{
 		internal Dictionary<string, RoutefilePatch> availableRoutefilePatches = new Dictionary<string, RoutefilePatch>();
 
-		private void CheckForAvailablePatch(string FileName, ref RouteData Data, ref List<Expression> Expressions, bool PreviewOnly)
+		private void CheckForAvailablePatch(string FileName, ref RouteData Data, ref IList<Expression> Expressions, bool PreviewOnly)
 		{
 			if (Plugin.CurrentOptions.EnableBveTsHacks == false)
 			{

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
@@ -12,9 +12,9 @@ namespace CsvRwRouteParser
 {
 	internal partial class Parser
 	{
-		private void PreprocessSplitIntoExpressions(string FileName, List<string> Lines, out Expression[] Expressions, bool AllowRwRouteDescription, double trackPositionOffset = 0.0) {
-			Expressions = new Expression[4096];
-			int e = 0;
+		private void PreprocessSplitIntoExpressions(string FileName, List<string> Lines, out List<Expression> Expressions, bool AllowRwRouteDescription, double trackPositionOffset = 0.0) {
+			// use a high initial capacity to try and minimize churn
+			Expressions = new List<Expression>(20000); 
 			// full-line rw comments
 			if (IsRW) {
 				for (int i = 0; i < Lines.Count; i++) {
@@ -80,7 +80,18 @@ namespace CsvRwRouteParser
 								if (!IsRW && Level == 0) n++;
 								break;
 							case '@':
-								if (IsRW && Level == 0) n++;
+								if (IsRW)
+								{
+									if (Level == 0)
+									{
+										n++;
+									}
+									else if (Plugin.CurrentOptions.EnableBveTsHacks)
+									{
+										n++;
+										Level = 0;
+									}
+								}
 								break;
 						}
 					}
@@ -103,10 +114,6 @@ namespace CsvRwRouteParser
 						}
 					}
 					// create expressions
-					int m = e + n + 1;
-					while (m >= Expressions.Length) {
-						Array.Resize(ref Expressions, Expressions.Length << 1);
-					}
 					Level = 0;
 					int a = 0, c = 0;
 					for (int j = 0; j < Lines[i].Length; j++) {
@@ -138,45 +145,33 @@ namespace CsvRwRouteParser
 									string t = Lines[i].Substring(a, j - a).Trim();
 									if (t.Length > 0 && !t.StartsWith(";"))
 									{
-										Expressions[e] = new Expression(FileName, t, i + 1, c + 1, trackPositionOffset);
-										
-										e++;
+										Expressions.Add(new Expression(FileName, t, i + 1, c + 1, trackPositionOffset));
 									}
 									a = j + 1;
 									c++;
 								}
 								break;
 							case '@':
-								if (Level == 1 && IsRW && Plugin.CurrentOptions.EnableBveTsHacks)
+								if (!IsRW)
 								{
-									//BVE2 doesn't care if a bracket is unclosed, fixes various routefiles
-									Level--;
+									// @ is not a valid control character in CSV files
+									break;
 								}
-								else if (Level == 2 && IsRW && Plugin.CurrentOptions.EnableBveTsHacks)
+
+								if (Plugin.CurrentOptions.EnableBveTsHacks)
 								{
-									int k = j;
-									while (k > 0)
+									if (Level != 0)
 									{
-										k--;
-										if (Lines[i][k] == '(')
-										{
-											//Opening bracket has been used instead of closing bracket, again BVE2 ignores this
-											Level -= 2;
-											break;
-										}
-										if (!char.IsWhiteSpace(Lines[i][k]))
-										{
-											//Bracket not found, and this isn't whitespace either, so break out
-											break;
-										}
+										Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "Expression " + (Expressions.Count -1) + " was not closed correctly at line " + i + " character " + j + " in file " + FileName);
 									}
+									Level = 0;
 								}
+								
 								if (Level == 0 && IsRW) {
 									string t = Lines[i].Substring(a, j - a).Trim();
 									if (t.Length > 0 && !t.StartsWith(";"))
 									{
-										Expressions[e] = new Expression(FileName, t, i + 1, c + 1, trackPositionOffset);
-										e++;
+										Expressions.Add(new Expression(FileName, t, i + 1, c + 1, trackPositionOffset));
 									}
 									a = j + 1;
 									c++;
@@ -188,20 +183,22 @@ namespace CsvRwRouteParser
 						string t = Lines[i].Substring(a).Trim();
 						if (t.Length > 0 && !t.StartsWith(";"))
 						{
-							Expressions[e] = new Expression(FileName, t, i + 1, c + 1, trackPositionOffset);
-							e++;
+							Expressions.Add(new Expression(FileName, t, i + 1, c + 1, trackPositionOffset));
 						}
 					}
 				}
 			}
-			Array.Resize(ref Expressions, e);
 		}
 
 		/// <summary>This function processes the list of expressions for $Char, $Rnd, $If and $Sub directives, and evaluates them into the final expressions dataset</summary>
-		private void PreprocessChrRndSub(string FileName, System.Text.Encoding Encoding, ref Expression[] Expressions) {
+		private void PreprocessChrRndSub(string FileName, System.Text.Encoding Encoding, ref List<Expression> Expressions) {
 			string[] Subs = new string[16];
 			int openIfs = 0;
-			for (int i = 0; i < Expressions.Length; i++) {
+			for (int i = 0; i < Expressions.Count; i++) {
+				if (Expressions[i].Skip)
+				{
+					continue;
+				}
 				string Epilog = " at line " + Expressions[i].Line.ToString(Culture) + ", column " + Expressions[i].Column.ToString(Culture) + " in file " + Expressions[i].File;
 				bool continueWithNextExpression = false;
 				for (int j = Expressions[i].Text.Length - 1; j >= 0; j--) {
@@ -261,9 +258,10 @@ namespace CsvRwRouteParser
 												 * */
 												i++;
 												int level = 1;
-												while (i < Expressions.Length) {
-													if (Expressions[i].Text.StartsWith("$if", StringComparison.OrdinalIgnoreCase)) {
-														Expressions[i].Text = string.Empty;
+												while (i < Expressions.Count) {
+													if (Expressions[i].Text.StartsWith("$if", StringComparison.OrdinalIgnoreCase))
+													{
+														Expressions[i].Skip = true;
 														level++;
 													} else if (Expressions[i].Text.StartsWith("$else", StringComparison.OrdinalIgnoreCase))
 													{
@@ -274,20 +272,20 @@ namespace CsvRwRouteParser
 															break;
 														}
 
-														Expressions[i].Text = string.Empty;
+														Expressions[i].Skip = true;
 														if (level == 1) {
 															level--;
 															break;
 														}
 													} else if (Expressions[i].Text.StartsWith("$endif", StringComparison.OrdinalIgnoreCase)) {
-														Expressions[i].Text = string.Empty;
+														Expressions[i].Skip = true;
 														level--;
 														if (level == 0) {
 															openIfs--;
 															break;
 														}
 													} else {
-														Expressions[i].Text = string.Empty;
+														Expressions[i].Skip = true;
 													}
 													i++;
 												}
@@ -306,28 +304,28 @@ namespace CsvRwRouteParser
 									/*
 									 * Blank every expression until the matching $EndIf
 									 * */
-									Expressions[i].Text = string.Empty;
+									Expressions[i].Skip = true;
 									if (openIfs != 0) {
 										i++;
 										int level = 1;
-										while (i < Expressions.Length) {
+										while (i < Expressions.Count) {
 											if (Expressions[i].Text.StartsWith("$if", StringComparison.OrdinalIgnoreCase)) {
-												Expressions[i].Text = string.Empty;
+												Expressions[i].Skip = true;
 												level++;
 											} else if (Expressions[i].Text.StartsWith("$else", StringComparison.OrdinalIgnoreCase)) {
-												Expressions[i].Text = string.Empty;
+												Expressions[i].Skip = true;
 												if (level == 1) {
 													Plugin.CurrentHost.AddMessage(MessageType.Error, false, "Duplicate $Else encountered" + Epilog);
 												}
 											} else if (Expressions[i].Text.StartsWith("$endif", StringComparison.OrdinalIgnoreCase)) {
-												Expressions[i].Text = string.Empty;
+												Expressions[i].Skip = true;
 												level--;
 												if (level == 0) {
 													openIfs--;
 													break;
 												}
 											} else {
-												Expressions[i].Text = string.Empty;
+												Expressions[i].Skip = true;
 											}
 											i++;
 										}
@@ -340,7 +338,7 @@ namespace CsvRwRouteParser
 									continueWithNextExpression = true;
 									break;
 								case "$endif":
-									Expressions[i].Text = string.Empty;
+									Expressions[i].Skip = true;
 									if (openIfs != 0) {
 										openIfs--;
 									} else {
@@ -389,12 +387,6 @@ namespace CsvRwRouteParser
 										{
 											continueWithNextExpression = true;
 											Plugin.CurrentHost.AddMessage(MessageType.Error, false, "The filename " + file + " contains invalid characters in " + t + Epilog);
-											for (int ta = i; ta < Expressions.Length - 1; ta++)
-											{
-												Expressions[ta] = Expressions[ta + 1];
-											}
-											Array.Resize(ref Expressions, Expressions.Length - 1);
-											i--;
 											break;
 										}
 										
@@ -402,12 +394,6 @@ namespace CsvRwRouteParser
 										if (!System.IO.File.Exists(files[ia])) {
 											continueWithNextExpression = true;
 											Plugin.CurrentHost.AddMessage(MessageType.Error, false, "The file " + file + " could not be found in " + t + Epilog);
-											for (int ta = i; ta < Expressions.Length - 1; ta++)
-											{
-												Expressions[ta] = Expressions[ta + 1];
-											}
-											Array.Resize(ref Expressions, Expressions.Length - 1);
-											i--;
 											break;
 										}
 										if (2 * ia + 1 < args.Length)
@@ -454,21 +440,10 @@ namespace CsvRwRouteParser
 											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "The text encoding of the $Include file " + files[chosenIndex] + " does not match that of the base routefile.");
 										}
 										List<string> lines = System.IO.File.ReadAllLines(files[chosenIndex], includeEncoding).ToList();
-										PreprocessSplitIntoExpressions(files[chosenIndex], lines, out Expression[] expr, false, offsets[chosenIndex] + Expressions[i].TrackPositionOffset);
-										int length = Expressions.Length;
-										if (expr.Length == 0) {
-											for (int ia = i; ia < Expressions.Length - 1; ia++) {
-												Expressions[ia] = Expressions[ia + 1];
-											}
-											Array.Resize(ref Expressions, length - 1);
-										} else {
-											Array.Resize(ref Expressions, length + expr.Length - 1);
-											for (int ia = Expressions.Length - 1; ia >= i + expr.Length; ia--) {
-												Expressions[ia] = Expressions[ia - expr.Length + 1];
-											}
-											for (int ia = 0; ia < expr.Length; ia++) {
-												Expressions[i + ia] = expr[ia];
-											}
+										PreprocessSplitIntoExpressions(files[chosenIndex], lines, out List<Expression> expr, false, offsets[chosenIndex] + Expressions[i].TrackPositionOffset);
+										if (expr.Count != 0) {
+											Expressions[i].Skip = true;
+											Expressions.InsertRange(i, expr);
 										}
 										i--;
 										continueWithNextExpression = true;
@@ -619,37 +594,25 @@ namespace CsvRwRouteParser
 				}
 			}
 			// handle comments introduced via chr, rnd, sub
+			for (int i = 0; i < Expressions.Count; i++)
 			{
-				int length = Expressions.Length;
-				for (int i = 0; i < length; i++) {
-					Expressions[i].Text = Expressions[i].Text.Trim();
-					if (Expressions[i].Text.Length != 0) {
-						if (Expressions[i].Text[0] == ';') {
-							for (int j = i; j < length - 1; j++) {
-								Expressions[j] = Expressions[j + 1];
-							}
-							length--;
-							i--;
-						}
-					} else {
-						for (int j = i; j < length - 1; j++) {
-							Expressions[j] = Expressions[j + 1];
-						}
-						length--;
-						i--;
-					}
-				}
-				if (length != Expressions.Length) {
-					Array.Resize(ref Expressions, length);
+				Expressions[i].Text = Expressions[i].Text.Trim();
+				if (Expressions[i].Text.Length != 0 && Expressions[i].Text[0] == ';')
+				{
+					Expressions[i].Skip = true;
 				}
 			}
 		}
 
-		private void PreprocessSortByTrackPosition(double[] unitFactors, ref Expression[] Expressions) {
+		private void PreprocessSortByTrackPosition(double[] unitFactors, ref List<Expression> Expressions) {
 			SortedList<double, Expression> positionedExpressions = new SortedList<double, Expression>(new DuplicateLessThanKeyComparer<double>());
 			double a = -1.0, pa = -1.0;
 			bool numberCheck = !IsRW;
-			for (int i = 0; i < Expressions.Length; i++) {
+			for (int i = 0; i < Expressions.Count; i++) {
+				if (Expressions[i].Skip)
+				{
+					continue;
+				}
 				if (IsRW) {
 					// only check for track positions in the railway section for RW routes
 					if (Expressions[i].Text.StartsWith("[", StringComparison.Ordinal) && Expressions[i].Text.EndsWith("]", StringComparison.Ordinal))
@@ -695,7 +658,7 @@ namespace CsvRwRouteParser
 					positionedExpressions.Add(a, Expressions[i]);
 				}
 			}
-			Expressions = positionedExpressions.Values.ToArray();
+			Expressions = positionedExpressions.Values.ToList();
 		}
 	}
 }

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
@@ -12,7 +12,7 @@ namespace CsvRwRouteParser
 {
 	internal partial class Parser
 	{
-		private void PreprocessSplitIntoExpressions(string FileName, List<string> Lines, out List<Expression> Expressions, bool AllowRwRouteDescription, double trackPositionOffset = 0.0) {
+		private void PreprocessSplitIntoExpressions(string FileName, List<string> Lines, out IList<Expression> Expressions, bool AllowRwRouteDescription, double trackPositionOffset = 0.0) {
 			// use a high initial capacity to try and minimize churn
 			Expressions = new List<Expression>(20000); 
 			// full-line rw comments
@@ -191,7 +191,7 @@ namespace CsvRwRouteParser
 		}
 
 		/// <summary>This function processes the list of expressions for $Char, $Rnd, $If and $Sub directives, and evaluates them into the final expressions dataset</summary>
-		private void PreprocessChrRndSub(string FileName, System.Text.Encoding Encoding, ref List<Expression> Expressions) {
+		private void PreprocessChrRndSub(string FileName, System.Text.Encoding Encoding, ref IList<Expression> Expressions) {
 			string[] Subs = new string[16];
 			int openIfs = 0;
 			for (int i = 0; i < Expressions.Count; i++) {
@@ -440,10 +440,11 @@ namespace CsvRwRouteParser
 											Plugin.CurrentHost.AddMessage(MessageType.Warning, false, "The text encoding of the $Include file " + files[chosenIndex] + " does not match that of the base routefile.");
 										}
 										List<string> lines = System.IO.File.ReadAllLines(files[chosenIndex], includeEncoding).ToList();
-										PreprocessSplitIntoExpressions(files[chosenIndex], lines, out List<Expression> expr, false, offsets[chosenIndex] + Expressions[i].TrackPositionOffset);
+										PreprocessSplitIntoExpressions(files[chosenIndex], lines, out IList<Expression> expr, false, offsets[chosenIndex] + Expressions[i].TrackPositionOffset);
 										if (expr.Count != 0) {
 											Expressions[i].Skip = true;
-											Expressions.InsertRange(i, expr);
+											// at this point, Expressions will always be List<T>
+											((List<Expression>)Expressions).InsertRange(i, expr);
 										}
 										i--;
 										continueWithNextExpression = true;
@@ -604,7 +605,7 @@ namespace CsvRwRouteParser
 			}
 		}
 
-		private void PreprocessSortByTrackPosition(double[] unitFactors, ref List<Expression> Expressions) {
+		private void PreprocessSortByTrackPosition(double[] unitFactors, ref IList<Expression> Expressions) {
 			SortedList<double, Expression> positionedExpressions = new SortedList<double, Expression>(new DuplicateLessThanKeyComparer<double>());
 			double a = -1.0, pa = -1.0;
 			bool numberCheck = !IsRW;
@@ -658,7 +659,7 @@ namespace CsvRwRouteParser
 					positionedExpressions.Add(a, Expressions[i]);
 				}
 			}
-			Expressions = positionedExpressions.Values.ToList();
+			Expressions = positionedExpressions.Values;
 		}
 	}
 }

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.PreprocessOptions.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.PreprocessOptions.cs
@@ -15,7 +15,7 @@ namespace CsvRwRouteParser
 		/// <param name="Data">The finalized route data</param>
 		/// <param name="UnitOfLength">The units of length conversion factor to be applied</param>
 		/// <param name="PreviewOnly">Whether this is a preview only</param>
-		private void PreprocessOptions(List<Expression> Expressions, ref RouteData Data, ref double[] UnitOfLength, bool PreviewOnly)
+		private void PreprocessOptions(IList<Expression> Expressions, ref RouteData Data, ref double[] UnitOfLength, bool PreviewOnly)
 		{
 			string Section = "";
 			bool SectionAlwaysPrefix = false;

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.PreprocessOptions.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.PreprocessOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenBveApi.Math;
 using OpenBveApi.Interface;
 using OpenBveApi.Routes;
@@ -14,12 +15,12 @@ namespace CsvRwRouteParser
 		/// <param name="Data">The finalized route data</param>
 		/// <param name="UnitOfLength">The units of length conversion factor to be applied</param>
 		/// <param name="PreviewOnly">Whether this is a preview only</param>
-		private void PreprocessOptions(Expression[] Expressions, ref RouteData Data, ref double[] UnitOfLength, bool PreviewOnly)
+		private void PreprocessOptions(List<Expression> Expressions, ref RouteData Data, ref double[] UnitOfLength, bool PreviewOnly)
 		{
 			string Section = "";
 			bool SectionAlwaysPrefix = false;
 			// process expressions
-			for (int j = 0; j < Expressions.Length; j++)
+			for (int j = 0; j < Expressions.Count; j++)
 			{
 				if (IsRW && Expressions[j].Text.StartsWith("[") && Expressions[j].Text.EndsWith("]"))
 				{

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
@@ -140,7 +140,7 @@ namespace CsvRwRouteParser {
 		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, ref RouteData Data, bool PreviewOnly) {
 			//Read the entire routefile into memory
 			List<string> Lines = System.IO.File.ReadAllLines(FileName, Encoding).ToList();
-			PreprocessSplitIntoExpressions(FileName, Lines, out List<Expression> Expressions, true);
+			PreprocessSplitIntoExpressions(FileName, Lines, out IList<Expression> Expressions, true);
 			PreprocessChrRndSub(FileName, Encoding, ref Expressions);
 			double[] UnitOfLength = { 1.0 };
 			//Set units of speed initially to km/h
@@ -158,7 +158,7 @@ namespace CsvRwRouteParser {
 		private readonly System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
 
 		// parse route for data
-		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, List<Expression> Expressions, double[] UnitOfLength, ref RouteData Data, bool PreviewOnly) {
+		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, IList<Expression> Expressions, double[] UnitOfLength, ref RouteData Data, bool PreviewOnly) {
 			CurrentStation = -1;
 			CurrentStop = -1;
 			CurrentSection = 0;

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.cs
@@ -140,7 +140,7 @@ namespace CsvRwRouteParser {
 		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, ref RouteData Data, bool PreviewOnly) {
 			//Read the entire routefile into memory
 			List<string> Lines = System.IO.File.ReadAllLines(FileName, Encoding).ToList();
-			PreprocessSplitIntoExpressions(FileName, Lines, out Expression[] Expressions, true);
+			PreprocessSplitIntoExpressions(FileName, Lines, out List<Expression> Expressions, true);
 			PreprocessChrRndSub(FileName, Encoding, ref Expressions);
 			double[] UnitOfLength = { 1.0 };
 			//Set units of speed initially to km/h
@@ -158,7 +158,7 @@ namespace CsvRwRouteParser {
 		private readonly System.Globalization.CultureInfo Culture = System.Globalization.CultureInfo.InvariantCulture;
 
 		// parse route for data
-		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, Expression[] Expressions, double[] UnitOfLength, ref RouteData Data, bool PreviewOnly) {
+		private void ParseRouteForData(string FileName, System.Text.Encoding Encoding, List<Expression> Expressions, double[] UnitOfLength, ref RouteData Data, bool PreviewOnly) {
 			CurrentStation = -1;
 			CurrentStop = -1;
 			CurrentSection = 0;
@@ -168,7 +168,7 @@ namespace CsvRwRouteParser {
 			int BlockIndex = 0;
 			CurrentRoute.Tracks[0].Direction = TrackDirection.Forwards;
 			CurrentRoute.Stations = new RouteStation[] { };
-			double progressFactor = Expressions.Length == 0 ? 0.3333 : 0.3333 / Expressions.Length;
+			double progressFactor = Expressions.Count == 0 ? 0.3333 : 0.3333 / Expressions.Count;
 			// process non-track namespaces
 			//Check for any special-cased fixes we might need
 			CheckForAvailablePatch(FileName, ref Data, ref Expressions, PreviewOnly);
@@ -189,7 +189,7 @@ namespace CsvRwRouteParser {
 				}
 			}
 			
-			for (int j = 0; j < Expressions.Length; j++) {
+			for (int j = 0; j < Expressions.Count; j++) {
 				Plugin.CurrentProgress = j * progressFactor;
 				if ((j & 255) == 0) {
 					System.Threading.Thread.Sleep(1);
@@ -391,7 +391,7 @@ namespace CsvRwRouteParser {
 			Data.Blocks[0].LightDefinition = new LightDefinition(Plugin.CurrentRoute.Atmosphere.AmbientLightColor, Plugin.CurrentRoute.Atmosphere.DiffuseLightColor, Plugin.CurrentRoute.Atmosphere.LightPosition, -1, -1);
 			Data.Blocks[0].DynamicLightDefinition = int.MaxValue;
 			// process track namespace
-			for (int j = 0; j < Expressions.Length; j++) {
+			for (int j = 0; j < Expressions.Count; j++) {
 				Plugin.CurrentProgress = 0.3333 + j * progressFactor;
 				if ((j & 255) == 0) {
 					System.Threading.Thread.Sleep(1);

--- a/source/Plugins/Route.CsvRw/Structures/Expression.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Expression.cs
@@ -12,6 +12,7 @@ namespace CsvRwRouteParser
 		internal int Line;
 		internal int Column;
 		internal double TrackPositionOffset;
+		internal bool Skip;
 
 		internal Expression(string file, string text, int line, int column, double trackPositionOffset)
 		{
@@ -20,6 +21,7 @@ namespace CsvRwRouteParser
 			Line = line;
 			Column = column;
 			TrackPositionOffset = trackPositionOffset;
+			Skip = false;
 		}
 
 		/// <summary>Converts a RW formatted expression to CSV format</summary>


### PR DESCRIPTION
This PR is to get rid of a bunch of array manipulation in the CSV RW route parser.

When adding a new file via $Include, we first resize the Expression array, before moving the expressions to accomodate the new ones.
This can be simplified by using a List<T>, which does this under the hood natively. The total cost of this should be identical either way, this is just cleaner code.

Also adds a Skip boolean to each expression. Use this, rather than resizing the array to remove skipped expressions should have a minor performance gain.