### PR TITLE
Hacks: Assorted Updates

### DIFF
--- a/assets/Compatibility/RoutePatches/Australia.xml
+++ b/assets/Compatibility/RoutePatches/Australia.xml
@@ -26,6 +26,7 @@
 		<Expression Number="298">.freeobj 0;47;0;0</Expression>
 		<Expression Number="301">.freeobj 0;47;0;0</Expression>
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
+		<InsufficientWallDikeArguments>true</InsufficientWallDikeArguments>
 	</Patch>
 	<Patch>
 		<Hash>64A20D1E8A55B9F54F4AE3C948B3E0F4E1B3701D94A551B27947834868ED799E</Hash>
@@ -34,6 +35,7 @@
 		<Expression Number="298">.freeobj 0;47;0;0</Expression>
 		<Expression Number="301">.freeobj 0;47;0;0</Expression>
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
+		<InsufficientWallDikeArguments>true</InsufficientWallDikeArguments>
 	</Patch>
 	<!-- ESR v1 -->
 	<Patch>

--- a/assets/Compatibility/RoutePatches/Japan.xml
+++ b/assets/Compatibility/RoutePatches/Japan.xml
@@ -222,6 +222,16 @@
 		<FileName>l-ﾃｴSlJoﾃｩﾃ嘘.csv</FileName>
 		<Expression Number="38">Texture.Background(1) gaku2\Back_Mt1.bmp</Expression>
 	</Patch>
+	<Patch>
+		<Hash>7C44D073DAF29776DAC50683B1272083443D1F0C69808D33590DB8C93E47EE48</Hash>
+		<FileName>Tangumi - noc.rw</FileName>
+		<InsufficientWallDikeArguments>true</InsufficientWallDikeArguments>
+	</Patch>
+	<Patch>
+		<Hash>23EBB924673CABF3450C785742D26E874C71F122E7B45287F6D819CF2D6074F4</Hash>
+		<FileName>Tanigumi - ráno.rw</FileName>
+		<InsufficientWallDikeArguments>true</InsufficientWallDikeArguments>
+	</Patch>
 	<!-- Minobu -->
 	<Patch>
 		<Hash>EE1F5FED84EE4EBD0469883BAEB7C8991486DE29557D93AE76530D0EAE2D84B6</Hash>

--- a/assets/Compatibility/RoutePatches/Misc.xml
+++ b/assets/Compatibility/RoutePatches/Misc.xml
@@ -31,6 +31,7 @@
 		<FileName>montserrat.rw</FileName>
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
 		<ReducedColorTransparency>true</ReducedColorTransparency>
+		<RailEndedObject>true</RailEndedObject>
 	</Patch>
 	<!-- Some Sanford Mace demo stuff -->
 	<Patch>

--- a/assets/Compatibility/RoutePatches/Spain.xml
+++ b/assets/Compatibility/RoutePatches/Spain.xml
@@ -114,11 +114,5 @@
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
 		<ReducedColorTransparency>true</ReducedColorTransparency>
 	</Patch>
-	<Patch>
-		<Hash>EDB673ED7BC2B4B5F80F48AE11ED75A604E92C6BFCDF3C177B19DB4791C6A9B4</Hash>
-		<FileName>montserrat.RW</FileName>
-		<AccurateObjectDisposal>true</AccurateObjectDisposal>
-		<RailEndedObject>true</RailEndedObject>
-	</Patch>
   </RoutePatches>
 </openBVE>

--- a/assets/Compatibility/RoutePatches/Spain.xml
+++ b/assets/Compatibility/RoutePatches/Spain.xml
@@ -114,5 +114,11 @@
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
 		<ReducedColorTransparency>true</ReducedColorTransparency>
 	</Patch>
+	<Patch>
+		<Hash>EDB673ED7BC2B4B5F80F48AE11ED75A604E92C6BFCDF3C177B19DB4791C6A9B4</Hash>
+		<FileName>montserrat.RW</FileName>
+		<AccurateObjectDisposal>true</AccurateObjectDisposal>
+		<RailEndedObject>true</RailEndedObject>
+	</Patch>
   </RoutePatches>
 </openBVE>

