### PR TITLE
Optimize shadow rendering: static object draw state caching and low-res far shadows option

### DIFF
--- a/source/LibRender2/Shadows/CascadedShadowCaster.cs
+++ b/source/LibRender2/Shadows/CascadedShadowCaster.cs
@@ -23,7 +23,7 @@ namespace LibRender2.ShadowMapping
         public double DepthMargin { get; set; } = 40.0;
 
         /// <summary>Active shadow map resolution (used for texel snapping).</summary>
-        public int Resolution { get; set; } = 2048;
+        public int[] Resolutions { get; set; }
 
         /// <summary>Per-cascade light-space VP matrices.</summary>
         public Matrix4D[] LightSpaceMatrices { get; private set; }
@@ -45,10 +45,12 @@ namespace LibRender2.ShadowMapping
             LightSpaceMatrices = new Matrix4D[cascadeCount];
             SplitDistances = new float[cascadeCount];
             CascadeBiases = new float[cascadeCount];
+            Resolutions = new int[cascadeCount];
 
             for (int i = 0; i < cascadeCount; i++)
             {
                 LightSpaceMatrices[i] = Matrix4D.Identity;
+                Resolutions[i] = 2048;
             }
         }
 
@@ -120,7 +122,7 @@ namespace LibRender2.ShadowMapping
                 // === Texel snapping to prevent shadow swimming on camera move ===
                 // Snap the light-space center to texel boundaries
                 // Each texel covers (2*orthoSize / Resolution) world units
-                double worldTexelSize = (orthoSize * 2.0) / (double)Resolution;
+                double worldTexelSize = (orthoSize * 2.0) / (double)Resolutions[i];
 
                 // Transform center into light view space to snap it
                 Vector3 centerLS = TransformPoint(center, lightView);
@@ -145,7 +147,7 @@ namespace LibRender2.ShadowMapping
 
                 // Z-Bias: Convert physical texel size into a Depth Buffer fraction.
                 // This ensures we push the depth exactly enough to cure acne, but no more.
-                double texelWorldSize = (orthoSize * 2.0) / (double)Resolution;
+                double texelWorldSize = (orthoSize * 2.0) / (double)Resolutions[i];
                 double depthRange = zFar - zNear;
                 double baseBias = texelWorldSize / depthRange;
                 CascadeBiases[i] = (float)baseBias;

--- a/source/LibRender2/Shadows/CascadedShadowMap.cs
+++ b/source/LibRender2/Shadows/CascadedShadowMap.cs
@@ -12,8 +12,11 @@ namespace LibRender2.ShadowMapping
         /// <summary>Number of cascades (shadow splits).</summary>
         public int CascadeCount { get; private set; }
 
-        /// <summary>Shadow map resolution per cascade.</summary>
-        public int Resolution { get; private set; }
+        /// <summary>Base shadow map resolution.</summary>
+        public int BaseResolution { get; private set; }
+
+        /// <summary>Resolutions per cascade.</summary>
+        public int[] Resolutions { get; private set; }
 
         /// <summary>Per-cascade FBO handles.</summary>
         public int[] FBOs { get; private set; }
@@ -26,15 +29,18 @@ namespace LibRender2.ShadowMapping
         /// </summary>
         /// <param name="cascadeCount">Number of cascades (typically 3 or 4).</param>
         /// <param name="resolution">Resolution of each cascade's depth texture.</param>
-        public CascadedShadowMap(int cascadeCount = 3, int resolution = 2048)
+        /// <param name="lowResFarShadows">Whether to downscale resolutions for far cascades.</param>
+        public CascadedShadowMap(int cascadeCount = 3, int resolution = 2048, bool lowResFarShadows = true)
         {
             CascadeCount = cascadeCount;
-            Resolution = resolution;
+            BaseResolution = resolution;
             FBOs = new int[cascadeCount];
             DepthTextures = new int[cascadeCount];
+            Resolutions = new int[cascadeCount];
 
             for (int i = 0; i < cascadeCount; i++)
             {
+                Resolutions[i] = (lowResFarShadows && i > 0) ? Math.Max(128, resolution >> i) : resolution;
                 CreateCascade(i);
             }
         }
@@ -45,24 +51,27 @@ namespace LibRender2.ShadowMapping
         /// </summary>
         /// <param name="newCascadeCount">New number of cascades.</param>
         /// <param name="newResolution">New resolution per cascade.</param>
