### PR TITLE
Rectangle projection

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -156,7 +156,7 @@ namespace LibRender2
 #endif
 
 		/// <summary>The current shader in use</summary>
-		protected internal AbstractShader CurrentShader;
+		public AbstractShader CurrentShader;
 
 		public Shader DefaultShader;
 		
@@ -364,15 +364,7 @@ namespace LibRender2
 			currentHost = CurrentHost;
 			currentOptions = CurrentOptions;
 			fileSystem = FileSystem;
-			if (CurrentHost.Application != HostApplication.TrainEditor && CurrentHost.Application != HostApplication.TrainEditor2)
-			{
-				/*
-				 * TrainEditor2 uses a GLControl
-				 * On the Linux SLD2 backend, this crashes when attempting to get the list of supported screen resolutions
-				 * As we don't care about fullscreen here, just don't bother with this constructor
-				 */
-				Screen = new Screen();
-			}
+			Screen = new Screen(this);
 			Camera = new CameraProperties(this);
 			Lighting = new Lighting(this);
 			Marker = new Marker(this);

--- a/source/LibRender2/Primitives/Rectangle.cs
+++ b/source/LibRender2/Primitives/Rectangle.cs
@@ -22,6 +22,7 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using LibRender2.Screens;
 using LibRender2.Shaders;
 using OpenBveApi.Colors;
 using OpenBveApi.Math;
@@ -48,6 +49,18 @@ namespace LibRender2.Primitives
 			{
 				//
 			}
+
+			Matrix4D.CreateOrthographicOffCenter(0.0f, renderer.Screen.Width, renderer.Screen.Height, 0.0f, -1.0f, 1.0f, out Matrix4D ProjectionMatrix);
+			Shader.Activate();
+			Shader.SetCurrentProjectionMatrix(ProjectionMatrix);
+			Shader.SetCurrentModelViewMatrix(Matrix4D.Identity);
+		}
+
+		public void Update()
+		{
+			Matrix4D.CreateOrthographicOffCenter(0.0f, renderer.Screen.Width, renderer.Screen.Height, 0.0f, -1.0f, 1.0f, out Matrix4D ProjectionMatrix);
+			Shader.Activate();
+			Shader.SetCurrentProjectionMatrix(ProjectionMatrix);
 		}
 
 		/// <summary>Draws a simple 2D rectangle using two-pass alpha blending.</summary>
@@ -156,8 +169,6 @@ namespace LibRender2.Primitives
 				Shader.DisableTexturing();
 			}
 			
-			Shader.SetCurrentProjectionMatrix(renderer.CurrentProjectionMatrix);
-			Shader.SetCurrentModelViewMatrix(renderer.CurrentViewMatrix);
 			Shader.SetColor(color ?? Color128.White);
 			Shader.SetPoint(point);
 			Shader.SetSize(size);

--- a/source/LibRender2/Primitives/Rectangle.cs
+++ b/source/LibRender2/Primitives/Rectangle.cs
@@ -101,20 +101,13 @@ namespace LibRender2.Primitives
 		/// <param name="wrapMode">A wrap mode if overriding that of the texture</param>
 		public void Draw(Texture texture, Vector2 point, Vector2 size, Color128? color = null, Vector2? textureCoordinates = null, OpenGlTextureWrapMode? wrapMode = null)
 		{
-			if (Shader != null)
+			if (textureCoordinates == null)
 			{
-				if (textureCoordinates == null)
-				{
-					DrawWithShader(texture, point, size, color, Vector2.One, wrapMode);
-				}
-				else
-				{
-					DrawWithShader(texture, point, size, color, (Vector2)textureCoordinates, wrapMode);
-				}
+				DrawWithShader(texture, point, size, color, Vector2.One, wrapMode);
 			}
 			else
 			{
-				DrawImmediate(texture, point, size, color, textureCoordinates, wrapMode);	
+				DrawWithShader(texture, point, size, color, (Vector2)textureCoordinates, wrapMode);
 			}
 		}
 
@@ -142,91 +135,6 @@ namespace LibRender2.Primitives
 			}
 		}
 