--- a/assets/Compatibility/RoutePatches/UnitedKingdom.xml
+++ b/assets/Compatibility/RoutePatches/UnitedKingdom.xml
@@ -643,5 +643,11 @@
 		<Expression Number="305"></Expression>
 		<Expression Number="811">.Sta Birkhill;16.4300;C;;1;;;;20;;</Expression>
 	</Patch>
+	<Patch>
+		<Hash>77FF1D93CCEC1E33AF54F413B003F47DD5A3574F03B6539BD5541E6B71FE30F6</Hash>
+		<FileName>somdor.rw</FileName>
+		<ReducedColorTransparency>true</ReducedColorTransparency>
+		<AccurateObjectDisposal>true</AccurateObjectDisposal>
+	</Patch>
   </RoutePatches>
 </openBVE>

--- a/assets/Compatibility/RoutePatches/UnitedKingdom.xml
+++ b/assets/Compatibility/RoutePatches/UnitedKingdom.xml
@@ -649,5 +649,16 @@
 		<ReducedColorTransparency>true</ReducedColorTransparency>
 		<AccurateObjectDisposal>true</AccurateObjectDisposal>
 	</Patch>
+	<!-- Edinburgh - Aberdeen v1.2-->
+	<Patch>
+		<Hash>E343E46938A7ACAAEC2F736867A1FAF1DB9BF9B4C69DBC7FBD7C7032AB28F794</Hash>
+		<FileName>Edin-Aberdeen-66.csv</FileName>
+		<SignalSet>BritishRail.xml</SignalSet>
+	</Patch>
+	<Patch>
+		<Hash>1E73BD564DE3B0BC111FB9F91CBE219F6C8ADD71FB5FE56DDB714E53212225CA</Hash>
+		<FileName>Edin-Carnoustie-150-2.csv</FileName>
+		<SignalSet>BritishRail.xml</SignalSet>
+	</Patch>
   </RoutePatches>
 </openBVE>

--- a/source/OpenBveApi/Objects/ObjectInterface.cs
+++ b/source/OpenBveApi/Objects/ObjectInterface.cs
@@ -83,5 +83,8 @@ namespace OpenBveApi.Objects
 		public bool AggressiveRwBrackets;
 		/// <summary> Whether a wall / dike with insufficient arguments is accepted</summary>
 		public bool InsufficientWallDikeArguments;
+		/// <summary>Whether the RailEnded object behaviour is reproduced</summary>
+		/// <remarks>If an object is placed on an ended Rail in BVE2, it actually appears at the start of the last valid block</remarks>
+		public bool RailEndedObject;
 	}
 }

--- a/source/OpenBveApi/System/Text.cs
+++ b/source/OpenBveApi/System/Text.cs
@@ -75,6 +75,18 @@ namespace OpenBveApi
 			return Builder.ToString();
 		}
 
+		/// <summary>Provides an exception free implimentation of string.Substring, returning less characters rather than an exception</summary>
+		public static string SafeSubstring(this string Text, int StartIndex, int Length)
+		{
+			if (StartIndex > Text.Length)
+			{
+				return string.Empty;
+			}
+
+			Length = System.Math.Min(Length, Text.Length - StartIndex);
+			return Text.Substring(StartIndex, Length);
+		}
+
 		/// <summary>Provides an escaped copy of a string</summary>
 		public static string Escape(this string text)
 		{

--- a/source/Plugins/Formats.OpenBve/CSVB3D/CSVB3DFile.cs
+++ b/source/Plugins/Formats.OpenBve/CSVB3D/CSVB3DFile.cs
@@ -206,9 +206,9 @@ namespace Formats.OpenBve
 	}
 	public class CSVB3DFile <T1, T2> : CSVB3DBlock<T1, T2> where T1 : struct, Enum where T2 : struct, Enum
 	{
-		public CSVB3DFile(string myFile, HostInterface currentHost) : base(myFile, currentHost)
+		public CSVB3DFile(string myFile, HostInterface currentHost, System.Text.Encoding Encoding) : base(myFile, currentHost)
 		{
-			List<string> Lines = File.ReadAllLines(myFile).ToList();
+			List<string> Lines = File.ReadAllLines(myFile, Encoding).ToList();
 
 			CSVB3DFileSection<T1, T2> currentSection = null;
 

--- a/source/Plugins/Formats.OpenBve/Enums/PatchDatabase/PatchDatabaseKey.cs
+++ b/source/Plugins/Formats.OpenBve/Enums/PatchDatabase/PatchDatabaseKey.cs
@@ -28,6 +28,7 @@
 		Incompatible,
 		DelayedAnimatedUpdates,
 		AdhesionHack,
-		InsufficientWallDikeArguments
+		InsufficientWallDikeArguments,
+		RailEndedObject
 	}
 }