-        public void Resize(int newCascadeCount, int newResolution)
+        /// <param name="lowResFarShadows">Whether to downscale resolutions for far cascades.</param>
+        public void Resize(int newCascadeCount, int newResolution, bool lowResFarShadows = true)
         {
             // Dispose old resources
             Dispose();
 
             // Reallocate
             CascadeCount = newCascadeCount;
-            Resolution = newResolution;
+            BaseResolution = newResolution;
             FBOs = new int[newCascadeCount];
             DepthTextures = new int[newCascadeCount];
+            Resolutions = new int[newCascadeCount];
 
             for (int i = 0; i < newCascadeCount; i++)
             {
+                Resolutions[i] = (lowResFarShadows && i > 0) ? Math.Max(128, newResolution >> i) : newResolution;
                 CreateCascade(i);
             }
 
             Console.WriteLine(
-                $"[CSM] Resized to {newCascadeCount} cascades at {newResolution}×{newResolution}");
+                $"[CSM] Resized to {newCascadeCount} cascades with downscaling={lowResFarShadows}");
         }
 
         private void CreateCascade(int index)
@@ -72,7 +81,7 @@ namespace LibRender2.ShadowMapping
             GL.BindTexture(TextureTarget.Texture2D, DepthTextures[index]);
             GL.TexImage2D(TextureTarget.Texture2D, 0,
                 PixelInternalFormat.DepthComponent24,
-                Resolution, Resolution, 0,
+                Resolutions[index], Resolutions[index], 0,
                 PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
             GL.TexParameter(TextureTarget.Texture2D,
                 TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
@@ -118,7 +127,7 @@ namespace LibRender2.ShadowMapping
         public void BindCascadeForWriting(int cascadeIndex)
         {
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, FBOs[cascadeIndex]);
-            GL.Viewport(0, 0, Resolution, Resolution);
+            GL.Viewport(0, 0, Resolutions[cascadeIndex], Resolutions[cascadeIndex]);
         }
 
         /// <summary>Unbinds shadow FBO.</summary>

--- a/source/LibRender2/Shadows/Shadows.cs
+++ b/source/LibRender2/Shadows/Shadows.cs
@@ -59,11 +59,11 @@ namespace LibRender2.ShadowMapping
 			{
 				if (Map == null)
 				{
-					Map = new CascadedShadowMap(cascadeCount, resolution);
+					Map = new CascadedShadowMap(cascadeCount, resolution, opts.LowResFarShadows);
 				}
 				else
 				{
-					Map.Resize(cascadeCount, resolution);
+					Map.Resize(cascadeCount, resolution, opts.LowResFarShadows);
 				}
 
 				if (Caster == null || cascadeCount != Caster.CascadeCount)
@@ -72,7 +72,7 @@ namespace LibRender2.ShadowMapping
 				}
 
 				Caster.ShadowDistance = shadowDistance;
-				Caster.Resolution = resolution;
+				Caster.Resolutions = Map.Resolutions;
 				Caster.SplitLambda = 0.75;
 				Caster.DepthMargin = 150.0;
 
@@ -119,7 +119,7 @@ namespace LibRender2.ShadowMapping
 			// 2. Update cascade matrices
 			// NOTE: We pass renderer.CurrentViewMatrix here which reflects the camera's rotation.
 			// The Caster will use this to align the shadow frustums with the view direction.
-			Caster.Resolution = Map.Resolution;
+			Caster.Resolutions = Map.Resolutions;
 			if (renderer.currentOptions.ShadowDrawDistance == ShadowDistance.ViewingDistance)
 			{
 				Caster.ShadowDistance = renderer.currentOptions.ViewingDistance;
@@ -194,6 +194,9 @@ namespace LibRender2.ShadowMapping
 		private void RenderFacesFiltered(IEnumerable<FaceState> faces, ref int lastVAO, double maxDistanceSquared)
 		{
 			Vector3 cameraPos = renderer.Camera.AbsolutePosition;
+			ObjectState lastObject = null;
+			MeshMaterial? lastMaterial = null;
+			int lastTextureId = -1;
 
 			foreach (var face in faces)
 			{
@@ -217,33 +220,50 @@ namespace LibRender2.ShadowMapping
 					}
 				}
 
-				DepthShader.SetModelMatrix(state.ModelMatrix * renderer.Camera.TranslationMatrix);
-				DepthShader.SetTextureMatrix(state.TextureTranslation);
-
 				var material = face.Object.Prototype.Mesh.Materials[face.Face.Material];
 				if ((material.Flags & MaterialFlags.NoShadow) != 0 || material.BlendMode == MeshMaterialBlendMode.Additive)
 				{
 					continue;
 				}
-				if (material.DaytimeTexture != null && renderer.currentHost.LoadTexture(ref material.DaytimeTexture, (OpenGlTextureWrapMode)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)))
+
+				// Cache and skip redundant object matrix/animation uniform updates
+				if (state != lastObject)
 				{
-					GL.ActiveTexture(TextureUnit.Texture0);
-					GL.BindTexture(TextureTarget.Texture2D, material.DaytimeTexture.OpenGlTextures[(int)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)].Name);
-					DepthShader.SetHasTexture(true);
-				}
-				else
-				{
-					DepthShader.SetHasTexture(false);
+					DepthShader.SetModelMatrix(state.ModelMatrix * renderer.Camera.TranslationMatrix);
+					DepthShader.SetTextureMatrix(state.TextureTranslation);
+
+					if (state.Matricies != null && state.Matricies.Length > 0)
+					{
+						DepthShader.SetCurrentAnimationMatricies(state);
+						GL.BindBufferBase(BufferTarget.UniformBuffer, 0, state.MatrixBufferIndex);
+					}
+					lastObject = state;
 				}
 