-		private void DrawImmediate(Texture texture, Vector2 point, Vector2 size, Color128? color, Vector2? textureCoordinates = null, OpenGlTextureWrapMode? wrapMode = null)
-		{
-			renderer.LastBoundTexture = null;
-			// TODO: Remove Nullable<T> from color once RenderOverlayTexture and RenderOverlaySolid are fully replaced.
-			GL.MatrixMode(MatrixMode.Projection);
-			GL.PushMatrix();
-			unsafe
-			{
-				fixed (double* matrixPointer = &renderer.CurrentProjectionMatrix.Row0.X)
-				{
-					GL.LoadMatrix(matrixPointer);
-				}
-				GL.MatrixMode(MatrixMode.Modelview);
-				GL.PushMatrix();
-				fixed (double* matrixPointer = &renderer.CurrentViewMatrix.Row0.X)
-				{
-					GL.LoadMatrix(matrixPointer);
-				}
-
-			}
-
-			if (wrapMode == null)
-			{
-				wrapMode = OpenGlTextureWrapMode.ClampClamp;
-			}
-			if (texture == null || !renderer.currentHost.LoadTexture(ref texture, (OpenGlTextureWrapMode)wrapMode))
-			{
-				GL.Disable(EnableCap.Texture2D);
-
-				if (color.HasValue)
-				{
-					GL.Color4(color.Value.R, color.Value.G, color.Value.B, color.Value.A);
-				}
-
-				GL.Begin(PrimitiveType.Quads);
-				GL.Vertex2(point.X, point.Y);
-				GL.Vertex2(point.X + size.X, point.Y);
-				GL.Vertex2(point.X + size.X, point.Y + size.Y);
-				GL.Vertex2(point.X, point.Y + size.Y);
-				GL.End();
-			}
-			else
-			{
-				GL.Enable(EnableCap.Texture2D);
-				GL.BindTexture(TextureTarget.Texture2D, texture.OpenGlTextures[(int)wrapMode].Name);
-
-				if (color.HasValue)
-				{
-					GL.Color4(color.Value.R, color.Value.G, color.Value.B, color.Value.A);
-				}
-
-				GL.Begin(PrimitiveType.Quads);
-				if (textureCoordinates == null)
-				{
-					GL.TexCoord2(0,0);
-					GL.Vertex2(point.X, point.Y);
-					GL.TexCoord2(1,0);
-					GL.Vertex2(point.X + size.X, point.Y);
-					GL.TexCoord2(1,1);
-					GL.Vertex2(point.X + size.X, point.Y + size.Y);
-					GL.TexCoord2(0,1);
-					GL.Vertex2(point.X, point.Y + size.Y);
-				}
-				else
-				{
-					Vector2 v = (Vector2) textureCoordinates;
-					GL.TexCoord2(0,0);
-					GL.Vertex2(point.X, point.Y);
-					GL.TexCoord2(v.X, 0);
-					GL.Vertex2(point.X + size.X, point.Y);
-					GL.TexCoord2(v.X, v.Y);
-					GL.Vertex2(point.X + size.X, point.Y + size.Y);
-					GL.TexCoord2(0, v.Y);
-					GL.Vertex2(point.X, point.Y + size.Y);
-				}
-				GL.End();
-				GL.Disable(EnableCap.Texture2D);
-			}
-
-			GL.PopMatrix();
-
-			GL.MatrixMode(MatrixMode.Projection);
-			GL.PopMatrix();
-		}
-
 		private void DrawWithShader(Texture texture, Vector2 point, Vector2 size, Color128? color, Vector2 coordinates, OpenGlTextureWrapMode? wrapMode = null)
 		{
 			Shader.Activate();
@@ -237,8 +145,11 @@ namespace LibRender2.Primitives
 
 			if (texture != null && renderer.currentHost.LoadTexture(ref texture, (OpenGlTextureWrapMode)wrapMode))
 			{
-				GL.BindTexture(TextureTarget.Texture2D, texture.OpenGlTextures[(int)wrapMode].Name);
-				renderer.LastBoundTexture = texture.OpenGlTextures[(int)wrapMode];
+				if (renderer.LastBoundTexture != texture.OpenGlTextures[(int)wrapMode])
+				{
+					GL.BindTexture(TextureTarget.Texture2D, texture.OpenGlTextures[(int)wrapMode].Name);
+					renderer.LastBoundTexture = texture.OpenGlTextures[(int)wrapMode];
+				}
 			}
 			else
 			{

--- a/source/LibRender2/Primitives/Rectangle.cs
+++ b/source/LibRender2/Primitives/Rectangle.cs
@@ -22,7 +22,6 @@
 //(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-using LibRender2.Screens;
 using LibRender2.Shaders;
 using OpenBveApi.Colors;
 using OpenBveApi.Math;

--- a/source/LibRender2/Screen/Screen.cs
+++ b/source/LibRender2/Screen/Screen.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using OpenBveApi.Hosts;
 using OpenTK;
 
 namespace LibRender2.Screens
@@ -18,19 +19,34 @@ namespace LibRender2.Screens
 		/// <summary>Holds the available screen resolutions</summary>
 		public readonly List<ScreenResolution> AvailableResolutions;
 
-		internal Screen()
+		internal Screen(BaseRenderer renderer)
 		{
-			//Find all resolutions our screen is capable of displaying, but don't store HZ info etc.
-			AvailableResolutions = new List<ScreenResolution>();
-			ScreenResolution lastResolution = new ScreenResolution(0,0);
-			for (int i = 0; i < DisplayDevice.Default.AvailableResolutions.Count; i++)
+			/*
+			 * TrainEditor2 uses a GLControl
+			 * On the Linux SLD2 backend, this crashes when attempting to get the list of supported screen resolutions
+			 * As we don't care about fullscreen here, just ignore
+			 */
+			if (renderer.currentHost.Application != HostApplication.TrainEditor2 && renderer.currentHost.Application != HostApplication.TrainEditor)
 			{
-				if (DisplayDevice.Default.AvailableResolutions[i].Width != lastResolution.Width || DisplayDevice.Default.AvailableResolutions[i].Height != lastResolution.Height)
+				//Find all resolutions our screen is capable of displaying, but don't store HZ info etc.
+				AvailableResolutions = new List<ScreenResolution>();
+				ScreenResolution lastResolution = new ScreenResolution(0, 0);
+				for (int i = 0; i < DisplayDevice.Default.AvailableResolutions.Count; i++)
 				{
-					lastResolution = new ScreenResolution(DisplayDevice.Default.AvailableResolutions[i].Width, DisplayDevice.Default.AvailableResolutions[i].Height);
-					AvailableResolutions.Add(lastResolution);
+					if (DisplayDevice.Default.AvailableResolutions[i].Width != lastResolution.Width || DisplayDevice.Default.AvailableResolutions[i].Height != lastResolution.Height)
+					{
+						lastResolution = new ScreenResolution(DisplayDevice.Default.AvailableResolutions[i].Width, DisplayDevice.Default.AvailableResolutions[i].Height);
+						AvailableResolutions.Add(lastResolution);
+					}
 				}
 			}
+			else
+			{
+				// Default TE size
+				Width = 568;
+				Height = 593;
+			}
+			
 		}
 	}
 }

