### PR TITLE
Try improve gif decoder

### DIFF
--- a/source/LibRender2/BaseRenderer.cs
+++ b/source/LibRender2/BaseRenderer.cs
@@ -447,7 +447,7 @@ namespace LibRender2
 			StaticObjectStates = new List<ObjectState>();
 			DynamicObjectStates = new List<ObjectState>();
 			VisibleObjects = new VisibleObjectLibrary(this);
-			whitePixel = new Texture(new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] {255, 255, 255, 255}, null));
+			whitePixel = new Texture(new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] {255, 255, 255, 255}, (OpenBveApi.Colors.Color24[])null));
 			nullDepthMap = GL.GenTexture();
 			GL.BindTexture(TextureTarget.Texture2D, nullDepthMap);
 			GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent16, 1, 1, 0, OpenTK.Graphics.OpenGL.PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);

--- a/source/LibRender2/Objects/ObjectLibrary.cs
+++ b/source/LibRender2/Objects/ObjectLibrary.cs
@@ -126,49 +126,28 @@ namespace LibRender2.Objects
 					}
 					else
 					{
-						if (State.Prototype.Mesh.Materials[face.Material].DaytimeTexture != null && State.Prototype.Mesh.Materials[face.Material].DaytimeTexture.Origin != null)
-						{
-							// Have to load the texture bytes in order to determine transparency type
-							Texture daytimeTexture;
-							TextureOrigin daytimeOrigin = State.Prototype.Mesh.Materials[face.Material].DaytimeTexture.Origin;
-							if (!TextureManager.textureCache.TryGetValue(daytimeOrigin, out daytimeTexture))
-							{
-								Stopwatch sw = Stopwatch.StartNew();
-								daytimeOrigin.GetTexture(out daytimeTexture);
-								sw.Stop();
-								TextureManager.TextureDecodeTime += sw.ElapsedMilliseconds;
-								TextureManager.textureCache[daytimeOrigin] = daytimeTexture;
-							}
+						Texture daytimeTexture = GetTransparencySourceTexture(State.Prototype.Mesh.Materials[face.Material].DaytimeTexture);
 
-							TextureTransparencyType transparencyType = TextureTransparencyType.Opaque;
-							if (daytimeTexture != null)
-							{
-								// as loading the cached texture may have failed, e.g. corrupt file etc
-								transparencyType = daytimeTexture.GetTransparencyType();
-							}
-							
-							if (transparencyType == TextureTransparencyType.Alpha)
-							{
-								alpha = true;
-							}
-							else if (transparencyType == TextureTransparencyType.Partial && renderer.currentOptions.TransparencyMode == TransparencyMode.Quality)
-							{
-								alpha = true;
-							}
+						TextureTransparencyType transparencyType = TextureTransparencyType.Opaque;
+						if (daytimeTexture != null)
+						{
+							// as loading the cached texture may have failed, e.g. corrupt file etc
+							transparencyType = daytimeTexture.GetTransparencyType();
 						}
 
-						if (!alpha && State.Prototype.Mesh.Materials[face.Material].NighttimeTexture != null && State.Prototype.Mesh.Materials[face.Material].NighttimeTexture.Origin != null)
+						if (transparencyType == TextureTransparencyType.Alpha)
 						{
-							Texture nighttimeTexture;
-							TextureOrigin nighttimeOrigin = State.Prototype.Mesh.Materials[face.Material].NighttimeTexture.Origin;
-							if (!TextureManager.textureCache.TryGetValue(nighttimeOrigin, out nighttimeTexture))
-							{
-								Stopwatch sw = Stopwatch.StartNew();
-								nighttimeOrigin.GetTexture(out nighttimeTexture);
-								sw.Stop();
-								TextureManager.TextureDecodeTime += sw.ElapsedMilliseconds;
-								TextureManager.textureCache[nighttimeOrigin] = nighttimeTexture;
-							}
+							alpha = true;
+						}
+						else if (transparencyType == TextureTransparencyType.Partial && renderer.currentOptions.TransparencyMode == TransparencyMode.Quality)
+						{
+							alpha = true;
+						}
+					}
+
+						if (!alpha)
+						{
+							Texture nighttimeTexture = GetTransparencySourceTexture(State.Prototype.Mesh.Materials[face.Material].NighttimeTexture);
 							TextureTransparencyType transparencyType = TextureTransparencyType.Opaque;
 							if (nighttimeTexture != null)
 							{
@@ -184,7 +163,6 @@ namespace LibRender2.Objects
 								alpha = true;
 							}
 						}
-					}
 
 					materialAlphaCache[face.Material] = alpha;
 				}
@@ -252,6 +230,29 @@ namespace LibRender2.Objects
 		public void HideObject(ObjectState State)
 		{
 			RemoveObject(State);
+		}
+
+		/// <summary>Gets a decoded texture for transparency classification without forcing a full re-decode.</summary>
+		/// <param name="handle">The material texture handle.</param>
+		/// <returns>A decoded texture, or null if unavailable.</returns>
+		/// <remarks>Unload drops textureCache entries, but the register-time decode survives on the
+		/// handle (DecodedTexture) and is reused while the source file is unchanged.</remarks>
+		private Texture GetTransparencySourceTexture(Texture handle)
+		{
+			if (handle == null || handle.Origin == null) return null;
+			if (TextureManager.textureCache.TryGetValue(handle.Origin, out Texture cached)) return cached;
+			Texture decoded = handle.DecodedTexture;
+			if (decoded != null && TextureManager.TextureFileUnchanged(handle.Origin))
+			{
+				TextureManager.textureCache[handle.Origin] = decoded;
+				return decoded;
+			}
+			Stopwatch sw = Stopwatch.StartNew();
+			handle.Origin.GetTexture(out Texture fresh);
+			sw.Stop();
+			TextureManager.TextureDecodeTime += sw.ElapsedMilliseconds;
+			TextureManager.textureCache[handle.Origin] = fresh;
+			return fresh;
 		}
 
 		public List<FaceState> GetSortedPolygons(bool overlay = false)

--- a/source/LibRender2/Text/OpenGlFontTable.cs
+++ b/source/LibRender2/Text/OpenGlFontTable.cs
@@ -132,7 +132,7 @@ namespace LibRender2.Text
 				System.Runtime.InteropServices.Marshal.Copy(data.Scan0, myBytes, 0, data.Stride * data.Height);
 				bitmap.UnlockBits(data);
 			}
-			Texture = new Texture(bitmap.Width, bitmap.Height, OpenBveApi.Textures.PixelFormat.RGBAlpha, myBytes, null);
+			Texture = new Texture(bitmap.Width, bitmap.Height, OpenBveApi.Textures.PixelFormat.RGBAlpha, myBytes, (OpenBveApi.Colors.Color24[])null);
 			bitmap.Dispose();
 		}
 

--- a/source/LibRender2/Textures/TextureManager.cs
+++ b/source/LibRender2/Textures/TextureManager.cs
@@ -228,11 +228,11 @@ namespace LibRender2.Textures
 			
 			if (handle.MultipleFrames)
 			{
-				if (!animatedTextures.TryGetValue(handle.Origin, out texture))
+			if (!animatedTextures.TryGetValue(handle.Origin, out texture))
+			{
+				// Reuse register-time decode from textureCache where possible to avoid decoding the same large animated GIF twice (2× memory). See RegisterTexture pre-seed at line 136.
+				lock (TextureLookupLock)
 				{
-					// Reuse register-time decode from textureCache where possible to avoid decoding the same large animated GIF twice (2× memory). See RegisterTexture pre-seed at line 136.
-					lock (TextureLookupLock)
-					{
 						if (textureCache.TryGetValue(handle.Origin, out Texture cachedTexture) && cachedTexture.MultipleFrames)
 						{
 							PathOrigin cachedPathOrigin = cachedTexture.Origin as PathOrigin;
@@ -253,16 +253,26 @@ namespace LibRender2.Textures
 							}
 						}
 					}
-					if (texture == null)
+				if (texture == null)
+				{
+					// Reuse the register-time decode when the on-disk file is unchanged (the caches
+					// were dropped by the unload): avoids decoding the same GIF into a 2nd pixel copy.
+					// (DecodedTexture already has this handle's parameters applied at registration.)
+					if (handle.Origin is PathOrigin && TextureFileUnchanged(handle.Origin) && handle.DecodedTexture != null && handle.DecodedTexture.MultipleFrames)
 					{
-						if (!handle.Origin.GetTexture(out texture))
-						{
-							//Loading animated texture barfed
-							return false;
-						}
+						texture = handle.DecodedTexture;
 					}
-					animatedTextures.Add(handle.Origin, texture);
 				}
+				if (texture == null)
+				{
+					if (!handle.Origin.GetTexture(out texture))
+					{
+						//Loading animated texture barfed
+						return false;
+					}
+				}
+				animatedTextures.Add(handle.Origin, texture);
+			}
 				
 				double elapsedTime = CPreciseTimer.GetElapsedTime(handle.LastAccess, currentTicks);
 				int elapsedFrames = (int)(elapsedTime / texture.FrameInterval);
@@ -283,34 +293,35 @@ namespace LibRender2.Textures
 						{
 							bool opaque = texture.GetTransparencyType() == TextureTransparencyType.Opaque;
 							int need = texture.Width * texture.Height * (opaque ? 3 : 4);
-							byte[] pooled;
+							// Hold the lock across fill + upload: the static buffer is shared, so releasing
+							// the lock before TexSubImage2D would let a concurrent upload corrupt the data.
 							lock (_expandLock)
 							{
 								if (_palettedExpandBuffer == null || _palettedExpandBuffer.Length < need) _palettedExpandBuffer = new byte[need];
-								pooled = _palettedExpandBuffer;
-							}
-							var pal = texture.Palette32;
-							if (opaque)
-							{
-								for (int p = 0; p < texture.Width * texture.Height; p++)
+								byte[] pooled = _palettedExpandBuffer;
+								var pal = texture.Palette32;
+								if (opaque)
 								{
-									int idx = subBytes[p] & 0xFF;
-									var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
-									pooled[p*3] = c.R; pooled[p*3+1] = c.G; pooled[p*3+2] = c.B;
+									for (int p = 0; p < texture.Width * texture.Height; p++)
+									{
+										int idx = subBytes[p] & 0xFF;
+										var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+										pooled[p*3] = c.R; pooled[p*3+1] = c.G; pooled[p*3+2] = c.B;
+									}
+									GL.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+									GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgb, PixelType.UnsignedByte, pooled);
 								}
-								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
-								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgb, PixelType.UnsignedByte, pooled);
-							}
-							else
-							{
-								for (int p = 0; p < texture.Width * texture.Height; p++)
+								else
 								{
-									int idx = subBytes[p] & 0xFF;
-									var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
-									pooled[p*4] = c.R; pooled[p*4+1] = c.G; pooled[p*4+2] = c.B; pooled[p*4+3] = c.A;
+									for (int p = 0; p < texture.Width * texture.Height; p++)
+									{
+										int idx = subBytes[p] & 0xFF;
+										var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+										pooled[p*4] = c.R; pooled[p*4+1] = c.G; pooled[p*4+2] = c.B; pooled[p*4+3] = c.A;
+									}
+									GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+									GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, pooled);
 								}
-								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
-								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, pooled);
 							}
 							GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
 						}
@@ -334,8 +345,10 @@ namespace LibRender2.Textures
 							}
 							GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
 						}
-						// Keep handle in sync – both point to same GL call
-						handle = texture;
+						// Keep the stable handle in sync without swapping identity: the handle keeps
+						// its origin so the animated cache keeps hitting every tick (swapping to the
+						// decoded texture gives it a fresh ByteArrayOrigin and the cache never hits again)
+						handle.CurrentFrame = texture.CurrentFrame;
 						return true;
 					}
 				}
@@ -346,12 +359,10 @@ namespace LibRender2.Textures
 			}
 			//Set last access time
 
-			if (texture != null)
-			{
-				handle = texture;
-			}
-
-			if (handle.OpenGlTextures[(int)wrap].Valid)
+			// Only early-out when there is nothing new to upload: a freshly decoded texture
+			// whose GL slot is not uploaded yet must fall through to the upload section,
+			// even if the handle still carries a stale Valid flag from before an unload.
+			if (handle.OpenGlTextures[(int)wrap].Valid && (texture == null || texture.OpenGlTextures[(int)wrap].Valid))
 			{
 				return true;
 			}
@@ -404,10 +415,25 @@ namespace LibRender2.Textures
 						}
 					}
 				}
