### PR TITLE
Fix shadow with cartesian coord xml

### DIFF
--- a/source/LibRender2/Lighting/Lighting.cs
+++ b/source/LibRender2/Lighting/Lighting.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using OpenBveApi.Colors;
 using OpenBveApi.Math;
 using OpenBveApi.Routes;
@@ -86,64 +86,30 @@ namespace LibRender2.Lightings
 			}
 
 			//Run through the array
-			int j = 0;
-
-			for (int i = j; i < LightDefinitions.Length; i++)
+			// Find the current time block index j and next time block index k.
+			// Handled wrapping around midnight using modulo. Supports > 2 time blocks.
+			int j = LightDefinitions.Length - 1;
+			for (int i = 0; i < LightDefinitions.Length; i++)
 			{
 				if (Time < LightDefinitions[i].Time)
 				{
 					break;
 				}
-
 				j = i;
 			}
-
-			//We now know that our light definition is between the values defined in j and j + 1 (Or 0 if this is the end of the array)
-			int k;
-
-			if (j == 0)
-			{
-				//Our NEW light is to be the first entry in the array
-				//This means the OLD light is the last entry, but j and k do not need reversing
-				k = 0;
-				j = LightDefinitions.Length - 1;
-			}
-			else if (j == LightDefinitions.Length - 1)
-			{
-				//We are wrapping around to the end of the array
-				//Reverse j and k, as we have not yet passed the time for the first array entry
-				j = 0;
-				k = LightDefinitions.Length - 1;
-			}
-			else
-			{
-				//Somewhere in the middle, so the NEW light is simply one greater
-				k = j + 1;
-			}
+			int k = (j + 1) % LightDefinitions.Length;
 
 			double t1 = LightDefinitions[j].Time, t2 = LightDefinitions[k].Time;
+			// Fixed typo: cb2 previously assigned LightDefinitions[k].Time instead of CabBrightness
+			double cb1 = LightDefinitions[j].CabBrightness, cb2 = LightDefinitions[k].CabBrightness;
 
-			double cb1 = LightDefinitions[j].CabBrightness, cb2 = LightDefinitions[k].Time;
-			//Calculate, inverting if necessary
-
-			//Ensure we're not about to divide by zero
-			if (t2 == 0)
-			{
-				t2 = 1;
-			}
-
-			if (t1 == 0)
-			{
-				t1 = 1;
-			}
-
-			//Calculate the percentage
 			double mu;
-
-			if (k == LightDefinitions.Length - 1)
+			// Calculate the interpolation factor mu (handles wrap-around when j > k)
+			if (j > k)
 			{
-				//Wrapping around
-				mu = (86400 - Time + t1) / (86400 - t2 + t1);
+				double duration = 86400 - t1 + t2;
+				double elapsed = Time >= t1 ? Time - t1 : 86400 - t1 + Time;
+				mu = elapsed / duration;
 			}
 			else
 			{

--- a/source/Plugins/Route.CsvRw/XML/DynamicLight.cs
+++ b/source/Plugins/Route.CsvRw/XML/DynamicLight.cs
@@ -1,4 +1,4 @@
-﻿using Formats.OpenBve;
+using Formats.OpenBve;
 using Formats.OpenBve.XML;
 using OpenBveApi.Interface;
 using OpenBveApi.Math;
@@ -48,7 +48,8 @@ namespace CsvRwRouteParser
 				ld = lightBlock.TryGetVector3(DynamicLightKey.LightDirection, ',', ref currentLight.LightPosition);
 				if (!ld && lightBlock.GetVector2(DynamicLightKey.SphericalLightDirection, ',', out Vector2 temp))
 				{
-					currentLight.LightPosition = new Vector3(Math.Cos(temp.X) * Math.Sin(temp.Y), -Math.Sin(temp.X), Math.Cos(temp.X) * Math.Cos(temp.Y));
+					double theta = temp.X.ToRadians(), phi = temp.Y.ToRadians();
+					currentLight.LightPosition = new Vector3(-Math.Cos(theta) * Math.Sin(phi), Math.Sin(theta), -Math.Cos(theta) * Math.Cos(phi));
 					ld = true;
 				}
 				//We want to be able to add a completely default light element,  but not one that's not been defined in the XML properly

--- a/source/Plugins/Route.CsvRw/XML/DynamicLight.cs
+++ b/source/Plugins/Route.CsvRw/XML/DynamicLight.cs
@@ -46,6 +46,10 @@ namespace CsvRwRouteParser
 				al = lightBlock.TryGetColor24(DynamicLightKey.AmbientLight, ref currentLight.AmbientColor);
 				dl = lightBlock.TryGetColor24(DynamicLightKey.DirectionalLight, ref currentLight.DiffuseColor);
 				ld = lightBlock.TryGetVector3(DynamicLightKey.LightDirection, ',', ref currentLight.LightPosition);
+				if (ld)
+				{
+					currentLight.LightPosition = -currentLight.LightPosition;
+				}
 				if (!ld && lightBlock.GetVector2(DynamicLightKey.SphericalLightDirection, ',', out Vector2 temp))
 				{
 					double theta = temp.X.ToRadians(), phi = temp.Y.ToRadians();


### PR DESCRIPTION
#1313 

In `DynamicLight.cs` we negate Cartesian `LightDirection` so it stores the vector pointing to the sun, aligning with Spherical coordinates and fixing shadows. 

In `Lighting.cs` we simplify time-block index wrapping logic using modulo and fix cab brightness variable assignment typo.

@leezer3 Please check.

I hope this didn't broke legacy stuff...