--- a/source/LibRender2/Text/OpenGlString.cs
+++ b/source/LibRender2/Text/OpenGlString.cs
@@ -208,7 +208,14 @@ namespace LibRender2.Text
 		{
 			Shader.Activate();
 			renderer.CurrentShader = Shader;
-			
+
+			/*
+			 * In order to call GL.DrawArrays with procedural data within the shader,
+			 * we first need to bind a dummy VAO
+			 * If this is not done, it will generate an InvalidOperation error code
+			 */
+			renderer.dummyVao.Bind();
+
 			for (int i = 0; i < text.Length; i++)
 			{
 				i += font.GetCharacterData(text, i, out Texture texture, out OpenGlFontChar data) - 1;
@@ -231,12 +238,7 @@ namespace LibRender2.Text
 					Shader.SetColor(new Color128(color.A, color.A, color.A, 1.0f));
 					Shader.SetPoint(new Vector2(x, y));
 					Shader.SetSize(data.PhysicalSize);
-					/*
-					 * In order to call GL.DrawArrays with procedural data within the shader,
-					 * we first need to bind a dummy VAO
-					* If this is not done, it will generate an InvalidOperation error code
-					*/
-					renderer.dummyVao.Bind();
+					
 					GL.DrawArrays(PrimitiveType.TriangleStrip, 0, 6);
 					GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.One);
 					Shader.SetColor(color);

--- a/source/LibRender2/Text/OpenGlString.cs
+++ b/source/LibRender2/Text/OpenGlString.cs
@@ -25,8 +25,20 @@ namespace LibRender2.Text
 			{
 				//
 			}
-			
+
+			Matrix4D.CreateOrthographicOffCenter(0.0f, renderer.Screen.Width, renderer.Screen.Height, 0.0f, -1.0f, 1.0f, out Matrix4D ProjectionMatrix);
+			Shader.Activate();
+			Shader.SetCurrentProjectionMatrix(ProjectionMatrix);
+			Shader.SetCurrentModelViewMatrix(Matrix4D.Identity);
 		}
