### PR TITLE
Improve fps limiter performance

### DIFF
--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -182,10 +182,6 @@ namespace ObjectViewer {
 		        Title = "Object Viewer"
 	        };
 	        Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? VSyncMode.On : VSyncMode.Off;
-	        if (Interface.CurrentOptions.FPSLimit > 0)
-	        {
-		        Renderer.GameWindow.TargetRenderFrequency = Interface.CurrentOptions.FPSLimit;
-	        }
 	        Renderer.GameWindow.Run();
 			// quit
 			Renderer.TextureManager.UnloadAllTextures(false);

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -264,7 +264,8 @@ namespace ObjectViewer
             Program.Renderer.Lighting.Initialize();
             Program.Renderer.RenderScene(timeElapsed);
             SwapBuffers();
-			// A hard cap of 1000fps is always applied, even when unlimited is selected
+			// Applies the FPS limit; a hard cap of 1000fps applies when unlimited is selected,
+			// although no pacing is performed above around 330fps as sleep granularity makes it impractical
 			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 
 			RenderRealTimeElapsed = 0.0;

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -264,7 +264,7 @@ namespace ObjectViewer
             Program.Renderer.Lighting.Initialize();
             Program.Renderer.RenderScene(timeElapsed);
             SwapBuffers();
-			// A hard cap of 540fps is always applied, even when unlimited is selected
+			// A hard cap of 1000fps is always applied, even when unlimited is selected
 			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 
 			RenderRealTimeElapsed = 0.0;

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -39,6 +39,7 @@ namespace ObjectViewer
 
         protected override void OnRenderFrame(FrameEventArgs e)
         {
+	        FrameLimiter.StartFrame();
 	        if (Program.Renderer.RenderThreadJobWaiting)
 	        {
 		        while (!Program.Renderer.RenderThreadJobs.IsEmpty)
@@ -263,6 +264,8 @@ namespace ObjectViewer
             Program.Renderer.Lighting.Initialize();
             Program.Renderer.RenderScene(timeElapsed);
             SwapBuffers();
+			// A hard cap of 540fps is always applied, even when unlimited is selected
+			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 
 			RenderRealTimeElapsed = 0.0;
         }
@@ -327,6 +330,7 @@ namespace ObjectViewer
 	        Interface.CurrentOptions.Save(Path.CombineFile(Program.FileSystem.SettingsFolder, "1.5.0/options_ov.cfg"));
 			Program.Renderer.VisibilityThreadShouldRun = false;
 			Program.Renderer.DeInitialize();
+			FrameLimiter.RestoreTimerResolution();
 			if (Program.CurrentHost.MonoRuntime)
 			{
 				Environment.Exit(0);

--- a/source/ObjectViewer/formOptions.Designer.cs
+++ b/source/ObjectViewer/formOptions.Designer.cs
@@ -987,7 +987,9 @@ namespace ObjectViewer
             this.comboBoxFPSLimit.Items.AddRange(new object[] {
             "Unlimited",
             "30",
+            "45",
             "60",
+            "75",
             "120",
             "240"});
             this.comboBoxFPSLimit.Location = new System.Drawing.Point(160, 279);

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -280,7 +280,6 @@ namespace ObjectViewer
 			int[] fpsPresets = { 0, 30, 60, 120, 240 };
 			Interface.CurrentOptions.FPSLimit = comboBoxFPSLimit.SelectedIndex >= 0 ? fpsPresets[comboBoxFPSLimit.SelectedIndex] : 0;
 			Program.Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? OpenTK.VSyncMode.On : OpenTK.VSyncMode.Off;
-			Program.Renderer.GameWindow.TargetRenderFrequency = Interface.CurrentOptions.FPSLimit > 0 ? Interface.CurrentOptions.FPSLimit : 0;
 
 			// Saving shadow settings
 			switch (comboBoxShadowResolution.SelectedIndex)

--- a/source/ObjectViewer/formOptions.cs
+++ b/source/ObjectViewer/formOptions.cs
@@ -90,13 +90,15 @@ namespace ObjectViewer
 
 			// VSync and FPS Limit
 			comboBoxVSync.SelectedIndex = Interface.CurrentOptions.VerticalSynchronization ? 1 : 0;
-			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=60, 3=120, 4=240
+			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=45, 3=60, 4=75, 5=120, 6=240
 			switch (Interface.CurrentOptions.FPSLimit)
 			{
 				case 30: comboBoxFPSLimit.SelectedIndex = 1; break;
-				case 60: comboBoxFPSLimit.SelectedIndex = 2; break;
-				case 120: comboBoxFPSLimit.SelectedIndex = 3; break;
-				case 240: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 45: comboBoxFPSLimit.SelectedIndex = 2; break;
+				case 60: comboBoxFPSLimit.SelectedIndex = 3; break;
+				case 75: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 120: comboBoxFPSLimit.SelectedIndex = 5; break;
+				case 240: comboBoxFPSLimit.SelectedIndex = 6; break;
 				default: comboBoxFPSLimit.SelectedIndex = 0; break;
 			}
 			UpdateFPSLimitEnabled();
@@ -277,7 +279,7 @@ namespace ObjectViewer
 			// VSync and FPS Limit
 			Interface.CurrentOptions.VerticalSynchronization = comboBoxVSync.SelectedIndex == 1;
 			// Map combo index to FPSLimit value
-			int[] fpsPresets = { 0, 30, 60, 120, 240 };
+			int[] fpsPresets = { 0, 30, 45, 60, 75, 120, 240 };
 			Interface.CurrentOptions.FPSLimit = comboBoxFPSLimit.SelectedIndex >= 0 ? fpsPresets[comboBoxFPSLimit.SelectedIndex] : 0;
 			Program.Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? OpenTK.VSyncMode.On : OpenTK.VSyncMode.Off;
 

--- a/source/OpenBVE/Graphics/Screen.cs
+++ b/source/OpenBVE/Graphics/Screen.cs
@@ -131,10 +131,11 @@ namespace OpenBve
 				return;
 			}
 
-			// Cap the render rate only, leaving the update rate uncapped.
-			// Setting the update rate too caused train shaking and dropped input device plugin events (issue #957)
+			// Cap the render rate via our own sleep-based limiter in OpenBVEGame.OnRenderFrame,
+			// as OpenTK's TargetRenderFrequency uses a spin-wait which causes very high power consumption.
+			// Setting the update rate caused train shaking and dropped input device plugin events (issue #957)
 			Program.Renderer.GameWindow.TargetUpdateFrequency = 0;
-			Program.Renderer.GameWindow.TargetRenderFrequency = Interface.CurrentOptions.FPSLimit > 0 ? Interface.CurrentOptions.FPSLimit : 0;
+			Program.Renderer.GameWindow.TargetRenderFrequency = 0;
 			Program.Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? VSyncMode.On : VSyncMode.Off;
 			
 		}

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -310,7 +310,7 @@ namespace OpenBve
 			{
 				Interface.CurrentOptions.BlackBox = false;
 			}
