### PR TITLE
Fix macos startup regressions

### DIFF
--- a/makefile
+++ b/makefile
@@ -201,6 +201,8 @@ $(MAC_BUILD_RESULT): all-release
 
 	@echo $(COLOR_RED)Copying build data into $(COLOR_CYAN)OpenBVE.app$(COLOR_END)
 	@cp -r $(RELEASE_DIR)/* mac/OpenBVE.app/Contents/Resources/
+	@cp source/OpenBVE/OpenTK.dll.config mac/OpenBVE.app/Contents/Resources/OpenTK.dll.config
+	@test -f mac/OpenBVE.app/Contents/Resources/OpenTK.dll.config || (echo "OpenTK.dll.config is missing from the macOS app bundle"; exit 1)
 
 # Because Azure is iffy on MacOS13, let's try a custom script
 	@echo $(COLOR_RED)Creating $(COLOR_CYAN)$(MAC_BUILD_RESULT)$(COLOR_END)

--- a/source/OpenBVE/Graphics/Renderers/Touch.cs
+++ b/source/OpenBVE/Graphics/Renderers/Touch.cs
@@ -47,12 +47,12 @@ namespace OpenBve.Graphics.Renderers
         {
             touchableObject.Clear();
 
-            CarBase Car = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar];
-
-			if (!Loading.SimulationSetup)
+            if (!Loading.SimulationSetup || TrainManager.PlayerTrain == null)
             {
                 return;
             }
+
+            CarBase Car = TrainManager.PlayerTrain.Cars[TrainManager.PlayerTrain.DriverCar];
 
             if (renderer.Camera.CurrentMode != CameraViewMode.Interior && renderer.Camera.CurrentMode != CameraViewMode.InteriorLookAhead || !Car.CarSections.ContainsKey(CarSectionType.Interior))
             {


### PR DESCRIPTION
I hit two separate startup problems on macOS with 1.14.0.2.

First, the app bundle was missing `OpenTK.dll.config`, so OpenBVE stopped immediately with the "corrupt installation" message. The file is in the repo, but it wasn't ending up in `OpenBVE.app/Contents/Resources`.

After adding the config manually, OpenBVE got further but the OpenGL menu started crashing and relaunching in a loop. Tracing the exception showed:

```text
System.NullReferenceException
at OpenBve.Graphics.Renderers.Touch.PreRender()
```

`Touch.PreRender()` was reading `TrainManager.PlayerTrain` before checking whether the simulation had actually been set up. On the menu there is no player train yet.

This changes that order and adds a null check.

For the macOS package, it also copies `OpenTK.dll.config` into the app bundle explicitly and checks that the file is there before building the DMG.

Tested on an Apple Silicon Mac, macOS 26.5.2, Mono 6.12. With the menu bypassed using `/route` and `/train`, the simulation itself started normally.