+
+		public void Update()
+		{
+			Matrix4D.CreateOrthographicOffCenter(0.0f, renderer.Screen.Width, renderer.Screen.Height, 0.0f, -1.0f, 1.0f, out Matrix4D ProjectionMatrix);
+			Shader.Activate();
+			Shader.SetCurrentProjectionMatrix(ProjectionMatrix);
+		}
+
 
 		/// <summary>Renders a string to the screen.</summary>
 		/// <param name="font">The font to use.</param>
@@ -197,9 +209,7 @@ namespace LibRender2.Text
 		{
 			Shader.Activate();
 			renderer.CurrentShader = Shader;
-			Shader.SetCurrentProjectionMatrix(renderer.CurrentProjectionMatrix);
-			Shader.SetCurrentModelViewMatrix(renderer.CurrentViewMatrix);
-
+			
 			for (int i = 0; i < text.Length; i++)
 			{
 				i += font.GetCharacterData(text, i, out Texture texture, out OpenGlFontChar data) - 1;

--- a/source/LibRender2/Text/OpenGlString.cs
+++ b/source/LibRender2/Text/OpenGlString.cs
@@ -53,7 +53,6 @@ namespace LibRender2.Text
 			{
 				return;
 			}
-			renderer.LastBoundTexture = null;
 			/*
 			 * Prepare the top-left coordinates for rendering, incorporating the
 			 * orientation of the string in relation to the specified location.
@@ -215,7 +214,12 @@ namespace LibRender2.Text
 				i += font.GetCharacterData(text, i, out Texture texture, out OpenGlFontChar data) - 1;
 				if (renderer.currentHost.LoadTexture(ref texture, OpenGlTextureWrapMode.ClampClamp))
 				{
-					GL.BindTexture(TextureTarget.Texture2D, texture.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp].Name);
+					if (renderer.LastBoundTexture != texture.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp])
+					{
+						GL.BindTexture(TextureTarget.Texture2D, texture.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp].Name);
+						renderer.LastBoundTexture = texture.OpenGlTextures[(int)OpenGlTextureWrapMode.ClampClamp];
+					}
+					
 					Shader.SetAtlasLocation(data.TextureCoordinates);
 					double x = left - (data.PhysicalSize.X - data.TypographicSize.X) / 2;
 					double y = top - (data.PhysicalSize.Y - data.TypographicSize.Y) / 2;

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -298,6 +298,7 @@ namespace ObjectViewer
 	        Program.Renderer.Screen.Height = Height;
             Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
 			Program.Renderer.Rectangle.Update();
+			Program.Renderer.OpenGlString.Update();
         }
 
         protected override void OnLoad(EventArgs e)

--- a/source/ObjectViewer/System/GameWindow.cs
+++ b/source/ObjectViewer/System/GameWindow.cs
@@ -297,6 +297,7 @@ namespace ObjectViewer
 	        Program.Renderer.Screen.Width = Width;
 	        Program.Renderer.Screen.Height = Height;
             Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
+			Program.Renderer.Rectangle.Update();
         }
 
         protected override void OnLoad(EventArgs e)

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -432,6 +432,7 @@ namespace OpenBve
 				Game.SwitchChangeDialog.Show();
 			}
 			Game.Menu.OnResize();
+			Program.Renderer.Rectangle.Update();
 		}
 
 		[DllImport("user32.dll")]

--- a/source/OpenBVE/System/GameWindow.cs
+++ b/source/OpenBVE/System/GameWindow.cs
@@ -433,6 +433,7 @@ namespace OpenBve
 			}
 			Game.Menu.OnResize();
 			Program.Renderer.Rectangle.Update();
+			Program.Renderer.OpenGlString.Update();
 		}
 
 		[DllImport("user32.dll")]

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -93,6 +93,7 @@ namespace RouteViewer
 	        Program.Renderer.Screen.Height = Height;
 	        Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
 			Program.Renderer.Rectangle.Update();
+			Program.Renderer.OpenGlString.Update();
 		}
 
         protected override void OnLoad(EventArgs e)

--- a/source/RouteViewer/System/Gamewindow.cs
+++ b/source/RouteViewer/System/Gamewindow.cs
@@ -92,7 +92,8 @@ namespace RouteViewer
 	        Program.Renderer.Screen.Width = Width;
 	        Program.Renderer.Screen.Height = Height;
 	        Program.Renderer.UpdateViewport(ViewportChangeMode.NoChange);
-        }
+			Program.Renderer.Rectangle.Update();
+		}
 
         protected override void OnLoad(EventArgs e)
         {

--- a/source/TrainEditor2/Models/Trains/Motor.Functions.cs
+++ b/source/TrainEditor2/Models/Trains/Motor.Functions.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using LibRender2.Screens;
 using OpenBveApi.Colors;
 using OpenBveApi.Graphics;
 using OpenBveApi.Math;
@@ -1062,10 +1063,14 @@ namespace TrainEditor2.Models.Trains
 			GL.Viewport(0, 0, GlControlWidth, GlControlHeight);
 			GL.ClearColor(Color.Black);
 			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+			Program.Renderer.Screen.Width = GlControlWidth;
+			Program.Renderer.Screen.Height = GlControlHeight;
+			Program.Renderer.Rectangle.Update();
+			Program.Renderer.OpenGlString.Update();
+			Program.Renderer.CurrentShader.Deactivate(); // TE2 is still mixed-mode, so deactivate shader
 
 			Matrix4D.CreateOrthographic(MaxVelocity - MinVelocity, MaxPitch - MinPitch, float.Epsilon, 1.0, out Matrix4D projPitch);
 			Matrix4D.CreateOrthographic(MaxVelocity - MinVelocity, MaxVolume - MinVolume, float.Epsilon, 1.0, out Matrix4D projVolume);
-			Matrix4D.CreateOrthographicOffCenter(0.0, GlControlWidth, GlControlHeight, 0.0, -1.0, 1.0, out Matrix4D projString);
 			Matrix4D lookPitch = Matrix4D.LookAt(new Vector3((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, float.Epsilon), new Vector3((MinVelocity + MaxVelocity) / 2.0, (MinPitch + MaxPitch) / 2.0, 0.0), new Vector3(0,1,0));
 			Matrix4D lookVolume = Matrix4D.LookAt(new Vector3((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, float.Epsilon), new Vector3((MinVelocity + MaxVelocity) / 2.0, (MinVolume + MaxVolume) / 2.0, 0.0), new Vector3(0,1,0));
 
@@ -1091,9 +1096,6 @@ namespace TrainEditor2.Models.Trains
 				}
 
 				GL.End();
-
-				Program.Renderer.CurrentProjectionMatrix = projString;
-				Program.Renderer.CurrentViewMatrix = Matrix4D.Identity;
 
 				for (double v = 0.0; v < MaxVelocity; v += 10.0)
 				{
@@ -1128,9 +1130,6 @@ namespace TrainEditor2.Models.Trains
 
 					GL.End();
 
-					Program.Renderer.CurrentProjectionMatrix = projString;
-					Program.Renderer.CurrentViewMatrix = Matrix4D.Identity;
-
 					for (double p = 0.0; p < MaxPitch; p += 100.0)
 					{
 						Program.Renderer.OpenGlString.Draw(Fonts.VerySmallFont, p.ToString("0", culture), new Vector2(1, PitchToY(p) + 1), TextAlignment.TopLeft, new Color128(Color24.Grey));
@@ -1159,9 +1158,6 @@ namespace TrainEditor2.Models.Trains
 					}
 
 					GL.End();
-
-					Program.Renderer.CurrentProjectionMatrix = projString;
-					Program.Renderer.CurrentViewMatrix = Matrix4D.Identity;
 
 					for (double v = 0.0; v < MaxVolume; v += 128.0)
 					{


### PR DESCRIPTION
Speedup to the drawing of rectangles + strings.

As we now keep the projection matrix & modelview matrix on a per-shader basis, it's occurred to me we don't need to re-upload them on every rectangle draw (as rectangles are never drawn in full 3D space, just the fixed 2D screen space)

Very marginal effect on the desktop (Ryzen 9700, GTX3060), but has more of an effect on the laptop.

TE2 is a very slight bodge, as it's still using GL2 for line drawing, so needed the current shader making public in order to deactivate it.