-				DepthShader.SetAlphaCutoff(0.5f);
-				DepthShader.SetMaterialAlpha(material.Color.A / 255.0f);
-				DepthShader.SetMaterialFlags(material.Flags);
-				
-				if (state.Matricies != null && state.Matricies.Length > 0)
+				// Cache and skip redundant material and texture state binds
+				if (!lastMaterial.HasValue || material != lastMaterial.Value)
 				{
-					DepthShader.SetCurrentAnimationMatricies(state);
-					GL.BindBufferBase(BufferTarget.UniformBuffer, 0, state.MatrixBufferIndex);
+					int textureId = -1;
+					if (material.DaytimeTexture != null && renderer.currentHost.LoadTexture(ref material.DaytimeTexture, (OpenGlTextureWrapMode)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)))
+					{
+						textureId = material.DaytimeTexture.OpenGlTextures[(int)(material.WrapMode ?? OpenGlTextureWrapMode.ClampClamp)].Name;
+					}
+
+					if (textureId != lastTextureId)
+					{
+						if (textureId != -1)
+						{
+							GL.ActiveTexture(TextureUnit.Texture0);
+							GL.BindTexture(TextureTarget.Texture2D, textureId);
+						}
+						DepthShader.SetHasTexture(textureId != -1);
+						lastTextureId = textureId;
+					}
+
+					DepthShader.SetAlphaCutoff(0.5f);
+					DepthShader.SetMaterialAlpha(material.Color.A / 255.0f);
+					DepthShader.SetMaterialFlags(material.Flags);
+					lastMaterial = material;
 				}
 
 				VertexArrayObject vao = (VertexArrayObject)face.Object.Prototype.Mesh.VAO;

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -87,6 +87,26 @@ namespace ObjectViewer
 			comboBoxBackwards.SelectedItem = Interface.CurrentOptions.CameraMoveBackward;
 			checkBoxAutoReload.Checked = Interface.CurrentOptions.AutoReloadObjects;
 			checkBoxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
+
+			// Dynamically add LowResFarShadows checkbox
+			CheckBox checkBoxLowResFarShadows = new CheckBox();
+			checkBoxLowResFarShadows.AutoSize = true;
+			checkBoxLowResFarShadows.Location = new System.Drawing.Point(160, 215);
+			checkBoxLowResFarShadows.Name = "checkBoxLowResFarShadows";
+			checkBoxLowResFarShadows.Size = new System.Drawing.Size(15, 14);
+			checkBoxLowResFarShadows.Text = "";
+			checkBoxLowResFarShadows.Checked = Interface.CurrentOptions.LowResFarShadows;
+			checkBoxLowResFarShadows.Enabled = (Interface.CurrentOptions.ShadowResolution != ShadowMapResolution.Off);
+			checkBoxLowResFarShadows.UseVisualStyleBackColor = true;
+			this.tabPageShadows.Controls.Add(checkBoxLowResFarShadows);
+
+			Label labelLowResFarShadows = new Label();
+			labelLowResFarShadows.AutoSize = true;
+			labelLowResFarShadows.Location = new System.Drawing.Point(6, 215);
+			labelLowResFarShadows.Name = "labelLowResFarShadows";
+			labelLowResFarShadows.Size = new System.Drawing.Size(126, 13);
+			labelLowResFarShadows.Text = "Low-res Far Shadows:";
+			this.tabPageShadows.Controls.Add(labelLowResFarShadows);
 		}
 
 		private void InitializeSunSliders()