--- a/source/Plugins/Object.CsvB3d/Plugin.NewParser.cs
+++ b/source/Plugins/Object.CsvB3d/Plugin.NewParser.cs
@@ -39,7 +39,7 @@ namespace Object.CsvB3d
 	{
 		internal static StaticObject ReadObject(string fileName, Encoding textEncoding)
 		{
-			CSVB3DFile<CSVB3DSection, CSVB3DKey> objectFile = new CSVB3DFile<CSVB3DSection, CSVB3DKey>(fileName, Plugin.currentHost);
+			CSVB3DFile<CSVB3DSection, CSVB3DKey> objectFile = new CSVB3DFile<CSVB3DSection, CSVB3DKey>(fileName, Plugin.currentHost, textEncoding);
 			string basePath = Path.GetDirectoryName(fileName);
 
 			StaticObject staticObject = new StaticObject(Plugin.currentHost);

--- a/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
+++ b/source/Plugins/Route.CsvRw/Compatability/RoutefilePatch.cs
@@ -38,6 +38,7 @@ namespace CsvRwRouteParser
 				EnabledHacks.CylinderHack = patch.CylinderHack;
 				EnabledHacks.DisableSemiTransparentFaces = patch.DisableSemiTransparentFaces;
 				EnabledHacks.InsufficientWallDikeArguments = patch.InsufficientWallDikeArguments;
+				EnabledHacks.RailEndedObject = patch.RailEndedObject;
 				Plugin.CurrentOptions.ObjectDisposalMode = patch.AccurateObjectDisposal ? ObjectDisposalMode.Accurate : ObjectDisposalMode.Legacy;
 
 				for (int i = 0; i < patch.ExpressionFixes.Count; i++)
@@ -166,5 +167,7 @@ namespace CsvRwRouteParser
 		internal bool AdhesionHack = false;
 		/// <summary>Whether walls / dikes with insufficient arguments are allowed</summary>
 		internal bool InsufficientWallDikeArguments;
+		/// <summary>Whether the RailEnded object behaviour is reproduced</summary>
+		internal bool RailEndedObject;
 	}
 }

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -886,6 +886,23 @@ namespace CsvRwRouteParser
 								Data.Blocks[i].Cracks[k].Create(railKey, RailTransformation, pos, Data.Blocks[i], Data.Blocks[i + 1], Data.Structure, railParameters);
 							}
 
