### PR TITLE
Render custom fonts in the route map view

### DIFF
--- a/source/LibRender2/Text/Fonts.cs
+++ b/source/LibRender2/Text/Fonts.cs
@@ -25,6 +25,8 @@ namespace LibRender2.Text
 		/// <summary>Represents the largest sans serif font.</summary>
 		public readonly OpenGlFont EvenLargerFont;
 
+		public readonly FontFamily uiFont;
+
 		private static HostInterface currentHost;
 
 		/// <summary>Gets the next smallest font</summary>
@@ -77,7 +79,7 @@ namespace LibRender2.Text
 		public Fonts(HostInterface host, BaseRenderer renderer, string fontName)
 		{
 			currentHost = host;
-			FontFamily uiFont = FontFamily.GenericSansSerif;
+			uiFont = FontFamily.GenericSansSerif;
 			if (!string.IsNullOrEmpty(fontName))
 			{
 				try

--- a/source/LibRender2/Text/Fonts.cs
+++ b/source/LibRender2/Text/Fonts.cs
@@ -25,7 +25,6 @@ namespace LibRender2.Text
 		/// <summary>Represents the largest sans serif font.</summary>
 		public readonly OpenGlFont EvenLargerFont;
 
-		public readonly FontFamily uiFont;
 
 		private static HostInterface currentHost;
 
@@ -79,13 +78,12 @@ namespace LibRender2.Text
 		public Fonts(HostInterface host, BaseRenderer renderer, string fontName)
 		{
 			currentHost = host;
-			uiFont = FontFamily.GenericSansSerif;
+			FontFamily uiFont = FontFamily.GenericSansSerif;
 			if (!string.IsNullOrEmpty(fontName))
 			{
 				try
 				{
 					FontFamily newFont = new FontFamily(fontName);
-					uiFont = newFont;
 				}
 				catch
 				{

--- a/source/LibRender2/Text/OpenGlFont.cs
+++ b/source/LibRender2/Text/OpenGlFont.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using OpenBveApi.Math;
 using OpenBveApi.Textures;
@@ -10,7 +10,7 @@ namespace LibRender2.Text
 	{
 		// --- members ---
 		/// <summary>The underlying font.</summary>
-		private readonly Font Font;
+		public readonly Font Font;
 		/// <summary>The size of the underlying font in pixels.</summary>
 		public readonly float FontSize;
 		/// <summary>The 4352 tables containing 256 character each to make up 1114112 code points (U+0000...U+10FFFF).</summary>

--- a/source/OpenBVE/Game/Menu/Menu.Route.cs
+++ b/source/OpenBVE/Game/Menu/Menu.Route.cs
@@ -267,7 +267,7 @@ namespace OpenBve
 					}
 				}
 
-				routeMapTexture = new Texture(Illustrations.CreateRouteMap((int)routePictureBox.Size.X, (int)routePictureBox.Size.Y, false, out _));
+				routeMapTexture = new Texture(Illustrations.CreateRouteMap((int)routePictureBox.Size.X, (int)routePictureBox.Size.Y, false, out _, fontFamily: Program.Renderer.Fonts.uiFont));
 				nextImageButton.IsVisible = true;
 				previousImageButton.IsVisible = true;
 				routePictureBox.Texture = routeImageTexture;

--- a/source/OpenBVE/Game/Menu/Menu.Route.cs
+++ b/source/OpenBVE/Game/Menu/Menu.Route.cs
@@ -267,7 +267,7 @@ namespace OpenBve
 					}
 				}
 
-				routeMapTexture = new Texture(Illustrations.CreateRouteMap((int)routePictureBox.Size.X, (int)routePictureBox.Size.Y, false, out _, fontFamily: Program.Renderer.Fonts.uiFont));
+				routeMapTexture = new Texture(Illustrations.CreateRouteMap((int)routePictureBox.Size.X, (int)routePictureBox.Size.Y, false, out _, font: Program.Renderer.Fonts.NormalFont.Font));
 				nextImageButton.IsVisible = true;
 				previousImageButton.IsVisible = true;
 				routePictureBox.Texture = routeImageTexture;

--- a/source/OpenBVE/Game/SwitchChange/SwitchChangeDialog.cs
+++ b/source/OpenBVE/Game/SwitchChange/SwitchChangeDialog.cs
@@ -86,7 +86,7 @@ namespace OpenBve
 			ZoomInButton.Location = new Vector2(Program.Renderer.Screen.Width * 0.7, Program.Renderer.Screen.Height * 0.9);
 			ZoomOutButton.Location = new Vector2(ZoomInButton.Location.X - ZoomOutButton.Size.X - 5, Program.Renderer.Screen.Height * 0.9);
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
 			TitleLabel.Location = new Vector2(Program.Renderer.Screen.Width * 0.5 - TitleLabel.Size.X * 0.5, 5);
 			CloseButton.IsVisible = true;
 			ZoomInButton.IsVisible = true;
@@ -172,7 +172,7 @@ namespace OpenBve
 				Program.CurrentRoute.Switches[selectedSwitch].Toggle();
 				// Unload existing texture and re-create with new path
 				TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-				Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius), TextureParameters.NoChange, out MapPicturebox.Texture);