-			// A hard cap of 540fps is always applied, even when unlimited is selected
+			// A hard cap of 1000fps is always applied, even when unlimited is selected
 			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 		}
 

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -310,7 +310,8 @@ namespace OpenBve
 			{
 				Interface.CurrentOptions.BlackBox = false;
 			}
-			// A hard cap of 1000fps is always applied, even when unlimited is selected
+			// Applies the FPS limit; a hard cap of 1000fps applies when unlimited is selected,
+			// although no pacing is performed above around 330fps as sleep granularity makes it impractical
 			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 		}
 

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -100,6 +100,7 @@ namespace OpenBve
 				//If the load is not complete, then we shouldn't be running the mainloop
 				return;
 			}
+			FrameLimiter.StartFrame();
 
 			if (Program.Renderer.RenderThreadJobWaiting)
 			{
@@ -309,6 +310,8 @@ namespace OpenBve
 			{
 				Interface.CurrentOptions.BlackBox = false;
 			}
+			// A hard cap of 540fps is always applied, even when unlimited is selected
+			FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
 		}
 
 		protected override void OnUpdateFrame(FrameEventArgs e)
@@ -547,6 +550,7 @@ namespace OpenBve
 				}
 			}
 			Program.Renderer.TextureManager.UnloadAllTextures(false);