+							if (EnabledHacks.RailEndedObject && railKey == 1)
+							{
+								/*
+								 * This one is *really* odd- if the rail key is 1
+								 * BVE2 seems to use the track transformation for FreeObjects,
+								 * not the rail transformation.
+								 *
+								 * I can find no mention of this behaviour in any documentation in my
+								 * archive.
+								 *
+								 * Only found a broken example of this on the Monserrat route,
+								 * and for the moment, I think this needs to be behind the
+								 * specific hack above. 
+								 */
+								RailTransformation = TrackTransformation;
+							}
+
 							// free objects
 							if (Data.Blocks[i].RailFreeObj.ContainsKey(railKey))
 							{

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.ApplyRouteData.cs
@@ -769,6 +769,7 @@ namespace CsvRwRouteParser
 
 						ObjectCreationParameters railParameters = new ObjectCreationParameters(StartingDistance, EndingDistance);
 
+						bool freeObjPositionHack = false;
 						if (!PreviewOnly)
 						{
 							if (railKey > 0 && !Data.Blocks[i].Rails[railKey].RailStarted)
@@ -779,8 +780,16 @@ namespace CsvRwRouteParser
 									CurrentRoute.Tracks[railKey].Elements[n].Events.Add(new TrackEndEvent(Plugin.CurrentHost, Data.BlockInterval));
 								}
 
-								//In order to run on other tracks, we need to calculate the positions and stuff, so continue after here instead
-								continue;
+								
+								if (Plugin.CurrentOptions.EnableBveTsHacks && EnabledHacks.RailEndedObject)
+								{
+									freeObjPositionHack = true;
+								}
+								else
+								{
+									// In order to run on other tracks, we need to calculate the positions and stuff, so continue after here instead
+									continue;
+								}
 							}
 
 							if (railKey >= 0 && Data.Structure.RailObjects.ContainsKey(Data.Blocks[i].RailType[railKey]))
@@ -882,7 +891,26 @@ namespace CsvRwRouteParser
 							{
 								for (int k = 0; k < Data.Blocks[i].RailFreeObj[railKey].Count; k++)
 								{
-									Data.Blocks[i].RailFreeObj[railKey][k].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, StartingDistance, EndingDistance);
+									if (freeObjPositionHack && i > 0)
+									{
+										// find last block in which rail was valid 
+										int blockSearch = i - 1;
+										while (blockSearch >= 0)
+										{
+											if (Data.Blocks[blockSearch].Rails[railKey].RailStarted)
+											{
+												Data.Blocks[i].RailFreeObj[railKey][k].CreateRailAligned(Data.Structure.FreeObjects, blockSearch * Data.BlockInterval, new Vector3(pos), RailTransformation, StartingDistance, EndingDistance);
+												break;
+											}
+											blockSearch--;
+										}
+										
+									}
+									else
+									{
+										Data.Blocks[i].RailFreeObj[railKey][k].CreateRailAligned(Data.Structure.FreeObjects, new Vector3(pos), RailTransformation, StartingDistance, EndingDistance);
+									}
+									
 								}
 							}
 							

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.CompatibilityObjects.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.CompatibilityObjects.cs
@@ -1,4 +1,4 @@
-﻿using Formats.OpenBve;
+using Formats.OpenBve;
 using Formats.OpenBve.XML;
 using OpenBveApi;
 using OpenBveApi.Interface;
@@ -139,8 +139,26 @@ namespace CsvRwRouteParser
 						return true;
 					}
 				}