+				Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
 			}
 			CloseButton.MouseDown(x, y);
 			ZoomInButton.MouseDown(x, y);
@@ -190,7 +190,7 @@ namespace OpenBve
 			drawRadius /= 2;
 			// Unload existing texture and re-create with new path
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
 		}
 
 		/// <summary>Zooms the map out</summary>
@@ -204,7 +204,7 @@ namespace OpenBve
 			drawRadius *= 2;
 			// Unload existing texture and re-create with new path
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
 		}
 
 		internal void Close(object sender, EventArgs e)

--- a/source/OpenBVE/Game/SwitchChange/SwitchChangeDialog.cs
+++ b/source/OpenBVE/Game/SwitchChange/SwitchChangeDialog.cs
@@ -86,7 +86,7 @@ namespace OpenBve
 			ZoomInButton.Location = new Vector2(Program.Renderer.Screen.Width * 0.7, Program.Renderer.Screen.Height * 0.9);
 			ZoomOutButton.Location = new Vector2(ZoomInButton.Location.X - ZoomOutButton.Size.X - 5, Program.Renderer.Screen.Height * 0.9);
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, font: Program.Renderer.Fonts.NormalFont.Font), TextureParameters.NoChange, out MapPicturebox.Texture);
 			TitleLabel.Location = new Vector2(Program.Renderer.Screen.Width * 0.5 - TitleLabel.Size.X * 0.5, 5);
 			CloseButton.IsVisible = true;
 			ZoomInButton.IsVisible = true;
@@ -172,7 +172,7 @@ namespace OpenBve
 				Program.CurrentRoute.Switches[selectedSwitch].Toggle();
 				// Unload existing texture and re-create with new path
 				TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-				Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
+				Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, Program.Renderer.Fonts.NormalFont.Font), TextureParameters.NoChange, out MapPicturebox.Texture);
 			}
 			CloseButton.MouseDown(x, y);
 			ZoomInButton.MouseDown(x, y);
@@ -190,7 +190,7 @@ namespace OpenBve
 			drawRadius /= 2;
 			// Unload existing texture and re-create with new path
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, Program.Renderer.Fonts.NormalFont.Font), TextureParameters.NoChange, out MapPicturebox.Texture);
 		}
 
 		/// <summary>Zooms the map out</summary>
@@ -204,7 +204,7 @@ namespace OpenBve
 			drawRadius *= 2;
 			// Unload existing texture and re-create with new path
 			TextureManager.UnloadTexture(ref MapPicturebox.Texture);
-			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, fontFamily: Program.Renderer.Fonts.uiFont), TextureParameters.NoChange, out MapPicturebox.Texture);
+			Program.CurrentHost.RegisterTexture(Illustrations.CreateRouteMap(Program.Renderer.Screen.Width, Program.Renderer.Screen.Height, true, out AvailableSwitches, trackFollower, drawRadius, Program.Renderer.Fonts.NormalFont.Font), TextureParameters.NoChange, out MapPicturebox.Texture);
 		}
 
 		internal void Close(object sender, EventArgs e)