@@ -111,6 +131,12 @@ namespace ObjectViewer
 
 			trackBarSunElevation.Enabled = enabled;
 			checkBoxShadowFilterCascades.Enabled = enabled;
+
+			CheckBox checkBoxLowResFarShadows = this.tabPageShadows.Controls["checkBoxLowResFarShadows"] as CheckBox;
+			if (checkBoxLowResFarShadows != null)
+			{
+				checkBoxLowResFarShadows.Enabled = enabled;
+			}
 		}
 
 		private void comboBoxShadowResolution_SelectedIndexChanged(object sender, EventArgs e)
@@ -281,6 +307,11 @@ namespace ObjectViewer
 			Interface.CurrentOptions.ShadowBias = (double)numericUpDownShadowBias.Value;
 			Interface.CurrentOptions.ShadowNormalBias = (double)numericUpDownShadowNormalBias.Value;
 			Interface.CurrentOptions.ShadowFilterCascades = checkBoxShadowFilterCascades.Checked;
+			CheckBox checkBoxLowResFarShadows = this.tabPageShadows.Controls["checkBoxLowResFarShadows"] as CheckBox;
+			if (checkBoxLowResFarShadows != null)
+			{
+				Interface.CurrentOptions.LowResFarShadows = checkBoxLowResFarShadows.Checked;
+			}
 			
 			Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_ov.cfg"));
 			Program.RefreshObjects();

--- a/source/OpenBVE/System/Options.cs
+++ b/source/OpenBVE/System/Options.cs
@@ -326,6 +326,7 @@ namespace OpenBve
 				Builder.AppendLine("shadowbias = " + ShadowBias.ToString(Culture));
 				Builder.AppendLine("shadownormalbias = " + ShadowNormalBias.ToString(Culture));
 				Builder.AppendLine("shadowfiltercascades = " + (ShadowFilterCascades ? "true" : "false"));
+				Builder.AppendLine("lowresfarshadows = " + (LowResFarShadows ? "true" : "false"));
 				Builder.AppendLine("fpslimit = " + FPSLimit.ToString(Culture));
 				Builder.AppendLine();
 				Builder.AppendLine("[objectOptimization]");
@@ -540,6 +541,7 @@ namespace OpenBve
 							block.TryGetValue(OptionsKey.ShadowNormalBias, ref CurrentOptions.ShadowNormalBias);
 							if (CurrentOptions.ShadowNormalBias < 0.0) CurrentOptions.ShadowNormalBias = 0.0;
 							block.GetValue(OptionsKey.ShadowFilterCascades, out Interface.CurrentOptions.ShadowFilterCascades);
