### PR TITLE
Add TriFace, TriFace2 to CSV B3D parser

### DIFF
--- a/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
+++ b/source/OpenBveApi/Objects/ObjectTypes/StaticObject.cs
@@ -12,7 +12,7 @@ namespace OpenBveApi.Objects
 	public class StaticObject : UnifiedObject
 	{
 		/// <summary>Whether the object is optimized</summary>
-		private bool isOptimized;
+		public bool Optimized;
 		/// <summary>The mesh of the object</summary>
 		public Mesh Mesh;
 		/// <summary>The starting track position, for static objects only.</summary>
@@ -47,7 +47,7 @@ namespace OpenBveApi.Objects
 				EndingTrackDistance = EndingTrackDistance,
 				Dynamic = Dynamic,
 				Mesh = {Vertices = new VertexTemplate[Mesh.Vertices.Length]},
-				isOptimized = isOptimized
+				Optimized = Optimized
 			};
 			// vertices
 			for (int j = 0; j < Mesh.Vertices.Length; j++)
@@ -89,7 +89,7 @@ namespace OpenBveApi.Objects
 				EndingTrackDistance = EndingTrackDistance,
 				Dynamic = Dynamic,
 				Mesh = {Vertices = new VertexTemplate[Mesh.Vertices.Length]},
-				isOptimized = isOptimized
+				Optimized = Optimized
 			};
 			// vertices
 			for (int j = 0; j < Mesh.Vertices.Length; j++)
@@ -136,7 +136,7 @@ namespace OpenBveApi.Objects
 				}
 				mirrorResult.Mesh.Faces[i].Flip();
 			}
-			mirrorResult.isOptimized = isOptimized;
+			mirrorResult.Optimized = Optimized;
 			return mirrorResult;
 		}
 
@@ -589,11 +589,11 @@ namespace OpenBveApi.Objects
 		/// <inheritdoc />
 		public override void OptimizeObject(bool preserveVerticies, int faceThreshold, bool vertexCulling)
 		{
-			if (isOptimized)
+			if (Optimized)
 			{
 				return;
 			}
-			isOptimized = true;
+			Optimized = true;
 			int m = Mesh.Materials.Length;
 			int f = Mesh.Faces.Length;
 			

--- a/source/Plugins/Formats.OpenBve/Enums/CSVB3D/CSVB3DKey.cs
+++ b/source/Plugins/Formats.OpenBve/Enums/CSVB3D/CSVB3DKey.cs
@@ -14,11 +14,13 @@ namespace Formats.OpenBve
 		AddFace = Face,
 		/// <summary>Adds a new 1-sided face consisting of triangles</summary>
 		TriFace,
+		AddTriFace = TriFace,
 		/// <summary>Adds a new 2-sided face</summary>
 		Face2,
 		AddFace2 = Face2,
 		/// <summary>Adds a new 2-sided face consisting of triangles</summary>
 		TriFace2,
+		AddTriFace2 = TriFace2,
 		/// <summary>Sets the color of all preceding faces in the MeshBuilder</summary>
 		Color,
 		SetColor = Color,

--- a/source/Plugins/Formats.OpenBve/Enums/CSVB3D/CSVB3DKey.cs
+++ b/source/Plugins/Formats.OpenBve/Enums/CSVB3D/CSVB3DKey.cs
@@ -12,9 +12,13 @@ namespace Formats.OpenBve
 		/// <summary>Adds a new 1-sided face</summary>
 		Face,
 		AddFace = Face,
+		/// <summary>Adds a new 1-sided face consisting of triangles</summary>
+		TriFace,
 		/// <summary>Adds a new 2-sided face</summary>
 		Face2,
 		AddFace2 = Face2,
+		/// <summary>Adds a new 2-sided face consisting of triangles</summary>
+		TriFace2,
 		/// <summary>Sets the color of all preceding faces in the MeshBuilder</summary>
 		Color,
 		SetColor = Color,

--- a/source/Plugins/Object.CsvB3d/Plugin.NewParser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.NewParser.cs
@@ -73,6 +73,8 @@ namespace Object.CsvB3d
 							currentMeshBuilder.Vertices.Add(subBlock.GetNextVertex(out Vector3 currentNormal));
 							currentNormals.Add(currentNormal);
 							break;
+						case CSVB3DKey.TriFace:
+						case CSVB3DKey.TriFace2:
 						case CSVB3DKey.Face:
 						case CSVB3DKey.Face2:
 							if (subBlock.TryGetNextVertexIndexArray(out int[] faceVertices, Plugin.enabledHacks.BveTsHacks))
@@ -98,6 +100,13 @@ namespace Object.CsvB3d
 								{
 									int l = f.Vertices.Length;
 									(f.Vertices[l - 2], f.Vertices[l - 1]) = (f.Vertices[l - 1], f.Vertices[l - 2]);
+								}
+
+								if (key == CSVB3DKey.TriFace || key == CSVB3DKey.TriFace2)
+								{
+									// if we're using TriFace, assume the exporter has optimised
+									f.Flags |= FaceFlags.Triangles;
+									staticObject.Optimized = true;
 								}
 
 								if (key == CSVB3DKey.Face2)


### PR DESCRIPTION
https://bveworldwide.forumotion.com/t2562-drastic-fps-drop#22526

https://gist.github.com/leezer3/b26f9780a0c740ba8717c37f4a34ee53

The underlying trouble here is in how the exporter structures the model, and ultimately the modelling decisions made by the user.

This is the best way I can think of at the minute to detect a face that has had triangularisation performed on it (exporting a model that has had Blender's Limited Dissolve performed on it also does this).

@adfriz any useful thoughts? 
I suppose we could possibly test for the tri pattern in each set of 6 vertices, but you'll end up running practically the entire itinerator loop on the thing...

The other thing to note is that this is backwards incompatible, which is problematic...
You could I suppose introduce a new extension into the mix to differentiate these files, but either way this feels iffy...