-				if (texture == null)
+			if (texture == null && handle.Origin != null)
+			{
+				// Reuse a live animated decode (e.g. after a reload dropped the register-time
+				// pre-seed from the texture cache) instead of decoding the same GIF twice.
+				if (animatedTextures.TryGetValue(handle.Origin, out Texture animatedTexture) && animatedTexture.MultipleFrames)
 				{
-					handle.Origin.GetTexture(out texture);
+					texture = animatedTexture;
 				}
+			}
+			if (texture == null && handle.Origin is PathOrigin && TextureFileUnchanged(handle.Origin) && handle.DecodedTexture != null)
+			{
+				// Reuse the register-time decode when the on-disk file is unchanged (the cache
+				// entry was dropped by the unload): same bytes GetTexture would decode, no 2nd copy.
+				texture = handle.DecodedTexture;
+			}
+			if (texture == null)
+			{
+				handle.Origin.GetTexture(out texture);
+			}
 			}
 			if (texture != null)
 			{
@@ -620,6 +646,13 @@ namespace LibRender2.Textures
 					if (texture.MultipleFrames)
 					{
 						texture.OpenGlTextures[(int)wrap].Valid = true;
+						// Cache the decode under the stable handle origin (upsert: the animated
+						// block above may already have added it) so later ticks hit the cache
+						// instead of re-decoding after a reload cleared everything.
+						if (handle.Origin != null)
+						{
+							animatedTextures[handle.Origin] = texture;
+						}
 					}
 					else
 					{
@@ -657,7 +690,8 @@ namespace LibRender2.Textures
 
 		/// <summary>Unloads the specified texture from OpenGL if loaded.</summary>
 		/// <param name="handle">The handle to the registered texture.</param>
-		public static void UnloadTexture(ref Texture handle)
+		/// <param name="preserveUnchangedCache">When true (route/object reload), decoded cache entries whose source file is unchanged are kept so the reloaded scene reuses them instead of decoding again.</param>
+		public static void UnloadTexture(ref Texture handle, bool preserveUnchangedCache = false)
 		{
 			//Null check the texture handle, as otherwise this can cause OpenGL to throw a fit
 			if (handle == null)
@@ -665,31 +699,34 @@ namespace LibRender2.Textures
 				return;
 			}
 
-			if (handle.MultipleFrames)
+		if (handle.MultipleFrames)
+		{
+			// Single GL name design: one pass per frame slot, at least one pass.
+			// (TotalFrames is 0 on re-created handles, which previously skipped deletion
+			// entirely and leaked the live GL names with stale Valid flags.)
+			int passes = handle.TotalFrames > 0 ? handle.TotalFrames : 1;
+			for (int i = 0; i < passes; i++)
 			{
-				for (int i = 0; i < handle.TotalFrames; i++)
+				handle.CurrentFrame = i;
+				foreach (OpenGlTexture t in handle.OpenGlTextures)
 				{
-					handle.CurrentFrame = i;
-					foreach (OpenGlTexture t in handle.OpenGlTextures)
+					if (t.Valid)
 					{
-						if (t.Valid)
-						{
-							GL.DeleteTextures(1, new[] { t.Name });
-							t.Valid = false;
-						}
+						GL.DeleteTextures(1, new[] { t.Name });
+						t.Valid = false;
 					}
 				}
-				/*
-				 * Clone the ref for the search and then re-create the original in the texturemanager array
-				 * This allows it to be re-loaded from disk
-				 */
-				var texture = handle;
-				TextureOrigin key = null;
-				if (texture.Origin != null && animatedTextures.ContainsKey(texture.Origin))
-				{
-					key = texture.Origin;
-				}
-				handle = new Texture(key);
+			}
+			/*
+			 * Clone the ref for the search and then re-create the original in the texturemanager array
+			 * This allows it to be re-loaded from disk
+			 */
+			var texture = handle;
+			// Preserve the origin directly so the texture can be re-loaded from disk.
+			// (Do not gate this on animatedTextures.ContainsKey: that cache may already have
+			// been cleared by UnloadAllTextures, which previously produced hollow handles with
+			// a null origin here and killed animated GIFs after a reload / filtering change.)
+			handle = new Texture(texture.Origin);
 			}
 			else
 			{
@@ -705,9 +742,15 @@ namespace LibRender2.Textures
 			handle.Ignore = false;
 			if (handle.Origin != null)
 			{
-				lock (TextureLookupLock)
+				// On reload, keep cache entries whose source file is unchanged: the reloaded
+				// scene reuses the decode instead of decoding the same file again.
+				// (UnloadAllTextures prunes changed files separately below.)
+				if (!preserveUnchangedCache || !TextureFileUnchanged(handle.Origin))
 				{
-					textureCache.Remove(handle.Origin);
+					lock (TextureLookupLock)
+					{
+						textureCache.Remove(handle.Origin);
+					}
 				}
 			}
 		}
@@ -747,7 +790,7 @@ namespace LibRender2.Textures
 				{
 					continue;
 				}
-				UnloadTexture(ref RegisteredTextures[i]);
+				UnloadTexture(ref RegisteredTextures[i], currentlyReloading);
 			}
 			if (currentlyReloading)
 			{
@@ -801,7 +844,7 @@ namespace LibRender2.Textures
 		}
 
 		/// <summary>Checks whether the on-disk source file of the given texture origin is unchanged.</summary>
-		private static bool TextureFileUnchanged(TextureOrigin origin)
+		internal static bool TextureFileUnchanged(TextureOrigin origin)
 		{
 			if (!(origin is PathOrigin pathOrigin))
 			{

--- a/source/LibRender2/Textures/TextureManager.cs
+++ b/source/LibRender2/Textures/TextureManager.cs
@@ -36,6 +36,9 @@ namespace LibRender2.Textures
 		public static long UploadMs;
 
 		private static Dictionary<TextureOrigin, Texture> animatedTextures;
+		// Reused buffer for paletted GIF to avoid per-frame new byte[] leak (Can get StackOverflow in glTexSubImage2D)
+		private static byte[] _palettedExpandBuffer;
+		private static readonly object _expandLock = new object();
 
 		/// <summary>Holds the registered path-based textures, indexed by path.</summary>
 		private static readonly Dictionary<string, List<Texture>> RegisteredTextureLookup = new Dictionary<string, List<Texture>>(StringComparer.OrdinalIgnoreCase);
@@ -227,10 +230,36 @@ namespace LibRender2.Textures
 			{
 				if (!animatedTextures.TryGetValue(handle.Origin, out texture))
 				{
-					if (!handle.Origin.GetTexture(out texture))
+					// Reuse register-time decode from textureCache where possible to avoid decoding the same large animated GIF twice (2× memory). See RegisterTexture pre-seed at line 136.
+					lock (TextureLookupLock)
 					{
-						//Loading animated texture barfed
-						return false;
+						if (textureCache.TryGetValue(handle.Origin, out Texture cachedTexture) && cachedTexture.MultipleFrames)
+						{
+							PathOrigin cachedPathOrigin = cachedTexture.Origin as PathOrigin;
+							PathOrigin handlePathOrigin = handle.Origin as PathOrigin;
+							// PathOrigin equality is path-only, so check Parameters explicitly; ByteArrayOrigin path never hits here (handled below)
+							if (cachedPathOrigin != null && handlePathOrigin != null)
+							{
+								if (cachedPathOrigin.Parameters == handlePathOrigin.Parameters)
+									texture = cachedTexture;
+							}
+							else if (handle.Origin is ByteArrayOrigin || cachedTexture.Origin is ByteArrayOrigin)
+							{
+								texture = cachedTexture;
+							}
+							else if (cachedPathOrigin == null && handlePathOrigin == null)
+							{
+								texture = cachedTexture;
+							}
+						}
+					}
+					if (texture == null)
+					{
+						if (!handle.Origin.GetTexture(out texture))
+						{
+							//Loading animated texture barfed
+							return false;
+						}
 					}
 					animatedTextures.Add(handle.Origin, texture);
 				}
@@ -239,9 +268,76 @@ namespace LibRender2.Textures
 				int elapsedFrames = (int)(elapsedTime / texture.FrameInterval);
 				if (elapsedFrames > 0)
 				{
+					int oldFrame = texture.CurrentFrame;
 					texture.CurrentFrame += elapsedFrames;
 					texture.CurrentFrame %= texture.TotalFrames;
 					handle.LastAccess = currentTicks;
+					// If frame changed and GL texture already uploaded, update in-place via TexSubImage2D to avoid creating a lot of GL calls and per-frame alloc leak
+					if (oldFrame != texture.CurrentFrame && texture.OpenGlTextures[(int)wrap].Valid && handle.OpenGlTextures[(int)wrap].Valid)
+					{
+						// Reuse same GL name across frames, update existing texture
+						GL.BindTexture(TextureTarget.Texture2D, handle.OpenGlTextures[(int)wrap].Name);
+						byte[] subBytes = texture.Bytes; // current frame's bytes (paletted or RGBA)
+						// For paletted, expand via reused static buffer to avoid per-frame new byte[] GC pressure. (I think this how web browser do frame discarding)
+						if (texture.PixelFormat == PixelFormat.Paletted)
+						{
+							bool opaque = texture.GetTransparencyType() == TextureTransparencyType.Opaque;
+							int need = texture.Width * texture.Height * (opaque ? 3 : 4);
+							byte[] pooled;
+							lock (_expandLock)
+							{
+								if (_palettedExpandBuffer == null || _palettedExpandBuffer.Length < need) _palettedExpandBuffer = new byte[need];
+								pooled = _palettedExpandBuffer;
+							}
+							var pal = texture.Palette32;
+							if (opaque)
+							{
+								for (int p = 0; p < texture.Width * texture.Height; p++)
+								{
+									int idx = subBytes[p] & 0xFF;
+									var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+									pooled[p*3] = c.R; pooled[p*3+1] = c.G; pooled[p*3+2] = c.B;
+								}
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgb, PixelType.UnsignedByte, pooled);
+							}
+							else
+							{
+								for (int p = 0; p < texture.Width * texture.Height; p++)
+								{
+									int idx = subBytes[p] & 0xFF;
+									var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+									pooled[p*4] = c.R; pooled[p*4+1] = c.G; pooled[p*4+2] = c.B; pooled[p*4+3] = c.A;
+								}
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, pooled);
+							}
+							GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
+						}
+						else
+						{
+							// RGB/RGBA direct – no expansion
+							if (texture.PixelFormat == PixelFormat.RGBAlpha || texture.GetTransparencyType() != TextureTransparencyType.Opaque)
+							{
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, subBytes);
+							}
+							else if (texture.PixelFormat == PixelFormat.RGB)
+							{
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgb, PixelType.UnsignedByte, subBytes);
+							}
+							else
+							{
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+								GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, texture.Width, texture.Height, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, subBytes);
+							}
+							GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
+						}
+						// Keep handle in sync – both point to same GL call
+						handle = texture;
+						return true;
+					}
 				}
 			}
 			else
@@ -282,11 +378,29 @@ namespace LibRender2.Textures
 					Texture cachedTexture;
 					if (textureCache.TryGetValue(handle.Origin, out cachedTexture))
 					{
-						PathOrigin cachedPathOrigin = cachedTexture.Origin as PathOrigin;
-						PathOrigin handlePathOrigin = handle.Origin as PathOrigin;
-						if (cachedPathOrigin != null && handlePathOrigin != null && cachedPathOrigin.Parameters == handlePathOrigin.Parameters)
+						// The cache value is the DecodedTexture (ByteArrayOrigin) created at registration – its Origin is not PathOrigin,
+						// so the original check (cachedPathOrigin != null) never succeeds for decoded GIFs and caused a second decode (2× memory).
+						// Reuse if the cached entry is animated (GIF video) or its ByteArrayOrigin, and parameters match (or both null).
+						if (cachedTexture.MultipleFrames)
 						{
+							// Animated: reuse single copy to halve memory usage for large GIFs
 							texture = cachedTexture;
+						}
+						else
+						{
+							PathOrigin cachedPathOrigin = cachedTexture.Origin as PathOrigin;
+							PathOrigin handlePathOrigin = handle.Origin as PathOrigin;
+							if (cachedPathOrigin != null && handlePathOrigin != null && cachedPathOrigin.Parameters == handlePathOrigin.Parameters)
+							{
+								texture = cachedTexture;
+							}
+							else if (cachedTexture.Origin is ByteArrayOrigin && handlePathOrigin != null)
+							{
+								// DecodedTexture path: key's Parameters are in handle.Origin; value has no Parameters to compare.
+								// Reuse when handle has no special parameters to avoid duplicate decode.
+								if (handlePathOrigin.Parameters == null)
+									texture = cachedTexture;
+							}
 						}
 					}
 				}