+			FrameLimiter.RestoreTimerResolution();
 			Program.Renderer.VisibilityThreadShouldRun = false;
 			for (int i = 0; i < InputDevicePlugin.AvailablePluginInfos.Count; i++)
 			{

--- a/source/OpenBVE/UserInterface/formMain.Designer.cs
+++ b/source/OpenBVE/UserInterface/formMain.Designer.cs
@@ -1718,7 +1718,9 @@ namespace OpenBve {
             this.comboBoxFPSLimit.Items.AddRange(new object[] {
             "Unlimited",
             "30",
+            "45",
             "60",
+            "75",
             "120",
             "240"});
             this.comboBoxFPSLimit.Location = new System.Drawing.Point(156, 99);

--- a/source/OpenBVE/UserInterface/formMain.cs
+++ b/source/OpenBVE/UserInterface/formMain.cs
@@ -387,13 +387,15 @@ namespace OpenBve {
 			comboboxVSync.Items.Add("");
 			comboboxVSync.Items.Add("");
 			comboboxVSync.SelectedIndex = Interface.CurrentOptions.VerticalSynchronization ? 1 : 0;
-			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=60, 3=120, 4=240
+			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=45, 3=60, 4=75, 5=120, 6=240
 			switch (Interface.CurrentOptions.FPSLimit)
 			{
 				case 30: comboBoxFPSLimit.SelectedIndex = 1; break;
-				case 60: comboBoxFPSLimit.SelectedIndex = 2; break;
-				case 120: comboBoxFPSLimit.SelectedIndex = 3; break;
-				case 240: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 45: comboBoxFPSLimit.SelectedIndex = 2; break;
+				case 60: comboBoxFPSLimit.SelectedIndex = 3; break;
+				case 75: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 120: comboBoxFPSLimit.SelectedIndex = 5; break;
+				case 240: comboBoxFPSLimit.SelectedIndex = 6; break;
 				default: comboBoxFPSLimit.SelectedIndex = 0; break;
 			}
 			UpdateFPSLimitEnabled();
@@ -1243,7 +1245,7 @@ namespace OpenBve {
 			Interface.CurrentOptions.FullscreenMode = radiobuttonFullscreen.Checked;
 			Interface.CurrentOptions.VerticalSynchronization = comboboxVSync.SelectedIndex == 1;
 			// Map combo index to FPSLimit value
-			int[] fpsPresets = { 0, 30, 60, 120, 240 };
+			int[] fpsPresets = { 0, 30, 45, 60, 75, 120, 240 };
 			Interface.CurrentOptions.FPSLimit = comboBoxFPSLimit.SelectedIndex >= 0 ? fpsPresets[comboBoxFPSLimit.SelectedIndex] : 0;
 			Interface.CurrentOptions.WindowWidth = (int)Math.Round(updownWindowWidth.Value);
 			Interface.CurrentOptions.WindowHeight = (int)Math.Round(updownWindowHeight.Value);

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -96,8 +96,8 @@ namespace OpenBveApi
 	{
 		// Tolerance as a fraction of the scheduler period, left unslept so that we do not overshoot the target
 		private const double Tolerance = 0.02;
-		// On Windows, timeBeginPeriod(8) is a good compromise between accuracy and power consumption
-		private const uint WindowsTimerPeriod = 8;
+		// On Windows, raise the timer resolution to 1ms for accurate frame pacing
+		private const uint WindowsTimerPeriod = 1;
 		// Hard cap applied even when the user selects 'Unlimited'
 		private const int HardFpsLimit = 540;
 
@@ -128,7 +128,7 @@ namespace OpenBveApi
 			}
 			RaiseTimerResolution();
 			long now = Stopwatch.GetTimestamp();
-			long target = frameStartTimestamp + (long)(Stopwatch.Frequency / limit);
+			long target = frameStartTimestamp + (long)((double)Stopwatch.Frequency / limit);
 			double remainingMs = (double)(target - now) * 1000.0 / Stopwatch.Frequency;
 			if (remainingMs <= 0.0)
 			{

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -100,6 +100,9 @@ namespace OpenBveApi
 		private const uint WindowsTimerPeriod = 1;
 		// Hard cap applied even when the user selects 'Unlimited'
 		private const int HardFpsLimit = 1000;
+		// Frameslots shorter than this multiple of the scheduler period cannot be paced accurately by
+		// Thread.Sleep without a power-hungry busy spin, so limiting is skipped above around 330fps
+		private const double MinimumSlotPeriods = 3.0;
 
 		private static bool timerResolutionRaised;
 		private static int schedulerPeriod = 1;
@@ -118,12 +121,18 @@ namespace OpenBveApi
 		}
 
 		/// <summary>Waits until the end of the current frame's allotted timeslot.</summary>
-		/// <param name="fpsLimit">The maximum frames per second selected by the user. A value of zero or less means unlimited, subject to the hard cap.</param>
+		/// <param name="fpsLimit">The maximum frames per second selected by the user. A value of zero or less means unlimited, subject to the hard cap.
+		/// Above around 330fps no limiting is performed, as sleep-based pacing is impractical at such frame rates.</param>
 		public static void ApplyLimit(int fpsLimit)
 		{
 			int limit = fpsLimit > 0 ? System.Math.Min(fpsLimit, HardFpsLimit) : HardFpsLimit;
 			if (frameStartTimestamp == 0)
 			{
+				return;
+			}
+			if ((double)Stopwatch.Frequency / limit < schedulerPeriod * MinimumSlotPeriods)
+			{
+				// The timeslot is too short to pace accurately without busy-spinning - skip limiting
 				return;
 			}
 			long now = Stopwatch.GetTimestamp();

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -126,14 +126,16 @@ namespace OpenBveApi
 			{
 				return;
 			}
-			RaiseTimerResolution();
 			long now = Stopwatch.GetTimestamp();
 			long target = frameStartTimestamp + (long)((double)Stopwatch.Frequency / limit);
 			double remainingMs = (double)(target - now) * 1000.0 / Stopwatch.Frequency;
 			if (remainingMs <= 0.0)
 			{
+				// The frame overran its timeslot (or was throttled by VSync) - nothing to wait for,
+				// so do not raise the system timer resolution needlessly
 				return;
 			}
+			RaiseTimerResolution();
 			double sleepMs = remainingMs - schedulerPeriod * Tolerance;
 			int ticks = (int)(sleepMs / schedulerPeriod);
 			if (ticks > 0)

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -99,7 +99,7 @@ namespace OpenBveApi
 		// On Windows, raise the timer resolution to 1ms for accurate frame pacing
 		private const uint WindowsTimerPeriod = 1;
 		// Hard cap applied even when the user selects 'Unlimited'
-		private const int HardFpsLimit = 540;
+		private const int HardFpsLimit = 1000;
 
 		private static bool timerResolutionRaised;
 		private static int schedulerPeriod = 1;

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace OpenBveApi
 {
@@ -84,5 +85,103 @@ namespace OpenBveApi
 		}
 
 
+	}
+
+	/// <summary>
+	/// Cross-platform frame rate limiter.
+	/// Uses a bulk Thread.Sleep followed by a short Thread.Yield wait, mirroring the approach used by modern OpenTK,
+	/// in order to avoid the high power consumption of a pure spin-wait based limiter.
+	/// </summary>
+	public static class FrameLimiter
+	{
+		// Tolerance as a fraction of the scheduler period, left unslept so that we do not overshoot the target
+		private const double Tolerance = 0.02;
+		// On Windows, timeBeginPeriod(8) is a good compromise between accuracy and power consumption
+		private const uint WindowsTimerPeriod = 8;
+		// Hard cap applied even when the user selects 'Unlimited'
+		private const int HardFpsLimit = 540;
+
+		private static bool timerResolutionRaised;
+		private static int schedulerPeriod = 1;
+		private static long frameStartTimestamp;
+
+		[DllImport("winmm")]
+		private static extern uint timeBeginPeriod(uint uPeriod);
+
+		[DllImport("winmm")]
+		private static extern uint timeEndPeriod(uint uPeriod);
+
+		/// <summary>Marks the start of a frame. Must be called once at the beginning of each rendered frame.</summary>
+		public static void StartFrame()
+		{
+			frameStartTimestamp = Stopwatch.GetTimestamp();
+		}
+
+		/// <summary>Waits until the end of the current frame's allotted timeslot.</summary>
+		/// <param name="fpsLimit">The maximum frames per second selected by the user. A value of zero or less means unlimited, subject to the hard cap.</param>
+		public static void ApplyLimit(int fpsLimit)
+		{
+			int limit = fpsLimit > 0 ? System.Math.Min(fpsLimit, HardFpsLimit) : HardFpsLimit;
+			RaiseTimerResolution();
+			long now = Stopwatch.GetTimestamp();
+			long target = frameStartTimestamp + (long)((1000.0 / fpsLimit / 1000.0) * Stopwatch.Frequency);
+			double remainingMs = (double)(target - now) * 1000.0 / Stopwatch.Frequency;
+			if (remainingMs <= 0.0)
+			{
+				return;
+			}
+			double sleepMs = remainingMs - schedulerPeriod * Tolerance;
+			int ticks = (int)(sleepMs / schedulerPeriod);
+			if (ticks > 0)
+			{
+				Thread.Sleep(ticks * schedulerPeriod);
+			}
+			while (Stopwatch.GetTimestamp() < target)
+			{
+				Thread.Yield();
+			}
+		}
+
+		/// <summary>Restores the system timer resolution, if it was previously raised.</summary>
+		public static void RestoreTimerResolution()
+		{
+			if (timerResolutionRaised)
+			{
+				timerResolutionRaised = false;
+				try
+				{
+					timeEndPeriod(WindowsTimerPeriod);
+				}
+				catch
+				{
+					// Not on Windows, or winmm unavailable
+				}
+			}
+		}
+
+		private static void RaiseTimerResolution()
+		{
+			if (!timerResolutionRaised)
+			{
+				timerResolutionRaised = true;
+				try
+				{
+					if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+					{
+						timeBeginPeriod(WindowsTimerPeriod);
+						schedulerPeriod = (int)WindowsTimerPeriod;
+					}
+					else
+					{
+						// Linux and macOS can accurately sleep for around 1ms
+						schedulerPeriod = 1;
+					}
+				}
+				catch
+				{
+					schedulerPeriod = 1;
+				}
+			}
+		}
 	}
 }

--- a/source/OpenBveApi/System/Timers.cs
+++ b/source/OpenBveApi/System/Timers.cs
@@ -122,9 +122,13 @@ namespace OpenBveApi
 		public static void ApplyLimit(int fpsLimit)
 		{
 			int limit = fpsLimit > 0 ? System.Math.Min(fpsLimit, HardFpsLimit) : HardFpsLimit;
+			if (frameStartTimestamp == 0)
+			{
+				return;
+			}
 			RaiseTimerResolution();
 			long now = Stopwatch.GetTimestamp();
-			long target = frameStartTimestamp + (long)((1000.0 / fpsLimit / 1000.0) * Stopwatch.Frequency);
+			long target = frameStartTimestamp + (long)(Stopwatch.Frequency / limit);
 			double remainingMs = (double)(target - now) * 1000.0 / Stopwatch.Frequency;
 			if (remainingMs <= 0.0)
 			{

--- a/source/RouteViewer/ProgramR.cs
+++ b/source/RouteViewer/ProgramR.cs
@@ -190,10 +190,6 @@ namespace RouteViewer
 			Renderer.GameWindow.TargetRenderFrequency = 0;
 			Renderer.GameWindow.Title = "Route Viewer";
 			Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? VSyncMode.On : VSyncMode.Off;
-			if (Interface.CurrentOptions.FPSLimit > 0)
-			{
-				Renderer.GameWindow.TargetRenderFrequency = Interface.CurrentOptions.FPSLimit;
-			}
 			processCommandLineArgs = true;
 			Renderer.GameWindow.Run();
 			//Unload

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -53,6 +53,7 @@ namespace RouteViewer
         //This renders the frame
         protected override void OnRenderFrame(FrameEventArgs e)
         {
+	        FrameLimiter.StartFrame();
 			Program.MouseMovement();
 			Program.Renderer.FrameRate = RenderFrequency;
 
@@ -83,8 +84,9 @@ namespace RouteViewer
             Program.Renderer.Lighting.UpdateLighting(Program.CurrentRoute.SecondsSinceMidnight, Program.CurrentRoute.LightDefinitions);
             Program.Renderer.RenderScene(TimeElapsed);
             MessageManager.UpdateMessages(TimeElapsed);
-            SwapBuffers();
-            
+	        SwapBuffers();
+	        // A hard cap of 540fps is always applied, even when unlimited is selected
+	        FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
         }
 
         protected override void OnResize(EventArgs e)
@@ -144,6 +146,7 @@ namespace RouteViewer
 				Loading.Cancel = true;
 			}
 			Program.Renderer.DeInitialize();
+			FrameLimiter.RestoreTimerResolution();
 			if (Program.CurrentHost.MonoRuntime)
 			{
 				// Mono often fails to close the main window properly

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -85,7 +85,8 @@ namespace RouteViewer
             Program.Renderer.RenderScene(TimeElapsed);
             MessageManager.UpdateMessages(TimeElapsed);
 	        SwapBuffers();
-	        // A hard cap of 1000fps is always applied, even when unlimited is selected
+	        // Applies the FPS limit; a hard cap of 1000fps applies when unlimited is selected,
+	        // although no pacing is performed above around 330fps as sleep granularity makes it impractical
 	        FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
         }
 

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -85,7 +85,7 @@ namespace RouteViewer
             Program.Renderer.RenderScene(TimeElapsed);
             MessageManager.UpdateMessages(TimeElapsed);
 	        SwapBuffers();
-	        // A hard cap of 540fps is always applied, even when unlimited is selected
+	        // A hard cap of 1000fps is always applied, even when unlimited is selected
 	        FrameLimiter.ApplyLimit(Interface.CurrentOptions.FPSLimit);
         }
 

--- a/source/RouteViewer/formOptions.Designer.cs
+++ b/source/RouteViewer/formOptions.Designer.cs
@@ -963,7 +963,9 @@ namespace RouteViewer
             this.comboBoxFPSLimit.Items.AddRange(new object[] {
             "Unlimited",
             "30",
+            "45",
             "60",
+            "75",
             "120",
             "240"});
             this.comboBoxFPSLimit.Location = new System.Drawing.Point(160, 495);

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -327,7 +327,6 @@ namespace RouteViewer
 			int[] fpsPresets = { 0, 30, 60, 120, 240 };
 			Interface.CurrentOptions.FPSLimit = comboBoxFPSLimit.SelectedIndex >= 0 ? fpsPresets[comboBoxFPSLimit.SelectedIndex] : 0;
 			Program.Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? OpenTK.VSyncMode.On : OpenTK.VSyncMode.Off;
-			Program.Renderer.GameWindow.TargetRenderFrequency = Interface.CurrentOptions.FPSLimit > 0 ? Interface.CurrentOptions.FPSLimit : 0;
 
             // Sun direction is already updated in real-time via slider events
 

--- a/source/RouteViewer/formOptions.cs
+++ b/source/RouteViewer/formOptions.cs
@@ -93,13 +93,15 @@ namespace RouteViewer
 
 			// VSync and FPS Limit
 			comboBoxVSync.SelectedIndex = Interface.CurrentOptions.VerticalSynchronization ? 1 : 0;
-			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=60, 3=120, 4=240
+			// Map FPSLimit value to combo index: 0=Unlimited, 1=30, 2=45, 3=60, 4=75, 5=120, 6=240
 			switch (Interface.CurrentOptions.FPSLimit)
 			{
 				case 30: comboBoxFPSLimit.SelectedIndex = 1; break;
-				case 60: comboBoxFPSLimit.SelectedIndex = 2; break;
-				case 120: comboBoxFPSLimit.SelectedIndex = 3; break;
-				case 240: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 45: comboBoxFPSLimit.SelectedIndex = 2; break;
+				case 60: comboBoxFPSLimit.SelectedIndex = 3; break;
+				case 75: comboBoxFPSLimit.SelectedIndex = 4; break;
+				case 120: comboBoxFPSLimit.SelectedIndex = 5; break;
+				case 240: comboBoxFPSLimit.SelectedIndex = 6; break;
 				default: comboBoxFPSLimit.SelectedIndex = 0; break;
 			}
 			UpdateFPSLimitEnabled();
@@ -324,7 +326,7 @@ namespace RouteViewer
 			// VSync and FPS Limit
 			Interface.CurrentOptions.VerticalSynchronization = comboBoxVSync.SelectedIndex == 1;
 			// Map combo index to FPSLimit value
-			int[] fpsPresets = { 0, 30, 60, 120, 240 };
+			int[] fpsPresets = { 0, 30, 45, 60, 75, 120, 240 };
 			Interface.CurrentOptions.FPSLimit = comboBoxFPSLimit.SelectedIndex >= 0 ? fpsPresets[comboBoxFPSLimit.SelectedIndex] : 0;
 			Program.Renderer.GameWindow.VSync = Interface.CurrentOptions.VerticalSynchronization ? OpenTK.VSyncMode.On : OpenTK.VSyncMode.Off;
 


### PR DESCRIPTION
New: Rewrite FPS limiter for accuracy and performance

Replace the old sleep-based limiter with a cross-platform FrameLimiter
(Thread.Sleep bulk wait + Thread.Yield tail, following OpenTK 4.x).

- 1ms timer resolution on Windows while waiting; restored on exit
- Double-precision timeslot calculation for accurate frame pacing
- Skip raising timer resolution when the frame overran its slot
- Skip pacing above ~330fps where sleep-based limiting is impractical
- Make hard FPS cap to 1000; fix OverflowException on unlimited
- Add 45 and 75 FPS presets to the FPS limit option

I hope this lower the power consumption when use fps preset and better frame pacing.

Vsync options not changed.