+							block.GetValue(OptionsKey.LowResFarShadows, out Interface.CurrentOptions.LowResFarShadows);
 							block.GetValue(OptionsKey.FPSLimit, out CurrentOptions.FPSLimit);
 							if (CurrentOptions.FPSLimit < 0)
 							{

--- a/source/OpenBVE/UserInterface/formMain.Options.cs
+++ b/source/OpenBVE/UserInterface/formMain.Options.cs
@@ -55,6 +55,12 @@ namespace OpenBve {
 			updownShadowNormalBias.Enabled = shadowEnabled;
 			checkboxShadowFilterCascades.Enabled = shadowEnabled;
 
+			CheckBox checkboxLowResFarShadows = this.groupboxShadows.Controls["checkboxLowResFarShadows"] as CheckBox;
+			if (checkboxLowResFarShadows != null)
+			{
+				checkboxLowResFarShadows.Enabled = shadowEnabled;
+			}
+
 			if (!shadowEnabled)
 			{
 				// Visual hint: grey out the strength label

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -499,6 +499,20 @@ namespace OpenBve {
 			checkboxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
 			// Enable/disable shadow sub-controls based on resolution setting
 			bool shadowEnabled = Interface.CurrentOptions.ShadowResolution != ShadowMapResolution.Off;
+
+			// Dynamically add LowResFarShadows checkbox
+			this.groupboxShadows.Height = 265;
+			CheckBox checkboxLowResFarShadows = new CheckBox();
+			checkboxLowResFarShadows.AutoSize = true;
+			checkboxLowResFarShadows.Location = new System.Drawing.Point(8, 238);
+			checkboxLowResFarShadows.Name = "checkboxLowResFarShadows";
+			checkboxLowResFarShadows.Size = new System.Drawing.Size(150, 17);
+			checkboxLowResFarShadows.Text = "Low-res Far Shadows";
+			checkboxLowResFarShadows.Checked = Interface.CurrentOptions.LowResFarShadows;
+			checkboxLowResFarShadows.Enabled = shadowEnabled;
+			checkboxLowResFarShadows.UseVisualStyleBackColor = true;
+			this.groupboxShadows.Controls.Add(checkboxLowResFarShadows);
+
 			comboboxShadowDistance.Enabled = shadowEnabled;
 			comboboxShadowCascades.Enabled = shadowEnabled;
 			checkboxShadowFilterCascades.Enabled = shadowEnabled;
@@ -1264,6 +1278,11 @@ namespace OpenBve {
 			Interface.CurrentOptions.ShadowBias = (double)updownShadowBias.Value;
 			Interface.CurrentOptions.ShadowNormalBias = (double)updownShadowNormalBias.Value;
 			Interface.CurrentOptions.ShadowFilterCascades = checkboxShadowFilterCascades.Checked;
+			CheckBox checkboxLowResFarShadows = this.groupboxShadows.Controls["checkboxLowResFarShadows"] as CheckBox;
+			if (checkboxLowResFarShadows != null)
+			{
+				Interface.CurrentOptions.LowResFarShadows = checkboxLowResFarShadows.Checked;
+			}
 			Interface.CurrentOptions.GameMode = (GameMode)comboboxMode.SelectedIndex;
 			Interface.CurrentOptions.BlackBox = checkboxBlackBox.Checked;
 			Interface.CurrentOptions.LoadingSway = checkBoxLoadingSway.Checked;

--- a/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
+++ b/source/OpenBveApi/System/BaseOptions.OptionsKey.cs
@@ -57,6 +57,7 @@ namespace OpenBveApi
 		ShadowBias,
 		ShadowNormalBias,
 		ShadowFilterCascades,
+		LowResFarShadows,
 		LightAzimuth,
 
 		LightElevation,

--- a/source/OpenBveApi/System/BaseOptions.cs
+++ b/source/OpenBveApi/System/BaseOptions.cs
@@ -96,6 +96,8 @@ namespace OpenBveApi
 		public double ShadowNormalBias = 2.0;
 		/// <summary>Whether to filter shadow casters per cascade to improve performance.</summary>
 		public bool ShadowFilterCascades = true;
+		/// <summary>Whether to downscale far cascade shadow map resolutions to improve performance.</summary>
+		public bool LowResFarShadows = true;
 
 
 		/// <summary>The sun azimuth in degrees</summary>

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -89,6 +89,26 @@ namespace RouteViewer
 				labelNearClip.Text = Translations.GetInterfaceString(OpenBveApi.Hosts.HostApplication.OpenBve, new[] { "options", "quality_distance_nearclip" });
 			}
 			checkBoxShadowFilterCascades.Checked = Interface.CurrentOptions.ShadowFilterCascades;
+
+            // Dynamically add LowResFarShadows checkbox
+            CheckBox checkBoxLowResFarShadows = new CheckBox();
+            checkBoxLowResFarShadows.AutoSize = true;
+            checkBoxLowResFarShadows.Location = new System.Drawing.Point(160, 215);
+            checkBoxLowResFarShadows.Name = "checkBoxLowResFarShadows";
+            checkBoxLowResFarShadows.Size = new System.Drawing.Size(15, 14);
+            checkBoxLowResFarShadows.Text = "";
+            checkBoxLowResFarShadows.Checked = Interface.CurrentOptions.LowResFarShadows;
+            checkBoxLowResFarShadows.Enabled = (Interface.CurrentOptions.ShadowResolution != ShadowMapResolution.Off);
+            checkBoxLowResFarShadows.UseVisualStyleBackColor = true;
+            this.tabPageShadows.Controls.Add(checkBoxLowResFarShadows);
+
+            Label labelLowResFarShadows = new Label();
+            labelLowResFarShadows.AutoSize = true;
+            labelLowResFarShadows.Location = new System.Drawing.Point(6, 215);
+            labelLowResFarShadows.Name = "labelLowResFarShadows";
+            labelLowResFarShadows.Size = new System.Drawing.Size(126, 13);
+            labelLowResFarShadows.Text = "Low-res Far Shadows:";
+            this.tabPageShadows.Controls.Add(labelLowResFarShadows);
         }
 
         private void InitializeSunSliders()
@@ -113,6 +133,12 @@ namespace RouteViewer
             trackBarSunAzimuth.Enabled = enabled;
             trackBarSunElevation.Enabled = enabled;
             checkBoxShadowFilterCascades.Enabled = enabled;
+
+            CheckBox checkBoxLowResFarShadows = this.tabPageShadows.Controls["checkBoxLowResFarShadows"] as CheckBox;
+            if (checkBoxLowResFarShadows != null)
+            {
+                checkBoxLowResFarShadows.Enabled = enabled;
+            }
         }
 
         private void comboBoxShadowResolution_SelectedIndexChanged(object sender, EventArgs e)
@@ -175,6 +201,7 @@ namespace RouteViewer
 	        double previousShadowBias = Interface.CurrentOptions.ShadowBias;
 	        double previousShadowNormalBias = Interface.CurrentOptions.ShadowNormalBias;
 	        bool previousShadowFilterCascades = Interface.CurrentOptions.ShadowFilterCascades;
+	        bool previousLowResFarShadows = Interface.CurrentOptions.LowResFarShadows;
 
 			//Interpolation mode
 			InterpolationMode previousInterpolationMode = Interface.CurrentOptions.Interpolation;
@@ -293,9 +320,14 @@ namespace RouteViewer
             Interface.CurrentOptions.ShadowBias = (double)numericUpDownShadowBias.Value;
             Interface.CurrentOptions.ShadowNormalBias = (double)numericUpDownShadowNormalBias.Value;
             Interface.CurrentOptions.ShadowFilterCascades = checkBoxShadowFilterCascades.Checked;
+            CheckBox checkBoxLowResFarShadows = this.tabPageShadows.Controls["checkBoxLowResFarShadows"] as CheckBox;
+            if (checkBoxLowResFarShadows != null)
+            {
+                Interface.CurrentOptions.LowResFarShadows = checkBoxLowResFarShadows.Checked;
+            }
 
 
-            
+
 
             // Sun direction is already updated in real-time via slider events
 
@@ -313,7 +345,7 @@ namespace RouteViewer
 			if (previousInterpolationMode != Interface.CurrentOptions.Interpolation || previousAnisotropicLevel != Interface.CurrentOptions.AnisotropicFilteringLevel || GraphicsModeChanged || Interface.CurrentOptions.ViewingDistance != previousViewingDistance ||
 			    previousShadowResolution != Interface.CurrentOptions.ShadowResolution || previousShadowDistance != Interface.CurrentOptions.ShadowDrawDistance || previousShadowCascades != Interface.CurrentOptions.ShadowCascades ||
 			    previousShadowStrength != Interface.CurrentOptions.ShadowStrength || previousShadowBias != Interface.CurrentOptions.ShadowBias || previousShadowNormalBias != Interface.CurrentOptions.ShadowNormalBias || 
-			    Interface.CurrentOptions.NearClipBase != previousNearClipBase || previousShadowFilterCascades != Interface.CurrentOptions.ShadowFilterCascades)
+			    Interface.CurrentOptions.NearClipBase != previousNearClipBase || previousShadowFilterCascades != Interface.CurrentOptions.ShadowFilterCascades || previousLowResFarShadows != Interface.CurrentOptions.LowResFarShadows)
 			{
 				this.DialogResult = DialogResult.OK;
 			}


### PR DESCRIPTION
This should improve shadow rendering and lower RAM usage.

1. Caching:
   - Cache active object, material, and texture bindings in Shadows.cs
   - Skip redundant GL binds and uniform updates to reduce CPU/driver overhead.
2. Low-res Far Shadows Option:
   - Add "Low-res Far Shadows" option to dynamically downscale far shadow map cascades (halving/quartering resolutions).
   - Saves rendering time and VRAM for distant shadow cascades.
   - Exposed via UI checkboxes in OpenBVE main settings, RouteViewer, and ObjectViewer.

---

not done yet, but i will set this PR as open.