### PR TITLE
Change: Update releases in MetaInfo

### DIFF
--- a/net.openbve_project.OpenBVE.metainfo.xml
+++ b/net.openbve_project.OpenBVE.metainfo.xml
@@ -40,8 +40,14 @@
   </screenshots>
 
   <releases>
+    <release version="1.13.0.8" date="2026-07-09">
+      <url type="details">https://openbve-project.net/intro/V1.13.0.8/</url>
+    </release>
+    <release version="1.13.0.5" date="2026-06-09">
+      <url type="details">https://openbve-project.net/intro/V1.13.0.5/</url>
+    </release>
     <release version="1.13.0.2" date="2026-05-14">
-      <url type="details">https://openbve-project.net/V1.13.0.2/</url>
+      <url type="details">https://openbve-project.net/intro/V1.13.0.2/</url>
     </release>
   </releases>
 </component>


### PR DESCRIPTION
This PR updates the release history in the MetaInfo file to reflect the current version.

This should also be bumped before each future release. Keeping this information up-to-date ensures that the correct version is displayed on Flathub website, GNOME Software and Plasma Discover.