--- a/source/OpenBVE/Game/Timetable.cs
+++ b/source/OpenBVE/Game/Timetable.cs
@@ -235,7 +235,7 @@ namespace OpenBve {
 					g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
 					g.Clear(Color.Transparent);
 					g.FillRectangle(Brushes.White, new RectangleF(xOffset, 0, w, actualHeight));
-					FontFamily fontFamily = Program.Renderer.Fonts.uiFont;
+					FontFamily fontFamily = Program.Renderer.Fonts.NormalFont.Font.FontFamily;
 					if (fontFamily == null)
 					{
 						fontFamily = FontFamily.GenericSansSerif;

--- a/source/OpenBVE/Game/Timetable.cs
+++ b/source/OpenBVE/Game/Timetable.cs
@@ -235,9 +235,14 @@ namespace OpenBve {
 					g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
 					g.Clear(Color.Transparent);
 					g.FillRectangle(Brushes.White, new RectangleF(xOffset, 0, w, actualHeight));
-					Font f = new Font(FontFamily.GenericSansSerif, 13.0f, GraphicsUnit.Pixel);
-					Font fs = new Font(FontFamily.GenericSansSerif, 11.0f, GraphicsUnit.Pixel);
-					Font fss = new Font(FontFamily.GenericSansSerif, 9.0f, GraphicsUnit.Pixel);
+					FontFamily fontFamily = Program.Renderer.Fonts.uiFont;
+					if (fontFamily == null)
+					{
+						fontFamily = FontFamily.GenericSansSerif;
+					}
+					Font f = new Font(fontFamily, 13.0f, GraphicsUnit.Pixel);
+					Font fs = new Font(fontFamily, 11.0f, GraphicsUnit.Pixel);
+					Font fss = new Font(fontFamily, 9.0f, GraphicsUnit.Pixel);
 					// draw timetable
 					string t;
 					// description

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -77,6 +77,7 @@ namespace OpenBve {
 			Program.CurrentRoute.Information.TrainFolder = trainFolder;
 			Program.CurrentRoute.Information.FilesNotFound = null;
 			Program.CurrentRoute.Information.ErrorsAndWarnings = null;
+			Program.CurrentRoute.Information.FontFamily = Program.Renderer.Fonts.uiFont; 
 			Loader = new Thread(LoadThreaded) {IsBackground = true};
 			Loader.Start();
 		}

--- a/source/OpenBVE/System/Loading.cs
+++ b/source/OpenBVE/System/Loading.cs
@@ -77,7 +77,7 @@ namespace OpenBve {
 			Program.CurrentRoute.Information.TrainFolder = trainFolder;
 			Program.CurrentRoute.Information.FilesNotFound = null;
 			Program.CurrentRoute.Information.ErrorsAndWarnings = null;
-			Program.CurrentRoute.Information.FontFamily = Program.Renderer.Fonts.uiFont; 
+			Program.CurrentRoute.Information.Font = Program.Renderer.Fonts.NormalFont.Font; 
 			Loader = new Thread(LoadThreaded) {IsBackground = true};
 			Loader.Start();
 		}

--- a/source/OpenBVE/UserInterface/formImageExport.cs
+++ b/source/OpenBVE/UserInterface/formImageExport.cs
@@ -34,12 +34,12 @@ namespace OpenBve
 				{
 					if (IsMap)
 					{
-						Image map = Illustrations.CreateRouteMap((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, out _);
+						Image map = Illustrations.CreateRouteMap((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, out _, fontFamily: Program.Renderer.Fonts.uiFont);
 						map.Save(finalPath);
 					}
 					else 
 					{
-						Image gradient = Illustrations.CreateRouteGradientProfile((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false);
+						Image gradient = Illustrations.CreateRouteGradientProfile((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, fontFamily: Program.Renderer.Fonts.uiFont);
 						gradient.Save(finalPath);
 					}
 				}

--- a/source/OpenBVE/UserInterface/formImageExport.cs
+++ b/source/OpenBVE/UserInterface/formImageExport.cs
@@ -34,12 +34,12 @@ namespace OpenBve
 				{
 					if (IsMap)
 					{
-						Image map = Illustrations.CreateRouteMap((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, out _, fontFamily: Program.Renderer.Fonts.uiFont);
+						Image map = Illustrations.CreateRouteMap((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, out _, font: Program.Renderer.Fonts.NormalFont.Font);
 						map.Save(finalPath);
 					}
 					else 
 					{
-						Image gradient = Illustrations.CreateRouteGradientProfile((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, fontFamily: Program.Renderer.Fonts.uiFont);
+						Image gradient = Illustrations.CreateRouteGradientProfile((int)numericUpDownWidth.Value, (int)numericUpDownHeight.Value, false, font: Program.Renderer.Fonts.NormalFont.Font);
 						gradient.Save(finalPath);
 					}
 				}

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -1303,9 +1303,9 @@ namespace OpenBve
 
 					lock (BaseRenderer.GdiPlusLock)
 					{
-						pictureboxRouteMap.Image = Illustrations.CreateRouteMap(pictureboxRouteMap.Width, pictureboxRouteMap.Height, false, out _);
+						pictureboxRouteMap.Image = Illustrations.CreateRouteMap(pictureboxRouteMap.Width, pictureboxRouteMap.Height, false, out _, fontFamily: Program.Renderer.Fonts.uiFont);
 						pictureboxRouteGradient.Image = Illustrations.CreateRouteGradientProfile(pictureboxRouteGradient.Width,
-							pictureboxRouteGradient.Height, false);
+							pictureboxRouteGradient.Height, false, fontFamily: Program.Renderer.Fonts.uiFont);
 					}
 
 					// image

--- a/source/OpenBVE/UserInterface/formMain.Start.cs
+++ b/source/OpenBVE/UserInterface/formMain.Start.cs
@@ -1303,9 +1303,9 @@ namespace OpenBve
 
 					lock (BaseRenderer.GdiPlusLock)
 					{
-						pictureboxRouteMap.Image = Illustrations.CreateRouteMap(pictureboxRouteMap.Width, pictureboxRouteMap.Height, false, out _, fontFamily: Program.Renderer.Fonts.uiFont);
+						pictureboxRouteMap.Image = Illustrations.CreateRouteMap(pictureboxRouteMap.Width, pictureboxRouteMap.Height, false, out _, font: Program.Renderer.Fonts.NormalFont.Font);
 						pictureboxRouteGradient.Image = Illustrations.CreateRouteGradientProfile(pictureboxRouteGradient.Width,
-							pictureboxRouteGradient.Height, false, fontFamily: Program.Renderer.Fonts.uiFont);
+							pictureboxRouteGradient.Height, false, font: Program.Renderer.Fonts.NormalFont.Font);
 					}
 
 					// image

--- a/source/RouteManager2/Illustrations/RouteMap.cs
+++ b/source/RouteManager2/Illustrations/RouteMap.cs
@@ -109,13 +109,18 @@ namespace RouteManager2
 		/// <param name="switchPositions">The list of switch positions on the map</param>
 		/// <param name="follower">The TrackFollower used for drawing</param>
 		/// <param name="drawRadius">The draw radius</param>
-		public static Bitmap CreateRouteMap(int Width, int Height, bool inGame, out Dictionary<Guid, Vector2> switchPositions, TrackFollower follower = null, int drawRadius = 500)
+		public static Bitmap CreateRouteMap(int Width, int Height, bool inGame, out Dictionary<Guid, Vector2> switchPositions, TrackFollower follower = null, int drawRadius = 500, FontFamily fontFamily = null)
 		{
 			switchPositions = null;
 			if (CurrentRoute.Tracks[0].Elements == null)
 			{
 				//Usually caused by selecting another route before preview has finished
 				return new Bitmap(1,1);
+			}
+			// Font check
+			if (fontFamily == null)
+			{
+				fontFamily = FontFamily.GenericSansSerif;
 			}
 			int firstUsedElement, lastUsedElement;
 			if (follower != null)
@@ -331,7 +336,7 @@ namespace RouteManager2
 			// STATION NAMES
 			{
 				double wh = imageSize.X * imageSize.Y;
-				Font f = new Font(FontFamily.GenericSansSerif, wh < 65536.0 ? 9.0f : 10.0f, GraphicsUnit.Pixel);
+				Font f = new Font(fontFamily, wh < 65536.0 ? 9.0f : 10.0f, GraphicsUnit.Pixel);
 				for (int i = firstUsedElement; i <= lastUsedElement; i++)
 				{
 					for (int j = 0; j < CurrentRoute.Tracks[0].Elements[i].Events.Count; j++)
@@ -463,7 +468,7 @@ namespace RouteManager2
 		/// <param name="Width">The width of the bitmap to create.</param>
 		/// <param name="Height">The height of the bitmap to create.</param>
 		/// <param name="inGame"><c>true</c> = bitmap for in-game overlay | <c>false</c> = for standard window.</param>
-		public static Bitmap CreateRouteGradientProfile(int Width, int Height, bool inGame)
+		public static Bitmap CreateRouteGradientProfile(int Width, int Height, bool inGame, FontFamily fontFamily = null)
 		{
 			if (CurrentRoute.Tracks[0].Elements == null)
 			{
@@ -475,6 +480,11 @@ namespace RouteManager2
 				// than the more generic one thrown later
 				// NOTE: Will throw the generic error message on routes shorter than 900m with no stations
 				throw new InvalidDataException(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"errors","route_corrupt_nostations"}));
+			}
+			// Font check
+			if (fontFamily == null)
+			{
+				fontFamily = FontFamily.GenericSansSerif;
 			}
 			// Track elements are assumed to be all of the same length, and this length
 			// is used as measure unit, rather than computing the incremental track length
@@ -545,7 +555,7 @@ namespace RouteManager2
 			}
 			// STATION NAMES
 			{
-				Font f = new Font(FontFamily.GenericSansSerif, 12.0f, GraphicsUnit.Pixel);
+				Font f = new Font(fontFamily, 12.0f, GraphicsUnit.Pixel);
 				StringFormat m = new StringFormat();
 				for (int i = firstUsedElement; i <= lastUsedElement; i++)
 				{
@@ -604,8 +614,8 @@ namespace RouteManager2
 			}
 			// ROUTE MARKERS
 			{
-				Font f = new Font(FontFamily.GenericSansSerif, 10.0f, GraphicsUnit.Pixel);
-				Font fs = new Font(FontFamily.GenericSansSerif, 9.0f, GraphicsUnit.Pixel);
+				Font f = new Font(fontFamily, 10.0f, GraphicsUnit.Pixel);
+				Font fs = new Font(fontFamily, 9.0f, GraphicsUnit.Pixel);
 				StringFormat m = new StringFormat
 				{
 					Alignment = StringAlignment.Far,
@@ -658,8 +668,13 @@ namespace RouteManager2
 			return b;
 		}
 
-		private static void DrawPlayerPath(Graphics g, TrackFollower follower, int firstUsedElement, int lastUsedElement, Vector2 imageOrigin, Vector2 imageSize, Vector2 imageScale, double x0, double z0)
+		private static void DrawPlayerPath(Graphics g, TrackFollower follower, int firstUsedElement, int lastUsedElement, Vector2 imageOrigin, Vector2 imageSize, Vector2 imageScale, double x0, double z0, FontFamily fontFamily = null)
 		{
+			// Font check
+			if (fontFamily == null)
+			{
+				fontFamily = FontFamily.GenericSansSerif;
+			}
 			int key = follower.TrackIndex;
 			Track currentTrack = CurrentRoute.Tracks[key];
 			int start = 0;
@@ -677,7 +692,7 @@ namespace RouteManager2
 				{
 					continue;
 				}
-				Font boldFont = new Font(FontFamily.GenericSansSerif, 10.0f, FontStyle.Bold, GraphicsUnit.Pixel);
+				Font boldFont = new Font(fontFamily, 10.0f, FontStyle.Bold, GraphicsUnit.Pixel);
 				int nextTrackIndex = -1;
 				for (int j = 0; j < currentTrack.Elements[i + firstUsedElement].Events.Count; j++)
 				{

--- a/source/RouteManager2/Illustrations/RouteMap.cs
+++ b/source/RouteManager2/Illustrations/RouteMap.cs
@@ -109,7 +109,7 @@ namespace RouteManager2
 		/// <param name="switchPositions">The list of switch positions on the map</param>
 		/// <param name="follower">The TrackFollower used for drawing</param>
 		/// <param name="drawRadius">The draw radius</param>
-		public static Bitmap CreateRouteMap(int Width, int Height, bool inGame, out Dictionary<Guid, Vector2> switchPositions, TrackFollower follower = null, int drawRadius = 500, FontFamily fontFamily = null)
+		public static Bitmap CreateRouteMap(int Width, int Height, bool inGame, out Dictionary<Guid, Vector2> switchPositions, TrackFollower follower = null, int drawRadius = 500, Font font = null)
 		{
 			switchPositions = null;
 			if (CurrentRoute.Tracks[0].Elements == null)
@@ -117,10 +117,12 @@ namespace RouteManager2
 				//Usually caused by selecting another route before preview has finished
 				return new Bitmap(1,1);
 			}
+
+			FontFamily fontFamily = FontFamily.GenericSansSerif;
 			// Font check
-			if (fontFamily == null)
+			if (font != null)
 			{
-				fontFamily = FontFamily.GenericSansSerif;
+				fontFamily = font.FontFamily;
 			}
 			int firstUsedElement, lastUsedElement;
 			if (follower != null)
@@ -468,7 +470,7 @@ namespace RouteManager2
 		/// <param name="Width">The width of the bitmap to create.</param>
 		/// <param name="Height">The height of the bitmap to create.</param>
 		/// <param name="inGame"><c>true</c> = bitmap for in-game overlay | <c>false</c> = for standard window.</param>
-		public static Bitmap CreateRouteGradientProfile(int Width, int Height, bool inGame, FontFamily fontFamily = null)
+		public static Bitmap CreateRouteGradientProfile(int Width, int Height, bool inGame, Font font = null)
 		{
 			if (CurrentRoute.Tracks[0].Elements == null)
 			{
@@ -481,10 +483,13 @@ namespace RouteManager2
 				// NOTE: Will throw the generic error message on routes shorter than 900m with no stations
 				throw new InvalidDataException(Translations.GetInterfaceString(HostApplication.OpenBve, new[] {"errors","route_corrupt_nostations"}));
 			}
+
+			FontFamily fontFamily = FontFamily.GenericSansSerif;
+
 			// Font check
-			if (fontFamily == null)
+			if (font != null)
 			{
-				fontFamily = FontFamily.GenericSansSerif;
+				fontFamily = font.FontFamily;
 			}
 			// Track elements are assumed to be all of the same length, and this length
 			// is used as measure unit, rather than computing the incremental track length

--- a/source/RouteManager2/RouteInformation.cs
+++ b/source/RouteManager2/RouteInformation.cs
@@ -39,16 +39,18 @@ namespace RouteManager2
 
 		public int RouteMinX, RouteMaxX, RouteMinZ, RouteMaxZ;
 
+		public FontFamily FontFamily;
+
 		public void LoadInformation()
 		{
 			lock (BaseRenderer.GdiPlusLock)
 			{
-				RouteMap = Illustrations.CreateRouteMap(500, 500, true, out _);
+				RouteMap = Illustrations.CreateRouteMap(500, 500, true, out _, fontFamily: FontFamily);
 				RouteMinX = Illustrations.LastRouteMinX;
 				RouteMaxX = Illustrations.LastRouteMaxX;
 				RouteMinZ = Illustrations.LastRouteMinZ;
 				RouteMaxZ = Illustrations.LastRouteMaxZ;
-				GradientProfile = Illustrations.CreateRouteGradientProfile(500, 500, true);
+				GradientProfile = Illustrations.CreateRouteGradientProfile(500, 500, true, fontFamily: FontFamily);
 				GradientMinTrack = Illustrations.LastGradientMinTrack;
 				GradientMaxTrack = Illustrations.LastGradientMaxTrack;
 			}

--- a/source/RouteManager2/RouteInformation.cs
+++ b/source/RouteManager2/RouteInformation.cs
@@ -39,18 +39,18 @@ namespace RouteManager2
 
 		public int RouteMinX, RouteMaxX, RouteMinZ, RouteMaxZ;
 
-		public FontFamily FontFamily;
+		public Font Font;
 
 		public void LoadInformation()
 		{
 			lock (BaseRenderer.GdiPlusLock)
 			{
-				RouteMap = Illustrations.CreateRouteMap(500, 500, true, out _, fontFamily: FontFamily);
+				RouteMap = Illustrations.CreateRouteMap(500, 500, true, out _, font: Font);
 				RouteMinX = Illustrations.LastRouteMinX;
 				RouteMaxX = Illustrations.LastRouteMaxX;
 				RouteMinZ = Illustrations.LastRouteMinZ;
 				RouteMaxZ = Illustrations.LastRouteMaxZ;
-				GradientProfile = Illustrations.CreateRouteGradientProfile(500, 500, true, fontFamily: FontFamily);
+				GradientProfile = Illustrations.CreateRouteGradientProfile(500, 500, true, font: Font);
 				GradientMinTrack = Illustrations.LastGradientMinTrack;
 				GradientMaxTrack = Illustrations.LastGradientMaxTrack;
 			}


### PR DESCRIPTION
Always bothered me that it wasn't a thing. Also, without the custom font selection I couldn't get Japanese characters to render on the route map in WINE, even with CJK fonts installed. I suppose it could be a bug in how the GenericSansSerif font is selected in .NET? Anyhow, custom font rendering fixes that.

Please let me know if I missed something.