-
-
+				// Seneca v2
+				if (fileName.StartsWith(@"seneca\", StringComparison.InvariantCultureIgnoreCase))
+				{
+					fn = "seneca2\\" + fileName.Substring(7);
+					try
+					{
+						//Catch completely malformed path references
+						n = Path.CombineFile(objectPath, fn);
+					}
+					catch
+					{
+						return false;
+					}
+					if (System.IO.File.Exists(n))
+					{
+						fileName = n;
+						//The object exists, and does not require a compatibility object
+						return true;
+					}
+				}
 			}
 			//We haven't found the object on-disk, so check the compatibility objects to see if a replacement is available
 			for (int i = 0; i < CompatibilityObjects.AvailableReplacements.Length; i++)

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.Functions.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.Functions.cs
@@ -177,11 +177,22 @@ namespace CsvRwRouteParser
 
 		private string[] SplitArguments(string ArgumentSequence)
 		{
+			char separator = Data.FileFormat == RoutefileFormat.RW ? ',' : ';';
+
+			if (Data.FileFormat == RoutefileFormat.RW)
+			{
+				int semiColon = ArgumentSequence.IndexOf(';');
+				if (semiColon != -1)
+				{
+					ArgumentSequence = ArgumentSequence.Substring(0, semiColon);
+				}
+			}
+
 			string[] Arguments;
 			{
 				int n = 0;
 				for (int k = 0; k < ArgumentSequence.Length; k++) {
-					if ((Data.FileFormat == RoutefileFormat.RW && ArgumentSequence[k] == ',') || ArgumentSequence[k] == ';') 
+					if (ArgumentSequence[k] == separator) 
 					{
 						n++;
 					}
@@ -189,7 +200,7 @@ namespace CsvRwRouteParser
 				Arguments = new string[n + 1];
 				int a = 0, h = 0;
 				for (int k = 0; k < ArgumentSequence.Length; k++) {
-					if ((Data.FileFormat == RoutefileFormat.RW && ArgumentSequence[k] == ',') || ArgumentSequence[k] == ';') 
+					if (ArgumentSequence[k] == separator) 
 					{
 						Arguments[h] = ArgumentSequence.Substring(a, k - a).Trim();
 						a = k + 1; h++;

--- a/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
+++ b/source/Plugins/Route.CsvRw/CsvRwRouteParser.Preprocess.cs
@@ -13,7 +13,7 @@ namespace CsvRwRouteParser
 		private void PreprocessSplitIntoExpressions(string FileName, List<string> Lines, out IList<Expression> Expressions, bool AllowRwRouteDescription, double trackPositionOffset = 0.0) {
 			// use a high initial capacity to try and minimize churn
 			Expressions = new List<Expression>(20000); 
-			// full-line rw comments
+			// RW comments
 			if (Data.FileFormat == RoutefileFormat.RW) {
 				for (int i = 0; i < Lines.Count; i++) {
 					int Level = 0;
@@ -26,7 +26,7 @@ namespace CsvRwRouteParser
 								Level--;
 								break;
 							case ';':
-								if (Level == 0)
+								if (Level == 0 || Plugin.CurrentOptions.EnableBveTsHacks)
 								{
 									Lines[i] = Lines[i].Substring(0, j).TrimEnd();
 									j = Lines[i].Length;

--- a/source/Plugins/Route.CsvRw/Namespaces/Track/Track.cs
+++ b/source/Plugins/Route.CsvRw/Namespaces/Track/Track.cs
@@ -1887,7 +1887,7 @@ namespace CsvRwRouteParser
 							}
 
 							int roof = 0, pf = 0;
-							if (Arguments.Length >= 3 && Arguments[2].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[2], out roof))
+							if (Arguments.Length >= 3 && Arguments[2].Length > 0 && !NumberFormats.TryParseIntVb6(Arguments[2], out roof) || roof < 0)
 							{
 								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex is invalid in Track.Form at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
 								roof = 0;
@@ -1898,8 +1898,8 @@ namespace CsvRwRouteParser
 								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "FormStructureIndex is invalid in Track.Form at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
 								pf = 0;
 							}
-
-							if (roof != 0 & (roof < 0 || (!Data.Structure.RoofL.ContainsKey(roof) && !Data.Structure.RoofR.ContainsKey(roof))))
+							
+							if (roof > 0 && !Data.Structure.RoofL.ContainsKey(roof) && !Data.Structure.RoofR.ContainsKey(roof))
 							{
 								Plugin.CurrentHost.AddMessage(MessageType.Error, false, "RoofStructureIndex " + roof + " references an object not loaded in Track.Form at line " + Expression.Line.ToString(Culture) + ", column " + Expression.Column.ToString(Culture) + " in file " + Expression.File);
 							}

--- a/source/Plugins/Route.CsvRw/Structures/Expression.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Expression.cs
@@ -1,6 +1,7 @@
 using System;
 using OpenBveApi.Math;
 using System.Linq;
+using OpenBveApi;
 using OpenBveApi.Interface;
 
 namespace CsvRwRouteParser
@@ -260,7 +261,7 @@ namespace CsvRwRouteParser
 									}
 									if (Text.StartsWith(".timetable", StringComparison.InvariantCultureIgnoreCase) || Text.StartsWith(".marker", StringComparison.InvariantCultureIgnoreCase) || Text.StartsWith(".announce", StringComparison.InvariantCultureIgnoreCase) || Text.IndexOf(".Load", StringComparison.InvariantCultureIgnoreCase) != -1)
 									{
-										if (Text.Substring(i + 1, 5).ToLowerInvariant() == ".load" || Text.Substring(i + 1, 9).ToLowerInvariant() == ".day.load" || Text.Substring(i + 1, 11).ToLowerInvariant() == ".night.load")
+										if (Text.SafeSubstring(i + 1, 5).ToLowerInvariant() == ".load" || Text.SafeSubstring(i + 1, 9).ToLowerInvariant() == ".day.load" || Text.SafeSubstring(i + 1, 11).ToLowerInvariant() == ".night.load")
 										{
 											found = true;
 											firstClosingBracket = i;

--- a/source/Plugins/Route.CsvRw/Structures/Expression.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Expression.cs
@@ -335,7 +335,7 @@ namespace CsvRwRouteParser
 
 			if (firstClosingBracket != 0 && firstClosingBracket < Text.Length - 1)
 			{
-				if (!char.IsWhiteSpace(Text[firstClosingBracket + 1]) && Text[firstClosingBracket + 1] != '.' && Text[firstClosingBracket + 1] != ';')
+				if (!char.IsWhiteSpace(Text[firstClosingBracket + 1]) && Text[firstClosingBracket + 1] != '.' && Text[firstClosingBracket + 1] != ';' && Text[firstClosingBracket + 1] != '_')
 				{
 					Text = Text.Insert(firstClosingBracket + 1, " ");
 					i = firstClosingBracket;

--- a/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
+++ b/source/Plugins/Route.CsvRw/Structures/Route/FreeObject.cs
@@ -26,6 +26,14 @@ namespace CsvRwRouteParser
 			Roll = roll;
 		}
 
+		internal void CreateRailAligned(ObjectDictionary FreeObjects, double TrackPositionOverride, Vector3 WorldPosition, Transformation RailTransformation, double StartingDistance, double EndingDistance)
+		{
+			double dz = TrackPositionOverride - StartingDistance;
+			WorldPosition += Position.X * RailTransformation.X + Position.Y * RailTransformation.Y + dz * RailTransformation.Z;
+			FreeObjects.TryGetValue(Type, out UnifiedObject obj);
+			obj?.CreateObject(WorldPosition, RailTransformation, new Transformation(Yaw, Pitch, Roll), new ObjectCreationParameters(TrackPositionOverride, StartingDistance, EndingDistance));
+		}
+
 		internal void CreateRailAligned(ObjectDictionary FreeObjects, Vector3 WorldPosition, Transformation RailTransformation, double StartingDistance, double EndingDistance)
 		{
 			double dz = TrackPosition - StartingDistance;

--- a/source/Plugins/Route.CsvRw/XML/RoutePatchDatabase.cs
+++ b/source/Plugins/Route.CsvRw/XML/RoutePatchDatabase.cs
@@ -63,6 +63,7 @@ namespace CsvRwRouteParser
 			patchBlock.GetValue(PatchDatabaseKey.DelayedAnimatedUpdates, out currentPatch.DelayedAnimatedUpdates);
 			patchBlock.GetValue(PatchDatabaseKey.AdhesionHack, out currentPatch.AdhesionHack);
 			patchBlock.GetValue(PatchDatabaseKey.InsufficientWallDikeArguments, out currentPatch.InsufficientWallDikeArguments);
+			patchBlock.GetValue(PatchDatabaseKey.RailEndedObject, out currentPatch.RailEndedObject);
 			if (patchBlock.GetEnumValue(PatchDatabaseKey.XParser, out XParsers parser))
 			{
 				currentPatch.XParser = parser;

--- a/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
+++ b/source/Plugins/Train.OpenBve/Panel/PanelCfgParser.cs
@@ -785,31 +785,35 @@ namespace Train.OpenBve
 				 */
 				double clipWidth = Math.Min(Width, panelTexture.Width - Left);
 				double clipHeight = Math.Min(Height, panelTexture.Height + SemiHeight - Top);
-				Texture temp = panelTexture.ApplyParameters(new TextureParameters(new TextureClipRegion(Math.Max(0, (int)Left)
-					, Math.Max(0, (int)(Top - SemiHeight)), (int)clipWidth, (int)clipHeight), Color24.Blue));
-				
-				temp.Origin.GetTexture(out Texture t);
-				switch (t.GetTransparencyType())
+				if (clipWidth > 1 && clipHeight > 1)
 				{
-					case TextureTransparencyType.Transparent:
-						// totally hidden
-						Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 }, new Color24[] { });
-						break;
-					case TextureTransparencyType.Partial:
-						if (IsNeedle)
-						{
-							// as needles rotate, we can't just apply a mask and have to hide the whole thing
-							Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 }, new Color24[] { });
-						}
-						else
-						{
-							Texture.Origin.GetTexture(out Texture tt);
-							Texture = tt.ApplyParameters(new TextureParameters(null, null, t));
-						}
-						
-						break;
-				}
+					Texture temp = panelTexture.ApplyParameters(new TextureParameters(new TextureClipRegion(Math.Max(0, (int)Left)
+						, Math.Max(0, (int)(Top - SemiHeight)), (int)clipWidth, (int)clipHeight), Color24.Blue));
 
+					temp.Origin.GetTexture(out Texture t);
+					switch (t.GetTransparencyType())
+					{
+						case TextureTransparencyType.Transparent:
+							// totally hidden
+							Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 },
+								new Color24[] { });
+							break;
+						case TextureTransparencyType.Partial:
+							if (IsNeedle)
+							{
+								// as needles rotate, we can't just apply a mask and have to hide the whole thing
+								Texture = new Texture(1, 1, PixelFormat.RGBAlpha, new byte[] { 0, 0, 0, 0 },
+									new Color24[] { });
+							}
+							else
+							{
+								Texture.Origin.GetTexture(out Texture tt);
+								Texture = tt.ApplyParameters(new TextureParameters(null, null, t));
+							}
+
+							break;
+					}
+				}
 			}
 
 


### PR DESCRIPTION
This PR introduces a new hack plus certain other changes, to handle an 'interesting' little bit of FreeObj positioning logic in BVE2.

If FreeObjs are placed on a rail which is not currently active, e.g.
```
150 @railend(1)@freeobj(1,6,0,0,0)
```

It turns out our FreeObj is actually placed at the *start* of the last valid block. In this case therefore, the FreeObj would be placed at track position 125.

This behaviour continues, even if we place our FreeObj say at track position 500. 

I've found one route which specifically relies on this behaviour at the minute- the Montserrat rack railway for BVE2. (missing pointwork at the initial station)

Probably not going to introduce this as a general hack at the minute, but needs to be considered when testing older content... 

---

~~Another find from the Montserrat route is that BVE2 actually uses the primary rail transform for FreeObjs.~~

~~The practical effect of this is that the rotation of any FreeObj is actually therefore relative to the path of the primary rail, not whichever secondary rail the object is placed upon.~~

~~This has been implemented for the RW file format *only*, and is not currently behind the hacks option.~~

Some further digging, *appears* to find that the primary rail transformation is for Rail 1 only. For the minute at least, this is gated behind the new hack for the above. I don't like this at all, but testing with BVE2 route viewer confirms this....

---

Changes to the handling of semi-colon comments in the RW format:

The previous behaviour assumed that the semi-colon was also valid as an argument separator in the RW format- It is not.

This has been changed as follows:
 * Discard *all* content remaining on a line after a semi-colon when hacks are active (matches BVE2 behaviour)
 * Do not treat semi-colon as an argument separator for RW at all times- trim to this index if present (if hacks are off)
---

https://openbvemodernizacoesbr.blogspot.com/p/downloads-de-rotas.html

This route only works in 1.4.3- couple of fixes to make it work correctly in the most recent version.
Essentially, it's got some misplaced underscores at the end of commands, which later fixes have broken. 


### Final Notes:
The changes to RW behaviour will require errata entries.
As Michelle never wrote proper documentation for the RW file format, I'm reasonably happy that anything written in RW format is actually BVE2 content.

The RW quick reference page will require updating to use the comma as separator, rather than the semi-colon.

The FreeObj rotation change will also want noting on the RW documentation page.