@@ -373,6 +487,21 @@ namespace LibRender2.Textures
 					{
 						switch (texture.PixelFormat)
 						{
+							case PixelFormat.Paletted:
+								{
+									// Expand indexed to RGB (alpha discarded for opaque)
+									byte[] expanded = new byte[texture.Width * texture.Height * 3];
+									var pal = texture.Palette32;
+									for (int p = 0; p < texture.Width * texture.Height; p++)
+									{
+										int idx = textureBytes[p] & 0xFF;
+										var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+										expanded[p*3] = c.R; expanded[p*3+1] = c.G; expanded[p*3+2] = c.B;
+									}
+									GL.PixelStore(PixelStoreParameter.UnpackAlignment, 1);
+									GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb8, texture.Width, texture.Height, 0, OpenTK.Graphics.OpenGL.PixelFormat.Rgb, PixelType.UnsignedByte, expanded);
+									break;
+								}
 							case PixelFormat.Grayscale:
 								// send as is to the luminance channel [NOTE: deprecated in GL4, so use Red channel instead]
 								// n.b. Make sure to set the unpack alignment as otherwise we corrupt textures where stride > width
@@ -417,6 +546,20 @@ namespace LibRender2.Textures
 					{
 						switch (texture.PixelFormat)
 						{
+						case PixelFormat.Paletted:
+							{
+								byte[] expanded = new byte[texture.Width * texture.Height * 4];
+								var pal = texture.Palette32;
+								for (int p = 0; p < texture.Width * texture.Height; p++)
+								{
+									int idx = textureBytes[p] & 0xFF;
+									var c = pal != null && idx < pal.Length ? pal[idx] : new OpenBveApi.Colors.Color32(0,0,0,255);
+									expanded[p*4] = c.R; expanded[p*4+1] = c.G; expanded[p*4+2] = c.B; expanded[p*4+3] = c.A;
+								}
+								GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
+								GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, texture.Width, texture.Height, 0, OpenTK.Graphics.OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, expanded);
+								break;
+							}
 						case PixelFormat.GrayscaleAlpha:
 							// NOTE: LuminanceAlpha is deprecated in GL4, so just upconvert to RGBA
 							if (noLuminanceChannel)

--- a/source/LibRender2/Textures/TextureManager.cs
+++ b/source/LibRender2/Textures/TextureManager.cs
@@ -732,6 +732,11 @@ namespace LibRender2.Textures
 		/// <summary>Unloads all registered textures.</summary>
 		public void UnloadAllTextures(bool currentlyReloading)
 		{
+			// Always clear animated texture cache to prevent memory leak on reload:
+			// animatedTextures retains decoded frame data for every GIF ever loaded,
+			// doubling memory on each reload because old entries are never removed.
+			animatedTextures.Clear();
+
 			for (int i = 0; i < RegisteredTexturesCount; i++)
 			{
 				/*

--- a/source/ObjectViewer/ProgramS.cs
+++ b/source/ObjectViewer/ProgramS.cs
@@ -624,15 +624,22 @@ namespace ObjectViewer {
                         Application.DoEvents();
 	                }
 	                break;
-				case Key.BackSpace:
-	            case Key.Delete:
-		            LightingRelative = -1.0;
-	                Game.Reset();
-		            Files.Clear();
-                    LastReloadTime = DateTime.UtcNow;
-					NearestTrain.UpdateSpecs();
-					Renderer.ApplyBackgroundColor();
-	                break;
+			case Key.BackSpace:
+            case Key.Delete:
+	            LightingRelative = -1.0;
+                Game.Reset();
+				// Pressing delete means unload current loaded objects, so release everything instead of preserving.
+				Renderer.TextureManager.UnloadAllTextures(false);
+				CurrentHost.StaticObjectCache.Clear();
+				CurrentHost.AnimatedObjectCollectionCache.Clear();
+	            Files.Clear();
+				// One full collect so the freed LOH buffers leave RAM immediately.
+				GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+				GC.WaitForPendingFinalizers();
+                LastReloadTime = DateTime.UtcNow;
+				NearestTrain.UpdateSpecs();
+				Renderer.ApplyBackgroundColor();
+                break;
 	            case Key.Left:
 	                RotateX = -1;
 	                break;

--- a/source/OpenBveApi/OpenBveApi.csproj
+++ b/source/OpenBveApi/OpenBveApi.csproj
@@ -305,6 +305,7 @@
     </Compile>
     <Compile Include="Textures\Textures.OpenGLWrapMode.cs" />
     <Compile Include="Textures\Textures.BitmapOrigin.cs" />
+    <Compile Include="Textures\Textures.StreamingGifOrigin.cs" />
     <Compile Include="Textures\Textures.TextureInterface.cs" />
     <Compile Include="Textures\Textures.TextureOrigin.cs" />
     <Compile Include="Textures\Textures.TextureParameters.cs" />

--- a/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
+++ b/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
@@ -148,10 +148,10 @@ namespace OpenBveApi.Textures
 			if (ReferenceEquals(a, b)) return false;
 			if (a is null) return true;
 			if (b is null) return true;
-			if (a.FrameInterval == b.FrameInterval) return false;
-			if (a.NumberOfFrames == b.NumberOfFrames) return false;
-			if (a.Width == b.Width) return false;
-			if (a.Height == b.Height) return false;
+			if (a.FrameInterval != b.FrameInterval) return true;
+			if (a.NumberOfFrames != b.NumberOfFrames) return true;
+			if (a.Width != b.Width) return true;
+			if (a.Height != b.Height) return true;
 			return a.TextureBytes != b.TextureBytes;
 		}
 

--- a/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
+++ b/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
@@ -163,11 +163,27 @@ namespace OpenBveApi.Textures
 			if (ReferenceEquals(this, obj)) return true;
 			if (obj is null) return false;
 			if (!(obj is ByteArrayOrigin)) return false;
-			if (FrameInterval == ((ByteArrayOrigin)obj).FrameInterval) return false;
-			if (NumberOfFrames == ((ByteArrayOrigin)obj).NumberOfFrames) return false;
-			if (Width == ((ByteArrayOrigin)obj).Width) return false;
-			if (Height == ((ByteArrayOrigin)obj).Height) return false;
-			return TextureBytes != ((ByteArrayOrigin)obj).TextureBytes;
+			if (FrameInterval != ((ByteArrayOrigin)obj).FrameInterval) return false;
+			if (NumberOfFrames != ((ByteArrayOrigin)obj).NumberOfFrames) return false;
+			if (Width != ((ByteArrayOrigin)obj).Width) return false;
+			if (Height != ((ByteArrayOrigin)obj).Height) return false;
+			return ReferenceEquals(TextureBytes, ((ByteArrayOrigin)obj).TextureBytes);
+		}
+
+		/// <summary>Returns the hash code for this origin.</summary>
+		/// <returns>A 32-bit signed integer hash code.</returns>
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				int hash = 17;
+				hash = hash * 31 + Width.GetHashCode();
+				hash = hash * 31 + Height.GetHashCode();
+				hash = hash * 31 + NumberOfFrames.GetHashCode();
+				hash = hash * 31 + FrameInterval.GetHashCode();
+				hash = hash * 31 + (TextureBytes?.GetHashCode() ?? 0);
+				return hash;
+			}
 		}
 
 	}

--- a/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
+++ b/source/OpenBveApi/Textures/Textures.ByteArrayOrigin.cs
@@ -16,6 +16,8 @@ namespace OpenBveApi.Textures
 
 		private readonly PixelFormat Format;
 
+		private readonly Color32[] Palette32;
+
 		private readonly int NumberOfFrames;
 
 		private readonly double FrameInterval;
@@ -42,6 +44,19 @@ namespace OpenBveApi.Textures
 			Height = height;
 			Format = pixelFormat;
 			TextureBytes = bytes;
+			Palette32 = null;
+			FrameInterval = frameInterval;
+			NumberOfFrames = bytes.Length;
+		}
+
+		/// <summary>Creates a paletted byte array origin (animated)</summary>
+		public ByteArrayOrigin(int width, int height, PixelFormat pixelFormat, byte[][] bytes, Color32[] palette32, double frameInterval)
+		{
+			Width = width;
+			Height = height;
+			Format = pixelFormat;
+			TextureBytes = bytes;
+			Palette32 = palette32;
 			FrameInterval = frameInterval;
 			NumberOfFrames = bytes.Length;
 		}
@@ -69,6 +84,18 @@ namespace OpenBveApi.Textures
 			{
 				bytes
 			};
+			Palette32 = null;
+			NumberOfFrames = 1;
+		}
+
+		/// <summary>Creates a paletted byte array origin</summary>
+		public ByteArrayOrigin(int width, int height, PixelFormat pixelFormat, byte[] bytes, Color32[] palette32)
+		{
+			Width = width;
+			Height = height;
+			Format = pixelFormat;
+			TextureBytes = new[] { bytes };
+			Palette32 = palette32;
 			NumberOfFrames = 1;
 		}
 
@@ -77,6 +104,16 @@ namespace OpenBveApi.Textures
 		/// <returns>Whether the texture could be obtained successfully.</returns>
 		public override bool GetTexture(out Texture texture)
 		{
+			if (Palette32 != null)
+			{
+				if (TextureBytes.Length == 1)
+				{
+					texture = new Texture(Width, Height, Format, TextureBytes[0], Palette32);
+					return true;
+				}
+				texture = new Texture(Width, Height, Format, TextureBytes, Palette32, FrameInterval);
+				return true;
+			}
 			if (TextureBytes.Length == 1)
 			{
 				texture = new Texture(Width, Height, Format, TextureBytes[0], Array.Empty<Color24>());

--- a/source/OpenBveApi/Textures/Textures.Functions.cs
+++ b/source/OpenBveApi/Textures/Textures.Functions.cs
@@ -218,15 +218,31 @@ namespace OpenBveApi.Textures {
 					if (texture.Palette32[i].R == color.Value.R && texture.Palette32[i].G == color.Value.G && texture.Palette32[i].B == color.Value.B)
 					{ matchIdx = i; break; }
 				}
-				if (matchIdx == -1) return texture;
-				// Check only current frame for usage, avoids decoding all frames for streaming GIFs
-				bool anyUse = false;
+			if (matchIdx == -1) return texture;
+			// For streaming GIFs check only the current frame for usage, as decoding every frame
+			// here would defeat on-demand loading; non-streaming textures hold all frames in memory, so scan them all
+			bool anyUse = false;
+			if (texture.MultipleFrames && !(texture.Origin is StreamingGifOrigin))
+			{
+				int savedFrame = texture.CurrentFrame;
+				for (int f = 0; f < texture.TotalFrames && !anyUse; f++)
+				{
+					texture.CurrentFrame = f;
+					byte[] frameData = texture.Bytes;
+					if (frameData == null) continue;
+					for (int i = 0; i < frameData.Length; i++) { if ((frameData[i] & 0xFF) == matchIdx) { anyUse = true; break; } }
+				}
+				texture.CurrentFrame = savedFrame;
+			}
+			else
+			{
 				byte[] curFrame = texture.Bytes;
 				if (curFrame != null)
 				{
 					for (int i = 0; i < curFrame.Length; i++) { if ((curFrame[i] & 0xFF) == matchIdx) { anyUse = true; break; } }
 				}
-				if (!anyUse) return texture;
+			}
+			if (!anyUse) return texture;
 				Color32[] newPal = (Color32[])texture.Palette32.Clone();
 				newPal[matchIdx].A = 0;
 				if (texture.MultipleFrames)

--- a/source/OpenBveApi/Textures/Textures.Functions.cs
+++ b/source/OpenBveApi/Textures/Textures.Functions.cs
@@ -25,7 +25,23 @@ namespace OpenBveApi.Textures {
 
 				if (parameters.TransparencyTexture != null && parameters.TransparencyTexture.Size == texture.Size)
 				{
-					result = new Texture(texture.Width, texture.Height, PixelFormat.RGBAlpha, ApplyTransparentTexture(texture.Bytes, texture.PixelFormat, texture.Width, texture.Height, parameters.TransparencyTexture), texture.Palette);
+					if (texture.PixelFormat == PixelFormat.Paletted && texture.Palette32 != null)
+					{
+						// Expand paletted to RGBA first, then apply texture transparency
+						byte[] expanded = new byte[texture.Width * texture.Height * 4];
+						byte[] src = texture.Bytes;
+						for (int p = 0; p < src.Length; p++)
+						{
+							int idx = src[p] & 0xFF;
+							Color32 c = idx < texture.Palette32.Length ? texture.Palette32[idx] : new Color32(0,0,0,255);
+							expanded[p*4] = c.R; expanded[p*4+1] = c.G; expanded[p*4+2] = c.B; expanded[p*4+3] = c.A;
+						}
+						result = new Texture(texture.Width, texture.Height, PixelFormat.RGBAlpha, ApplyTransparentTexture(expanded, PixelFormat.RGBAlpha, texture.Width, texture.Height, parameters.TransparencyTexture), texture.Palette);
+					}
+					else
+					{
+						result = new Texture(texture.Width, texture.Height, PixelFormat.RGBAlpha, ApplyTransparentTexture(texture.Bytes, texture.PixelFormat, texture.Width, texture.Height, parameters.TransparencyTexture), texture.Palette);
+					}
 				}
 				else if (parameters.FirstColorTransparent) {
 					result = ApplyTransparentColor(result, result.Palette[0]);
@@ -83,6 +99,20 @@ namespace OpenBveApi.Textures {
 					    }
 				    }
 				    return new Texture(clipWidth, clipHeight, PixelFormat.Grayscale, newBytes, texture.Palette);
+				case PixelFormat.Paletted:
+					newBytes = new byte[clipWidth * clipHeight];
+					for (int y = 0; y < clipHeight; y++)
+					{
+						int j = width * (clipTop + y) + clipLeft;
+						for (int x = 0; x < clipWidth; x++)
+						{
+							newBytes[i] = bytes[j];
+							i++;
+							j++;
+						}
+					}
+					if (texture.Palette32 != null) return new Texture(clipWidth, clipHeight, PixelFormat.Paletted, newBytes, texture.Palette32);
+					return new Texture(clipWidth, clipHeight, PixelFormat.Paletted, newBytes, texture.Palette);
 				case PixelFormat.GrayscaleAlpha:
 				    newBytes = new byte[2 * clipWidth * clipHeight];
 				    for (int y = 0; y < clipHeight; y++)
@@ -179,6 +209,53 @@ namespace OpenBveApi.Textures {
 				}
 			}
 
+			// Paletted special handling: check palette index directly, modify palette alpha without iterating all frames
+			if (texture.PixelFormat == PixelFormat.Paletted && texture.Palette32 != null)
+			{
+				int matchIdx = -1;
+				for (int i = 0; i < texture.Palette32.Length; i++)
+				{
+					if (texture.Palette32[i].R == color.Value.R && texture.Palette32[i].G == color.Value.G && texture.Palette32[i].B == color.Value.B)
+					{ matchIdx = i; break; }
+				}
+				if (matchIdx == -1) return texture;
+				// Check only current frame for usage, avoids decoding all frames for streaming GIFs
+				bool anyUse = false;
+				byte[] curFrame = texture.Bytes;
+				if (curFrame != null)
+				{
+					for (int i = 0; i < curFrame.Length; i++) { if ((curFrame[i] & 0xFF) == matchIdx) { anyUse = true; break; } }
+				}
+				if (!anyUse) return texture;
+				Color32[] newPal = (Color32[])texture.Palette32.Clone();
+				newPal[matchIdx].A = 0;
+				if (texture.MultipleFrames)
+				{
+					// For streaming GIFs, create a new origin with modified palette, avoids decoding all frames
+					if (texture.Origin is StreamingGifOrigin sgo)
+					{
+						var newOrigin = sgo.WithModifiedPalette(newPal);
+						return new Texture(newOrigin);
+					}
+					// For non-streaming, share original frame references, palette index data doesn't change
+					byte[][] framesRef = new byte[texture.TotalFrames][];
+					int saved = texture.CurrentFrame;
+					for (int f = 0; f < texture.TotalFrames; f++)
+					{
+						texture.CurrentFrame = f;
+						byte[] frameData = texture.Bytes;
+						if (frameData == null) frameData = new byte[texture.Width * texture.Height];
+						framesRef[f] = frameData;
+					}
+					texture.CurrentFrame = saved;
+					return new Texture(texture.Width, texture.Height, PixelFormat.Paletted, framesRef, newPal, texture.FrameInterval);
+				}
+				else
+				{
+					return new Texture(texture.Width, texture.Height, PixelFormat.Paletted, (byte[])texture.Bytes.Clone(), newPal);
+				}
+			}
+
 			bool usedTransparentColor = false;
 			if (texture.MultipleFrames)
 			{
@@ -236,6 +313,25 @@ namespace OpenBveApi.Textures {
 			int targetIndex = 0;
 			switch (pixelFormat)
 			{
+				case PixelFormat.Paletted:
+					// Caller should have expanded to RGBA before calling this as a fallback, just apply transparency alpha to the source index treated as luminance
+					for (int i = 0; i < width * height; i++)
+					{
+						byte val = source[i];
+						target[i*4] = val;
+						target[i*4+1] = val;
+						target[i*4+2] = val;
+						if (transparencyTexture.PixelFormat == PixelFormat.Grayscale || transparencyTexture.PixelFormat == PixelFormat.RGB)
+						{
+							Color24 c = transparencyTexture.GetPixel(i);
+							target[i*4 + 3] = (byte)(255 * c.GetBrightness());
+						}
+						else
+						{
+							target[i*4 + 3] = transparencyTexture.GetAlpha(i);
+						}
+					}
+					break;
 				case PixelFormat.Grayscale:
 					for (int i = 0; i < source.Length; i++, targetIndex += 4)
 					{
@@ -364,6 +460,9 @@ namespace OpenBveApi.Textures {
 						}
 					}
 					return false;
+				case PixelFormat.Paletted:
+					// Cannot determine without palette, just assume true to trigger palette path handled at higher level
+					return true;
 				case PixelFormat.RGBAlpha:
 					for (int i = 0; i + 2 < source.Length; i += 4)
 					{
@@ -439,6 +538,8 @@ namespace OpenBveApi.Textures {
 						}
 					}
 					break;
+				case PixelFormat.Paletted:
+					throw new NotSupportedException("Paletted ApplyTransparentColor should be handled at texture level with palette");
 				case PixelFormat.RGBAlpha:
 					if (source[0] == r && source[1] == g && source[2] == b) {
 						target[0] = 128;

--- a/source/OpenBveApi/Textures/Textures.PixelFormat.cs
+++ b/source/OpenBveApi/Textures/Textures.PixelFormat.cs
@@ -12,7 +12,27 @@
 		/// <summary>The pixel is a RGB triple</summary>
 		RGB = 3,
 		/// <summary>The pixel is a RGB triple and an alpha byte</summary>
-		RGBAlpha = 4
+		RGBAlpha = 4,
+		/// <summary>The pixel is a single palette index byte (requires Palette)</summary>
+		Paletted = 5
 
+	}
+
+	/// <summary>Helper for PixelFormat</summary>
+	public static class PixelFormatExtensions
+	{
+		/// <summary>Gets the bytes per pixel for the format (palette index counts as 1)</summary>
+		public static int BytesPerPixel(this PixelFormat format)
+		{
+			switch (format)
+			{
+				case PixelFormat.Grayscale: return 1;
+				case PixelFormat.Paletted: return 1;
+				case PixelFormat.GrayscaleAlpha: return 2;
+				case PixelFormat.RGB: return 3;
+				case PixelFormat.RGBAlpha: return 4;
+				default: return 0;
+			}
+		}
 	}
 }

--- a/source/OpenBveApi/Textures/Textures.StreamingGifOrigin.cs
+++ b/source/OpenBveApi/Textures/Textures.StreamingGifOrigin.cs
@@ -1,0 +1,125 @@
+#pragma warning disable 0659,0661
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using OpenBveApi.Colors;
+using OpenBveApi.Math;
+
+namespace OpenBveApi.Textures
+{
+	/// <summary>Streaming origin for large animated GIFs – desktop OpenGL keeps file bytes 36 MB instead of 1205 decoded frames 208 MB (single TexSubImage, not 1205 glGen)</summary>
+	public class StreamingGifOrigin : TextureOrigin
+	{
+		private readonly string Path;
+		private readonly byte[] FileBytes;
+		private readonly int Width;
+		private readonly int Height;
+		private readonly Color32[] Palette;
+		private readonly int FrameCount;
+		private readonly double Interval;
+		private readonly Vector2 Size;
+		private int cachedFrame = -1;
+		private byte[] cachedBytes;
+		private readonly object sync = new object();
+		private Func<int, byte[]> frameDecoder;
+
+		public StreamingGifOrigin(string path, byte[] fileBytes, int width, int height, Color32[] palette, int frameCount, double interval)
+		{
+			Path = path;
+			FileBytes = fileBytes;
+			Width = width;
+			Height = height;
+			Palette = palette;
+			FrameCount = frameCount;
+			Interval = interval;
+			Size = new Vector2(width, height);
+		}
+		public void SetDecoder(Func<int, byte[]> decoder) => frameDecoder = decoder;
+
+		public int GetFrameCount() => FrameCount;
+		public double GetInterval() => Interval;
+		public Vector2 GetSize() => Size;
+		public Color32[] GetPalette() => Palette;
+
+		/// <summary>Create a copy of this origin with a modified palette (for transparency changes)</summary>
+		public StreamingGifOrigin WithModifiedPalette(Color32[] newPalette)
+		{
+			return new StreamingGifOrigin(Path, FileBytes, Width, Height, newPalette, FrameCount, Interval) { frameDecoder = this.frameDecoder };
+		}
+
+		/// <summary>Get bytes for specific frame – desktop on-demand decode (1 frame cached) to stop RAM naik terus</summary>
+		public byte[] GetFrameBytes(int frame)
+		{
+			lock (sync)
+			{
+				if (cachedFrame == frame && cachedBytes != null) return cachedBytes;
+				if (frameDecoder != null)
+				{
+					try
+					{
+						var b = frameDecoder(frame);
+						if (b != null) { cachedFrame = frame; cachedBytes = b; return b; }
+					}
+					catch { }
+				}
+				// Fallback System.Drawing (no Plugin reference)
+				try
+				{
+					using (var ms = new MemoryStream(FileBytes))
+					using (var img = Image.FromStream(ms))
+					{
+						var dim = new FrameDimension(img.FrameDimensionsList[0]);
+						int count = img.GetFrameCount(dim);
+						int target = System.Math.Max(0, System.Math.Min(frame, count - 1));
+						img.SelectActiveFrame(dim, target);
+						using (var bmp = new Bitmap(img))
+						{
+							var rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
+							Bitmap indexed = bmp;
+							bool cloned = false;
+							if (bmp.PixelFormat != System.Drawing.Imaging.PixelFormat.Format8bppIndexed)
+							{
+								indexed = new Bitmap(Width, Height, System.Drawing.Imaging.PixelFormat.Format8bppIndexed);
+								var pal = indexed.Palette;
+								for (int i = 0; i < System.Math.Min(Palette.Length, 256); i++) pal.Entries[i] = Color.FromArgb(Palette[i].A, Palette[i].R, Palette[i].G, Palette[i].B);
+								indexed.Palette = pal;
+								using (var g = System.Drawing.Graphics.FromImage(indexed)) g.DrawImage(bmp, rect);
+								cloned = true;
+							}
+							var data = indexed.LockBits(rect, ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format8bppIndexed);
+							byte[] bytes = new byte[Width * Height];
+							System.Runtime.InteropServices.Marshal.Copy(data.Scan0, bytes, 0, bytes.Length);
+							indexed.UnlockBits(data);
+							if (cloned) indexed.Dispose();
+							cachedFrame = frame;
+							cachedBytes = bytes;
+							return bytes;
+						}
+					}
+				}
+				catch
+				{
+					return cachedBytes;
+				}
+				return null;
+			}
+		}
+
+		public override bool GetTexture(out Texture texture)
+		{
+			texture = new Texture(this);
+			return true;
+		}
+
+		public static bool operator ==(StreamingGifOrigin a, StreamingGifOrigin b)
+		{
+			if (ReferenceEquals(a, b)) return true;
+			if (a is null || b is null) return false;
+			return a.Path == b.Path;
+		}
+		public static bool operator !=(StreamingGifOrigin a, StreamingGifOrigin b) => !(a == b);
+		public override bool Equals(object obj) => obj is StreamingGifOrigin o && Path == o.Path;
+		public override int GetHashCode() => Path?.GetHashCode() ?? 0;
+	}
+}

--- a/source/OpenBveApi/Textures/Textures.TextureOrigin.cs
+++ b/source/OpenBveApi/Textures/Textures.TextureOrigin.cs
@@ -30,6 +30,14 @@ namespace OpenBveApi.Textures
 			{
 				return (PathOrigin)a == (PathOrigin)b;
 			}
+			if (a is ByteArrayOrigin && b is ByteArrayOrigin)
+			{
+				return (ByteArrayOrigin)a == (ByteArrayOrigin)b;
+			}
+			if (a is StreamingGifOrigin && b is StreamingGifOrigin)
+			{
+				return (StreamingGifOrigin)a == (StreamingGifOrigin)b;
+			}
 			if (a is BitmapOrigin && b is BitmapOrigin)
 			{
 				return (BitmapOrigin)a == (BitmapOrigin)b;
@@ -60,6 +68,14 @@ namespace OpenBveApi.Textures
 			{
 				return (PathOrigin)a != (PathOrigin)b;
 			}
+			if (a is ByteArrayOrigin && b is ByteArrayOrigin)
+			{
+				return (ByteArrayOrigin)a != (ByteArrayOrigin)b;
+			}
+			if (a is StreamingGifOrigin && b is StreamingGifOrigin)
+			{
+				return (StreamingGifOrigin)a != (StreamingGifOrigin)b;
+			}
 			if (a is BitmapOrigin && b is BitmapOrigin)
 			{
 				return (BitmapOrigin)a != (BitmapOrigin)b;
@@ -88,6 +104,14 @@ namespace OpenBveApi.Textures
 			if (this is PathOrigin && obj is PathOrigin)
 			{
 				return (PathOrigin)this == (PathOrigin)obj;
+			}
+			if (this is ByteArrayOrigin && obj is ByteArrayOrigin)
+			{
+				return (ByteArrayOrigin)this == (ByteArrayOrigin)obj;
+			}
+			if (this is StreamingGifOrigin && obj is StreamingGifOrigin)
+			{
+				return (StreamingGifOrigin)this == (StreamingGifOrigin)obj;
 			}
 			if (this is BitmapOrigin && obj is BitmapOrigin)
 			{

--- a/source/OpenBveApi/Textures/Textures.cs
+++ b/source/OpenBveApi/Textures/Textures.cs
@@ -18,6 +18,8 @@ namespace OpenBveApi.Textures {
 		private byte[][] MyBytes;
 		/// <summary>The restricted color palette for this texture, or a null reference if the texture was 24/ 32 bit originally</summary>
 		public readonly Color24[] Palette;
+		/// <summary>The palette for indexed (Paletted) textures as 32-bit colors (includes alpha)</summary>
+		public readonly Color32[] Palette32;
 		/// <summary>Whether the texture is invalid and should be ignored</summary>
 		/// <remarks>Set when loading the texture fails unexpectedly</remarks>
 		public bool Ignore;
@@ -50,6 +52,13 @@ namespace OpenBveApi.Textures {
 		/// <summary>Gets the color of the given pixel</summary>
 		/// <param name="pix">The pixel index</param>
 		/// <param name="frame">The frame</param>
+		private byte[] GetBytesForFrame(int frame)
+		{
+			if (Origin is StreamingGifOrigin sgo) return sgo.GetFrameBytes(frame) ?? MyBytes[0];
+			if (MyBytes == null) return null;
+			if (frame < MyBytes.Length) return MyBytes[frame];
+			return MyBytes[0];
+		}
 		public Color24 GetPixel(int pix, int frame = 0)
 		{
 			if (pix > Size.X * Size.Y)
@@ -58,20 +67,28 @@ namespace OpenBveApi.Textures {
 			}
 
 			int firstByte;
+			byte[] fBytes = GetBytesForFrame(frame);
 			switch (PixelFormat)
 			{
 				case PixelFormat.Grayscale:
 					firstByte = pix;
-					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte], MyBytes[frame][firstByte]);
+					return new Color24(fBytes[firstByte], fBytes[firstByte], fBytes[firstByte]);
 				case PixelFormat.GrayscaleAlpha:
 					firstByte = 2 * pix;
-					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte], MyBytes[frame][firstByte]);
+					return new Color24(fBytes[firstByte], fBytes[firstByte], fBytes[firstByte]);
 				case PixelFormat.RGB:
 					firstByte = 3 * pix;
-					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte + 1], MyBytes[frame][firstByte + 2]);
+					return new Color24(fBytes[firstByte], fBytes[firstByte + 1], fBytes[firstByte + 2]);
 				case PixelFormat.RGBAlpha:
 					firstByte = 4 * pix;
-					return new Color24(MyBytes[frame][firstByte], MyBytes[frame][firstByte + 1], MyBytes[frame][firstByte + 2]);
+					return new Color24(fBytes[firstByte], fBytes[firstByte + 1], fBytes[firstByte + 2]);
+				case PixelFormat.Paletted:
+					{
+						int idx = fBytes[pix] & 0xFF;
+						if (Palette32 != null && idx < Palette32.Length) return new Color24(Palette32[idx].R, Palette32[idx].G, Palette32[idx].B);
+						if (Palette != null && idx < Palette.Length) return Palette[idx];
+						return Color24.Black;
+					}
 				default:
 					throw new Exception("Unable to get a pixel value with invalid data.");
 			}
@@ -89,9 +106,15 @@ namespace OpenBveApi.Textures {
 				case PixelFormat.RGB:
 					return 255;
 				case PixelFormat.GrayscaleAlpha:
-					return MyBytes[frame][2 * pix + 1];
+					return GetBytesForFrame(frame)[2 * pix + 1];
 				case PixelFormat.RGBAlpha:
-					return MyBytes[frame][4 * pix + 3];
+					return GetBytesForFrame(frame)[4 * pix + 3];
+				case PixelFormat.Paletted:
+					{
+						int idx = GetBytesForFrame(frame)[pix] & 0xFF;
+						if (Palette32 != null && idx < Palette32.Length) return Palette32[idx].A;
+						return 255;
+					}
 				default:
 					return 255;
 			}
@@ -113,7 +136,7 @@ namespace OpenBveApi.Textures {
 				throw new ArgumentNullException(nameof(bytes));
 			}
 
-			if (bytes.Length != width * height * (int)pixelFormat)
+			if (bytes.Length != width * height * pixelFormat.BytesPerPixel())
 			{
 				throw new ArgumentException("The data bytes are not of the expected length.");
 			}
@@ -126,6 +149,26 @@ namespace OpenBveApi.Textures {
 			this.MyBytes = new byte[1][];
 			this.MyBytes[0] = bytes;
 			this.Palette = palette;
+			this.Palette32 = palette != null ? Array.ConvertAll(palette, c => new Color32(c.R, c.G, c.B, 255)) : null;
+		}
+
+		/// <summary>Creates a new paletted texture with 32-bit palette (with alpha)</summary>
+		public Texture(int width, int height, PixelFormat pixelFormat, byte[] bytes, Color32[] palette32)
+		{
+			if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+			if (pixelFormat != PixelFormat.Paletted) throw new ArgumentException("Palette32 constructor requires Paletted format");
+			if (bytes.Length != width * height * pixelFormat.BytesPerPixel())
+				throw new ArgumentException("The data bytes are not of the expected length.");
+			this.Origin = new ByteArrayOrigin(width, height, pixelFormat, bytes, palette32);
+			this.MyOpenGlTextures = new OpenGlTexture[1][];
+			this.MyOpenGlTextures[0] = new[] { new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture() };
+			this.Size.X = width;
+			this.Size.Y = height;
+			this.PixelFormat = pixelFormat;
+			this.MyBytes = new byte[1][];
+			this.MyBytes[0] = bytes;
+			this.Palette32 = palette32;
+			this.Palette = palette32 != null ? Array.ConvertAll(palette32, c => new Color24(c.R, c.G, c.B)) : null;
 		}
 
 		/// <summary>Creates a new instance of this class.</summary>
@@ -144,7 +187,7 @@ namespace OpenBveApi.Textures {
 				throw new ArgumentNullException(nameof(bytes));
 			}
 
-			if (bytes[0].Length != width * height * (int)pixelFormat)
+			if (bytes[0].Length != width * height * pixelFormat.BytesPerPixel())
 			{
 				throw new ArgumentException("The data bytes are not of the expected length.");
 			}
@@ -155,14 +198,35 @@ namespace OpenBveApi.Textures {
 			PixelFormat = pixelFormat;
 			MyBytes = bytes;
 			Palette = null;
+			Palette32 = null;
 			MultipleFrames = true;
 			FrameInterval = frameInterval;
 			TotalFrames = bytes.Length;
-			MyOpenGlTextures = new OpenGlTexture[bytes.Length][];
-			for (int i = 0; i < bytes.Length; i++)
-			{
-				MyOpenGlTextures[i] = new[] {new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture()};
-			}
+			// Single GL name for all frames – TexSubImage2D updates in place to avoid GL leak
+			MyOpenGlTextures = new OpenGlTexture[1][];
+			MyOpenGlTextures[0] = new[] {new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture()};
+		}
+
+		/// <summary>Creates a new paletted animated texture</summary>
+		public Texture(int width, int height, PixelFormat pixelFormat, byte[][] bytes, Color32[] palette32, double frameInterval)
+		{
+			if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+			if (pixelFormat != PixelFormat.Paletted) throw new ArgumentException("Palette32 constructor requires Paletted format");
+			if (bytes[0].Length != width * height * pixelFormat.BytesPerPixel())
+				throw new ArgumentException("The data bytes are not of the expected length.");
+			Origin = new ByteArrayOrigin(width, height, pixelFormat, bytes, palette32, frameInterval);
+			Size.X = width;
+			Size.Y = height;
+			PixelFormat = pixelFormat;
+			MyBytes = bytes;
+			Palette32 = palette32;
+			Palette = palette32 != null ? Array.ConvertAll(palette32, c => new Color24(c.R, c.G, c.B)) : null;
+			MultipleFrames = true;
+			FrameInterval = frameInterval;
+			TotalFrames = bytes.Length;
+			// Single GL name for all frames – TexSubImage2D updates in place to avoid GL leak
+			MyOpenGlTextures = new OpenGlTexture[1][];
+			MyOpenGlTextures[0] = new[] { new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture() };
 		}
 
 		/// <summary>Creates a new texture.</summary>
@@ -215,6 +279,23 @@ namespace OpenBveApi.Textures {
 			MyOpenGlTextures[0] = new[] {new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture()};
 		}
 
+		/// <summary>Streaming GIF – desktop OpenGL (not browser) keeps file bytes 36 MB instead of 1205×172k 208 MB, decodes on demand via TexSubImage</summary>
+		public Texture(StreamingGifOrigin origin)
+		{
+			Origin = origin;
+			Size = origin.GetSize();
+			PixelFormat = PixelFormat.Paletted;
+			Palette32 = origin.GetPalette();
+			Palette = Palette32 != null ? Array.ConvertAll(Palette32, c => new Color24(c.R, c.G, c.B)) : null;
+			MultipleFrames = true;
+			TotalFrames = origin.GetFrameCount();
+			FrameInterval = origin.GetInterval();
+			MyBytes = new byte[1][];
+			MyBytes[0] = origin.GetFrameBytes(0) ?? new byte[(int)Size.X * (int)Size.Y];
+			MyOpenGlTextures = new OpenGlTexture[1][];
+			MyOpenGlTextures[0] = new[] {new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture(), new OpenGlTexture()};
+		}
+
 		/// <summary>Gets the width of the texture in pixels.</summary>
 		public int Width
 		{
@@ -236,6 +317,10 @@ namespace OpenBveApi.Textures {
 		{
 			get
 			{
+				if (Origin is StreamingGifOrigin sgo && MultipleFrames)
+				{
+					return sgo.GetFrameBytes(CurrentFrame) ?? MyBytes[0];
+				}
 				if (MyBytes == null && Origin != null)
 				{
 					Origin.GetTexture(out Texture t);
@@ -245,6 +330,8 @@ namespace OpenBveApi.Textures {
 				{
 					return MyBytes[0];
 				}
+				// Streaming: MyBytes holds 1 entry but TotalFrames clamped to avoid Out of range
+				if (MyBytes.Length == 1 && TotalFrames > 1) return MyBytes[0];
 				return MyBytes[CurrentFrame];
 			}
 		}
@@ -255,10 +342,12 @@ namespace OpenBveApi.Textures {
 		{
 			get
 			{
+				if (Origin is StreamingGifOrigin) return MyOpenGlTextures[0]; // single GL name + TexSubImage
 				if (MultipleFrames == false)
 				{
 					return MyOpenGlTextures[0];
 				}
+				if (MyOpenGlTextures.Length == 1) return MyOpenGlTextures[0];
 				return MyOpenGlTextures[CurrentFrame];
 			}
 		}
@@ -371,6 +460,35 @@ namespace OpenBveApi.Textures {
 			knownTransparencyType = true;
 			switch (PixelFormat)
 			{
+				case PixelFormat.Paletted:
+				if (Palette32 != null)
+				{
+					bool hasTransparent = false, hasOpaque = false, hasAlpha = false;
+					// scan used indices vs palette alpha
+					byte[] indices = null;
+					if (Origin is StreamingGifOrigin sgo2) indices = sgo2.GetFrameBytes(CurrentFrame);
+					else if (MyBytes != null) indices = CurrentFrame < MyBytes.Length ? MyBytes[CurrentFrame] : MyBytes[0];
+					if (indices == null)
+					{
+						if (Origin == null || !Origin.GetTexture(out Texture released) || released == null) return TextureTransparencyType.Opaque;
+						return released.GetTransparencyType();
+					}
+					bool[] used = new bool[256];
+					for (int i = 0; i < indices.Length; i++) used[indices[i] & 0xFF] = true;
+					for (int i = 0; i < 256; i++)
+					{
+						if (!used[i]) continue;
+						byte a = i < Palette32.Length ? Palette32[i].A : (byte)255;
+						if (a == 0) hasTransparent = true;
+						else if (a == 255) hasOpaque = true;
+						else hasAlpha = true;
+					}
+					if (hasAlpha) { transparencyType = TextureTransparencyType.Alpha; return transparencyType; }
+					if (hasTransparent && hasOpaque) { transparencyType = TextureTransparencyType.Partial; return transparencyType; }
+					if (hasTransparent && !hasOpaque) { transparencyType = TextureTransparencyType.Transparent; return transparencyType; }
+				}
+				transparencyType = TextureTransparencyType.Opaque;
+				break;
 				case PixelFormat.RGB:
 					transparencyType = TextureTransparencyType.Opaque;
 					break;

--- a/source/Plugins/Texture.Ace/Plugin.Parser.cs
+++ b/source/Plugins/Texture.Ace/Plugin.Parser.cs
@@ -302,7 +302,7 @@ namespace Texture.Ace {
 
 							offset -= 2;
 						}
-						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGB, bytes, null);
+						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGB, bytes, (OpenBveApi.Colors.Color24[])null);
 					}
 
 					if (type == 16 & channels == 4)
@@ -362,7 +362,7 @@ namespace Texture.Ace {
 
 							offset -= 3;
 						}
-						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGBAlpha, bytes, null);
+						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGBAlpha, bytes, (OpenBveApi.Colors.Color24[])null);
 					}
 
 					if (type == 17 & channels == 5)
@@ -410,7 +410,7 @@ namespace Texture.Ace {
 
 							offset -= 3;
 						}
-						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGBAlpha, bytes, null);
+						return new OpenBveApi.Textures.Texture(width, height, PixelFormat.RGBAlpha, bytes, (OpenBveApi.Colors.Color24[])null);
 					}
 
 					if (type == 18 & (channels == 3 | channels == 4))
@@ -470,7 +470,7 @@ namespace Texture.Ace {
 
 						}
 
-						return new OpenBveApi.Textures.Texture(width, height, channels == 3 ? PixelFormat.RGB :  PixelFormat.RGBAlpha, bytes, null);
+						return new OpenBveApi.Textures.Texture(width, height, channels == 3 ? PixelFormat.RGB :  PixelFormat.RGBAlpha, bytes, (OpenBveApi.Colors.Color24[])null);
 					}
 
 					// --- not supported ---

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
@@ -100,6 +100,8 @@ namespace Plugin.GIF
 		protected byte[] compositionBuffer;
 		protected byte[] block = new byte[256]; // current data block
 		protected int blockSize; // block size
+		/// <summary>Pixels actually decoded for the current frame; the raster data may end early.</summary>
+		protected int decodedPixelCount;
 
 		// last graphic control extension info
 		protected DisposeMode dispose = DisposeMode.NoAction;
@@ -184,7 +186,9 @@ namespace Plugin.GIF
 			Array.Clear(dest, 0, bufLen);
 			// Backgrounds use the transparent slot once reserved.
 			byte bg = transparentEntry >= 0 ? (byte)transparentEntry : bgIndexByte;
-			bool hasPrev = lastDispose > DisposeMode.NoAction && bitmapBytes != null;
+			// NoAction leaves the canvas like LeaveInPlace; lastImageBytes proves a frame completed
+			// (bitmapBytes is already allocated for the current frame, so it can't decide).
+			bool hasPrev = lastImageBytes != null;
 			if (hasPrev)
 			{
 				Array.Copy(bitmapBytes, dest, bitmapBytes.Length);
@@ -280,7 +284,8 @@ namespace Plugin.GIF
 					int dlim = dx + (int)imageSize.X;
 					if (k + width < dlim) dlim = k + width;
 					int sx = i * (int)imageSize.X;
-					while (dx < dlim) 
+					if (sx >= decodedPixelCount) break; // raster data ended early: leave the canvas
+					while (dx < dlim && sx < decodedPixelCount)
 					{
 						int index = pixels[sx] & 0xff;
 						int orig = pixels[sx++] & 0xff;
@@ -301,7 +306,8 @@ namespace Plugin.GIF
 		{
 			int[] dest = new int[width * height];
 			// fill in starting image contents based on last image's dispose code
-			if (lastDispose > DisposeMode.NoAction)
+			// (NoAction leaves the canvas too, see SetPixelsIndexed)
+			if (lastDispose >= DisposeMode.NoAction)
 			{
 				Array.Copy(bitmap, dest, bitmap.Length);
 				
@@ -380,7 +386,8 @@ namespace Plugin.GIF
 						dlim = k + width; // past dest edge
 					}
 					int sx = i * (int)imageSize.X; // start of line in source
-					while (dx < dlim) 
+					if (sx >= decodedPixelCount) break; // raster data ended early: leave the canvas
+					while (dx < dlim && sx < decodedPixelCount)
 					{
 						// map color and insert in destination
 						int index = pixels[sx++] & 0xff;
@@ -583,19 +590,20 @@ namespace Plugin.GIF
 					}
 					first = suffix[code] & 0xff;
 
-					//  Add a new string to the string table,
-
-					if (available >= MaxStackSize)
-						break;
+					//  Add a new string to the string table, unless full:
+					// deferred-CLEAR streams keep decoding instead of truncating.
 					pixelStack[top++] = (byte) first;
-					prefix[available] = (short) old_code;
-					suffix[available] = (byte) first;
-					available++;
-					if ((available & code_mask) == 0
-						&& available < MaxStackSize) 
+					if (available < MaxStackSize)
 					{
-						code_size++;
-						code_mask += available;
+						prefix[available] = (short) old_code;
+						suffix[available] = (byte) first;
+						available++;
+						if ((available & code_mask) == 0
+							&& available < MaxStackSize)
+						{
+							code_size++;
+							code_mask += available;
+						}
 					}
 					old_code = in_code;
 				}
@@ -609,8 +617,9 @@ namespace Plugin.GIF
 
 			for (i = pi; i < npix; i++) 
 			{
-				pixels[i] = 0; // clear missing pixels
+				pixels[i] = 0; // clear missing pixels (never drawn: see decodedPixelCount)
 			}
+			decodedPixelCount = pi;
 
 		}
 
@@ -638,6 +647,7 @@ namespace Plugin.GIF
 			lastImageBytes = null;
 			_cachedExpandedFrame = null;
 			_cachedExpandedIndex = -1;
+			decodedPixelCount = 0;
 		}
 
 		/// <summary>Reads a single byte from the input stream</summary>

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
@@ -90,6 +90,8 @@ namespace Plugin.GIF
 		protected byte[] lastImageBytes;
 		/// <summary>Whether to use paletted (indexed) storage</summary>
 		protected bool usePaletted = true;
+		/// <summary>Reserved transparent palette slot, or -1. Never in paletteMap.</summary>
+		protected int transparentEntry = -1;
 		protected bool hasLocalPalette = false;
 		/// <summary>Reusable remap table for local-to-unified palette mapping (avoids per-frame allocation)</summary>
 		protected byte[] remapTable;
@@ -180,7 +182,8 @@ namespace Plugin.GIF
 			if (compositionBuffer == null || compositionBuffer.Length != bufLen) compositionBuffer = new byte[bufLen];
 			byte[] dest = compositionBuffer;
 			Array.Clear(dest, 0, bufLen);
-			byte bg = bgIndexByte;
+			// Backgrounds use the transparent slot once reserved.
+			byte bg = transparentEntry >= 0 ? (byte)transparentEntry : bgIndexByte;
 			bool hasPrev = lastDispose > DisposeMode.NoAction && bitmapBytes != null;
 			if (hasPrev)
 			{
@@ -628,6 +631,7 @@ namespace Plugin.GIF
 			unifiedPalette = null;
 			paletteMap = null;
 			usePaletted = true;
+			transparentEntry = -1;
 			hasLocalPalette = false;
 			bitmapBytes = null;
 			imageBytes = null;
@@ -905,7 +909,8 @@ namespace Plugin.GIF
 						{
 							if (paletteMap.Count >= 256) { canMerge = false; break; }
 							int newIdx = paletteMap.Count;
-							while (newIdx < 256 && paletteMap.ContainsValue(newIdx)) newIdx++;
+							// Keep real colors off the transparent slot.
+							while (newIdx < 256 && (paletteMap.ContainsValue(newIdx) || newIdx == transparentEntry)) newIdx++;
 							if (newIdx >= 256) { canMerge = false; break; }
 							unifiedPalette[newIdx] = c;
 							paletteMap[key] = newIdx;
@@ -931,6 +936,20 @@ namespace Plugin.GIF
 				activeColorTable[transIndex] = 0; // set transparent color if specified (for legacy RGBA path)
 				// For paletted path, transparency is handled by skipping the index in SetPixelsIndexed,
 				// so do NOT modify unifiedPalette alpha here – it would make that palette entry transparent for all frames
+				// Instead reserve one transparent slot (global-table slots are never free).
+				if (usePaletted && transparentEntry < 0 && unifiedPalette != null && paletteMap != null)
+				{
+					int minSlot = golbalColorTableFlag ? golbalColorTableSize : 0;
+					for (int i = minSlot; i < 256; i++)
+					{
+						if (!paletteMap.ContainsValue(i))
+						{
+							transparentEntry = i;
+							unifiedPalette[i] = new Color32(0, 0, 0, 0);
+							break;
+						}
+					}
+				}
 			}
 
 			if (activeColorTable == null) 

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenBveApi.Colors;
 using OpenBveApi.Math;
 
 namespace Plugin.GIF
@@ -56,10 +57,20 @@ namespace Plugin.GIF
 		protected int[] localColorTable;
 		/// <summary>Gets the active color table</summary>
 		protected int[] activeColorTable => lctFlag ? localColorTable : globalColorTable;
+		/// <summary>Stores the global palette as 32-bit colors (for paletted output)</summary>
+		protected Color32[] globalPalette32;
+		/// <summary>Unified palette for paletted output (global + merged locals)</summary>
+		protected Color32[] unifiedPalette;
+		/// <summary>Map from packed ARGB to unified palette index</summary>
+		protected Dictionary<int,int> paletteMap;
+		private static int PackColor(Color32 c) => (c.A << 24) | (c.R << 16) | (c.G << 8) | c.B;
+		private static int PackColor(byte r, byte g, byte b, byte a) => (a << 24) | (r << 16) | (g << 8) | b;
 		/// <summary>The index of the background color within the global color table</summary>
 		protected int bgIndex;
+		protected byte bgIndexByte;
 		protected int bgColor; // background color
 		protected int lastBgColor; // previous bg color
+		protected byte lastBgIndex;
 		/// <summary>The pixel aspect ratio</summary>
 		protected int pixelAspect;
 		/// <summary>Whether the local color table is in use</summary>
@@ -73,6 +84,15 @@ namespace Plugin.GIF
 		protected int[] image; // current frame
 		protected int[] bitmap;
 		protected int[] lastImage; // previous frame
+		/// <summary>Indexed (1 Bpp) storage for paletted optimization</summary>
+		protected byte[] imageBytes;
+		protected byte[] bitmapBytes;
+		protected byte[] lastImageBytes;
+		/// <summary>Whether to use paletted (indexed) storage</summary>
+		protected bool usePaletted = true;
+		protected bool hasLocalPalette = false;
+		/// <summary>Reusable remap table for local-to-unified palette mapping (avoids per-frame allocation)</summary>
+		protected byte[] remapTable;
 
 		protected byte[] block = new byte[256]; // current data block
 		protected int blockSize; // block size
@@ -94,6 +114,8 @@ namespace Plugin.GIF
 		protected byte[] pixels;
 
 		protected List<int[]> frames;
+		/// <summary>Indexed frames for paletted output (1 byte per pixel)</summary>
+		protected List<byte[]> indexedFrames;
 		protected List<int> delays;
 
 		protected int frameCount;
@@ -116,7 +138,139 @@ namespace Plugin.GIF
 		{
 			return frameCount;
 		}
+
+		/// <summary>Gets palette for paletted output (Color32 with alpha)</summary>
+		public Color32[] GetPalette()
+		{
+			if (unifiedPalette != null) return unifiedPalette;
+			if (globalPalette32 != null) return globalPalette32;
+			return null;
+		}
+
+		/// <summary>Gets an indexed frame (1 byte per pixel) for paletted output</summary>
+		public byte[] GetIndexedFrame(int n)
+		{
+			if (n >= 0 && n < frameCount && indexedFrames != null && n < indexedFrames.Count) return indexedFrames[n];
+			return null;
+		}
 		
+		/// <summary>Sets the pixels for a GIF frame, indexed version (1 Bpp) for paletted optimization</summary>
+		protected void SetPixelsIndexed() 
+		{
+			byte[] dest = new byte[width * height];
+			byte bg = bgIndexByte;
+			bool hasPrev = lastDispose > DisposeMode.NoAction && bitmapBytes != null;
+			if (hasPrev)
+			{
+				Array.Copy(bitmapBytes, dest, bitmapBytes.Length);
+				if (lastDispose == DisposeMode.RestoreToPrevious)
+				{
+					int n = frameCount - 2;
+					byte[] prev = n > 0 ? GetIndexedFrame(n - 1) : null;
+					if (prev != null) lastImageBytes = prev;
+				}
+				if (lastImageBytes != null) 
+				{
+					if (lastDispose == DisposeMode.RestoreToBackground) 
+					{
+						int startX = (int)imagePosition.X;
+						int startY = (int)imagePosition.Y;
+						int w = (int)imageSize.X;
+						int h = (int)imageSize.Y;
+						for (int y = 0; y < h; y++)
+						{
+							int line = startY + y;
+							if (line < 0 || line >= height) continue;
+							int baseIdx = line * width + startX;
+							for (int x = 0; x < w; x++)
+							{
+								if (baseIdx + x >= 0 && baseIdx + x < dest.Length)
+									dest[baseIdx + x] = bg;
+							}
+						}
+					}
+					else
+					{
+						Array.Copy(lastImageBytes, 0, dest, 0, Math.Min(lastImageBytes.Length, dest.Length));
+						Array.Copy(lastImageBytes, 0, bitmapBytes, 0, Math.Min(lastImageBytes.Length, bitmapBytes.Length));
+					}
+				}
+			}
+			else
+			{
+				for (int i = 0; i < dest.Length; i++) dest[i] = bg;
+			}
+			byte[] remap = null;
+			if (lctFlag && localColorTable != null && unifiedPalette != null)
+			{
+				if (remapTable == null) remapTable = new byte[256];
+				remap = remapTable;
+				for (int i = 0; i < 256; i++) remap[i] = (byte)i;
+				if (paletteMap != null)
+				{
+					int localSize = 2 << 7; // will be overridden by actual size; use localColorTable length
+					localSize = Math.Min(localSize, localColorTable.Length);
+					// Determine actual local size from packed value would need caller; approximate by scanning non-zero
+					for (int i = 0; i < localColorTable.Length && i < 256; i++)
+					{
+						int col = localColorTable[i];
+						byte r = (byte)(col & 0xFF);
+						byte g = (byte)((col >> 8) & 0xFF);
+						byte b = (byte)((col >> 16) & 0xFF);
+						Color32 c = new Color32(r,g,b,255);
+						if (transparency && i == transIndex) c.A = 0;
+						int key = PackColor(c);
+						int unifiedIdx;
+						if (paletteMap.TryGetValue(key, out unifiedIdx))
+							remap[i] = (byte)unifiedIdx;
+					}
+				}
+			}
+			int pass = 1;
+			int inc = 8;
+			int iline = 0;
+			for (int i = 0; i < imageSize.Y; i++) 
+			{
+				int line = i;
+				if (interlace) 
+				{
+					if (iline >= imageSize.Y) 
+					{
+						pass++;
+						switch (pass) 
+						{
+							case 2 : iline = 4; break;
+							case 3 : iline = 2; inc = 4; break;
+							case 4 : iline = 1; inc = 2; break;
+						}
+					}
+					line = iline;
+					iline += inc;
+				}
+				line += (int)imagePosition.Y;
+				if (line < height) 
+				{
+					int k = line * width;
+					int dx = k + (int)imagePosition.X;
+					int dlim = dx + (int)imageSize.X;
+					if (k + width < dlim) dlim = k + width;
+					int sx = i * (int)imageSize.X;
+					while (dx < dlim) 
+					{
+						int index = pixels[sx] & 0xff;
+						int orig = pixels[sx++] & 0xff;
+						if (lctFlag && remap != null) index = remap[index] & 0xFF;
+						if (!(transparency && orig == transIndex))
+						{
+							dest[dx] = (byte)index;
+						}
+						dx++;
+					}
+				}
+			}
+			Array.Copy(dest, bitmapBytes, dest.Length);
+		}
+
 		/// <summary>Sets the pixels for a GIF frame from the current bitmap</summary>
 		protected void SetPixels() 
 		{
@@ -143,7 +297,7 @@ namespace Plugin.GIF
 						{
 							if (transparency)
 							{
-								image[i] = BitConverter.ToInt32(new byte[] {0,0,0,byte.MaxValue}, 0); 	// assume background is transparent
+								image[i] = unchecked((int)0xFF000000); 	// assume background is transparent
 							} 
 							else
 							{
@@ -222,6 +376,22 @@ namespace Plugin.GIF
 		/// <returns>The image</returns>
 		public int[] GetFrame(int n) 
 		{
+			// If paletted optimization is active, expand on demand for legacy callers
+			if (usePaletted && indexedFrames != null && n >= 0 && n < indexedFrames.Count && indexedFrames[n] != null)
+			{
+				byte[] idx = indexedFrames[n];
+				Color32[] pal = GetPalette();
+				int[] expanded = new int[idx.Length];
+				for (int i = 0; i < idx.Length; i++)
+				{
+					int index = idx[i] & 0xFF;
+						if (pal != null && index < pal.Length)
+						expanded[i] = pal[index].R | (pal[index].G << 8) | (pal[index].B << 16) | (pal[index].A << 24);
+					else
+						expanded[i] = unchecked((int)0xFF000000);
+				}
+				return expanded;
+			}
 			int[] im = null;
 			if (n >= 0 && n < frameCount) 
 			{
@@ -424,9 +594,15 @@ namespace Plugin.GIF
 			status = DecoderStatus.OK;
 			frameCount = 0;
 			frames = new List<int[]>();
+			indexedFrames = new List<byte[]>();
 			delays = new List<int>();
 			globalColorTable = null;
 			localColorTable = null;
+			globalPalette32 = null;
+			unifiedPalette = null;
+			paletteMap = null;
+			usePaletted = true;
+			hasLocalPalette = false;
 		}
 
 		/// <summary>Reads a single byte from the input stream</summary>
@@ -481,6 +657,25 @@ namespace Plugin.GIF
 			return n;
 		}
 
+		/// <summary>Reads the GIF Color Table as Color32 array</summary>
+		protected Color32[] ReadColorTable32(int numberOfColors)
+		{
+			int nbytes = 3 * numberOfColors;
+			Color32[] tab = new Color32[256];
+			byte[] c = new byte[nbytes];
+			int n = 0;
+			try { n = inStream.Read(c, 0, c.Length); } catch (IOException) {}
+			if (n < nbytes) { status = DecoderStatus.FormatError; return null; }
+			int j = 0;
+			for (int i=0;i<numberOfColors;i++)
+			{
+				byte r = c[j++]; byte g = c[j++]; byte b = c[j++];
+				tab[i] = new Color32(r,g,b,255);
+			}
+			for (int i=numberOfColors;i<256;i++) tab[i] = new Color32(0,0,0,255);
+			return tab;
+		}
+
 		/// <summary>Reads the GIF Color Table as 256 integer values</summary>
 		/// <param name="numberOfColors">The number of colors to read</param>
 		/// <returns>The GIF color table</returns>
@@ -511,7 +706,7 @@ namespace Plugin.GIF
 					byte r = (byte) (c[j++] & 0xff);
 					byte g = (byte) (c[j++] & 0xff);
 					byte b = (byte) (c[j++] & 0xff);
-					tab[i++] = BitConverter.ToInt32(new[] {r,g,b,byte.MaxValue}, 0);
+					tab[i++] = r | (g << 8) | (b << 16) | unchecked((int)0xFF000000);
 				}
 			}
 			return tab;
@@ -609,6 +804,25 @@ namespace Plugin.GIF
 			{
 				globalColorTable = ReadColorTable(golbalColorTableSize);
 				bgColor = globalColorTable[bgIndex];
+				bgIndexByte = (byte)bgIndex;
+				if (globalColorTable != null)
+				{
+					globalPalette32 = new Color32[256];
+					for (int i=0;i<256;i++)
+					{
+						int col = globalColorTable[i];
+						byte r = (byte)(col & 0xFF);
+						byte g = (byte)((col>>8)&0xFF);
+						byte b = (byte)((col>>16)&0xFF);
+						byte a = (byte)((col>>24)&0xFF);
+						if (a==0) a=255;
+						globalPalette32[i] = new Color32(r,g,b,a);
+					}
+					unifiedPalette = new Color32[256];
+					Array.Copy(globalPalette32, unifiedPalette, 256);
+					paletteMap = new Dictionary<int,int>();
+					for (int i=0;i<golbalColorTableSize;i++) paletteMap[PackColor(unifiedPalette[i])] = i;
+				}
 			}
 		}
 
@@ -627,6 +841,51 @@ namespace Plugin.GIF
 			if (lctFlag) 
 			{
 				localColorTable = ReadColorTable(localColorTableSize); // read table
+				if (usePaletted && unifiedPalette == null && localColorTable != null)
+				{
+					// No global palette – initialise unified from first local palette
+					unifiedPalette = new Color32[256];
+					paletteMap = new Dictionary<int,int>();
+					for (int i = 0; i < localColorTableSize; i++)
+					{
+						int col = localColorTable[i];
+						byte r = (byte)(col & 0xFF); byte g = (byte)((col>>8)&0xFF); byte b = (byte)((col>>16)&0xFF);
+						Color32 c = new Color32(r,g,b,255);
+						unifiedPalette[i] = c;
+						paletteMap[PackColor(c)] = i;
+					}
+					for (int i = localColorTableSize; i < 256; i++) unifiedPalette[i] = new Color32(0,0,0,255);
+					hasLocalPalette = true;
+				}
+				if (usePaletted && unifiedPalette != null && localColorTable != null)
+				{
+					Color32[] localPal = new Color32[localColorTableSize];
+					for (int i=0;i<localColorTableSize;i++)
+					{
+						int col = localColorTable[i];
+						byte r = (byte)(col & 0xFF); byte g = (byte)((col>>8)&0xFF); byte b = (byte)((col>>16)&0xFF);
+						localPal[i] = new Color32(r,g,b,255);
+					}
+					bool canMerge = true;
+					foreach (var c in localPal)
+					{
+						int key = PackColor(c);
+						if (!paletteMap.ContainsKey(key))
+						{
+							if (paletteMap.Count >= 256) { canMerge = false; break; }
+							int newIdx = paletteMap.Count;
+							while (newIdx < 256 && paletteMap.ContainsValue(newIdx)) newIdx++;
+							if (newIdx >= 256) { canMerge = false; break; }
+							unifiedPalette[newIdx] = c;
+							paletteMap[key] = newIdx;
+						}
+					}
+					if (!canMerge)
+					{
+						usePaletted = false;
+					}
+					else hasLocalPalette = true;
+				}
 			} 
 			else 
 			{
@@ -635,10 +894,12 @@ namespace Plugin.GIF
 			}
 			int save = 0;
 			
-			if (transparency) 
+			if (transparency && activeColorTable != null) 
 			{
 				save = activeColorTable[transIndex];
-				activeColorTable[transIndex] = 0; // set transparent color if specified
+				activeColorTable[transIndex] = 0; // set transparent color if specified (for legacy RGBA path)
+				// For paletted path, transparency is handled by skipping the index in SetPixelsIndexed,
+				// so do NOT modify unifiedPalette alpha here – it would make that palette entry transparent for all frames
 			}
 
 			if (activeColorTable == null) 
@@ -654,17 +915,38 @@ namespace Plugin.GIF
 			if (Error) return;
 
 			frameCount++;
-			// create new image to receive frame data
-			bitmap = new int[width * height];
-			image = bitmap;
-			SetPixels(); // transfer pixel data to image
-
-			frames.Add(bitmap); // add image to frame list
-			delays.Add(delay);
-
-			if (transparency && activeColorTable != null) 
+			if (usePaletted)
 			{
-				activeColorTable[transIndex] = save;
+				bitmapBytes = bitmapBytes ?? new byte[width * height];
+				if (bitmapBytes.Length != width*height) bitmapBytes = new byte[width*height];
+				imageBytes = bitmapBytes;
+				SetPixelsIndexed();
+				byte[] stored = new byte[bitmapBytes.Length];
+				Array.Copy(bitmapBytes, stored, stored.Length);
+				indexedFrames.Add(stored);
+				frames.Add(null); // keep frames list aligned for legacy callers
+				delays.Add(delay);
+				if (transparency && activeColorTable != null) 
+				{
+					activeColorTable[transIndex] = save;
+				}
+			}
+			else
+			{
+				// Fallback RGBA path (preserves original comments and logic)
+				// create new image to receive frame data
+				bitmap = new int[width * height];
+				image = bitmap;
+				SetPixels(); // transfer pixel data to image
+
+				frames.Add(bitmap); // add image to frame list
+				indexedFrames.Add(null);
+				delays.Add(delay);
+
+				if (transparency && activeColorTable != null) 
+				{
+					activeColorTable[transIndex] = save;
+				}
 			}
 			ResetFrame();
 
@@ -723,8 +1005,16 @@ namespace Plugin.GIF
 		protected void ResetFrame() 
 		{
 			lastDispose = dispose;
-			lastImage = image;
-			lastBgColor = bgColor;
+			if (usePaletted)
+			{
+				lastImageBytes = imageBytes;
+				lastBgIndex = bgIndexByte;
+			}
+			else
+			{
+				lastImage = image;
+				lastBgColor = bgColor;
+			}
 			transparency = false;
 			delay = 0;
 			localColorTable = null;

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
@@ -94,6 +94,8 @@ namespace Plugin.GIF
 		/// <summary>Reusable remap table for local-to-unified palette mapping (avoids per-frame allocation)</summary>
 		protected byte[] remapTable;
 
+			/// <summary>Reusable composition buffer for SetPixelsIndexed (avoids per-frame alloc)</summary>
+		protected byte[] compositionBuffer;
 		protected byte[] block = new byte[256]; // current data block
 		protected int blockSize; // block size
 
@@ -117,6 +119,10 @@ namespace Plugin.GIF
 		/// <summary>Indexed frames for paletted output (1 byte per pixel)</summary>
 		protected List<byte[]> indexedFrames;
 		protected List<int> delays;
+
+		/// <summary>Cached expanded frame for GetFrame() paletted path (avoids per-call alloc)</summary>
+		private int[] _cachedExpandedFrame;
+		private int _cachedExpandedIndex = -1;
 
 		protected int frameCount;
 
@@ -157,7 +163,10 @@ namespace Plugin.GIF
 		/// <summary>Sets the pixels for a GIF frame, indexed version (1 Bpp) for paletted optimization</summary>
 		protected void SetPixelsIndexed() 
 		{
-			byte[] dest = new byte[width * height];
+			int bufLen = width * height;
+			if (compositionBuffer == null || compositionBuffer.Length != bufLen) compositionBuffer = new byte[bufLen];
+			byte[] dest = compositionBuffer;
+			Array.Clear(dest, 0, bufLen);
 			byte bg = bgIndexByte;
 			bool hasPrev = lastDispose > DisposeMode.NoAction && bitmapBytes != null;
 			if (hasPrev)
@@ -379,6 +388,8 @@ namespace Plugin.GIF
 			// If paletted optimization is active, expand on demand for legacy callers
 			if (usePaletted && indexedFrames != null && n >= 0 && n < indexedFrames.Count && indexedFrames[n] != null)
 			{
+				// Return cached expanded frame if same index (avoids per-call alloc)
+				if (_cachedExpandedFrame != null && _cachedExpandedIndex == n) return _cachedExpandedFrame;
 				byte[] idx = indexedFrames[n];
 				Color32[] pal = GetPalette();
 				int[] expanded = new int[idx.Length];
@@ -390,6 +401,8 @@ namespace Plugin.GIF
 					else
 						expanded[i] = unchecked((int)0xFF000000);
 				}
+				_cachedExpandedFrame = expanded;
+				_cachedExpandedIndex = n;
 				return expanded;
 			}
 			int[] im = null;

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/GIF/GifDecoder.cs
@@ -159,6 +159,19 @@ namespace Plugin.GIF
 			if (n >= 0 && n < frameCount && indexedFrames != null && n < indexedFrames.Count) return indexedFrames[n];
 			return null;
 		}
+
+		/// <summary>Gets whether every decoded frame is stored as indexed (paletted) data</summary>
+		/// <remarks>If a mid-stream local palette cannot be merged (&gt;256 total colors), later frames fall back
+		/// to RGBA and this returns false — callers must then use the RGBA path for all frames.</remarks>
+		public bool IsFullyPaletted()
+		{
+			if (frameCount <= 0 || indexedFrames == null || indexedFrames.Count != frameCount) return false;
+			for (int i = 0; i < indexedFrames.Count; i++)
+			{
+				if (indexedFrames[i] == null) return false;
+			}
+			return true;
+		}
 		
 		/// <summary>Sets the pixels for a GIF frame, indexed version (1 Bpp) for paletted optimization</summary>
 		protected void SetPixelsIndexed() 
@@ -616,6 +629,11 @@ namespace Plugin.GIF
 			paletteMap = null;
 			usePaletted = true;
 			hasLocalPalette = false;
+			bitmapBytes = null;
+			imageBytes = null;
+			lastImageBytes = null;
+			_cachedExpandedFrame = null;
+			_cachedExpandedIndex = -1;
 		}
 
 		/// <summary>Reads a single byte from the input stream</summary>
@@ -949,6 +967,22 @@ namespace Plugin.GIF
 				// Fallback RGBA path (preserves original comments and logic)
 				// create new image to receive frame data
 				bitmap = new int[width * height];
+				if (bitmapBytes != null && unifiedPalette != null)
+				{
+					// First RGBA frame after indexed frames: seed the canvas from the indexed
+					// composition so disposal/compositing continues instead of restarting from black.
+					int len = Math.Min(bitmap.Length, bitmapBytes.Length);
+					for (int i = 0; i < len; i++)
+					{
+						int index = bitmapBytes[i] & 0xFF;
+						if (index < unifiedPalette.Length)
+						{
+							Color32 c = unifiedPalette[index];
+							bitmap[i] = c.R | (c.G << 8) | (c.B << 16) | (c.A << 24);
+						}
+						else bitmap[i] = unchecked((int)0xFF000000);
+					}
+				}
 				image = bitmap;
 				SetPixels(); // transfer pixel data to image
 
@@ -1020,7 +1054,14 @@ namespace Plugin.GIF
 			lastDispose = dispose;
 			if (usePaletted)
 			{
-				lastImageBytes = imageBytes;
+				// Copy, do not alias: imageBytes references the reused bitmapBytes canvas,
+				// so a plain assignment would make lastImageBytes track future mutations.
+				if (imageBytes != null)
+				{
+					if (lastImageBytes == null || lastImageBytes.Length != imageBytes.Length) lastImageBytes = new byte[imageBytes.Length];
+					Array.Copy(imageBytes, lastImageBytes, imageBytes.Length);
+				}
+				else lastImageBytes = null;
 				lastBgIndex = bgIndexByte;
 			}
 			else

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/Plugin.Parser.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/Plugin.Parser.cs
@@ -49,20 +49,38 @@ namespace Plugin {
 					{
 						decoder.Read(file);
 						int frameCount = decoder.GetFrameCount();
-						int duration = 0;
-						if (frameCount != 1)
+						if (frameCount > 0)
 						{
 							Vector2 frameSize = decoder.GetFrameSize();
-							byte[][] frameBytes = new byte[frameCount][];
-							for (int i = 0; i < frameCount; i++)
+							int duration = 0;
+							for (int i = 0; i < frameCount; i++) duration += decoder.GetDuration(i);
+							double interval = frameCount > 0 ? ((double)duration / frameCount) / 10000000.0 : 0;
+							if (frameCount > 1)
 							{
-								int[] framePixels = decoder.GetFrame(i);
-								frameBytes[i] = new byte[framePixels.Length * sizeof(int)];
-								Buffer.BlockCopy(framePixels, 0, frameBytes[i], 0, frameBytes[i].Length);
-								duration += decoder.GetDuration(i);
+								var palette = decoder.GetPalette();
+								byte[] firstIndexed = decoder.GetIndexedFrame(0);
+								if (palette != null && firstIndexed != null)
+								{
+									byte[][] frameBytes = new byte[frameCount][];
+									for (int i = 0; i < frameCount; i++) frameBytes[i] = decoder.GetIndexedFrame(i);
+									texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.Paletted, frameBytes, palette, interval);
+									return true;
+								}
 							}
-							texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.RGBAlpha, frameBytes, ((double)duration / frameCount) / 10000000.0);
-							return true;
+							// Fallback RGBA (single-frame or local palette >256)
+							if (frameCount != 1)
+							{
+								byte[][] frameBytes = new byte[frameCount][];
+								for (int i = 0; i < frameCount; i++)
+								{
+									int[] framePixels = decoder.GetFrame(i);
+									if (framePixels == null) continue;
+									frameBytes[i] = new byte[framePixels.Length * sizeof(int)];
+									Buffer.BlockCopy(framePixels, 0, frameBytes[i], 0, frameBytes[i].Length);
+								}
+								texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.RGBAlpha, frameBytes, interval);
+								return true;
+							}
 						}
 					}
 				}
@@ -87,7 +105,7 @@ namespace Plugin {
 					{
 						if (decoder.Read(file))
 						{
-							texture = new Texture(decoder.Width, decoder.Height, (OpenBveApi.Textures.PixelFormat)decoder.BytesPerPixel, decoder.pixelBuffer, null);
+							texture = new Texture(decoder.Width, decoder.Height, (OpenBveApi.Textures.PixelFormat)decoder.BytesPerPixel, decoder.pixelBuffer, (OpenBveApi.Colors.Color24[])null);
 							return true;
 						}
 					}
@@ -109,7 +127,7 @@ namespace Plugin {
 				byte[] raw = GetRawBitmapData(bitmap, out width, out height);
 				if (raw != null)
 				{
-					texture = new Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, raw, null);
+					texture = new Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, raw, (OpenBveApi.Colors.Color24[])null);
 					return true;
 				}
 				texture = null;

--- a/source/Plugins/Texture.BmpGifJpegPngTiff/Plugin.Parser.cs
+++ b/source/Plugins/Texture.BmpGifJpegPngTiff/Plugin.Parser.cs
@@ -55,26 +55,39 @@ namespace Plugin {
 							int duration = 0;
 							for (int i = 0; i < frameCount; i++) duration += decoder.GetDuration(i);
 							double interval = frameCount > 0 ? ((double)duration / frameCount) / 10000000.0 : 0;
-							if (frameCount > 1)
+						if (frameCount >= 1)
+						{
+							var palette = decoder.GetPalette();
+							// Only use the paletted fast path when EVERY frame decoded as indexed:
+							// a mid-stream palette merge failure (>256 total colors) leaves later
+							// frames as RGBA, which the fallback path below expands correctly.
+							if (palette != null && decoder.IsFullyPaletted())
 							{
-								var palette = decoder.GetPalette();
-								byte[] firstIndexed = decoder.GetIndexedFrame(0);
-								if (palette != null && firstIndexed != null)
+								if (frameCount == 1)
 								{
-									byte[][] frameBytes = new byte[frameCount][];
-									for (int i = 0; i < frameCount; i++) frameBytes[i] = decoder.GetIndexedFrame(i);
-									texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.Paletted, frameBytes, palette, interval);
+									texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.Paletted, decoder.GetIndexedFrame(0), palette);
 									return true;
 								}
-							}
-							// Fallback RGBA (single-frame or local palette >256)
-							if (frameCount != 1)
-							{
 								byte[][] frameBytes = new byte[frameCount][];
+								for (int i = 0; i < frameCount; i++) frameBytes[i] = decoder.GetIndexedFrame(i);
+								texture = new Texture((int)frameSize.X, (int)frameSize.Y, OpenBveApi.Textures.PixelFormat.Paletted, frameBytes, palette, interval);
+								return true;
+							}
+						}
+						// Fallback RGBA (multi-frame with >256 total colors or mixed indexed/RGBA frames; single-frame failures use the GDI+ path below)
+						if (frameCount != 1)
+						{
+							byte[][] frameBytes = new byte[frameCount][];
 								for (int i = 0; i < frameCount; i++)
 								{
 									int[] framePixels = decoder.GetFrame(i);
-									if (framePixels == null) continue;
+									if (framePixels == null)
+									{
+										// Should not happen (every decoded frame has indexed or RGBA data),
+										// but never hand a null frame to Texture - it would NRE downstream.
+										frameBytes[i] = new byte[(int)frameSize.X * (int)frameSize.Y * sizeof(int)];
+										continue;
+									}
 									frameBytes[i] = new byte[framePixels.Length * sizeof(int)];
 									Buffer.BlockCopy(framePixels, 0, frameBytes[i], 0, frameBytes[i].Length);
 								}

--- a/source/Plugins/Texture.Dds/Plugin.Parser.cs
+++ b/source/Plugins/Texture.Dds/Plugin.Parser.cs
@@ -70,7 +70,7 @@ namespace Texture.Dds
 
         private void CreateTexture(int width, int height, byte[] rawData)
         {
-	        myTexture = new OpenBveApi.Textures.Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, rawData, null);
+	        myTexture = new OpenBveApi.Textures.Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, rawData, (OpenBveApi.Colors.Color24[])null);
         }
 
         private static PixelFormat GetFormat(DdsHeader header, out int blocksize)

--- a/source/Plugins/Texture.Tga/Plugin.Parser.cs
+++ b/source/Plugins/Texture.Tga/Plugin.Parser.cs
@@ -646,7 +646,7 @@ namespace Texture.Tga
 				int width = bitmap.Width;
 				int height = bitmap.Height;
 				bitmap.Dispose();
-				texture = new OpenBveApi.Textures.Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, raw, null);
+				texture = new OpenBveApi.Textures.Texture(width, height, OpenBveApi.Textures.PixelFormat.RGBAlpha, raw, (OpenBveApi.Colors.Color24[])null);
 				return true;
 			}
 			else

--- a/source/RouteViewer/LoadingR.cs
+++ b/source/RouteViewer/LoadingR.cs
@@ -68,7 +68,7 @@ namespace RouteViewer {
 			Program.Renderer.Loading.InitLoading(Program.FileSystem.GetDataFolder("In-game"), typeof(NewRenderer).Assembly.GetName().Version.ToString(), Interface.CurrentOptions.LoadingLogo, Interface.CurrentOptions.LoadingProgressBar);
 			if (textureBytes != null && textureBytes.Length > 0)
 			{
-				Texture t = new Texture(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, PixelFormat.RGBAlpha, textureBytes, null);
+				Texture t = new Texture(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, PixelFormat.RGBAlpha, textureBytes, (OpenBveApi.Colors.Color24[])null);
 				Program.Renderer.Loading.SetLoadingBkg(t);
 			}
 			// members


### PR DESCRIPTION
WIP, although it works Im pretty sure we can pull down the RAM usage more...

As mentioned on https://github.com/leezer3/OpenBVE/issues/1402#issuecomment-5478917728

Testing with file LCD_Gif.csv from that issue, in train type 280 folder.

Currently loading that csv file can take fixed 430MB~ RAM

Tested with locally release build object viewer:
This one is latest master with the last commit 21f1bb790af49143301dd6411c6acd316e65ce17

<img width="500" height="86" alt="image" src="https://github.com/user-attachments/assets/d27ef456-2a0f-4a60-b677-f68f59a3f240" />

Pretty crazy for just one file. it was feels like memory leaks or need more aggressive GC

This one is this PR.

<img width="483" height="25" alt="image" src="https://github.com/user-attachments/assets/6a0cc548-a174-4995-ac1c-05a48d250de6" />

No visual difference as far as i see.


---

@leezer3 what do you think? 

Sorry the code a bit messy 😅